### PR TITLE
Fix snakeyaml version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Duplicative of legend-shared-pac4j dep 
+                (via jackson-dataformat-yaml). If not set,
+                snakeyaml version shown in the build is 1.24
+                Could be caused by a mvn conflict resolution,
+                the safest approach is to force version here.
+            -->
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.26</version>
+            </dependency>
             <!-- ENGINE -->
             <dependency>
                 <groupId>org.finos.legend.engine</groupId>


### PR DESCRIPTION
Running `mvn dependency:tree` I see snakeyaml 1.26 , so I expect it fixes the issue.

@gs-bracej - is this a valid solution, although we haven't quite figured out why this version conflict only happens on this module and not on others?