### PR TITLE
Support numeric values in Boolean result serialization transformer

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/transformer/SetImplTransformers.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/transformer/SetImplTransformers.java
@@ -58,6 +58,30 @@ public class SetImplTransformers
         transformers = Lists.mutable.empty();
     }
 
+    private Boolean toBoolean(Object o) 
+    {
+        if (o == null)
+        {
+            return null;
+        } 
+        else if (o instanceof Boolean) 
+        {
+            return (Boolean) o;
+        } 
+        else if (o instanceof String)
+        {
+            return Boolean.parseBoolean((String) o);
+        } 
+        else if (o instanceof  Number)
+        {
+            return ((Number) o).intValue() != 0;
+        } 
+        else 
+        {
+            throw new IllegalArgumentException("Transformer Error: Could not convert to Boolean");
+        }
+    }
+
     private <T> Function<Object, Object> buildTransformer(TransformerInput<T> transformerInput)
     {
         if (transformerInput.type != null && transformerInput.test.valueOf(transformerInput.identifier))
@@ -66,7 +90,7 @@ public class SetImplTransformers
         }
         else if (transformerInput.type != null && transformerInput.type.equals("Boolean"))
         {
-            return o -> o == null ? null : o instanceof Boolean ? o : Boolean.parseBoolean((String) o);
+            return o -> toBoolean(o);
         }
         else if (transformerInput.type != null && (transformerInput.type.equals("StrictDate") || transformerInput.type.equals("DateTime") || transformerInput.type.equals("Date")))
         {

--- a/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/transformer/TestSetImplTransformers.java
+++ b/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/transformer/TestSetImplTransformers.java
@@ -1,0 +1,81 @@
+package org.finos.legend.engine.plan.execution.result.transformer;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSetImplTransformers 
+{
+    public SetImplTransformers testBooleanTransformerSetup()
+    {
+        List<TransformerInput<Integer>> testTransformerInput= new ArrayList<>();
+        testTransformerInput.add(new TransformerInput<Integer>(1, "Boolean", o -> false, null));
+        return new SetImplTransformers(testTransformerInput);
+    }
+    
+    @Test 
+    public void testBooleanTransformerBooleanValue()
+    {
+        SetImplTransformers s = testBooleanTransformerSetup();
+        Object trueValue = s.transformers.get(0).valueOf(true);
+        assert(trueValue instanceof Boolean);
+        assert((Boolean) trueValue);
+
+        Object falseValue = s.transformers.get(0).valueOf(false);
+        assert(falseValue instanceof Boolean);
+        assert(!(Boolean) falseValue);
+    }
+
+    @Test
+    public void testBooleanTransformerStringValue()
+    {
+        SetImplTransformers s = testBooleanTransformerSetup();
+        Object trueValue = s.transformers.get(0).valueOf("true");
+        assert(trueValue instanceof Boolean);
+        assert((Boolean) trueValue);
+
+        Object falseValue = s.transformers.get(0).valueOf("false");
+        assert(falseValue instanceof Boolean);
+        assert(!(Boolean) falseValue);
+    }
+
+    @Test
+    public void testBooleanTransformerLongValue()
+    {
+        SetImplTransformers s = testBooleanTransformerSetup();
+        Object trueValue = s.transformers.get(0).valueOf(1L);
+        assert(trueValue instanceof Boolean);
+        assert((Boolean) trueValue);
+
+        Object falseValue = s.transformers.get(0).valueOf(0L);
+        assert(falseValue instanceof Boolean);
+        assert(!(Boolean) falseValue);
+    }
+
+    @Test
+    public void testBooleanTransformerIntValue()
+    {
+        SetImplTransformers s = testBooleanTransformerSetup();
+        Object trueValue = s.transformers.get(0).valueOf(1);
+        assert(trueValue instanceof Boolean);
+        assert((Boolean) trueValue);
+
+        Object falseValue = s.transformers.get(0).valueOf(0);
+        assert(falseValue instanceof Boolean);
+        assert(!(Boolean) falseValue);
+    }
+
+    @Test
+    public void testBooleanTransformerDoubleValue()
+    {
+        SetImplTransformers s = testBooleanTransformerSetup();
+        Object trueValue = s.transformers.get(0).valueOf(1.0);
+        assert(trueValue instanceof Boolean);
+        assert((Boolean) trueValue);
+
+        Object falseValue = s.transformers.get(0).valueOf(0.0);
+        assert(falseValue instanceof Boolean);
+        assert(!(Boolean) falseValue);
+    }
+}


### PR DESCRIPTION
Serialization transformers for Boolean datatypes should handle numeric values, where zero means false and non-zero values means true.