### PR TITLE
Add Docker security scan

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,31 @@
+name: Docker
+
+on:
+  schedule:
+    - cron: '0 0 * * 2' # every Tuesday on default/base branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  release:
+    name: Run Image Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build simplified Docker image for checks
+        # NOTE: if this gets more complicated, consider having this as a bash script
+        run: mkdir -p ./legend-engine-server/target && touch ./legend-engine-server/target/legend-engine-server-dummy.jar && docker build --quiet --tag local/legend-engine-server:${{ github.sha }} ./legend-engine-server
+      - name: Scan image for security issues
+        uses: Azure/container-scan@v0
+        env:
+          # Skip `won't fix` CVEs
+          # See https://github.com/Azure/container-scan/issues/61
+          TRIVY_IGNORE_UNFIXED: true
+        with:
+          image-name: local/legend-engine-server:${{ github.sha }}
+          severity-threshold: CRITICAL

--- a/legend-engine-server/Dockerfile
+++ b/legend-engine-server/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:11
+FROM openjdk:11.0.10
 COPY target/legend-engine-server-*.jar /app/bin/
-CMD java -Xmx2G -Xms256M -Xss4M -cp /app/bin/*-shaded.jar -Dfile.encoding=UTF8 org.finos.legend.engine.server.Server server /config/config.json
+CMD java -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=60 -Xss4M -cp /app/bin/*-shaded.jar -Dfile.encoding=UTF8 org.finos.legend.engine.server.Server server /config/config.json


### PR DESCRIPTION
Add Docker security scan.
Also update `Dockerfile` to use a fixed version of `openjdk` base image instead of `openjdk:11` which is equivalent to the `latest` tag. Otherwise, we are not confident of which `openjdk` image we're using and thus, making debugging harder - For example, see https://github.com/aquasecurity/trivy/issues/885

Context https://github.com/finos/legend/issues/360
