### PR TITLE
Fix MacOSX tests (#115)

### DIFF
--- a/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/test/serialization/TestTemporaryFile.java
+++ b/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/test/serialization/TestTemporaryFile.java
@@ -26,15 +26,15 @@ public class TestTemporaryFile
     {
         TemporaryFile tempFileWithoutEndingSlash = new TemporaryFile("/tmp");
         TemporaryFile tempFileWithEndingSlash = new TemporaryFile("/tmp/");
-        if (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_UNIX)
-        {
-            Assert.assertEquals(2, (int) tempFileWithoutEndingSlash.getTemporaryPathForFile().chars().filter(ch -> ch == '/').count());
-            Assert.assertEquals(2, (int) tempFileWithEndingSlash.getTemporaryPathForFile().chars().filter(ch -> ch == '/').count());
-        }
-        else if (SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX)
+        if (SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX)
         {
             Assert.assertEquals(1, (int) tempFileWithoutEndingSlash.getTemporaryPathForFile().chars().filter(ch -> ch == '/').count());
             Assert.assertEquals(1, (int) tempFileWithEndingSlash.getTemporaryPathForFile().chars().filter(ch -> ch == '/').count());
+        }
+        else if (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_UNIX)
+        {
+            Assert.assertEquals(2, (int) tempFileWithoutEndingSlash.getTemporaryPathForFile().chars().filter(ch -> ch == '/').count());
+            Assert.assertEquals(2, (int) tempFileWithEndingSlash.getTemporaryPathForFile().chars().filter(ch -> ch == '/').count());
         }
         else
         {


### PR DESCRIPTION
Evaluate whether on mac first since IS_OS_LINUX || IS_OS_UNIX is true on a Mac