### PR TITLE
Add support for storeSubPath in included mapping

### DIFF
--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/mapping/MappingParseTreeWalker.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/mapping/MappingParseTreeWalker.java
@@ -44,6 +44,7 @@ import org.finos.legend.engine.shared.core.operational.errorManagement.EngineExc
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class MappingParseTreeWalker
@@ -91,9 +92,21 @@ public class MappingParseTreeWalker
         MappingInclude mappingInclude = new MappingInclude();
         mappingInclude.setIncludedMapping(PureGrammarParserUtility.fromQualifiedName(ctx.qualifiedName().packagePath() == null ? Collections.emptyList() : ctx.qualifiedName().packagePath().identifier(), ctx.qualifiedName().identifier()));
         mappingInclude.sourceInformation = this.walkerSourceInformation.getSourceInformation(ctx);
-        // TODO support storeSubPath
-        mappingInclude.sourceDatabasePath = null;
-        mappingInclude.targetDatabasePath = null;
+        List<MappingParserGrammar.StoreSubPathContext> storeSubPathContextList = ctx.storeSubPath();
+
+        if (storeSubPathContextList.size() == 1) {
+            visitStoreSubPath(storeSubPathContextList.get(0), mappingInclude);
+        } else {
+            mappingInclude.sourceDatabasePath = null;
+            mappingInclude.targetDatabasePath = null;
+        }
+        return mappingInclude;
+    }
+
+    private MappingInclude visitStoreSubPath(MappingParserGrammar.StoreSubPathContext ctx, MappingInclude mappingInclude)
+    {
+        mappingInclude.sourceDatabasePath = PureGrammarParserUtility.fromQualifiedName(ctx.sourceStore().qualifiedName().packagePath() == null ? Collections.emptyList() : ctx.sourceStore().qualifiedName().packagePath().identifier(), ctx.sourceStore().qualifiedName().identifier());
+        mappingInclude.targetDatabasePath = PureGrammarParserUtility.fromQualifiedName(ctx.targetStore().qualifiedName().packagePath() == null ? Collections.emptyList() : ctx.targetStore().qualifiedName().packagePath().identifier(), ctx.targetStore().qualifiedName().identifier());
         return mappingInclude;
     }
 

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
@@ -442,4 +442,28 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "  }\n" +
                 ")\n");
     }
+
+    @Test
+    public void testMappingWithIncludedMapping()
+    {
+        test("###Mapping\n" +
+                "Mapping test::decomposeMapping\n" +
+                "(\n" +
+                "  *test::_Person: Pure\n" +
+                "  {\n" +
+                "    ~src test::Person\n" +
+                "    weightUnit: $src.weight->unitType(),\n" +
+                "    weightValue: $src.weight->unitValue()\n" +
+                "  }\n" +
+                ")\n\n" +
+                "Mapping test::convertMapping\n" +
+                "(\n" +
+                "  include test::decomposeMapping[dbInc->db]\n\n" +
+                "  *test::PersonWithPound: Pure\n" +
+                "  {\n" +
+                "    ~src test::Person\n" +
+                "    weight: $src.weight->convert(test::Mass~Pound)->cast(@test::Mass~Pound)\n" +
+                "  }\n" +
+                ")\n");
+    }
 }

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
@@ -442,28 +442,4 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "  }\n" +
                 ")\n");
     }
-
-    @Test
-    public void testMappingWithIncludedMapping()
-    {
-        test("###Mapping\n" +
-                "Mapping test::decomposeMapping\n" +
-                "(\n" +
-                "  *test::_Person: Pure\n" +
-                "  {\n" +
-                "    ~src test::Person\n" +
-                "    weightUnit: $src.weight->unitType(),\n" +
-                "    weightValue: $src.weight->unitValue()\n" +
-                "  }\n" +
-                ")\n\n" +
-                "Mapping test::convertMapping\n" +
-                "(\n" +
-                "  include test::decomposeMapping[dbInc->db]\n\n" +
-                "  *test::PersonWithPound: Pure\n" +
-                "  {\n" +
-                "    ~src test::Person\n" +
-                "    weight: $src.weight->convert(test::Mass~Pound)->cast(@test::Mass~Pound)\n" +
-                "  }\n" +
-                ")\n");
-    }
 }

--- a/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
+++ b/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
@@ -573,4 +573,30 @@ public class TestRelationalGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
                 "  }\n" +
                 ")\n", unformatted);
     }
+
+    @Test
+    public void testMappingWithIncludedMapping()
+    {
+        test("###Mapping\n" +
+                "Mapping test::includedRelationalMapping\n" +
+                "(\n" +
+                "  simple::Person[simple_Person]: Relational\n" +
+                "  {\n" +
+                "    ~mainTable [dbInc]personTable\n" +
+                "    firstName: [dbInc]personTable.FIRSTNAME,\n" +
+                "    lastName: [dbInc]personTable.LASTNAME,\n" +
+                "    age: [dbInc]personTable.AGE\n" +
+                "  }\n" +
+                ")\n\n" +
+                "Mapping test::simpleRelationalMapping\n" +
+                "(\n" +
+                "  include test::includedRelationalMapping[dbInc->db]\n\n" +
+                "  simple::Firm[simple_Firm]: Relational\n" +
+                "  {\n" +
+                "    ~mainTable [db]firmTable\n" +
+                "    legalName: [db]firmTable.LEGALNAME,\n" +
+                "    employees: [db]@Firm_Person\n" +
+                "  }\n" +
+                ")\n");
+    }
 }


### PR DESCRIPTION
When compiling included mapping, substitute store "[dbInc->db]" syntax was not parsed to graph