### PR TITLE
make relational grammar parser more consistent with protocol

### DIFF
--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -927,7 +927,7 @@ public class HelperRelationalBuilder
 
     public static SetImplementation processRelationalClassMapping(RelationalClassMapping relationalClassMapping, CompileContext context, RelationalInstanceSetImplementation base, RootRelationalInstanceSetImplementation topParent, Mapping parent, MutableList<org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.EmbeddedRelationalInstanceSetImplementation> embeddedRelationalPropertyMappings, RichIterable<org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EnumerationMapping<Object>> enumerationMappings, MutableMap<String, TableAlias> aliasMap)
     {
-        final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass = relationalClassMapping._class != null ? context.resolveClass(relationalClassMapping._class, relationalClassMapping.classSourceInformation) : base._class();
+        final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass = relationalClassMapping._class != null && !relationalClassMapping._class.isEmpty() ? context.resolveClass(relationalClassMapping._class, relationalClassMapping.classSourceInformation) : base._class();
         RichIterable<org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.RelationalOperationElement> primaryKey = ListIterate.collect(relationalClassMapping.primaryKey, p -> processRelationalOperationElement(p, context, UnifiedMap.newMap(), FastList.newList()));
         MutableList<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.PropertyMapping> localMappingProperties = ListIterate.select(relationalClassMapping.propertyMappings, p -> p.localMappingProperty != null);
         if (localMappingProperties.notEmpty())
@@ -1005,7 +1005,7 @@ public class HelperRelationalBuilder
 
     private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class getPropertyOwnerForRelationalPropertyMapping(CompileContext context, RelationalPropertyMapping propertyMapping, PropertyMappingsImplementation immediateParent)
     {
-        if (propertyMapping.property._class != null)
+        if (propertyMapping.property._class != null && !propertyMapping.property._class.isEmpty())
         {
             return context.resolveClass(propertyMapping.property._class, propertyMapping.property.sourceInformation);
         }
@@ -1021,7 +1021,7 @@ public class HelperRelationalBuilder
 
     public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class extractPropertyOwner(CompileContext context, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.PropertyMapping propertyMapping, PropertyMappingsImplementation immediateParent)
     {
-        if (propertyMapping.property._class != null)
+        if (propertyMapping.property._class != null && !propertyMapping.property._class.isEmpty())
         {
             return context.resolveClass(propertyMapping.property._class, propertyMapping.property.sourceInformation);
         }
@@ -1049,7 +1049,7 @@ public class HelperRelationalBuilder
         {
             id = firstParent._id() + "_" + propertyMapping.property.property;
         }
-        else if (propertyMapping.classMapping._class != null)
+        else if (propertyMapping.classMapping._class != null && !propertyMapping.classMapping._class.isEmpty())
         {
             id = HelperMappingBuilder.getClassMappingId(propertyMapping.classMapping, context);
         }
@@ -1066,7 +1066,7 @@ public class HelperRelationalBuilder
                 ._id(id)
                 ._setMappingOwner(topParent);
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class;
-        if (propertyMapping.classMapping._class != null)
+        if (propertyMapping.classMapping._class != null && !propertyMapping.classMapping._class.isEmpty())
         {
             _class = context.resolveClass(propertyMapping.classMapping._class, propertyMapping.property.sourceInformation);
         }
@@ -1095,7 +1095,7 @@ public class HelperRelationalBuilder
             return ((InstanceSetImplementation) immediateParent)._mappingClass()._properties().detect(p -> p._name().equals(propertyName));
         }
         // case were class is not defined and the parent is an association mapping. search for property inside the asssociation
-        else if (immediateParent instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.AssociationImplementation && propertyMapping.property._class == null)
+        else if (immediateParent instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.AssociationImplementation && (propertyMapping.property._class == null || propertyMapping.property._class.isEmpty()))
         {
             org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association association = ((AssociationImplementation) immediateParent)._association();
             Property property = association._properties().detect(p -> (propertyName.equals(p.getName())) || (isTypeTemporalMilestoned.apply(p._genericType()._rawType()) && edgePointPropertyName.equals(p.getName())));

--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -1046,7 +1046,7 @@ public class RelationalParseTreeWalker
             RelationalParserGrammar.SinglePropertyMappingWithoutPlusContext propertyMappingCtx = ctx.singlePropertyMappingWithoutPlus();
             PropertyPointer propertyPointer = new PropertyPointer();
             propertyPointer.property = PureGrammarParserUtility.fromIdentifier(propertyMappingCtx.identifier());
-            propertyPointer._class = _class;
+            propertyPointer._class = _class == null ? "" : _class;
             propertyPointer.sourceInformation = this.walkerSourceInformation.getSourceInformation(propertyMappingCtx.identifier());
             String sourceId = null;
             String targetId = null;
@@ -1111,6 +1111,7 @@ public class RelationalParseTreeWalker
     {
         RelationalClassMapping relationalClassMapping = new RelationalClassMapping();
         relationalClassMapping.sourceInformation = this.walkerSourceInformation.getSourceInformation(ctx);
+        relationalClassMapping._class = "";
         relationalClassMapping.id = targetId;
         relationalClassMapping.root = false;
         relationalClassMapping.primaryKey = ctx.mappingPrimaryKey() != null


### PR DESCRIPTION
For `PropertyPointer` instead of outputting `null` for `class` when the property is of embedded property mapping, we will output `empty string`. This behaviour will make this:
- comply with the protocol
- in sync with Studio
- compiler more resilient