### PR TITLE
Ensure properties are always added to RelationalDBConnection

### DIFF
--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalDatabaseConnectionBuilder.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalDatabaseConnectionBuilder.java
@@ -47,11 +47,12 @@ public class HelperRelationalDatabaseConnectionBuilder
     public static void addDatabaseConnectionProperties(org.finos.legend.pure.m3.coreinstance.meta.relational.runtime.DatabaseConnection pureConnection, String element, SourceInformation elementSourceInformation, String connectionType, String timeZone, Boolean quoteIdentifiers, CompileContext context)
     {
         org.finos.legend.pure.m3.coreinstance.meta.relational.runtime.DatabaseConnection connection = pureConnection._type(context.pureModel.getEnumValue("meta::relational::runtime::DatabaseType", connectionType));
+        connection._timeZone(timeZone);
+        connection._quoteIdentifiers(quoteIdentifiers);
+
         try
         {
             connection._element(HelperRelationalBuilder.resolveDatabase(element, elementSourceInformation, context));
-            connection._timeZone(timeZone);
-            connection._quoteIdentifiers(quoteIdentifiers);
         }
         catch (RuntimeException e)
         {


### PR DESCRIPTION
If HelperRelationalBuilder.resolveDatabase fails, we still want to add
properties to the connection - common use case is if the connection is using a
place holder element for which database resolution will fail but we still want
to construct a connection