### PR TITLE
Allow extra authentication strategy transformer to be provided as plugins

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/manager/strategic/StrategicConnectionExtension.java
+++ b/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/manager/strategic/StrategicConnectionExtension.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.plan.execution.stores.relational.connection.mana
 
 import org.finos.legend.engine.plan.execution.stores.relational.connection.ConnectionKey;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.RelationalExecutorInfo;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.AuthenticationStrategy;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.keys.AuthenticationStrategyKey;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.OAuthProfile;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.DataSourceSpecification;
@@ -31,6 +32,7 @@ import java.util.function.Function;
 public interface StrategicConnectionExtension
 {
     AuthenticationStrategyVisitor<AuthenticationStrategyKey> getExtraAuthenticationKeyGenerators();
+    AuthenticationStrategyVisitor<AuthenticationStrategy> getExtraAuthenticationStrategyTransformGenerators(List<OAuthProfile> oauthProfiles);
     Function<RelationalDatabaseConnection, DatasourceSpecificationVisitor<DataSourceSpecificationKey>> getExtraDataSourceSpecificationKeyGenerators(int testDbPort);
     Function2<RelationalDatabaseConnection, ConnectionKey, DatasourceSpecificationVisitor<DataSourceSpecification>> getExtraDataSourceSpecificationTransformerGenerators(List<OAuthProfile> oauthProfiles, RelationalExecutorInfo relationalExecutorInfo);
 }


### PR DESCRIPTION
Allow extra authentication strategy transformer to be provided as plugins
Example - Oauth with SnowflakeDatasourceSpec