### PR TITLE
Check if resultSet is closed before invoking next

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/RelationalResultToJsonDefaultSerializer.java
+++ b/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/RelationalResultToJsonDefaultSerializer.java
@@ -96,7 +96,7 @@ public class RelationalResultToJsonDefaultSerializer extends Serializer
         int rowCount = 0;
         try (Scope scope = GlobalTracer.get().buildSpan("Relational Streaming: Fetch first row").startActive(true))
         {
-            if (relationalResult.resultSet.next())
+            if (!relationalResult.resultSet.isClosed() && relationalResult.resultSet.next())
             {
                 processRow(outputStream);
                 rowCount++;
@@ -104,7 +104,7 @@ public class RelationalResultToJsonDefaultSerializer extends Serializer
         }
         try (Scope scope = GlobalTracer.get().buildSpan("Relational Streaming: remaining rows").startActive(true))
         {
-            while (relationalResult.resultSet.next())
+            while (!relationalResult.resultSet.isClosed() && relationalResult.resultSet.next())
             {
                 outputStream.write(b_comma);
                 processRow(outputStream);

--- a/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/RelationalResultToPureFormatSerializer.java
+++ b/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/RelationalResultToPureFormatSerializer.java
@@ -97,14 +97,14 @@ public class RelationalResultToPureFormatSerializer extends Serializer
         int rowCount = 0;
         try (Scope ignored = GlobalTracer.get().buildSpan("Relational Streaming: Fetch first row").startActive(true))
         {
-            if (relationalResult.resultSet.next())
+            if (!relationalResult.resultSet.isClosed() && relationalResult.resultSet.next())
             {
                 this.processRow(outputStream);
             }
         }
         try (Scope scope = GlobalTracer.get().buildSpan("Relational Streaming: remaining rows").startActive(true))
         {
-            while (relationalResult.resultSet.next())
+            while (!relationalResult.resultSet.isClosed() && relationalResult.resultSet.next())
             {
                 outputStream.write(b_comma);
                 this.processRow(outputStream);


### PR DESCRIPTION
We need to add this check as db2 closes out the resultSet after streaming last row and fails on next call
(https://www.ibm.com/support/pages/invalid-operation-result-set-closed-error-data-server-driver-jdbc)