### PR TITLE
upgrade openjdk image to fix CVEs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,8 @@
 
 name: Docker
 
+# NOTE: this job does not scan for the latest image published on Docker Hub
+# We might need to use some other tools such as http://snyk.io/ to monitor
 on:
   schedule:
     - cron: '0 0 * * 2' # every Tuesday on default/base branch


### PR DESCRIPTION
This will bump the version for `openjdk` and do the Docker check again.