### PR TITLE
Fix issue with number in expression being parsed as time zone

### DIFF
--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -453,6 +453,25 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
+    public void testFunctionWithExpressionInParameter()
+    {
+        test("Class test::A\n" +
+                "[\n" +
+                "  constraint1\n" +
+                "  (" +
+                "    ~externalId: 'ext ID'\n" +
+                "    ~function: greaterThanEqual($this.start, $this.end-1000)\n" +
+                "    ~enforcementLevel: Warn\n" +
+                "    ~message: $this.start + ' should be greater or equal ' + $this.end\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  start: Integer[1];\n" +
+                "  end: Integer[1];\n" +
+                "}\n");
+    }
+
+    @Test
     public void testFunctionOrLambdaWithUnknownToken()
     {
         test("Class test::A\n" +

--- a/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/core/CoreLexerGrammar.g4
+++ b/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/core/CoreLexerGrammar.g4
@@ -31,8 +31,6 @@ FILE_NAME:                                  FileName;
 FILE_NAME_END:                              FileNameEnd;
 PATH_SEPARATOR:                             PathSeparator;
 
-TIMEZONE:                                   TimeZone;
-
 AND:                                        '&&';
 OR:                                         '||';
 NOT:                                        '!';

--- a/legend-engine-language-pure-store-relational/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/RelationalDatabaseConnectionLexerGrammar.g4
+++ b/legend-engine-language-pure-store-relational/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/RelationalDatabaseConnectionLexerGrammar.g4
@@ -12,6 +12,8 @@ RELATIONAL_AUTH_STRATEGY:               'auth';
 RELATIONAL_POST_PROCESSORS:             'postProcessors';
 
 DB_TIMEZONE:                            'timezone';
+TIMEZONE:                                TimeZone;
+
 QUOTE_IDENTIFIERS:                      'quoteIdentifiers';
 
 BRACE_OPEN:                             '{' -> pushMode(SPECIFICATION_ISLAND_MODE);


### PR DESCRIPTION
We use time zone in numeric format for relational database connection that is specified as (('+' | '-')(Digit)(Digit)(Digit)(Digit))
When this is available in Core Lexer, the parser can sometimes take a part of expression for a time zone e.g. 
 greaterThanEqual($this.start, $this.end **-1000** ) and fail as a result.

Proposed solution is to move time zone from Core Lexer to Relational Database Connection Lexer.

Note that this is not affecting time zone that is a part of date - that part is still untacked as we are using timeZone fragment there, not TIMEZONE from lexer.