### PR TITLE
Use null login for DelegatedKerberos authentication strategy

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/DelegatedKerberosAuthenticationStrategy.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/DelegatedKerberosAuthenticationStrategy.java
@@ -21,7 +21,6 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.Da
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.finos.legend.engine.shared.core.kerberos.SubjectTools;
 import org.pac4j.core.profile.CommonProfile;
 
 import javax.security.auth.Subject;
@@ -64,7 +63,7 @@ public class DelegatedKerberosAuthenticationStrategy extends InteractiveAuthenti
     @Override
     public String getLogin()
     {
-        return SubjectTools.getCurrentUsername();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
If a non-null username is passed in HikariConfig, getConnection call is made with [username and password](https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L364). Avoid this in case of DelegatedKerberos authentication strategy and rely on performing the call as a particular subject (Subject.doAs). In the case that some database driver requires _user_ datasource property to be set for DelegatedKerberos authentication strategy, it should be handled in the respective database manager.