### PR TITLE
Grammar composer: Make formatting indentation more consistent and fix `pretty` rendering for lambda

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperValueSpecificationBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperValueSpecificationBuilder.java
@@ -106,7 +106,7 @@ public class HelperValueSpecificationBuilder
     {
         // for X.property. X is the first parameter
         processingContext.push("Processing property " + property);
-        org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification firstParameter = parameters.get(0);
+        org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification firstArgument = parameters.get(0);
         MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification> processedParameters = ListIterate.collect(parameters, p -> p.accept(new ValueSpecificationBuilder(context, openVariables, processingContext)));
 
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType genericType;
@@ -114,7 +114,7 @@ public class HelperValueSpecificationBuilder
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification inferredVariable;
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification result;
 
-        if (firstParameter instanceof org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Enum // Only for backward compatibility!
+        if (firstArgument instanceof org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Enum // Only for backward compatibility!
             || (processedParameters.get(0)._genericType()._rawType().equals(context.pureModel.getType("meta::pure::metamodel::type::Enumeration"))))
         {
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity m = new org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity();
@@ -123,17 +123,17 @@ public class HelperValueSpecificationBuilder
             CString enumValue = new CString();
             enumValue.values = Lists.mutable.of(property);
             enumValue.multiplicity = m;
-            context.resolveEnumValue(((PackageableElementPtr) firstParameter).fullPath, enumValue.values.get(0), firstParameter.sourceInformation, sourceInformation); // validation to make sure the enum value can be found
+            context.resolveEnumValue(((PackageableElementPtr) firstArgument).fullPath, enumValue.values.get(0), firstArgument.sourceInformation, sourceInformation); // validation to make sure the enum value can be found
             AppliedFunction extractEnum = new AppliedFunction();
             extractEnum.function = "extractEnumValue";
-            extractEnum.parameters = Lists.mutable.of(firstParameter, enumValue);
+            extractEnum.parameters = Lists.mutable.of(firstArgument, enumValue);
             result = extractEnum.accept(new ValueSpecificationBuilder(context, openVariables, processingContext));
         }
         else
         {
-            if (firstParameter instanceof Variable)
+            if (firstArgument instanceof Variable)
             {
-                inferredVariable = processingContext.getInferredVariable(((Variable) firstParameter).name);
+                inferredVariable = processingContext.getInferredVariable(((Variable) firstArgument).name);
             }
             else
             {
@@ -168,7 +168,7 @@ public class HelperValueSpecificationBuilder
             // FIXME: remove this when we cleanup the extension method designed specifically for flatdata
             Type finalInferredType = inferredType;
             LazyIterate.flatCollect(context.getCompilerExtensions().getExtensions(), CompilerExtension::DEPRECATED_getExtraInferredTypeProcessors).forEach(processor -> processor.value(
-                    finalInferredType, firstParameter, context, processingContext, parameters, property, genericType, processedParameters
+                    finalInferredType, firstArgument, context, processingContext, parameters, property, genericType, processedParameters
             ));
 
             if (!inferredVariable._multiplicity().getName().equals("PureOne")) // autoMap

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestJsonToGrammarApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestJsonToGrammarApi.java
@@ -156,18 +156,7 @@ public class TestJsonToGrammarApi
     public void testGroupByAggStructure()
     {
         testIsolatedLambdaFromProtocol(
-                "{\"isolatedLambdas\":{\"testLambda\":\"" +
-                        "|meta::datasetMetadata::domain::physicalCatalogPURE.all()\\n" +
-                        "   ->groupBy\\n" +
-                        "    (\\n" +
-                        "      x: meta::datasetMetadata::domain::physicalCatalogPURE[1]|$x.owningBU, \\n" +
-                        "      agg(x: meta::datasetMetadata::domain::physicalCatalogPURE[1]|$x.classPackage->toOne() + '::' + $x.className->toOne(), y: String[*]|$y->distinct()->count()), \\n" +
-                        "      [\\n" +
-                        "        'Owning BU', \\n" +
-                        "        'fullClass Distinct Count'\\n" +
-                        "      ]\\n" +
-                        "    )" +
-                        "\"}}",
+                "{\"isolatedLambdas\":{\"testLambda\":\"|meta::datasetMetadata::domain::physicalCatalogPURE.all()->groupBy(\\n  x: meta::datasetMetadata::domain::physicalCatalogPURE[1]|$x.owningBU,\\n  agg(x: meta::datasetMetadata::domain::physicalCatalogPURE[1]|$x.classPackage->toOne() + '::' + $x.className->toOne(), y: String[*]|$y->distinct()->count()),\\n  [\\n    'Owning BU',\\n    'fullClass Distinct Count'\\n  ]\\n)\"}}",
                 getJsonString("testLambdaObj.json"),
                 PureGrammarComposerContext.RenderStyle.PRETTY
         );
@@ -177,18 +166,7 @@ public class TestJsonToGrammarApi
     public void testGroupByAggStructureHTML()
     {
         testIsolatedLambdaFromProtocol(
-                "{\"isolatedLambdas\":{\"testLambda\":\"" +
-                        "|<span class='pureGrammar-package'>meta::datasetMetadata::domain::</span><span class='pureGrammar-packageableElement'>physicalCatalogPURE</span>.<span class='pureGrammar-function'>all</span>()</BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span></BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>(</BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>: <span class='pureGrammar-package'>meta::datasetMetadata::domain::</span><span class='pureGrammar-packageableElement'>physicalCatalogPURE</span>[1]|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>owningBU</span>, </BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>: <span class='pureGrammar-package'>meta::datasetMetadata::domain::</span><span class='pureGrammar-packageableElement'>physicalCatalogPURE</span>[1]|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>classPackage</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>toOne</span>() + <span class='pureGrammar-string'>'::'</span> + <span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>className</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>toOne</span>(), <span class='pureGrammar-var'>y</span>: <span class='pureGrammar-packageableElement'>String</span>[*]|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>distinct</span>()<span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>count</span>()), </BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Owning BU'</span>, </BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'fullClass Distinct Count'</span></BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>)" +
-                        "\"}}",
+                "{\"isolatedLambdas\":{\"testLambda\":\"|<span class='pureGrammar-package'>meta::datasetMetadata::domain::</span><span class='pureGrammar-packageableElement'>physicalCatalogPURE</span>.<span class='pureGrammar-function'>all</span>()<span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span>(</BR>\\n<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>: <span class='pureGrammar-package'>meta::datasetMetadata::domain::</span><span class='pureGrammar-packageableElement'>physicalCatalogPURE</span>[1]|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>owningBU</span>,</BR>\\n<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>: <span class='pureGrammar-package'>meta::datasetMetadata::domain::</span><span class='pureGrammar-packageableElement'>physicalCatalogPURE</span>[1]|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>classPackage</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>toOne</span>() + <span class='pureGrammar-string'>'::'</span> + <span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>className</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>toOne</span>(), <span class='pureGrammar-var'>y</span>: <span class='pureGrammar-packageableElement'>String</span>[*]|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>distinct</span>()<span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>count</span>()),</BR>\\n<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\\n<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Owning BU'</span>,</BR>\\n<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'fullClass Distinct Count'</span></BR>\\n<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\\n)\"}}",
                 getJsonString("testLambdaObj.json"),
                 PureGrammarComposerContext.RenderStyle.PRETTY_HTML
         );
@@ -221,69 +199,7 @@ public class TestJsonToGrammarApi
     public void testDeepFetchTreeWithFormatting()
     {
         testIsolatedLambdaFromProtocol(
-                "{\"isolatedLambdas\":{\"testLambdas\":\"|model::complex::L1.all()->graphFetchChecked(#{\\n" +
-                        "     model::complex::L1{\\n" +
-                        "       name1,\\n" +
-                        "       l14{\\n" +
-                        "         name4,\\n" +
-                        "         l42{\\n" +
-                        "           name2,\\n" +
-                        "           l23_1{\\n" +
-                        "             name3\\n" +
-                        "           },\\n" +
-                        "           l23{\\n" +
-                        "             name3\\n" +
-                        "           }\\n" +
-                        "         },\\n" +
-                        "         l45{\\n" +
-                        "           name3\\n" +
-                        "         }\\n" +
-                        "       },\\n" +
-                        "       l12{\\n" +
-                        "         name2,\\n" +
-                        "         l23_1{\\n" +
-                        "           name3\\n" +
-                        "         },\\n" +
-                        "         l23{\\n" +
-                        "           name3\\n" +
-                        "         }\\n" +
-                        "       },\\n" +
-                        "       l13{\\n" +
-                        "         name3\\n" +
-                        "       }\\n" +
-                        "     }\\n" +
-                        "   }#)->serialize(#{\\n" +
-                        "     model::complex::L1{\\n" +
-                        "       name1,\\n" +
-                        "       l14{\\n" +
-                        "         name4,\\n" +
-                        "         l42{\\n" +
-                        "           name2,\\n" +
-                        "           l23_1{\\n" +
-                        "             name3\\n" +
-                        "           },\\n" +
-                        "           l23{\\n" +
-                        "             name3\\n" +
-                        "           }\\n" +
-                        "         },\\n" +
-                        "         l45{\\n" +
-                        "           name3\\n" +
-                        "         }\\n" +
-                        "       },\\n" +
-                        "       l12{\\n" +
-                        "         name2,\\n" +
-                        "         l23_1{\\n" +
-                        "           name3\\n" +
-                        "         },\\n" +
-                        "         l23{\\n" +
-                        "           name3\\n" +
-                        "         }\\n" +
-                        "       },\\n" +
-                        "       l13{\\n" +
-                        "         name3\\n" +
-                        "       }\\n" +
-                        "     }\\n" +
-                        "   }#)\"}}",
+                "{\"isolatedLambdas\":{\"testLambdas\":\"|model::complex::L1.all()->graphFetchChecked(\\n  #{\\n    model::complex::L1{\\n      name1,\\n      l14{\\n        name4,\\n        l42{\\n          name2,\\n          l23_1{\\n            name3\\n          },\\n          l23{\\n            name3\\n          }\\n        },\\n        l45{\\n          name3\\n        }\\n      },\\n      l12{\\n        name2,\\n        l23_1{\\n          name3\\n        },\\n        l23{\\n          name3\\n        }\\n      },\\n      l13{\\n        name3\\n      }\\n    }\\n  }#\\n)->serialize(\\n  #{\\n    model::complex::L1{\\n      name1,\\n      l14{\\n        name4,\\n        l42{\\n          name2,\\n          l23_1{\\n            name3\\n          },\\n          l23{\\n            name3\\n          }\\n        },\\n        l45{\\n          name3\\n        }\\n      },\\n      l12{\\n        name2,\\n        l23_1{\\n          name3\\n        },\\n        l23{\\n          name3\\n        }\\n      },\\n      l13{\\n        name3\\n      }\\n    }\\n  }#\\n)\"}}",
                 getJsonString("testGraphFetchTreeLambda.json"),
                 PureGrammarComposerContext.RenderStyle.PRETTY
         );

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.*;
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.getTabSize;
 
 public final class DEPRECATED_PureGrammarComposerCore implements
         PackageableElementVisitor<String>,
@@ -621,8 +622,8 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         boolean addCR = lambda.body.size() > 1;
         return (addWrapper ? "{" : "")
                 + (lambda.parameters.isEmpty() ? "" : LazyIterate.collect(lambda.parameters, variable -> variable.accept(Builder.newInstance(this).withVariableInFunctionSignature().build())).makeString(","))
-                + "|" + (addCR ? this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, 2) : "")
-                + LazyIterate.collect(lambda.body, valueSpecification -> valueSpecification.accept(addCR ? DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(2).build() : this)).makeString(";" + this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, 2))
+                + "|" + (addCR ? this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1)) : "")
+                + LazyIterate.collect(lambda.body, valueSpecification -> valueSpecification.accept(addCR ? DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(getTabSize(1)).build() : this)).makeString(";" + this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1)))
                 + (addCR ? ";" + this.returnChar() : "") + (addWrapper ? this.indentationString + "}" : "");
     }
 
@@ -646,7 +647,7 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         String function = appliedFunction.function;
         List<ValueSpecification> parameters = appliedFunction.parameters;
         boolean toCreateNewLine = this.isRenderingPretty() && HelperValueSpecificationGrammarComposer.NEXT_LINE_FN.contains(function);
-        DEPRECATED_PureGrammarComposerCore shiftedTransformer = toCreateNewLine ? DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(3).build() : this;
+        DEPRECATED_PureGrammarComposerCore shiftedTransformer = toCreateNewLine ? DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(getTabSize(1)).build() : this;
 
         if (function.equals("getAll"))
         {
@@ -679,8 +680,8 @@ public final class DEPRECATED_PureGrammarComposerCore implements
             if (function.equals("if") && shiftedTransformer.isRenderingPretty())
             {
                 return HelperValueSpecificationGrammarComposer.renderFunctionName(function, this) + "(" + parameters.get(0).accept(this) + ", " +
-                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, 3)) + parameters.get(1).accept(this) + ", " +
-                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, 3)) + parameters.get(2).accept(this) +
+                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1))) + parameters.get(1).accept(this) + ", " +
+                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1))) + parameters.get(2).accept(this) +
                         (this.returnChar()) + ")";
             }
             return HelperValueSpecificationGrammarComposer.renderFunctionName(function, this) + "(" + LazyIterate.collect(parameters, p -> p.accept(this)).makeString(", ") + ")";
@@ -804,12 +805,12 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         String subTreeString = "";
         if (rootGraphFetchTree.subTrees != null && !rootGraphFetchTree.subTrees.isEmpty())
         {
-            subTreeString = rootGraphFetchTree.subTrees.stream().map(x -> x.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(2).build())).collect(Collectors.joining("," + (this.isRenderingPretty() ? this.returnChar() : "")));
+            subTreeString = rootGraphFetchTree.subTrees.stream().map(x -> x.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(getTabSize(1)).build())).collect(Collectors.joining("," + (this.isRenderingPretty() ? this.returnChar() : "")));
         }
         return "#{" + (this.isRenderingPretty() ? this.returnChar() : "") +
-                DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, 2) + HelperValueSpecificationGrammarComposer.printFullPath(rootGraphFetchTree._class, this) + "{" + (this.isRenderingPretty() ? this.returnChar() : "") +
+                DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1)) + HelperValueSpecificationGrammarComposer.printFullPath(rootGraphFetchTree._class, this) + "{" + (this.isRenderingPretty() ? this.returnChar() : "") +
                 subTreeString + (this.isRenderingPretty() ? this.returnChar() : "") +
-                DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, 2) + "}" + (this.isRenderingPretty() ? this.returnChar() : "") +
+                DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1)) + "}" + (this.isRenderingPretty() ? this.returnChar() : "") +
                 this.indentationString + "}#";
     }
 
@@ -826,8 +827,8 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         if (propertyGraphFetchTree.subTrees != null && !propertyGraphFetchTree.subTrees.isEmpty())
         {
             subTreeString = "{" + (this.isRenderingPretty() ? this.returnChar() : "") +
-                    propertyGraphFetchTree.subTrees.stream().map(x -> x.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(2).build())).collect(Collectors.joining("," + (this.isRenderingPretty() ? this.returnChar() : ""))) + (this.isRenderingPretty() ? this.returnChar() : "") +
-                    DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, 2) + "}";
+                    propertyGraphFetchTree.subTrees.stream().map(x -> x.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(getTabSize(1)).build())).collect(Collectors.joining("," + (this.isRenderingPretty() ? this.returnChar() : ""))) + (this.isRenderingPretty() ? this.returnChar() : "") +
+                    DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1)) + "}";
         }
 
         String parametersString = "";
@@ -842,7 +843,7 @@ public final class DEPRECATED_PureGrammarComposerCore implements
             subTypeString = "->subType(@" + HelperValueSpecificationGrammarComposer.printFullPath(propertyGraphFetchTree.subType, this) + ")";
         }
 
-        return DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, 2) + aliasString + propertyGraphFetchTree.property + parametersString + subTypeString + subTreeString;
+        return DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1)) + aliasString + propertyGraphFetchTree.property + parametersString + subTypeString + subTreeString;
     }
 
     @Override

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
@@ -653,13 +653,23 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         {
             return parameters.get(0).accept(this) + "." + HelperValueSpecificationGrammarComposer.renderFunctionName("all", this) + "(" + LazyIterate.collect(parameters.subList(1, parameters.size()), v -> v.accept(this)).makeString(", ") + ")";
         }
-        if (function.equals("getAllVersions"))
+        else if (function.equals("getAllVersions"))
         {
             return parameters.get(0).accept(this) + "." + HelperValueSpecificationGrammarComposer.renderFunctionName("allVersions", this) + "(" + LazyIterate.collect(parameters.subList(1, parameters.size()), v -> v.accept(this)).makeString(", ") + ")";
         }
         else if (function.equals("letFunction"))
         {
             return "let " + PureGrammarComposerUtility.convertIdentifier(((CString) parameters.get(0)).values.get(0)) + " = " + parameters.get(1).accept(this);
+        }
+        else if (function.equals("new"))
+        {
+            List<ValueSpecification> values = ((Collection) parameters.get(parameters.size() - 1)).values;
+            String rendered = Lists.mutable.withAll(values).collect(v -> v.accept(this)).makeString(" , ");
+            return "^" + parameters.get(0).accept(this) + "(" + rendered + ")";
+        }
+        else if (function.equals("not"))
+        {
+            return "!(" + parameters.get(0).accept(this) + ")";
         }
         else if (HelperValueSpecificationGrammarComposer.SPECIAL_INFIX.get(function) != null)
         {
@@ -685,12 +695,6 @@ public final class DEPRECATED_PureGrammarComposerCore implements
                         (this.returnChar()) + ")";
             }
             return HelperValueSpecificationGrammarComposer.renderFunctionName(function, this) + "(" + LazyIterate.collect(parameters, p -> p.accept(this)).makeString(", ") + ")";
-        }
-        else if (function.equals("new"))
-        {
-            List<ValueSpecification> values = ((Collection) parameters.get(parameters.size() - 1)).values;
-            String rendered = Lists.mutable.withAll(values).collect(v -> v.accept(this)).makeString(" , ");
-            return "^" + parameters.get(0).accept(this) + "(" + rendered + ")";
         }
         return HelperValueSpecificationGrammarComposer.renderFunction(appliedFunction, toCreateNewLine, shiftedTransformer, this, this);
     }

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
@@ -647,56 +647,55 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         String function = appliedFunction.function;
         List<ValueSpecification> parameters = appliedFunction.parameters;
         boolean toCreateNewLine = this.isRenderingPretty() && HelperValueSpecificationGrammarComposer.NEXT_LINE_FN.contains(function);
-        DEPRECATED_PureGrammarComposerCore shiftedTransformer = toCreateNewLine ? DEPRECATED_PureGrammarComposerCore.Builder.newInstance(this).withIndentation(getTabSize(1)).build() : this;
 
-        if (function.equals("getAll"))
+        if ("getAll".equals(function))
         {
             return parameters.get(0).accept(this) + "." + HelperValueSpecificationGrammarComposer.renderFunctionName("all", this) + "(" + LazyIterate.collect(parameters.subList(1, parameters.size()), v -> v.accept(this)).makeString(", ") + ")";
         }
-        else if (function.equals("getAllVersions"))
+        else if ("getAllVersions".equals(function))
         {
             return parameters.get(0).accept(this) + "." + HelperValueSpecificationGrammarComposer.renderFunctionName("allVersions", this) + "(" + LazyIterate.collect(parameters.subList(1, parameters.size()), v -> v.accept(this)).makeString(", ") + ")";
         }
-        else if (function.equals("letFunction"))
+        else if ("letFunction".equals(function))
         {
             return "let " + PureGrammarComposerUtility.convertIdentifier(((CString) parameters.get(0)).values.get(0)) + " = " + parameters.get(1).accept(this);
         }
-        else if (function.equals("new"))
+        else if ("new".equals(function))
         {
             List<ValueSpecification> values = ((Collection) parameters.get(parameters.size() - 1)).values;
             String rendered = Lists.mutable.withAll(values).collect(v -> v.accept(this)).makeString(" , ");
             return "^" + parameters.get(0).accept(this) + "(" + rendered + ")";
         }
-        else if (function.equals("not"))
+        else if ("not".equals(function))
         {
             return "!(" + parameters.get(0).accept(this) + ")";
         }
         else if (HelperValueSpecificationGrammarComposer.SPECIAL_INFIX.get(function) != null)
         {
-            if (parameters.get(0) instanceof Collection && (function.equals("plus") || function.equals("minus") || function.equals("times")))
+            if (parameters.get(0) instanceof Collection && ("plus".equals(function) || "minus".equals(function) || "times".equals(function) || "divide".equals(function)))
             {
                 return LazyIterate.collect(((Collection) parameters.get(0)).values, v -> HelperValueSpecificationGrammarComposer.possiblyAddParenthesis(function, v, this)).makeString(" " + HelperValueSpecificationGrammarComposer.SPECIAL_INFIX.get(function) + " ");
             }
             if (parameters.size() == 1)
             {
-                return HelperValueSpecificationGrammarComposer.renderFunction(appliedFunction, toCreateNewLine, this, shiftedTransformer, this);
+                return HelperValueSpecificationGrammarComposer.renderFunction(appliedFunction, toCreateNewLine, this);
             }
             String first = HelperValueSpecificationGrammarComposer.possiblyAddParenthesis(function, parameters.get(0), this) + " " + HelperValueSpecificationGrammarComposer.SPECIAL_INFIX.get(function);
-            return first + (toCreateNewLine ? this.returnChar() + shiftedTransformer.indentationString : " ") + HelperValueSpecificationGrammarComposer.possiblyAddParenthesis(function, parameters.get(1), this);
+            return first + (toCreateNewLine ? this.returnChar() + this.indentationString : " ") + HelperValueSpecificationGrammarComposer.possiblyAddParenthesis(function, parameters.get(1), this);
         }
         else if (HelperValueSpecificationGrammarComposer.FN_PREFIX.contains(function))
         {
             // TODO extends this for other functions?
-            if (function.equals("if") && shiftedTransformer.isRenderingPretty())
+            if ("if".equals(function) && this.isRenderingPretty())
             {
                 return HelperValueSpecificationGrammarComposer.renderFunctionName(function, this) + "(" + parameters.get(0).accept(this) + ", " +
-                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1))) + parameters.get(1).accept(this) + ", " +
-                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1))) + parameters.get(2).accept(this) +
+                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1))) + parameters.get(1).accept(this) + ", " +
+                        (this.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(this, getTabSize(1))) + parameters.get(2).accept(this) +
                         (this.returnChar()) + ")";
             }
             return HelperValueSpecificationGrammarComposer.renderFunctionName(function, this) + "(" + LazyIterate.collect(parameters, p -> p.accept(this)).makeString(", ") + ")";
         }
-        return HelperValueSpecificationGrammarComposer.renderFunction(appliedFunction, toCreateNewLine, shiftedTransformer, this, this);
+        return HelperValueSpecificationGrammarComposer.renderFunction(appliedFunction, toCreateNewLine, this);
     }
 
     @Override

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperMappingGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperMappingGrammarComposer.java
@@ -35,9 +35,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.m
 
 import java.util.Objects;
 
-import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.convertString;
-import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.getTabString;
-import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.unsupported;
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.*;
 
 public class HelperMappingGrammarComposer
 {

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
@@ -141,6 +141,9 @@ public class HelperValueSpecificationGrammarComposer
 
     public static String renderCollection(List<?> values, org.eclipse.collections.api.block.function.Function<Object, String> func, DEPRECATED_PureGrammarComposerCore transformer)
     {
+        if (values.isEmpty()) {
+            return "[]";
+        }
         return "[" + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : "")
                 + LazyIterate.collect(values, func).makeString(", " + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : ""))
                 + (transformer.isRenderingPretty() ? transformer.returnChar() + transformer.getIndentationString() : "") + "]";

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
@@ -61,25 +61,28 @@ public class HelperValueSpecificationGrammarComposer
 
     public static final MutableSet<String> NEXT_LINE_FN = Sets.mutable.with("filter", "project", "and", "or", "groupBy");
 
-    public static String renderFunction(AppliedFunction appliedFunction, boolean toCreateNewLine, DEPRECATED_PureGrammarComposerCore shiftedTransformer, DEPRECATED_PureGrammarComposerCore topParameterTransfomer, DEPRECATED_PureGrammarComposerCore transformer)
+    public static String renderFunction(AppliedFunction appliedFunction, boolean toCreateNewLine, DEPRECATED_PureGrammarComposerCore shiftedTransformer, DEPRECATED_PureGrammarComposerCore topParameterTransformer, DEPRECATED_PureGrammarComposerCore transformer)
     {
         List<ValueSpecification> parameters = appliedFunction.parameters;
         String function = LazyIterate.collect(FastList.newListWith(appliedFunction.function.split("::")), PureGrammarComposerUtility::convertIdentifier).makeString("::");
         if (!parameters.isEmpty())
+        // TODO: if length === 1 and firstParam is primitive (i.e. CString, CInteger, etc.) -> use `func(...)` form
         {
             ValueSpecification firstParameter = parameters.get(0);
-            String top = firstParameter.accept(topParameterTransfomer);
+            String top = firstParameter.accept(topParameterTransformer);
             if (function.equals("not") || firstParameter instanceof AppliedFunction && SPECIAL_INFIX.get(((AppliedFunction) firstParameter).function) != null)
             {
                 return function + "(" + top + ")";
             }
             return top + (toCreateNewLine ? shiftedTransformer.returnChar() + shiftedTransformer.getIndentationString() : "") + (shiftedTransformer.isRenderingHTML() ? "<span class='pureGrammar-arrow'>" : "") + "->" + (shiftedTransformer.isRenderingHTML() ? "</span>" : "")
                     + renderFunctionName(function, transformer)
-                    + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, 1) : "") + "("
-                    + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, 3) : "")
-                    + ListIterate.collect(parameters.subList(1, parameters.size()), p -> p.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(shiftedTransformer).withIndentation(3).build()))
-                                 .makeString(", " + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, 3) : ""))
-                    + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, 1) : "") + ")";
+                    + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1)) : "") + "("
+                    + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(2)) : "")
+
+                // TODO: check if this list is empty -> `func()` form
+                + ListIterate.collect(parameters.subList(1, parameters.size()), p -> p.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(shiftedTransformer).withIndentation(getTabSize(2)).build()))
+                                 .makeString(", " + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(2)) : ""))
+                    + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1)) : "") + ")";
         }
         return renderFunctionName(function, transformer) + "()";
     }
@@ -138,8 +141,8 @@ public class HelperValueSpecificationGrammarComposer
 
     public static String renderCollection(List<?> values, org.eclipse.collections.api.block.function.Function<Object, String> func, DEPRECATED_PureGrammarComposerCore transformer)
     {
-        return "[" + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, 2) : "")
-                + LazyIterate.collect(values, func).makeString(", " + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, 2) : ""))
+        return "[" + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : "")
+                + LazyIterate.collect(values, func).makeString(", " + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : ""))
                 + (transformer.isRenderingPretty() ? transformer.returnChar() + transformer.getIndentationString() : "") + "]";
     }
 

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
@@ -64,18 +64,18 @@ public class HelperValueSpecificationGrammarComposer
     public static String renderFunction(AppliedFunction appliedFunction, boolean toCreateNewLine, DEPRECATED_PureGrammarComposerCore shiftedTransformer, DEPRECATED_PureGrammarComposerCore topParameterTransformer, DEPRECATED_PureGrammarComposerCore transformer)
     {
         List<ValueSpecification> parameters = appliedFunction.parameters;
-        String function = LazyIterate.collect(FastList.newListWith(appliedFunction.function.split("::")), PureGrammarComposerUtility::convertIdentifier).makeString("::");
+        String functionName = LazyIterate.collect(FastList.newListWith(appliedFunction.function.split("::")), PureGrammarComposerUtility::convertIdentifier).makeString("::");
         if (!parameters.isEmpty())
         // TODO: if length === 1 and firstParam is primitive (i.e. CString, CInteger, etc.) -> use `func(...)` form
         {
             ValueSpecification firstParameter = parameters.get(0);
             String top = firstParameter.accept(topParameterTransformer);
-            if (function.equals("not") || firstParameter instanceof AppliedFunction && SPECIAL_INFIX.get(((AppliedFunction) firstParameter).function) != null)
+            if (functionName.equals("not") || firstParameter instanceof AppliedFunction && SPECIAL_INFIX.get(((AppliedFunction) firstParameter).function) != null)
             {
-                return function + "(" + top + ")";
+                return functionName + "(" + top + ")";
             }
             return top + (toCreateNewLine ? shiftedTransformer.returnChar() + shiftedTransformer.getIndentationString() : "") + (shiftedTransformer.isRenderingHTML() ? "<span class='pureGrammar-arrow'>" : "") + "->" + (shiftedTransformer.isRenderingHTML() ? "</span>" : "")
-                    + renderFunctionName(function, transformer)
+                    + renderFunctionName(functionName, transformer)
                     + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1)) : "") + "("
                     + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(2)) : "")
 
@@ -84,7 +84,7 @@ public class HelperValueSpecificationGrammarComposer
                                  .makeString(", " + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(2)) : ""))
                     + (toCreateNewLine ? shiftedTransformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(shiftedTransformer, getTabSize(1)) : "") + ")";
         }
-        return renderFunctionName(function, transformer) + "()";
+        return renderFunctionName(functionName, transformer) + "()";
     }
 
     public static String renderFunctionName(String name, DEPRECATED_PureGrammarComposerCore transformer)
@@ -144,9 +144,11 @@ public class HelperValueSpecificationGrammarComposer
         if (values.isEmpty()) {
             return "[]";
         }
-        return "[" + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : "")
-                + LazyIterate.collect(values, func).makeString(", " + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : ""))
-                + (transformer.isRenderingPretty() ? transformer.returnChar() + transformer.getIndentationString() : "") + "]";
+        return "[" +
+            (values.size() == 1 ? "" : (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : "")) +
+            LazyIterate.collect(values, func).makeString(", " + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(1)) : "")) +
+            (values.size() == 1 ? "" : (transformer.isRenderingPretty() ? transformer.returnChar() + transformer.getIndentationString() : "")) +
+            "]";
     }
 
     public static String renderDecimal(BigDecimal b, DEPRECATED_PureGrammarComposerCore transformer)

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -344,7 +344,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     {
         test("function withPath::f(s: Integer[1]): String[1]\n" +
                 "{\n" +
-                "   'ok'->println();\n" +
+                "   println('ok');\n" +
                 "   'a';\n" +
                 "}\n");
 
@@ -389,7 +389,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     {
         test("function f(s: Integer[1], s2: Interger[2]): String[1]\n" +
                 "{\n" +
-                "   'ok'->println()\n" +
+                "   println('ok')\n" +
                 "}\n");
     }
 
@@ -597,7 +597,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
                 "\n" +
                 "function <<goes.test>> {goes.doc = 'Tag Value for assoc prop'} f(s: goes2[1], s1: goes2[1]): goes2[1]\n" +
                 "{\n" +
-                "   'ok'->println()\n" +
+                "   println('ok')\n" +
                 "}\n");
     }
 

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
@@ -30,48 +30,38 @@ public class TestLambdaPrettyRendering
     public void testRenderingEmptyCollectionInPrettyRendering()
     {
         testLambda("|Person.all()->project([])",
-            "|Person.all()\n" +
-                "  ->project\n" +
-                "    (\n" +
-                "      []\n" +
-                "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+            "|Person.all()->project(\n" +
+                "  []\n" +
+                ")", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
     public void testLambdaWithProjectWithColInPrettyRendering()
     {
         testLambda("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok')])",
-                "|Person.all()\n" +
-                    "  ->filter\n" +
-                    "    (\n" +
-                    "      f|$f.name->startsWith('ok') &&\n" +
-                    "        (true ||\n" +
-                    "        (3 == 4))\n" +
-                    "    )\n" +
-                    "  ->project\n" +
-                    "    (\n" +
-                    "      [col(p|$p.name, 'ok')]\n" +
-                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+                "|Person.all()->filter(\n" +
+                    "  f|$f.name->startsWith('ok') &&\n" +
+                    "  (true ||\n" +
+                    "  (3 == 4))\n" +
+                    ")->project(\n" +
+                    "  [col(p|$p.name, 'ok')]\n" +
+                    ")", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
     public void testLambdaWithProjectWithColsInPrettyRendering()
     {
         testLambda("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok'), col(p|$p.name, 'ok2')])",
-                "|Person.all()\n" +
-                    "  ->filter\n" +
-                    "    (\n" +
-                    "      f|$f.name->startsWith('ok') &&\n" +
-                    "        (true ||\n" +
-                    "        (3 == 4))\n" +
-                    "    )\n" +
-                    "  ->project\n" +
-                    "    (\n" +
-                    "      [\n" +
-                    "        col(p|$p.name, 'ok'), \n" +
-                    "        col(p|$p.name, 'ok2')\n" +
-                    "      ]\n" +
-                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+                "|Person.all()->filter(\n" +
+                    "  f|$f.name->startsWith('ok') &&\n" +
+                    "  (true ||\n" +
+                    "  (3 == 4))\n" +
+                    ")->project(\n" +
+                    "  [\n" +
+                    "    col(p|$p.name, 'ok'), \n" +
+                    "    col(p|$p.name, 'ok2')\n" +
+                    "  ]\n" +
+                    ")", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
@@ -101,24 +91,22 @@ public class TestLambdaPrettyRendering
                         "       );\n" +
                         "}",
                 "{|\n" +
-                        "  let businessDate = now();\n" +
-                        "  model::domain::referenceData::account::FirmAccount.all($businessDate)\n" +
-                        "    ->groupBy\n" +
-                        "      (\n" +
-                        "        [\n" +
-                        "          x|$x.trader($businessDate).lastName, \n" +
-                        "          x|$x.trader($businessDate).firstName, \n" +
-                        "          x|$x.trader($businessDate).isActive\n" +
-                        "        ], \n" +
-                        "        [agg(x|$x.trader($businessDate).kerberos, y|$y->uniqueValueOnly())], \n" +
-                        "        [\n" +
-                        "          'Trader/Last Name', \n" +
-                        "          'Trader/First Name', \n" +
-                        "          'Trader/Is Active', \n" +
-                        "          'Trader/Kerberos Distinct Value'\n" +
-                        "        ]\n" +
-                        "      );\n" +
-                        "}", PureGrammarComposerContext.RenderStyle.PRETTY);
+                    "  let businessDate = now();\n" +
+                    "  model::domain::referenceData::account::FirmAccount.all($businessDate)->groupBy(\n" +
+                    "    [\n" +
+                    "      x|$x.trader($businessDate).lastName, \n" +
+                    "      x|$x.trader($businessDate).firstName, \n" +
+                    "      x|$x.trader($businessDate).isActive\n" +
+                    "    ], \n" +
+                    "    [agg(x|$x.trader($businessDate).kerberos, y|$y->uniqueValueOnly())], \n" +
+                    "    [\n" +
+                    "      'Trader/Last Name', \n" +
+                    "      'Trader/First Name', \n" +
+                    "      'Trader/Is Active', \n" +
+                    "      'Trader/Kerberos Distinct Value'\n" +
+                    "    ]\n" +
+                    "  );\n" +
+                    "}", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
@@ -138,27 +126,25 @@ public class TestLambdaPrettyRendering
                         "       );\n" +
                         "}",
                 "{|\n" +
-                        "  let businessDate = now();\n" +
-                        "  model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
-                        "    ->groupBy\n" +
-                        "      (\n" +
-                        "        [\n" +
-                        "          x|$x.trader(%latest).lastName, \n" +
-                        "          x|$x.trader(%latest).firstName, \n" +
-                        "          x|$x.trader(%latest).isActive\n" +
-                        "        ], \n" +
-                        "        [\n" +
-                        "          agg(x|$x.trader(%latest).kerberos, y|$y->uniqueValueOnly()), \n" +
-                        "          agg(x|$x.trader(%latest).age, y|$y->average())\n" +
-                        "        ], \n" +
-                        "        [\n" +
-                        "          'Trader/Last Name', \n" +
-                        "          'Trader/First Name', \n" +
-                        "          'Trader/Is Active', \n" +
-                        "          'Trader/Kerberos Distinct Value'\n" +
-                        "        ]\n" +
-                        "      );\n" +
-                        "}", PureGrammarComposerContext.RenderStyle.PRETTY);
+                    "  let businessDate = now();\n" +
+                    "  model::domain::referenceData::account::FirmAccount.all(%latest)->groupBy(\n" +
+                    "    [\n" +
+                    "      x|$x.trader(%latest).lastName, \n" +
+                    "      x|$x.trader(%latest).firstName, \n" +
+                    "      x|$x.trader(%latest).isActive\n" +
+                    "    ], \n" +
+                    "    [\n" +
+                    "      agg(x|$x.trader(%latest).kerberos, y|$y->uniqueValueOnly()), \n" +
+                    "      agg(x|$x.trader(%latest).age, y|$y->average())\n" +
+                    "    ], \n" +
+                    "    [\n" +
+                    "      'Trader/Last Name', \n" +
+                    "      'Trader/First Name', \n" +
+                    "      'Trader/Is Active', \n" +
+                    "      'Trader/Kerberos Distinct Value'\n" +
+                    "    ]\n" +
+                    "  );\n" +
+                    "}", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
@@ -179,44 +165,36 @@ public class TestLambdaPrettyRendering
                         "}",
                 "{|</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>let businessDate = <span class='pureGrammar-function'>now</span>();</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-package'>model::domain::referenceData::account::</span><span class='pureGrammar-packageableElement'>FirmAccount</span>.<span class='pureGrammar-function'>all</span>(%latest)</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span></BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>(</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()), </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Kerberos Distinct Value'</span></BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>);</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-package'>model::domain::referenceData::account::</span><span class='pureGrammar-packageableElement'>FirmAccount</span>.<span class='pureGrammar-function'>all</span>(%latest)<span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span>(</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()), </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Kerberos Distinct Value'</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>);</BR>\n" +
                     "}", PureGrammarComposerContext.RenderStyle.PRETTY_HTML);
     }
 
     @Test
     public void testComplexGroupByLambdaRoundtripInPrettyRendering()
     {
-        testLambda("test::Person.all()->filter(\n" +
-            "  f|$f.name->startsWith('ok') && (true || (3 == 4))\n" +
+        testLambda("|test::Person.all()->filter(\n" +
+            "  f|$f.name->startsWith('ok') &&\n" +
+            "  (true ||\n" +
+            "  (3 == 4))\n" +
             ")->groupBy(\n" +
-            "  [],\n" +
-            "  [\n" +
-            "    agg(\n" +
-            "      x|$x.lastName,\n" +
-            "      x|$x->distinct()->someFunc(\n" +
-            "        true,\n" +
-            "        'someString',\n" +
-            "        90\n" +
-            "      ) + $x.lastName)\n" +
-            "  ],\n" +
+            "  [], \n" +
+            "  [agg(x|$x.lastName, x|$x->distinct()->someFunc(true, 'someString', 90) + $x.lastName)], \n" +
             "  ['LastName']\n" +
             ")->distinct()->sort(\n" +
             "  [asc('LastName')]\n" +
@@ -228,8 +206,8 @@ public class TestLambdaPrettyRendering
         testLambda(text, text, renderStyle);
     }
 
-    private static void testLambda(String text, String toCompare, PureGrammarComposerContext.RenderStyle renderStyle)
+    private static void testLambda(String text, String formattedText, PureGrammarComposerContext.RenderStyle renderStyle)
     {
-        Assert.assertEquals(toCompare, new DomainParser().parseLambda(text, "").accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle).build()));
+        Assert.assertEquals(formattedText, new DomainParser().parseLambda(text, "").accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle).build()));
     }
 }

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
@@ -41,10 +41,14 @@ public class TestLambdaPrettyRendering
         testLambda("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok')])",
                 "|Person.all()->filter(\n" +
                     "  f|$f.name->startsWith('ok') &&\n" +
-                    "  (true ||\n" +
-                    "  (3 == 4))\n" +
+                    "    (true || (3 == 4))\n" +
                     ")->project(\n" +
-                    "  [col(p|$p.name, 'ok')]\n" +
+                    "  [\n" +
+                    "    col(\n" +
+                    "      p|$p.name,\n" +
+                    "      'ok'\n" +
+                    "    )\n" +
+                    "  ]\n" +
                     ")", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
@@ -54,12 +58,17 @@ public class TestLambdaPrettyRendering
         testLambda("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok'), col(p|$p.name, 'ok2')])",
                 "|Person.all()->filter(\n" +
                     "  f|$f.name->startsWith('ok') &&\n" +
-                    "  (true ||\n" +
-                    "  (3 == 4))\n" +
+                    "    (true || (3 == 4))\n" +
                     ")->project(\n" +
                     "  [\n" +
-                    "    col(p|$p.name, 'ok'),\n" +
-                    "    col(p|$p.name, 'ok2')\n" +
+                    "    col(\n" +
+                    "      p|$p.name,\n" +
+                    "      'ok'\n" +
+                    "    ),\n" +
+                    "    col(\n" +
+                    "      p|$p.name,\n" +
+                    "      'ok2'\n" +
+                    "    )\n" +
                     "  ]\n" +
                     ")", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
@@ -99,7 +108,12 @@ public class TestLambdaPrettyRendering
                     "      x|$x.trader($businessDate).firstName,\n" +
                     "      x|$x.trader($businessDate).isActive\n" +
                     "    ],\n" +
-                    "    [agg(x|$x.trader($businessDate).kerberos, y|$y->uniqueValueOnly())],\n" +
+                    "    [\n" +
+                    "      agg(\n" +
+                    "        x|$x.trader($businessDate).kerberos,\n" +
+                    "        y|$y->uniqueValueOnly()\n" +
+                    "      )\n" +
+                    "    ],\n" +
                     "    [\n" +
                     "      'Trader/Last Name',\n" +
                     "      'Trader/First Name',\n" +
@@ -135,8 +149,14 @@ public class TestLambdaPrettyRendering
                     "      x|$x.trader(%latest).isActive\n" +
                     "    ],\n" +
                     "    [\n" +
-                    "      agg(x|$x.trader(%latest).kerberos, y|$y->uniqueValueOnly()),\n" +
-                    "      agg(x|$x.trader(%latest).age, y|$y->average())\n" +
+                    "      agg(\n" +
+                    "        x|$x.trader(%latest).kerberos,\n" +
+                    "        y|$y->uniqueValueOnly()\n" +
+                    "      ),\n" +
+                    "      agg(\n" +
+                    "        x|$x.trader(%latest).age,\n" +
+                    "        y|$y->average()\n" +
+                    "      )\n" +
                     "    ],\n" +
                     "    [\n" +
                     "      'Trader/Last Name',\n" +
@@ -173,8 +193,14 @@ public class TestLambdaPrettyRendering
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>],</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()),</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>,</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>),</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>,</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>()</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>)</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>],</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>,</BR>\n" +
@@ -191,14 +217,24 @@ public class TestLambdaPrettyRendering
     {
         testLambda("|test::Person.all()->filter(\n" +
             "  f|$f.name->startsWith('ok') &&\n" +
-            "  (true ||\n" +
-            "  (3 == 4))\n" +
+            "    (true || (3 == 4))\n" +
             ")->groupBy(\n" +
             "  [],\n" +
-            "  [agg(x|$x.lastName, x|$x->distinct()->someFunc(true, 'someString', 90) + $x.lastName)],\n" +
+            "  [\n" +
+            "    agg(\n" +
+            "      x|$x.lastName,\n" +
+            "      x|$x->distinct()->someFunc(\n" +
+            "        true,\n" +
+            "        'someString',\n" +
+            "        90\n" +
+            "      ) + $x.lastName\n" +
+            "    )\n" +
+            "  ],\n" +
             "  ['LastName']\n" +
             ")->distinct()->sort(\n" +
-            "  [asc('LastName')]\n" +
+            "  [\n" +
+            "    asc('LastName')\n" +
+            "  ]\n" +
             ")->take(30)", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
@@ -1,0 +1,235 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.test.roundtrip;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.finos.legend.engine.language.pure.grammar.from.domain.DomainParser;
+import org.finos.legend.engine.language.pure.grammar.to.DEPRECATED_PureGrammarComposerCore;
+import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestLambdaPrettyRendering
+{
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
+
+    @Test
+    public void testRenderingEmptyCollectionInPrettyRendering()
+    {
+        testLambda("|Person.all()->project([])",
+            "|Person.all()\n" +
+                "  ->project\n" +
+                "    (\n" +
+                "      []\n" +
+                "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    @Test
+    public void testLambdaWithProjectWithColInPrettyRendering()
+    {
+        testLambda("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok')])",
+                "|Person.all()\n" +
+                    "  ->filter\n" +
+                    "    (\n" +
+                    "      f|$f.name->startsWith('ok') &&\n" +
+                    "        (true ||\n" +
+                    "        (3 == 4))\n" +
+                    "    )\n" +
+                    "  ->project\n" +
+                    "    (\n" +
+                    "      [col(p|$p.name, 'ok')]\n" +
+                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    @Test
+    public void testLambdaWithProjectWithColsInPrettyRendering()
+    {
+        testLambda("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok'), col(p|$p.name, 'ok2')])",
+                "|Person.all()\n" +
+                    "  ->filter\n" +
+                    "    (\n" +
+                    "      f|$f.name->startsWith('ok') &&\n" +
+                    "        (true ||\n" +
+                    "        (3 == 4))\n" +
+                    "    )\n" +
+                    "  ->project\n" +
+                    "    (\n" +
+                    "      [\n" +
+                    "        col(p|$p.name, 'ok'), \n" +
+                    "        col(p|$p.name, 'ok2')\n" +
+                    "      ]\n" +
+                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    @Test
+    public void testLambdaWithIfInPrettyRendering()
+    {
+        testLambda("|if($this.id == 'testing',|'test',|'nonTest')",
+                "|if($this.id == 'testing', \n" +
+                        "  |'test', \n" +
+                        "  |'nonTest'\n" +
+                        ")", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    @Test
+    public void testLambdaWithGroupByInPrettyRendering()
+    {
+        testLambda("{|\n" +
+                        "   let businessDate = now();\n" +
+                        "   model::domain::referenceData::account::FirmAccount.all($businessDate)\n" +
+                        "       ->groupBy([x | $x.trader($businessDate).lastName,\n" +
+                        "                  x | $x.trader($businessDate).firstName,\n" +
+                        "                  x | $x.trader($businessDate).isActive],\n" +
+                        "                 [agg(x | $x.trader($businessDate).kerberos, y | $y->uniqueValueOnly())],\n" +
+                        "                 ['Trader/Last Name',\n" +
+                        "                  'Trader/First Name',\n" +
+                        "                  'Trader/Is Active',\n" +
+                        "                  'Trader/Kerberos Distinct Value']\n" +
+                        "       );\n" +
+                        "}",
+                "{|\n" +
+                        "  let businessDate = now();\n" +
+                        "  model::domain::referenceData::account::FirmAccount.all($businessDate)\n" +
+                        "    ->groupBy\n" +
+                        "      (\n" +
+                        "        [\n" +
+                        "          x|$x.trader($businessDate).lastName, \n" +
+                        "          x|$x.trader($businessDate).firstName, \n" +
+                        "          x|$x.trader($businessDate).isActive\n" +
+                        "        ], \n" +
+                        "        [agg(x|$x.trader($businessDate).kerberos, y|$y->uniqueValueOnly())], \n" +
+                        "        [\n" +
+                        "          'Trader/Last Name', \n" +
+                        "          'Trader/First Name', \n" +
+                        "          'Trader/Is Active', \n" +
+                        "          'Trader/Kerberos Distinct Value'\n" +
+                        "        ]\n" +
+                        "      );\n" +
+                        "}", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    @Test
+    public void testLambdaWithGroupByWithLatestInPrettyRendering()
+    {
+        testLambda("{|\n" +
+                        "   let businessDate = now();\n" +
+                        "   model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
+                        "       ->groupBy([x | $x.trader(%latest).lastName,\n" +
+                        "                  x | $x.trader(%latest).firstName,\n" +
+                        "                  x | $x.trader(%latest).isActive],\n" +
+                        "                 [agg(x | $x.trader(%latest).kerberos, y | $y->uniqueValueOnly()),agg(x | $x.trader(%latest).age, y | $y->average())],\n" +
+                        "                 ['Trader/Last Name',\n" +
+                        "                  'Trader/First Name',\n" +
+                        "                  'Trader/Is Active',\n" +
+                        "                  'Trader/Kerberos Distinct Value']\n" +
+                        "       );\n" +
+                        "}",
+                "{|\n" +
+                        "  let businessDate = now();\n" +
+                        "  model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
+                        "    ->groupBy\n" +
+                        "      (\n" +
+                        "        [\n" +
+                        "          x|$x.trader(%latest).lastName, \n" +
+                        "          x|$x.trader(%latest).firstName, \n" +
+                        "          x|$x.trader(%latest).isActive\n" +
+                        "        ], \n" +
+                        "        [\n" +
+                        "          agg(x|$x.trader(%latest).kerberos, y|$y->uniqueValueOnly()), \n" +
+                        "          agg(x|$x.trader(%latest).age, y|$y->average())\n" +
+                        "        ], \n" +
+                        "        [\n" +
+                        "          'Trader/Last Name', \n" +
+                        "          'Trader/First Name', \n" +
+                        "          'Trader/Is Active', \n" +
+                        "          'Trader/Kerberos Distinct Value'\n" +
+                        "        ]\n" +
+                        "      );\n" +
+                        "}", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    @Test
+    public void testLambdaWithGroupByWithLatestInPrettyHTMLRendering()
+    {
+        testLambda("{|\n" +
+                        "   let businessDate = now();\n" +
+                        "   model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
+                        "       ->groupBy([x | $x.trader(%latest).lastName,\n" +
+                        "                  x | $x.trader(%latest).firstName,\n" +
+                        "                  x | $x.trader(%latest).isActive],\n" +
+                        "                 [agg(x | $x.trader(%latest).kerberos, y | $y->uniqueValueOnly()),agg(x | $x.trader(%latest).age, y | $y->average())],\n" +
+                        "                 ['Trader/Last Name',\n" +
+                        "                  'Trader/First Name',\n" +
+                        "                  'Trader/Is Active',\n" +
+                        "                  'Trader/Kerberos Distinct Value']\n" +
+                        "       );\n" +
+                        "}",
+                "{|</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>let businessDate = <span class='pureGrammar-function'>now</span>();</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-package'>model::domain::referenceData::account::</span><span class='pureGrammar-packageableElement'>FirmAccount</span>.<span class='pureGrammar-function'>all</span>(%latest)</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>(</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()), </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Kerberos Distinct Value'</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>);</BR>\n" +
+                    "}", PureGrammarComposerContext.RenderStyle.PRETTY_HTML);
+    }
+
+    @Test
+    public void testComplexGroupByLambdaRoundtripInPrettyRendering()
+    {
+        testLambda("test::Person.all()->filter(\n" +
+            "  f|$f.name->startsWith('ok') && (true || (3 == 4))\n" +
+            ")->groupBy(\n" +
+            "  [],\n" +
+            "  [\n" +
+            "    agg(\n" +
+            "      x|$x.lastName,\n" +
+            "      x|$x->distinct()->someFunc(\n" +
+            "        true,\n" +
+            "        'someString',\n" +
+            "        90\n" +
+            "      ) + $x.lastName)\n" +
+            "  ],\n" +
+            "  ['LastName']\n" +
+            ")->distinct()->sort(\n" +
+            "  [asc('LastName')]\n" +
+            ")->take(30)", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    private static void testLambda(String text, PureGrammarComposerContext.RenderStyle renderStyle)
+    {
+        testLambda(text, text, renderStyle);
+    }
+
+    private static void testLambda(String text, String toCompare, PureGrammarComposerContext.RenderStyle renderStyle)
+    {
+        Assert.assertEquals(toCompare, new DomainParser().parseLambda(text, "").accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle).build()));
+    }
+}

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
@@ -58,7 +58,7 @@ public class TestLambdaPrettyRendering
                     "  (3 == 4))\n" +
                     ")->project(\n" +
                     "  [\n" +
-                    "    col(p|$p.name, 'ok'), \n" +
+                    "    col(p|$p.name, 'ok'),\n" +
                     "    col(p|$p.name, 'ok2')\n" +
                     "  ]\n" +
                     ")", PureGrammarComposerContext.RenderStyle.PRETTY);
@@ -68,10 +68,11 @@ public class TestLambdaPrettyRendering
     public void testLambdaWithIfInPrettyRendering()
     {
         testLambda("|if($this.id == 'testing',|'test',|'nonTest')",
-                "|if($this.id == 'testing', \n" +
-                        "  |'test', \n" +
-                        "  |'nonTest'\n" +
-                        ")", PureGrammarComposerContext.RenderStyle.PRETTY);
+                "|if(\n" +
+                    "  $this.id == 'testing',\n" +
+                    "  |'test',\n" +
+                    "  |'nonTest'\n" +
+                    ")", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
@@ -94,15 +95,15 @@ public class TestLambdaPrettyRendering
                     "  let businessDate = now();\n" +
                     "  model::domain::referenceData::account::FirmAccount.all($businessDate)->groupBy(\n" +
                     "    [\n" +
-                    "      x|$x.trader($businessDate).lastName, \n" +
-                    "      x|$x.trader($businessDate).firstName, \n" +
+                    "      x|$x.trader($businessDate).lastName,\n" +
+                    "      x|$x.trader($businessDate).firstName,\n" +
                     "      x|$x.trader($businessDate).isActive\n" +
-                    "    ], \n" +
-                    "    [agg(x|$x.trader($businessDate).kerberos, y|$y->uniqueValueOnly())], \n" +
+                    "    ],\n" +
+                    "    [agg(x|$x.trader($businessDate).kerberos, y|$y->uniqueValueOnly())],\n" +
                     "    [\n" +
-                    "      'Trader/Last Name', \n" +
-                    "      'Trader/First Name', \n" +
-                    "      'Trader/Is Active', \n" +
+                    "      'Trader/Last Name',\n" +
+                    "      'Trader/First Name',\n" +
+                    "      'Trader/Is Active',\n" +
                     "      'Trader/Kerberos Distinct Value'\n" +
                     "    ]\n" +
                     "  );\n" +
@@ -129,18 +130,18 @@ public class TestLambdaPrettyRendering
                     "  let businessDate = now();\n" +
                     "  model::domain::referenceData::account::FirmAccount.all(%latest)->groupBy(\n" +
                     "    [\n" +
-                    "      x|$x.trader(%latest).lastName, \n" +
-                    "      x|$x.trader(%latest).firstName, \n" +
+                    "      x|$x.trader(%latest).lastName,\n" +
+                    "      x|$x.trader(%latest).firstName,\n" +
                     "      x|$x.trader(%latest).isActive\n" +
-                    "    ], \n" +
+                    "    ],\n" +
                     "    [\n" +
-                    "      agg(x|$x.trader(%latest).kerberos, y|$y->uniqueValueOnly()), \n" +
+                    "      agg(x|$x.trader(%latest).kerberos, y|$y->uniqueValueOnly()),\n" +
                     "      agg(x|$x.trader(%latest).age, y|$y->average())\n" +
-                    "    ], \n" +
+                    "    ],\n" +
                     "    [\n" +
-                    "      'Trader/Last Name', \n" +
-                    "      'Trader/First Name', \n" +
-                    "      'Trader/Is Active', \n" +
+                    "      'Trader/Last Name',\n" +
+                    "      'Trader/First Name',\n" +
+                    "      'Trader/Is Active',\n" +
                     "      'Trader/Kerberos Distinct Value'\n" +
                     "    ]\n" +
                     "  );\n" +
@@ -167,18 +168,18 @@ public class TestLambdaPrettyRendering
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>let businessDate = <span class='pureGrammar-function'>now</span>();</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-package'>model::domain::referenceData::account::</span><span class='pureGrammar-packageableElement'>FirmAccount</span>.<span class='pureGrammar-function'>all</span>(%latest)<span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span>(</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>,</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>,</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>],</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()), </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()),</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>],</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>,</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>,</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>,</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Kerberos Distinct Value'</span></BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\n" +
                     "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>);</BR>\n" +
@@ -193,8 +194,8 @@ public class TestLambdaPrettyRendering
             "  (true ||\n" +
             "  (3 == 4))\n" +
             ")->groupBy(\n" +
-            "  [], \n" +
-            "  [agg(x|$x.lastName, x|$x->distinct()->someFunc(true, 'someString', 90) + $x.lastName)], \n" +
+            "  [],\n" +
+            "  [agg(x|$x.lastName, x|$x->distinct()->someFunc(true, 'someString', 90) + $x.lastName)],\n" +
             "  ['LastName']\n" +
             ")->distinct()->sort(\n" +
             "  [asc('LastName')]\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
@@ -198,13 +198,8 @@ public class TestLambdaRoundtrip
     @Test
     public void testLambdaWithNot()
     {
-        testLambda("|not(true && false)");
-    }
-
-    @Test
-    public void testLambdaWithNotEquals()
-    {
-        testLambda("|not(true == false)");
+        testLambda("|!(true == false)");
+        testLambda("|not(true == false)", "|!(true == false)");
     }
 
     @Test
@@ -301,195 +296,16 @@ public class TestLambdaRoundtrip
     }
 
     @Test
-    public void testRenderingEmptyCollectionInPrettyRendering()
-    {
-        testLambdaWithFormat("|Person.all()->project([])",
-            "|Person.all()\n" +
-                "  ->project\n" +
-                "    (\n" +
-                "      []\n" +
-                "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
-    }
-
-    @Test
-    public void testLambdaWithProjectWithColInPrettyRendering()
-    {
-        testLambdaWithFormat("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok')])",
-                "|Person.all()\n" +
-                    "  ->filter\n" +
-                    "    (\n" +
-                    "      f|$f.name->startsWith('ok') &&\n" +
-                    "        (true ||\n" +
-                    "        (3 == 4))\n" +
-                    "    )\n" +
-                    "  ->project\n" +
-                    "    (\n" +
-                    "      [\n" +
-                    "        col(p|$p.name, 'ok')\n" +
-                    "      ]\n" +
-                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
-    }
-
-    @Test
-    public void testLambdaWithProjectWithColsInPrettyRendering()
-    {
-        testLambdaWithFormat("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok'), col(p|$p.name, 'ok2')])",
-                "|Person.all()\n" +
-                    "  ->filter\n" +
-                    "    (\n" +
-                    "      f|$f.name->startsWith('ok') &&\n" +
-                    "        (true ||\n" +
-                    "        (3 == 4))\n" +
-                    "    )\n" +
-                    "  ->project\n" +
-                    "    (\n" +
-                    "      [\n" +
-                    "        col(p|$p.name, 'ok'), \n" +
-                    "        col(p|$p.name, 'ok2')\n" +
-                    "      ]\n" +
-                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
-    }
-
-    @Test
-    public void testLambdaWithIfInPrettyRendering()
-    {
-        testLambdaWithFormat("|if($this.id == 'testing',|'test',|'nonTest')",
-                "|if($this.id == 'testing', \n" +
-                        "  |'test', \n" +
-                        "  |'nonTest'\n" +
-                        ")", PureGrammarComposerContext.RenderStyle.PRETTY);
-    }
-
-    @Test
-    public void testLambdaWithGroupByInPrettyRendering()
-    {
-        testLambdaWithFormat("{|\n" +
-                        "   let businessDate = now();\n" +
-                        "   model::domain::referenceData::account::FirmAccount.all($businessDate)\n" +
-                        "       ->groupBy([x | $x.trader($businessDate).lastName,\n" +
-                        "                  x | $x.trader($businessDate).firstName,\n" +
-                        "                  x | $x.trader($businessDate).isActive],\n" +
-                        "                 [agg(x | $x.trader($businessDate).kerberos, y | $y->uniqueValueOnly())],\n" +
-                        "                 ['Trader/Last Name',\n" +
-                        "                  'Trader/First Name',\n" +
-                        "                  'Trader/Is Active',\n" +
-                        "                  'Trader/Kerberos Distinct Value']\n" +
-                        "       );\n" +
-                        "}",
-                "{|\n" +
-                        "  let businessDate = now();\n" +
-                        "  model::domain::referenceData::account::FirmAccount.all($businessDate)\n" +
-                        "    ->groupBy\n" +
-                        "      (\n" +
-                        "        [\n" +
-                        "          x|$x.trader($businessDate).lastName, \n" +
-                        "          x|$x.trader($businessDate).firstName, \n" +
-                        "          x|$x.trader($businessDate).isActive\n" +
-                        "        ], \n" +
-                        "        [\n" +
-                        "          agg(x|$x.trader($businessDate).kerberos, y|$y->uniqueValueOnly())\n" +
-                        "        ], \n" +
-                        "        [\n" +
-                        "          'Trader/Last Name', \n" +
-                        "          'Trader/First Name', \n" +
-                        "          'Trader/Is Active', \n" +
-                        "          'Trader/Kerberos Distinct Value'\n" +
-                        "        ]\n" +
-                        "      );\n" +
-                        "}", PureGrammarComposerContext.RenderStyle.PRETTY);
-    }
-
-    @Test
-    public void testLambdaWithGroupByWithLatestInPrettyRendering()
-    {
-        testLambdaWithFormat("{|\n" +
-                        "   let businessDate = now();\n" +
-                        "   model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
-                        "       ->groupBy([x | $x.trader(%latest).lastName,\n" +
-                        "                  x | $x.trader(%latest).firstName,\n" +
-                        "                  x | $x.trader(%latest).isActive],\n" +
-                        "                 [agg(x | $x.trader(%latest).kerberos, y | $y->uniqueValueOnly()),agg(x | $x.trader(%latest).age, y | $y->average())],\n" +
-                        "                 ['Trader/Last Name',\n" +
-                        "                  'Trader/First Name',\n" +
-                        "                  'Trader/Is Active',\n" +
-                        "                  'Trader/Kerberos Distinct Value']\n" +
-                        "       );\n" +
-                        "}",
-                "{|\n" +
-                        "  let businessDate = now();\n" +
-                        "  model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
-                        "    ->groupBy\n" +
-                        "      (\n" +
-                        "        [\n" +
-                        "          x|$x.trader(%latest).lastName, \n" +
-                        "          x|$x.trader(%latest).firstName, \n" +
-                        "          x|$x.trader(%latest).isActive\n" +
-                        "        ], \n" +
-                        "        [\n" +
-                        "          agg(x|$x.trader(%latest).kerberos, y|$y->uniqueValueOnly()), \n" +
-                        "          agg(x|$x.trader(%latest).age, y|$y->average())\n" +
-                        "        ], \n" +
-                        "        [\n" +
-                        "          'Trader/Last Name', \n" +
-                        "          'Trader/First Name', \n" +
-                        "          'Trader/Is Active', \n" +
-                        "          'Trader/Kerberos Distinct Value'\n" +
-                        "        ]\n" +
-                        "      );\n" +
-                        "}", PureGrammarComposerContext.RenderStyle.PRETTY);
-    }
-
-    @Test
-    public void testLambdaWithGroupByWithLatestInPrettyHTMLRendering()
-    {
-        testLambdaWithFormat("{|\n" +
-                        "   let businessDate = now();\n" +
-                        "   model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
-                        "       ->groupBy([x | $x.trader(%latest).lastName,\n" +
-                        "                  x | $x.trader(%latest).firstName,\n" +
-                        "                  x | $x.trader(%latest).isActive],\n" +
-                        "                 [agg(x | $x.trader(%latest).kerberos, y | $y->uniqueValueOnly()),agg(x | $x.trader(%latest).age, y | $y->average())],\n" +
-                        "                 ['Trader/Last Name',\n" +
-                        "                  'Trader/First Name',\n" +
-                        "                  'Trader/Is Active',\n" +
-                        "                  'Trader/Kerberos Distinct Value']\n" +
-                        "       );\n" +
-                        "}",
-                "{|</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>let businessDate = <span class='pureGrammar-function'>now</span>();</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-package'>model::domain::referenceData::account::</span><span class='pureGrammar-packageableElement'>FirmAccount</span>.<span class='pureGrammar-function'>all</span>(%latest)</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span></BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>(</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()), </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>, </BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Kerberos Distinct Value'</span></BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\n" +
-                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>);</BR>\n" +
-                    "}", PureGrammarComposerContext.RenderStyle.PRETTY_HTML);
-    }
-
-    @Test
     public void testAppliedFunctionWithParametersUsingInfixOperations()
     {
-        testLambda("|'data1' + toString('data1'->someTransformation::fn() + 1)");
+        testLambda("|'data1' + toString(someTransformation::fn('data1') + 1)");
     }
 
     @Test
     public void testFunctionNameWithRichIdentifier()
     {
-        testLambda("|'data1'->someTransformation::fn() + 1");
-        testLambda("|'data1'->someTransformation::fn::'special function 1'() + 1");
+        testLambda("|someTransformation::fn('data1') + 1");
+        testLambda("|someTransformation::fn::'special function 1'('data1') + 1");
     }
 
     @Test
@@ -504,12 +320,39 @@ public class TestLambdaRoundtrip
         testLambda("|$this.'1@3'->isEmpty()");
     }
 
-    private void testLambda(String string)
+    @Test
+    public void testRenderingFunctionExpressionWithSinglePrimitiveArgument()
+    {
+        testLambda("|sort('car')");
+        testLambda("|reverse(true)");
+        testLambda("|reverse(false)");
+        testLambda("|abs(4)");
+        testLambda("|abs(4.0)");
+        testLambda("|round(4.04)");
+        testLambda("|someDateFn(%9999-12-30)");
+        testLambda("|someDateFn(%9999-12-30T19:00:00.0000)");
+
+        testLambda("|'car'->sort()", "|sort('car')");
+        testLambda("|true->reverse()", "|reverse(true)");
+        testLambda("|false->reverse()", "|reverse(false)");
+        testLambda("|4->abs()", "|abs(4)");
+        testLambda("|4.0->abs()", "|abs(4.0)");
+        testLambda("|4.04->round()", "|round(4.04)");
+        testLambda("|%9999-12-30->someDateFn()", "|someDateFn(%9999-12-30)");
+        testLambda("|%9999-12-30T19:00:00.0000->someDateFn()", "|someDateFn(%9999-12-30T19:00:00.0000)");
+    }
+
+    private static void testLambda(String text)
+    {
+        testLambda(text, text);
+    }
+
+    private static void testLambda(String text, String formattedText)
     {
         Lambda postJSON_lambda;
         try
         {
-            Lambda lambda = new DomainParser().parseLambda(string, "");
+            Lambda lambda = new DomainParser().parseLambda(text, "");
             String json = objectMapper.writeValueAsString(lambda);
             postJSON_lambda = objectMapper.readValue(json, Lambda.class);
         }
@@ -517,11 +360,6 @@ public class TestLambdaRoundtrip
         {
             throw new RuntimeException(e);
         }
-        Assert.assertEquals(string, postJSON_lambda.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().build()));
-    }
-
-    private void testLambdaWithFormat(String string, String toCompare, PureGrammarComposerContext.RenderStyle renderStyle)
-    {
-        Assert.assertEquals(toCompare, new DomainParser().parseLambda(string, "").accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle).build()));
+        Assert.assertEquals(formattedText, postJSON_lambda.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().build()));
     }
 }

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
@@ -301,22 +301,33 @@ public class TestLambdaRoundtrip
     }
 
     @Test
+    public void testRenderingEmptyCollectionInPrettyRendering()
+    {
+        testLambdaWithFormat("|Person.all()->project([])",
+            "|Person.all()\n" +
+                "  ->project\n" +
+                "    (\n" +
+                "      []\n" +
+                "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+    }
+
+    @Test
     public void testLambdaWithProjectWithColInPrettyRendering()
     {
         testLambdaWithFormat("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok')])",
                 "|Person.all()\n" +
-                        "   ->filter\n" +
-                        "    (\n" +
-                        "      f|$f.name->startsWith('ok') &&\n" +
-                        "         (true ||\n" +
-                        "         (3 == 4))\n" +
-                        "    )\n" +
-                        "   ->project\n" +
-                        "    (\n" +
-                        "      [\n" +
-                        "        col(p|$p.name, 'ok')\n" +
-                        "      ]\n" +
-                        "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+                    "  ->filter\n" +
+                    "    (\n" +
+                    "      f|$f.name->startsWith('ok') &&\n" +
+                    "        (true ||\n" +
+                    "        (3 == 4))\n" +
+                    "    )\n" +
+                    "  ->project\n" +
+                    "    (\n" +
+                    "      [\n" +
+                    "        col(p|$p.name, 'ok')\n" +
+                    "      ]\n" +
+                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
@@ -324,19 +335,19 @@ public class TestLambdaRoundtrip
     {
         testLambdaWithFormat("|Person.all()->filter(f|$f.name->startsWith('ok') && (true || 3 == 4))->project([col(p|$p.name, 'ok'), col(p|$p.name, 'ok2')])",
                 "|Person.all()\n" +
-                        "   ->filter\n" +
-                        "    (\n" +
-                        "      f|$f.name->startsWith('ok') &&\n" +
-                        "         (true ||\n" +
-                        "         (3 == 4))\n" +
-                        "    )\n" +
-                        "   ->project\n" +
-                        "    (\n" +
-                        "      [\n" +
-                        "        col(p|$p.name, 'ok'), \n" +
-                        "        col(p|$p.name, 'ok2')\n" +
-                        "      ]\n" +
-                        "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
+                    "  ->filter\n" +
+                    "    (\n" +
+                    "      f|$f.name->startsWith('ok') &&\n" +
+                    "        (true ||\n" +
+                    "        (3 == 4))\n" +
+                    "    )\n" +
+                    "  ->project\n" +
+                    "    (\n" +
+                    "      [\n" +
+                    "        col(p|$p.name, 'ok'), \n" +
+                    "        col(p|$p.name, 'ok2')\n" +
+                    "      ]\n" +
+                    "    )", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
     @Test
@@ -344,8 +355,8 @@ public class TestLambdaRoundtrip
     {
         testLambdaWithFormat("|if($this.id == 'testing',|'test',|'nonTest')",
                 "|if($this.id == 'testing', \n" +
-                        "   |'test', \n" +
-                        "   |'nonTest'\n" +
+                        "  |'test', \n" +
+                        "  |'nonTest'\n" +
                         ")", PureGrammarComposerContext.RenderStyle.PRETTY);
     }
 
@@ -368,7 +379,7 @@ public class TestLambdaRoundtrip
                 "{|\n" +
                         "  let businessDate = now();\n" +
                         "  model::domain::referenceData::account::FirmAccount.all($businessDate)\n" +
-                        "     ->groupBy\n" +
+                        "    ->groupBy\n" +
                         "      (\n" +
                         "        [\n" +
                         "          x|$x.trader($businessDate).lastName, \n" +
@@ -407,7 +418,7 @@ public class TestLambdaRoundtrip
                 "{|\n" +
                         "  let businessDate = now();\n" +
                         "  model::domain::referenceData::account::FirmAccount.all(%latest)\n" +
-                        "     ->groupBy\n" +
+                        "    ->groupBy\n" +
                         "      (\n" +
                         "        [\n" +
                         "          x|$x.trader(%latest).lastName, \n" +
@@ -445,27 +456,27 @@ public class TestLambdaRoundtrip
                         "       );\n" +
                         "}",
                 "{|</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>let businessDate = <span class='pureGrammar-function'>now</span>();</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-package'>model::domain::referenceData::account::</span><span class='pureGrammar-packageableElement'>FirmAccount</span>.<span class='pureGrammar-function'>all</span>(%latest)</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span></BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>(</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>, </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>, </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()), </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>, </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>, </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>, </BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Kerberos Distinct Value'</span></BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\n" +
-                        "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>);</BR>\n" +
-                        "}", PureGrammarComposerContext.RenderStyle.PRETTY_HTML);
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>let businessDate = <span class='pureGrammar-function'>now</span>();</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-package'>model::domain::referenceData::account::</span><span class='pureGrammar-packageableElement'>FirmAccount</span>.<span class='pureGrammar-function'>all</span>(%latest)</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>groupBy</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>(</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>lastName</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>firstName</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>isActive</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>kerberos</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>uniqueValueOnly</span>()), </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-function'>agg</span>(<span class='pureGrammar-var'>x</span>|<span class='pureGrammar-var'>$x</span>.<span class=pureGrammar-property>trader</span>(%latest).<span class=pureGrammar-property>age</span>, <span class='pureGrammar-var'>y</span>|<span class='pureGrammar-var'>$y</span><span class='pureGrammar-arrow'>-></span><span class='pureGrammar-function'>average</span>())</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>], </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>[</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Last Name'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/First Name'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Is Active'</span>, </BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-string'>'Trader/Kerberos Distinct Value'</span></BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>]</BR>\n" +
+                    "<span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span><span class='pureGrammar-space'></span>);</BR>\n" +
+                    "}", PureGrammarComposerContext.RenderStyle.PRETTY_HTML);
     }
 
     @Test


### PR DESCRIPTION
We made a few modifications to how lambda JSON is transformed to text. See the list below for details:

- [x] render `not(...)` as `!(...)`
- [x] change render `'someString'->sort()` to `sort('someString')`: when there is one argument of primitive type provided, we shouldn't use `->` syntax
- [x] fix bug where if the first parameter of the function is a lambda, `->` syntax is used
- [x] `PRETTY rendering` collection with 1 entry are rendered as `[entry]` (i.e. on the same line)
- [x] `PRETTY rendering` make sure empty collections are rendered as `[]`
- [x] `PRETTY rendering` ensure tab (2 spaces) are consistently applied
- [x] `PRETTY rendering` for boolean operators `&&` and `||`, if there are 2 arguments and neither are primitive values -> do not split to a new line
- [x] `PRETTY rendering` do not make exception in formatting based on specific functions like `project()`, `agg()`, `groupBy()`, etc. - this is just not scalable

Before:
```
|test::Person.all()
   ->filter
    (
      f|$f.name->startsWith('ok') &&
         (true ||
         (3 == 4))
    )
   ->groupBy
    (
      [
        
      ], 
      [
        agg(x|$x.lastName, x|$x->distinct()->someFunc(true, 'someString', 90) + $x.lastName)
      ], 
      [
        'LastName'
      ]
    )->distinct()->sort([
     'LastName'->asc()
   ])->take(30)
```

After:
```
|test::Person.all()->filter(
  f|$f.name->startsWith('ok') &&
    (true || (3 == 4))
)->groupBy(
  [],
  [
    agg(
      x|$x.lastName,
      x|$x->distinct()->someFunc(
        true,
        'someString',
        90
      ) + $x.lastName
    )
  ],
  ['LastName']
)->distinct()->sort(
  [
    asc('LastName')
  ]
)->take(30)
```
