### PR TITLE
Quote snowflake identifiers when quoteIdentifiers flag is set in connection

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational-connection/pom.xml
+++ b/legend-engine-executionPlan-execution-store-relational-connection/pom.xml
@@ -41,6 +41,7 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <includes>
                         <include>**/*_local.java</include>
+                        <include>**/*DataSourceSpecificationTest.java</include>
                     </includes>
                     <argLine>${argLine} -Xmx2g -Xms1g -XX:MaxPermSize=1024m -XX:SoftRefLRUPolicyMSPerMB=1</argLine>
                 </configuration>

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeManager.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeManager.java
@@ -26,9 +26,8 @@ public class SnowflakeManager extends DatabaseManager
         Assert.assertTrue(extraUserDataSourceProperties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_WAREHOUSE_NAME) != null, () -> SnowflakeDataSourceSpecification.SNOWFLAKE_WAREHOUSE_NAME + " is not set");
         String accountName = extraUserDataSourceProperties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ACCOUNT_NAME);
         String region = extraUserDataSourceProperties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION);
-        String warehouse = extraUserDataSourceProperties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_WAREHOUSE_NAME);
         String cloudType = extraUserDataSourceProperties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE);
-        return "jdbc:snowflake://" + accountName + "." + region + "." + cloudType + ".snowflakecomputing.com/?warehouse=" + warehouse;
+        return "jdbc:snowflake://" + accountName + "." + region + "." + cloudType + ".snowflakecomputing.com";
     }
 
     @Override

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
@@ -32,21 +32,26 @@ public class SnowflakeDataSourceSpecification extends DataSourceSpecification
     public static String SNOWFLAKE_WAREHOUSE_NAME = "legend_snowflake_warehouseName";
     public static String SNOWFLAKE_DATABASE_NAME= "legend_snowflake_databaseName";
     public static String SNOWFLAKE_CLOUD_TYPE= "legend_snowflake_cloudType";
+    public static String SNOWFLAKE_QUOTE_IDENTIFIERS= "legend_snowflake_quoteIdentifiers";
 
 
     public SnowflakeDataSourceSpecification(SnowflakeDataSourceSpecificationKey key, DatabaseManager databaseManager, AuthenticationStrategy authenticationStrategy, Properties extraUserProperties, RelationalExecutorInfo relationalExecutorInfo)
     {
         super(key, databaseManager, authenticationStrategy, extraUserProperties, relationalExecutorInfo);
 
+        String warehouseName = updateSnowflakeIdentifiers(key.getWarehouseName(), key.getQuoteIdentifiers());
+        String databaseName  = updateSnowflakeIdentifiers(key.getDatabaseName(), key.getQuoteIdentifiers());
+
         this.extraDatasourceProperties.put(SNOWFLAKE_ACCOUNT_NAME, key.getAccountName());
         this.extraDatasourceProperties.put(SNOWFLAKE_REGION, key.getRegion());
-        this.extraDatasourceProperties.put(SNOWFLAKE_WAREHOUSE_NAME, key.getWarehouseName());
-        this.extraDatasourceProperties.put(SNOWFLAKE_DATABASE_NAME, key.getDatabaseName());
+        this.extraDatasourceProperties.put(SNOWFLAKE_WAREHOUSE_NAME, warehouseName);
+        this.extraDatasourceProperties.put(SNOWFLAKE_DATABASE_NAME, databaseName);
         this.extraDatasourceProperties.put(SNOWFLAKE_CLOUD_TYPE, key.getCloudType());
+        this.extraDatasourceProperties.put(SNOWFLAKE_QUOTE_IDENTIFIERS, key.getQuoteIdentifiers());
 
         this.extraDatasourceProperties.put("account", key.getAccountName());
-        this.extraDatasourceProperties.put("warehouse", key.getWarehouseName());
-        this.extraDatasourceProperties.put("db", key.getDatabaseName());
+        this.extraDatasourceProperties.put("warehouse", warehouseName);
+        this.extraDatasourceProperties.put("db", databaseName);
         this.extraDatasourceProperties.put("ocspFailOpen", true);
     }
 
@@ -59,5 +64,14 @@ public class SnowflakeDataSourceSpecification extends DataSourceSpecification
     protected DataSource buildDataSource(MutableList<CommonProfile> profiles)
     {
         return this.buildDataSource(null, -1, null, profiles);
+    }
+
+    public static String updateSnowflakeIdentifiers(String identifier, boolean quoteIdentifiers)
+    {
+        if (quoteIdentifiers && identifier != null && !(identifier.startsWith("\"") && identifier.endsWith("\"")))
+        {
+            identifier = "\"" + identifier + "\"";
+        }
+        return identifier;
     }
 }

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/keys/SnowflakeDataSourceSpecificationKey.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/keys/SnowflakeDataSourceSpecificationKey.java
@@ -26,14 +26,16 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
     private final String databaseName;
     private final String cloudType;
 
+    private final Boolean quoteIdentifiers;
 
-    public SnowflakeDataSourceSpecificationKey(String accountName, String region, String warehouseName, String databaseName, String cloudType)
+    public SnowflakeDataSourceSpecificationKey(String accountName, String region, String warehouseName, String databaseName, String cloudType, Boolean quoteIdentifiers)
     {
         this.accountName = accountName;
         this.region = region;
         this.warehouseName = warehouseName;
         this.databaseName = databaseName;
         this.cloudType = cloudType == null ? "privatelink" : cloudType;
+        this.quoteIdentifiers = quoteIdentifiers == null ? false : quoteIdentifiers;
     }
 
     public String getAccountName()
@@ -61,6 +63,11 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
         return cloudType;
     }
 
+    public Boolean getQuoteIdentifiers()
+    {
+        return quoteIdentifiers;
+    }
+
     @Override
     public String toString()
     {
@@ -70,6 +77,7 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
                 ", warehouseName='" + warehouseName + '\'' +
                 ", databaseName='" + databaseName + '\'' +
                 ", cloudType='" + cloudType + '\'' +
+                ", quoteIdentifiers='" + quoteIdentifiers + '\'' +
                 '}';
     }
 
@@ -78,9 +86,11 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
     {
         return "Snowflake_" +
                 "account:" + accountName + "_" +
+                "region:" + region + "_" +
                 "warehouse:" + warehouseName + "_" +
                 "db:" + databaseName + "_" +
-                "cloudType:" + cloudType;
+                "cloudType:" + cloudType + "_" +
+                "quoteIdentifiers:" + quoteIdentifiers;
     }
 
     @Override
@@ -99,12 +109,13 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
                 Objects.equals(region, that.region) &&
                 Objects.equals(warehouseName, that.warehouseName) &&
                 Objects.equals(databaseName, that.databaseName) &&
-                Objects.equals(cloudType, that.cloudType);
+                Objects.equals(cloudType, that.cloudType) &&
+                Objects.equals(quoteIdentifiers, that.quoteIdentifiers);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(accountName, region, warehouseName, databaseName, cloudType);
+        return Objects.hash(accountName, region, warehouseName, databaseName, cloudType, quoteIdentifiers);
     }
 }

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/SnowflakeDataSourceSpecificationTest.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/SnowflakeDataSourceSpecificationTest.java
@@ -1,0 +1,83 @@
+package org.finos.legend.engine.plan.execution.stores.relational.connection.ds;
+
+import org.finos.legend.engine.plan.execution.stores.relational.connection.RelationalExecutorInfo;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.SnowflakePublicAuthenticationStrategy;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.snowflake.SnowflakeManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.SnowflakeDataSourceSpecification;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.keys.SnowflakeDataSourceSpecificationKey;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class SnowflakeDataSourceSpecificationTest extends SnowflakeDataSourceSpecification
+{
+    public SnowflakeDataSourceSpecificationTest()
+    {
+        super(new SnowflakeDataSourceSpecificationKey("dummy", "dummy", "dummy", "dummy", "dummy", null),
+                new SnowflakeManager(),
+                new SnowflakePublicAuthenticationStrategy("dummy", "dummy", "dummy"),
+                new Properties(),
+                new RelationalExecutorInfo());
+    }
+
+    @Test
+    public void testSnowflakeDataSourceSpecificationProperties()
+    {
+        SnowflakeDataSourceSpecification ds =
+                new SnowflakeDataSourceSpecification(
+                        new SnowflakeDataSourceSpecificationKey("ki79827", "us-east-2", "LEGENDRO_WH", "KNOEMA_RENEWABLES_DATA_ATLAS", "aws", null),
+                        new SnowflakeManager(),
+                        new SnowflakePublicAuthenticationStrategy("SF_KEY", "SF_PASS", "LEGEND_RO_PIERRE"),
+                        new RelationalExecutorInfo());
+
+        Properties properties = ds.extraDatasourceProperties;
+
+        Assert.assertEquals("ki79827", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ACCOUNT_NAME));
+        Assert.assertEquals("us-east-2", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION));
+        Assert.assertEquals("aws", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE));
+        Assert.assertEquals(false, properties.get(SnowflakeDataSourceSpecification.SNOWFLAKE_QUOTE_IDENTIFIERS));
+        Assert.assertEquals("KNOEMA_RENEWABLES_DATA_ATLAS", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_DATABASE_NAME));
+        Assert.assertEquals("LEGENDRO_WH", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_WAREHOUSE_NAME));
+    }
+
+    @Test
+    public void testSnowflakeDataSourceSpecificationPropertiesWithQuoteIdentifiersSetAsFalse()
+    {
+        SnowflakeDataSourceSpecification ds =
+                new SnowflakeDataSourceSpecification(
+                        new SnowflakeDataSourceSpecificationKey("ki79827", "us-east-2", "LEGENDRO_WH", "KNOEMA_RENEWABLES_DATA_ATLAS", "aws", false),
+                        new SnowflakeManager(),
+                        new SnowflakePublicAuthenticationStrategy("SF_KEY", "SF_PASS", "LEGEND_RO_PIERRE"),
+                        new RelationalExecutorInfo());
+
+        Properties properties = ds.extraDatasourceProperties;
+
+        Assert.assertEquals("ki79827", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ACCOUNT_NAME));
+        Assert.assertEquals("us-east-2", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION));
+        Assert.assertEquals("aws", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE));
+        Assert.assertEquals(false, properties.get(SnowflakeDataSourceSpecification.SNOWFLAKE_QUOTE_IDENTIFIERS));
+        Assert.assertEquals("KNOEMA_RENEWABLES_DATA_ATLAS", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_DATABASE_NAME));
+        Assert.assertEquals("LEGENDRO_WH", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_WAREHOUSE_NAME));
+    }
+
+    @Test
+    public void testSnowflakeDataSourceSpecificationPropertiesWithQuoteIdentifiersSetAsTrue()
+    {
+        SnowflakeDataSourceSpecification ds =
+                new SnowflakeDataSourceSpecification(
+                        new SnowflakeDataSourceSpecificationKey("ki79827", "us-east-2", "LEGENDRO_WH", "KNOEMA_RENEWABLES_DATA_ATLAS", "aws", true),
+                        new SnowflakeManager(),
+                        new SnowflakePublicAuthenticationStrategy("SF_KEY", "SF_PASS", "LEGEND_RO_PIERRE"),
+                        new RelationalExecutorInfo());
+
+        Properties properties = ds.extraDatasourceProperties;
+
+        Assert.assertEquals("ki79827", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ACCOUNT_NAME));
+        Assert.assertEquals("us-east-2", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION));
+        Assert.assertEquals("aws", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE));
+        Assert.assertEquals(true, properties.get(SnowflakeDataSourceSpecification.SNOWFLAKE_QUOTE_IDENTIFIERS));
+        Assert.assertEquals("\"KNOEMA_RENEWABLES_DATA_ATLAS\"", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_DATABASE_NAME));
+        Assert.assertEquals("\"LEGENDRO_WH\"", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_WAREHOUSE_NAME));
+    }
+}

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/TestConnectionObjectProtocol_server.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/TestConnectionObjectProtocol_server.java
@@ -58,7 +58,7 @@ public class TestConnectionObjectProtocol_server extends org.finos.legend.engine
 
         SnowflakeDataSourceSpecification ds =
                 new SnowflakeDataSourceSpecification(
-                        new SnowflakeDataSourceSpecificationKey("ki79827", "us-east-2", "LEGENDRO_WH", "KNOEMA_RENEWABLES_DATA_ATLAS", "aws"),
+                        new SnowflakeDataSourceSpecificationKey("ki79827", "us-east-2", "LEGENDRO_WH", "KNOEMA_RENEWABLES_DATA_ATLAS", "aws", null),
                         new SnowflakeManager(),
                         new SnowflakePublicAuthenticationStrategy("SF_KEY", "SF_PASS", "LEGEND_RO_PIERRE"),
                         new RelationalExecutorInfo());

--- a/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/manager/strategic/DataSourceSpecificationKeyGenerator.java
+++ b/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/manager/strategic/DataSourceSpecificationKeyGenerator.java
@@ -72,7 +72,8 @@ public class DataSourceSpecificationKeyGenerator implements DatasourceSpecificat
                     snowflakeDatasourceSpecification.region,
                     snowflakeDatasourceSpecification.warehouseName,
                     snowflakeDatasourceSpecification.databaseName,
-                    snowflakeDatasourceSpecification.cloudType);
+                    snowflakeDatasourceSpecification.cloudType,
+                    connection.quoteIdentifiers);
         }
         else if (datasourceSpecification instanceof BigQueryDatasourceSpecification)
         {


### PR DESCRIPTION
Quote snowflake identifiers when quoteIdentifiers flag is set in connection.
This is required to connect to warehouse/database whose names are in case other than upper_case