### PR TITLE
Rework Query APIs to get configuration from Vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .project
 /legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/snowflake.properties
 /legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/query.properties
+/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userLocalConfig.json

--- a/legend-engine-application-query/pom.xml
+++ b/legend-engine-application-query/pom.xml
@@ -33,13 +33,6 @@
         </dependency>
         <!-- ENGINE -->
 
-        <!-- Required to support Configuration -->
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-core</artifactId>
-        </dependency>
-        <!-- Required to support Configuration -->
-
         <!-- JACKSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryAPI.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryAPI.java
@@ -16,8 +16,8 @@ package org.finos.legend.engine.application.query.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import io.opentracing.Scope;
@@ -33,6 +33,7 @@ import org.finos.legend.engine.application.query.model.Query;
 import org.finos.legend.engine.shared.core.kerberos.ProfileManagerHelper;
 import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionTool;
 import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
+import org.finos.legend.engine.shared.core.vault.Vault;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
@@ -60,13 +61,20 @@ public class QueryAPI
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Document EMPTY_FILTER = Document.parse("{}");
 
-    private final MongoDatabase mongoDatabase;
-    private final String mongoCollection;
+    private final MongoClient mongoClient;
 
-    public QueryAPI(MongoDatabase mongoDatabase, String mongoCollection)
+    public QueryAPI(MongoClient mongoClient)
     {
-        this.mongoDatabase = mongoDatabase;
-        this.mongoCollection = mongoCollection;
+        this.mongoClient = mongoClient;
+    }
+
+    private MongoCollection<Document> getQueryCollection()
+    {
+        if (Vault.INSTANCE.hasValue("query.mongo.database") && Vault.INSTANCE.hasValue("query.mongo.collection"))
+        {
+            return this.mongoClient.getDatabase(Vault.INSTANCE.getValue("query.mongo.database")).getCollection(Vault.INSTANCE.getValue("query.mongo.collection"));
+        }
+        throw new RuntimeException("Query MongoDB database and collection have not been configured properly");
     }
 
     private static Query documentToQuery(Document document)
@@ -106,7 +114,6 @@ public class QueryAPI
     {
         try
         {
-            MongoCollection<Document> queryCollection = this.mongoDatabase.getCollection(this.mongoCollection, Document.class);
             List<Bson> filters = new ArrayList<>();
             if (showCurrentUserQueriesOnly)
             {
@@ -117,7 +124,7 @@ public class QueryAPI
             {
                 filters.add(Filters.regex("name", Pattern.quote(search), "i"));
             }
-            List<Query> queries = LazyIterate.collect(queryCollection
+            List<Query> queries = LazyIterate.collect(this.getQueryCollection()
                 .find(filters.isEmpty() ? EMPTY_FILTER : Filters.and(filters))
                 .projection(Projections.include("id", "name", "projectId", "versionId"))
                 .limit(limit), QueryAPI::documentToQuery).toList();
@@ -137,8 +144,7 @@ public class QueryAPI
     {
         try
         {
-            MongoCollection<Document> queryCollection = this.mongoDatabase.getCollection(this.mongoCollection, Document.class);
-            List<Query> matchingQueries = LazyIterate.collect(queryCollection.find(Filters.eq("id", queryId)), QueryAPI::documentToQuery).toList();
+            List<Query> matchingQueries = LazyIterate.collect(this.getQueryCollection().find(Filters.eq("id", queryId)), QueryAPI::documentToQuery).toList();
             if (matchingQueries.size() > 1)
             {
                 throw new IllegalStateException("Found multiple query with ID '" + queryId + "'");
@@ -166,13 +172,12 @@ public class QueryAPI
             // Force the current user as owner regardless of user input
             query.owner = getCurrentUser(profileManager);
 
-            MongoCollection<Document> queryCollection = this.mongoDatabase.getCollection(this.mongoCollection, Document.class);
-            List<Query> matchingQueries = LazyIterate.collect(queryCollection.find(Filters.eq("id", query.id)), QueryAPI::documentToQuery).toList();
+            List<Query> matchingQueries = LazyIterate.collect(this.getQueryCollection().find(Filters.eq("id", query.id)), QueryAPI::documentToQuery).toList();
             if (matchingQueries.size() >= 1)
             {
                 return Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON_TYPE).entity("{\"message\":\"Query with ID '" + query.id + "' already exists\"}").build();
             }
-            queryCollection.insertOne(queryToDocument(query));
+            this.getQueryCollection().insertOne(queryToDocument(query));
             return Response.ok().entity(query).build();
         }
         catch (Exception e)
@@ -190,8 +195,7 @@ public class QueryAPI
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(profileManager);
         try (Scope scope = GlobalTracer.get().buildSpan("Query: Update Query").startActive(true))
         {
-            MongoCollection<Document> queryCollection = this.mongoDatabase.getCollection(this.mongoCollection, Document.class);
-            List<Query> matchingQueries = LazyIterate.collect(queryCollection.find(Filters.eq("id", queryId)), QueryAPI::documentToQuery).toList();
+            List<Query> matchingQueries = LazyIterate.collect(this.getQueryCollection().find(Filters.eq("id", queryId)), QueryAPI::documentToQuery).toList();
             if (!queryId.equals(query.id))
             {
                 return Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON_TYPE).entity("{\"message\":\"Updating query ID is not supported\"}").build();
@@ -214,7 +218,7 @@ public class QueryAPI
                 return Response.status(Response.Status.FORBIDDEN).type(MediaType.APPLICATION_JSON_TYPE).entity("{\"message\":\"Only owner can update the query\"}").build();
             }
             query.owner = currentUser;
-            queryCollection.findOneAndUpdate(Filters.eq("id", queryId), queryToDocument(query));
+            this.getQueryCollection().findOneAndUpdate(Filters.eq("id", queryId), queryToDocument(query));
             return Response.ok().entity(query).build();
         }
         catch (Exception e)
@@ -232,8 +236,7 @@ public class QueryAPI
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(profileManager);
         try (Scope scope = GlobalTracer.get().buildSpan("Query: Delete Query").startActive(true))
         {
-            MongoCollection<Document> queryCollection = this.mongoDatabase.getCollection(this.mongoCollection, Document.class);
-            List<Query> matchingQueries = LazyIterate.collect(queryCollection.find(Filters.eq("id", queryId)), QueryAPI::documentToQuery).toList();
+            List<Query> matchingQueries = LazyIterate.collect(this.getQueryCollection().find(Filters.eq("id", queryId)), QueryAPI::documentToQuery).toList();
             if (matchingQueries.size() > 1)
             {
                 throw new IllegalStateException("Found multiple query with ID '" + queryId + "'");
@@ -251,7 +254,7 @@ public class QueryAPI
                 return Response.status(Response.Status.FORBIDDEN).type(MediaType.APPLICATION_JSON_TYPE).entity("{\"message\":\"Only owner can delete the query\"}").build();
             }
 
-            queryCollection.findOneAndDelete(Filters.eq("id", queryId));
+            this.getQueryCollection().findOneAndDelete(Filters.eq("id", queryId));
             return Response.noContent().build();
         }
         catch (Exception e)

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/configuration/QueryAPIConfiguration.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/configuration/QueryAPIConfiguration.java
@@ -14,12 +14,42 @@
 
 package org.finos.legend.engine.application.query.configuration;
 
-import io.dropwizard.Configuration;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import org.finos.legend.engine.shared.core.vault.Vault;
 
-public class QueryAPIConfiguration extends Configuration
+public class QueryAPIConfiguration
 {
-    public String mongoUrl;
-    public int mongoPort;
-    public String mongoDatabase;
-    public String mongoCollection;
+    public static MongoClient getMongoDBClient()
+    {
+        String mongoUrl = Vault.INSTANCE.hasValue("query.mongo.url") ? Vault.INSTANCE.getValue("query.mongo.url") : null;
+        Integer mongoPort = Vault.INSTANCE.hasValue("query.mongo.port") ? Integer.parseInt(Vault.INSTANCE.getValue("query.mongo.port")) : null;
+
+        String mongoUsername = Vault.INSTANCE.hasValue("query.mongo.username") ? Vault.INSTANCE.getValue("query.mongo.username") : null;
+        String mongoPassword = Vault.INSTANCE.hasValue("query.mongo.password") ? Vault.INSTANCE.getValue("query.mongo.password") : null;
+        String mongoCredentialSource = Vault.INSTANCE.hasValue("query.mongo.credentialSource") ? Vault.INSTANCE.getValue("query.mongo.credentialSource") : null;
+
+        MongoCredential credential = null;
+        if (mongoUsername != null && mongoPassword != null)
+        {
+            credential = MongoCredential.createPlainCredential(mongoUsername, mongoCredentialSource != null ? mongoCredentialSource : "$external", mongoPassword.toCharArray());
+        }
+
+        MongoClient mongoClient = new MongoClient();
+        if (mongoUrl != null && mongoPort != null)
+        {
+            if (credential != null)
+            {
+                mongoClient = new MongoClient(new ServerAddress(mongoUrl, mongoPort), credential, new MongoClientOptions.Builder().build());
+            }
+            else
+            {
+                mongoClient = new MongoClient(mongoUrl, mongoPort);
+            }
+        }
+
+        return mongoClient;
+    }
 }

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -323,14 +323,6 @@
         </dependency>
         <!-- COMMONS IO -->
 
-
-        <!-- MONGODB -->
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-        </dependency>
-        <!-- MONGODB -->
-
         <!-- LOG -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.server;
 
-import com.mongodb.MongoClient;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.forms.MultiPartBundle;
@@ -29,6 +28,8 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.finos.legend.engine.application.query.api.QueryAPI;
+import org.finos.legend.engine.application.query.configuration.QueryAPIConfiguration;
 import org.finos.legend.engine.external.shared.format.extension.GenerationExtension;
 import org.finos.legend.engine.external.shared.format.extension.GenerationMode;
 import org.finos.legend.engine.external.shared.format.generations.loaders.CodeGenerators;
@@ -51,7 +52,6 @@ import org.finos.legend.engine.plan.execution.stores.relational.plugin.Relationa
 import org.finos.legend.engine.plan.execution.stores.relational.plugin.RelationalStoreExecutor;
 import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransformers;
 import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
-import org.finos.legend.engine.application.query.api.QueryAPI;
 import org.finos.legend.engine.query.pure.api.Execute;
 import org.finos.legend.engine.server.core.ServerShared;
 import org.finos.legend.engine.server.core.api.CurrentUser;
@@ -176,7 +176,7 @@ public class Server extends Application<ServerConfiguration>
         environment.jersey().register(new ExecutePlan(planExecutor));
 
         // Query
-        environment.jersey().register(new QueryAPI(new MongoClient(serverConfiguration.query.mongoUrl, serverConfiguration.query.mongoPort).getDatabase(serverConfiguration.query.mongoDatabase), serverConfiguration.query.mongoCollection));
+        environment.jersey().register(new QueryAPI(QueryAPIConfiguration.getMongoDBClient()));
 
         // Global
         environment.jersey().register(new JsonInformationExceptionMapper());

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/ServerConfiguration.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/ServerConfiguration.java
@@ -16,8 +16,6 @@ package org.finos.legend.engine.server;
 
 import io.dropwizard.Configuration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-import org.finos.legend.engine.application.query.api.QueryAPI;
-import org.finos.legend.engine.application.query.configuration.QueryAPIConfiguration;
 import org.finos.legend.engine.language.pure.modelManager.sdlc.configuration.MetaDataServerConfiguration;
 import org.finos.legend.engine.plan.execution.stores.relational.config.RelationalExecutionConfiguration;
 import org.finos.legend.engine.plan.execution.stores.relational.config.TemporaryTestDbConfiguration;
@@ -40,6 +38,5 @@ public class ServerConfiguration extends Configuration
     public List<VaultConfiguration> vaults;
 
     public RelationalExecutionConfiguration relationalexecution;
-    public QueryAPIConfiguration query;
     public TemporaryTestDbConfiguration temporarytestdb;
 }

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
@@ -64,11 +64,5 @@
   },
   "relationalexecution": {
     "tempPath": "/tmp/"
-  },
-  "query": {
-    "mongoUrl": "127.0.0.1",
-    "mongoPort": 27017,
-    "mongoDatabase": "local",
-    "mongoCollection": "query"
   }
 }

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/PropertiesVaultImplementation.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/PropertiesVaultImplementation.java
@@ -16,4 +16,10 @@ public class PropertiesVaultImplementation implements VaultImplementation
     {
         return properties.getProperty(vaultKey);
     }
+
+    @Override
+    public boolean hasValue(String vaultKey)
+    {
+        return properties.containsKey(vaultKey);
+    }
 }

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/PropertiesVaultImplementation.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/PropertiesVaultImplementation.java
@@ -4,7 +4,7 @@ import java.util.Properties;
 
 public class PropertiesVaultImplementation implements VaultImplementation
 {
-    private Properties properties;
+    private final Properties properties;
 
     public PropertiesVaultImplementation(Properties properties)
     {

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/Vault.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/Vault.java
@@ -7,7 +7,7 @@ public class Vault
 {
     public static Vault INSTANCE = new Vault();
 
-    private MutableList<VaultImplementation> implementations = Lists.mutable.empty();
+    private final MutableList<VaultImplementation> implementations = Lists.mutable.empty();
 
     private Vault()
     {
@@ -23,4 +23,8 @@ public class Vault
         return this.implementations.collect(i -> i.getValue(key)).getFirst();
     }
 
+    public boolean hasValue(String key)
+    {
+        return !this.implementations.select(i -> i.hasValue(key)).isEmpty();
+    }
 }

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/VaultImplementation.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/VaultImplementation.java
@@ -3,4 +3,6 @@ package org.finos.legend.engine.shared.core.vault;
 public interface VaultImplementation
 {
     String getValue(String key);
+
+    boolean hasValue(String key);
 }

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/VoidVault.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/vault/VoidVault.java
@@ -13,4 +13,10 @@ public class VoidVault implements VaultImplementation
     {
         throw new RuntimeException("No vault was provided");
     }
+
+    @Override
+    public boolean hasValue(String vaultKey)
+    {
+        throw new RuntimeException("No vault was provided");
+    }
 }


### PR DESCRIPTION
Continuation of #333 and related to https://github.com/finos/legend-studio/issues/325

- [x] Use `Vault` for keeping MongoDB configuration and credential