### PR TITLE
Upgrade openjdk:11.0.12-bullseye for Docker image

### DIFF
--- a/legend-engine-server/Dockerfile
+++ b/legend-engine-server/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:11.0.11
+FROM openjdk:11.0.12-bullseye
 COPY target/legend-engine-server-*.jar /app/bin/
 CMD java -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=60 -Xss4M -cp /app/bin/*-shaded.jar -Dfile.encoding=UTF8 org.finos.legend.engine.server.Server server /config/config.json


### PR DESCRIPTION
Trying to fix issue with Docker build, since `Bullseye` is the latest stable version of `Debian`, while waiting for `openjdk` to bump this for their `debian-based` image (which I'm not too sure when would that happen), we can go with this first.

I figured [this conversation](https://github.com/zulu-openjdk/zulu-openjdk/issues/107) prompted that `CVE-2021-3711` is resolved by this upgrade.
