### PR TITLE
Add support for tagged values and stereotypes in `Service` and `DataSpace`

### DIFF
--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/ApplicationQuery.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/ApplicationQuery.java
@@ -77,13 +77,13 @@ public class ApplicationQuery
             List<QueryProjectCoordinates> coordinates = ListIterate.distinct(projectCoordinates).collect((projectCoordinate) ->
             {
                 QueryProjectCoordinates coordinate = new QueryProjectCoordinates();
-                int idx = projectCoordinate.lastIndexOf('.');
-                if (idx == -1)
+                String[] gaCoordinate = projectCoordinate.split(":");
+                if (gaCoordinate.length != 2)
                 {
                     return null;
                 }
-                coordinate.groupId = projectCoordinate.substring(0, idx);
-                coordinate.artifactId = projectCoordinate.substring(idx + 1);
+                coordinate.groupId = gaCoordinate[0];
+                coordinate.artifactId = gaCoordinate[1];
                 return coordinate;
             }).select(Objects::nonNull);
             return Response.ok().entity(this.queryStoreManager.getQueries(search, coordinates, limit, showCurrentUserQueriesOnly, getCurrentUser(profileManager))).build();

--- a/legend-engine-language-pure-dsl-data-space/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceLexerGrammar.g4
+++ b/legend-engine-language-pure-dsl-data-space/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceLexerGrammar.g4
@@ -5,6 +5,9 @@ import CoreLexerGrammar;
 
 // ------------------------------------ KEYWORD --------------------------------------
 
+STEREOTYPES:                    'stereotypes';
+TAGS:                           'tags';
+
 DATA_SPACE:                     'DataSpace';
 DATA_SPACE_GROUP_ID:            'groupId';
 DATA_SPACE_ARTIFACT_ID:         'artifactId';

--- a/legend-engine-language-pure-dsl-data-space/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceParserGrammar.g4
+++ b/legend-engine-language-pure-dsl-data-space/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceParserGrammar.g4
@@ -10,6 +10,7 @@ options
 // -------------------------------------- IDENTIFIER --------------------------------------
 
 identifier:                 VALID_STRING | STRING
+                            | STEREOTYPES | TAGS
                             | DATA_SPACE
                             | DATA_SPACE_GROUP_ID
                             | DATA_SPACE_ARTIFACT_ID
@@ -26,7 +27,7 @@ identifier:                 VALID_STRING | STRING
 definition:                 (dataSpaceElement)*
                             EOF
 ;
-dataSpaceElement:           DATA_SPACE qualifiedName
+dataSpaceElement:           DATA_SPACE stereotypes? taggedValues? qualifiedName
                                 BRACE_OPEN
                                     (
                                         groupId
@@ -39,6 +40,14 @@ dataSpaceElement:           DATA_SPACE qualifiedName
                                         | supportEmail
                                     )*
                                 BRACE_CLOSE
+;
+stereotypes:                LESS_THAN LESS_THAN stereotype (COMMA stereotype)* GREATER_THAN GREATER_THAN
+;
+stereotype:                 qualifiedName DOT identifier
+;
+taggedValues:               BRACE_OPEN taggedValue (COMMA taggedValue)* BRACE_CLOSE
+;
+taggedValue:                qualifiedName DOT identifier EQUAL STRING
 ;
 groupId:                    DATA_SPACE_GROUP_ID COLON STRING SEMI_COLON
 ;

--- a/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/compiler/toPureGraph/DataSpaceCompilerExtension.java
+++ b/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/compiler/toPureGraph/DataSpaceCompilerExtension.java
@@ -14,10 +14,12 @@
 
 package org.finos.legend.engine.language.pure.dsl.dataSpace.compiler.toPureGraph;
 
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpace;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_PackageableElement_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_TaggedValue_Impl;
 
 import java.util.Collections;
 
@@ -27,6 +29,9 @@ public class DataSpaceCompilerExtension implements CompilerExtension
     public Iterable<? extends Processor<?>> getExtraProcessors()
     {
         // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
-        return Collections.singletonList(Processor.newProcessor(DataSpace.class, (dataSpace, context) -> new Root_meta_pure_metamodel_PackageableElement_Impl("")));
+        return Collections.singletonList(Processor.newProcessor(DataSpace.class, (dataSpace, context) -> new Root_meta_pure_metamodel_PackageableElement_Impl("")
+            ._stereotypes(ListIterate.collect(dataSpace.stereotypes, s -> context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
+            ._taggedValues(ListIterate.collect(dataSpace.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("")._tag(context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value)))
+        ));
     }
 }

--- a/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/grammar/to/DataSpaceGrammarComposerExtension.java
+++ b/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/grammar/to/DataSpaceGrammarComposerExtension.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.dsl.dataSpace.grammar.from.DataSpaceParserExtension;
+import org.finos.legend.engine.language.pure.grammar.to.HelperDomainGrammarComposer;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility;
 import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
@@ -65,7 +66,7 @@ public class DataSpaceGrammarComposerExtension implements PureGrammarComposerExt
 
     private static String renderDataSpace(DataSpace dataSpace)
     {
-        return "DataSpace " + PureGrammarComposerUtility.convertPath(dataSpace.getPath()) + "\n" +
+        return "DataSpace " + HelperDomainGrammarComposer.renderAnnotations(dataSpace.stereotypes, dataSpace.taggedValues) + PureGrammarComposerUtility.convertPath(dataSpace.getPath()) + "\n" +
             "{\n" +
             getTabString() + "groupId: " + convertString(dataSpace.groupId, true) + ";\n" +
             getTabString() + "artifactId: " + convertString(dataSpace.artifactId, true) + ";\n" +

--- a/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/dataSpace/DataSpace.java
+++ b/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/dataSpace/DataSpace.java
@@ -16,11 +16,17 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSp
 
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElementVisitor;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.StereotypePtr;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.TaggedValue;
 
+import java.util.Collections;
 import java.util.List;
 
 public class DataSpace extends PackageableElement
 {
+    public List<StereotypePtr> stereotypes = Collections.emptyList();
+    public List<TaggedValue> taggedValues = Collections.emptyList();
+
     public String description;
     public String groupId;
     public String artifactId;

--- a/legend-engine-language-pure-dsl-data-space/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
+++ b/legend-engine-language-pure-dsl-data-space/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
@@ -40,6 +40,32 @@ public class TestDataSpaceCompilationFromGrammar extends TestCompilationFromGram
     }
 
     @Test
+    public void testFaultyAnnotations()
+    {
+        // Faulty stereotype
+        test("###DataSpace\n" +
+            "DataSpace <<NoProfile.NoKey>> model::dataSpace" +
+            "{\n" +
+            "  groupId: 'test.group';\n" +
+            "  artifactId: 'test-data-space';\n" +
+            "  versionId: '1.0.0';\n" +
+            "  mapping: 'model::Mapping';\n" +
+            "  runtime: 'model::Runtime';\n" +
+            "}\n", "COMPILATION error at [2:13-21]: Can't find the profile 'NoProfile'");
+        // Faulty tagged value
+
+        test("###DataSpace\n" +
+            "DataSpace { NoProfile.NoKey = 'something' } model::dataSpace" +
+            "{\n" +
+            "  groupId: 'test.group';\n" +
+            "  artifactId: 'test-data-space';\n" +
+            "  versionId: '1.0.0';\n" +
+            "  mapping: 'model::Mapping';\n" +
+            "  runtime: 'model::Runtime';\n" +
+            "}\n", "COMPILATION error at [2:13-21]: Can't find the profile 'NoProfile'");
+    }
+
+    @Test
     public void testDiagramCompilation()
     {
         test("###DataSpace\n" +

--- a/legend-engine-language-pure-dsl-data-space/src/test/java/org/finos/legend/engine/language/pure/dsl/text/grammar/test/TestDataSpaceGrammarParser.java
+++ b/legend-engine-language-pure-dsl-data-space/src/test/java/org/finos/legend/engine/language/pure/dsl/text/grammar/test/TestDataSpaceGrammarParser.java
@@ -39,8 +39,8 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n";
     }
 
@@ -53,24 +53,24 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "{\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-7:1]: Field 'groupId' is required");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
             "{\n" +
             "  groupId: 'test.group';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-7:1]: Field 'artifactId' is required");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
             "{\n" +
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-7:1]: Field 'versionId' is required");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
@@ -78,7 +78,7 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-7:1]: Field 'mapping' is required");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
@@ -86,7 +86,7 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
+            "  mapping: model::Mapping;\n" +
             "}\n", "PARSER error at [2:1-7:1]: Field 'runtime' is required");
         // Duplicated fields
         test("###DataSpace\n" +
@@ -96,8 +96,8 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-9:1]: Field 'groupId' should be specified only once");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
@@ -106,8 +106,8 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  artifactId: 'test-data-space';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-9:1]: Field 'artifactId' should be specified only once");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
@@ -116,8 +116,8 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-9:1]: Field 'versionId' should be specified only once");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
@@ -125,9 +125,9 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-9:1]: Field 'mapping' should be specified only once");
         test("###DataSpace\n" +
             "DataSpace model::dataSpace" +
@@ -135,9 +135,9 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: 'model::Mapping';\n" +
-            "  runtime: 'model::Runtime';\n" +
-            "  runtime: 'model::Runtime';\n" +
+            "  mapping: model::Mapping;\n" +
+            "  runtime: model::Runtime;\n" +
+            "  runtime: model::Runtime;\n" +
             "}\n", "PARSER error at [2:1-9:1]: Field 'runtime' should be specified only once");
     }
 }

--- a/legend-engine-language-pure-dsl-data-space/src/test/java/org/finos/legend/engine/language/pure/dsl/text/grammar/test/TestDataSpaceGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-data-space/src/test/java/org/finos/legend/engine/language/pure/dsl/text/grammar/test/TestDataSpaceGrammarRoundtrip.java
@@ -23,12 +23,12 @@ public class TestDataSpaceGrammarRoundtrip extends TestGrammarRoundtrip.TestGram
     public void testDataSpace()
     {
         test("###DataSpace\n" +
-            "DataSpace model::dataSpace\n" +
+            "DataSpace <<meta::pure::profiles::typemodifiers.abstract>> {doc.doc = 'bla'} model::dataSpace\n" +
             "{\n" +
             "  groupId: 'test.group';\n" +
             "  artifactId: 'test-data-space';\n" +
             "  versionId: '1.0.0';\n" +
-            "  mapping: model::Mapping;\n" +
+            "  mapping: model::String;\n" +
             "  runtime: model::Runtime;\n" +
             "  description: 'some description';\n" +
             "  diagrams: [\n" +

--- a/legend-engine-language-pure-dsl-service/pom.xml
+++ b/legend-engine-language-pure-dsl-service/pom.xml
@@ -74,80 +74,67 @@
     </build>
 
     <dependencies>
-
         <!-- PURE -->
-
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-mapping</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-code-java-compiled-core</artifactId>
         </dependency>
-
         <!-- PURE -->
 
         <!-- ENGINE -->
-
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-shared-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
         </dependency>
-
         <!-- ENGINE -->
 
         <!-- ANTLR -->
-
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
             <scope>compile</scope>
         </dependency>
-
         <!-- ANTLR -->
 
         <!-- ECLIPSE COLLECTIONS -->
-
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
-
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- For String Manipulation -->
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-
         </dependency>
         <!-- For String Manipulation -->
 
@@ -164,22 +151,18 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
         <!-- TEST -->
-
     </dependencies>
 </project>

--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
@@ -5,6 +5,9 @@ import M3LexerGrammar;
 
 // -------------------------------------- KEYWORD --------------------------------------
 
+STEREOTYPES:                        'stereotypes';
+TAGS:                               'tags';
+
 SERVICE:                            'Service';
 IMPORT:                             'import';
 

--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
@@ -12,6 +12,7 @@ options
 
 identifier:                             VALID_STRING | STRING
                                         | ALL | LET | ALL_VERSIONS | ALL_VERSIONS_IN_RANGE      // from M3Parser
+                                        | STEREOTYPES | TAGS
                                         | SERVICE | IMPORT
                                         | SERVICE_SINGLE | SERVICE_MULTI
                                         | SERVICE_PATTERN | SERVICE_OWNERS | SERVICE_DOCUMENTATION | SERVICE_AUTO_ACTIVATE_UPDATES
@@ -20,7 +21,7 @@ identifier:                             VALID_STRING | STRING
 ;
 
 
-// -------------------------------------- IDENTIFIER --------------------------------------
+// -------------------------------------- DEFINITION --------------------------------------
 
 definition:                             imports
                                             (service)*
@@ -30,7 +31,7 @@ imports:                                (importStatement)*
 ;
 importStatement:                        IMPORT packagePath PATH_SEPARATOR STAR SEMI_COLON
 ;
-service:                                SERVICE qualifiedName
+service:                                SERVICE stereotypes? taggedValues? qualifiedName
                                             BRACE_OPEN
                                                 (
                                                     servicePattern
@@ -41,6 +42,14 @@ service:                                SERVICE qualifiedName
                                                     | serviceTest
                                                 )*
                                             BRACE_CLOSE
+;
+stereotypes:                            LESS_THAN LESS_THAN stereotype (COMMA stereotype)* GREATER_THAN GREATER_THAN
+;
+stereotype:                             qualifiedName DOT identifier
+;
+taggedValues:                           BRACE_OPEN taggedValue (COMMA taggedValue)* BRACE_CLOSE
+;
+taggedValue:                            qualifiedName DOT identifier EQUAL STRING
 ;
 servicePattern:                         SERVICE_PATTERN COLON STRING SEMI_COLON
 ;

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
@@ -15,12 +15,14 @@
 package org.finos.legend.engine.language.pure.dsl.service.compiler.toPureGraph;
 
 import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.PackageableConnection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.PackageableRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_Service;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_Service_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_TaggedValue_Impl;
 
 import java.util.Collections;
 
@@ -38,6 +40,8 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
                     Root_meta_legend_service_metamodel_Service pureService = new Root_meta_legend_service_metamodel_Service_Impl("")
                             ._package(pack)
                             ._name(service.name)
+                            ._stereotypes(ListIterate.collect(service.stereotypes, s -> context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
+                            ._taggedValues(ListIterate.collect(service.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("")._tag(context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value)))
                             ._pattern(service.pattern)
                             ._owners(Lists.mutable.withAll(service.owners))
                             ._documentation(service.documentation);

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.language.pure.dsl.service.grammar.from;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.misc.Interval;
+import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserContext;
@@ -25,6 +26,9 @@ import org.finos.legend.engine.language.pure.grammar.from.domain.DomainParser;
 import org.finos.legend.engine.language.pure.grammar.from.runtime.RuntimeParser;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.StereotypePtr;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.TagPtr;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.TaggedValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.RuntimePointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.ImportAwareCodeSection;
@@ -43,6 +47,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lam
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class ServiceParseTreeWalker
@@ -74,6 +79,9 @@ public class ServiceParseTreeWalker
         service.name = PureGrammarParserUtility.fromIdentifier(ctx.qualifiedName().identifier());
         service._package = ctx.qualifiedName().packagePath() == null ? "" : PureGrammarParserUtility.fromPath(ctx.qualifiedName().packagePath().identifier());
         service.sourceInformation = walkerSourceInformation.getSourceInformation(ctx);
+        service.stereotypes = ctx.stereotypes() == null ? Lists.mutable.empty() : this.visitStereotypes(ctx.stereotypes());
+        service.taggedValues = ctx.taggedValues() == null ? Lists.mutable.empty() : this.visitTaggedValues(ctx.taggedValues());
+
         // pattern
         ServiceParserGrammar.ServicePatternContext patternContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.servicePattern(), "pattern", service.sourceInformation);
         service.pattern = PureGrammarParserUtility.fromGrammarString(patternContext.STRING().getText(), true);
@@ -93,6 +101,36 @@ public class ServiceParseTreeWalker
         ServiceParserGrammar.ServiceTestContext testContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.serviceTest(), "test", service.sourceInformation);
         service.test = this.visitTest(testContext);
         return service;
+    }
+
+    private List<TaggedValue> visitTaggedValues(ServiceParserGrammar.TaggedValuesContext ctx)
+    {
+        return ListIterate.collect(ctx.taggedValue(), taggedValueContext ->
+        {
+            TaggedValue taggedValue = new TaggedValue();
+            TagPtr tagPtr = new TagPtr();
+            taggedValue.tag = tagPtr;
+            tagPtr.profile = PureGrammarParserUtility.fromQualifiedName(taggedValueContext.qualifiedName().packagePath() == null ? Collections.emptyList() : taggedValueContext.qualifiedName().packagePath().identifier(), taggedValueContext.qualifiedName().identifier());
+            tagPtr.value = PureGrammarParserUtility.fromIdentifier(taggedValueContext.identifier());
+            taggedValue.value = PureGrammarParserUtility.fromGrammarString(taggedValueContext.STRING().getText(), true);
+            taggedValue.tag.profileSourceInformation = this.walkerSourceInformation.getSourceInformation(taggedValueContext.qualifiedName());
+            taggedValue.tag.sourceInformation = this.walkerSourceInformation.getSourceInformation(taggedValueContext.identifier());
+            taggedValue.sourceInformation = this.walkerSourceInformation.getSourceInformation(taggedValueContext);
+            return taggedValue;
+        });
+    }
+
+    private List<StereotypePtr> visitStereotypes(ServiceParserGrammar.StereotypesContext ctx)
+    {
+        return ListIterate.collect(ctx.stereotype(), stereotypeContext ->
+        {
+            StereotypePtr stereotypePtr = new StereotypePtr();
+            stereotypePtr.profile = PureGrammarParserUtility.fromQualifiedName(stereotypeContext.qualifiedName().packagePath() == null ? Collections.emptyList() : stereotypeContext.qualifiedName().packagePath().identifier(), stereotypeContext.qualifiedName().identifier());
+            stereotypePtr.value = PureGrammarParserUtility.fromIdentifier(stereotypeContext.identifier());
+            stereotypePtr.profileSourceInformation = this.walkerSourceInformation.getSourceInformation(stereotypeContext.qualifiedName());
+            stereotypePtr.sourceInformation = this.walkerSourceInformation.getSourceInformation(stereotypeContext);
+            return stereotypePtr;
+        });
     }
 
     private Execution visitExecution(ServiceParserGrammar.ServiceExecContext ctx)

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/ServiceGrammarComposerExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/ServiceGrammarComposerExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.dsl.service.grammar.from.ServiceParserExtension;
+import org.finos.legend.engine.language.pure.grammar.to.HelperDomainGrammarComposer;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility;
 import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
@@ -65,7 +66,7 @@ public class ServiceGrammarComposerExtension implements PureGrammarComposerExten
 
     private static String renderService(Service service, PureGrammarComposerContext context)
     {
-        StringBuilder serviceBuilder = new StringBuilder().append("Service").append(" ").append(PureGrammarComposerUtility.convertPath(service.getPath()));
+        StringBuilder serviceBuilder = new StringBuilder().append("Service").append(" ").append(HelperDomainGrammarComposer.renderAnnotations(service.stereotypes, service.taggedValues)).append(PureGrammarComposerUtility.convertPath(service.getPath()));
         serviceBuilder.append("\n{\n");
         serviceBuilder.append(getTabString()).append("pattern: ").append(convertString(service.pattern, true)).append(";\n");
         if (!service.owners.isEmpty())

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/service/Service.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/service/Service.java
@@ -17,12 +17,18 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.servic
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElementVisitor;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.StereotypePtr;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.TaggedValue;
 
+import java.util.Collections;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Service extends PackageableElement
 {
+    public List<StereotypePtr> stereotypes = Collections.emptyList();
+    public List<TaggedValue> taggedValues = Collections.emptyList();
+
     public String pattern;
     public List<String> owners;
     public String documentation;

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
@@ -57,6 +57,66 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
     }
 
     @Test
+    public void testFaultyAnnotations()
+    {
+        // Faulty stereotype
+        test("###Mapping\n" +
+            "Mapping anything::somethingelse ()\n" +
+            "###Service\n" +
+            "Service <<NoProfile.NoKey>> anything::class\n" +
+            "{\n" +
+            "  pattern: 'url/myUrl/';\n" +
+            "  owners: ['test'];\n" +
+            "  documentation: 'test';\n" +
+            "  autoActivateUpdates: true;\n" +
+            "  execution: Single\n" +
+            "  {\n" +
+            "    query: '';\n" +
+            "    mapping: anything::somethingelse;\n" +
+            "    runtime:\n" +
+            "    #{\n" +
+            "     connections: [];\n" +
+            "    }#;\n" +
+            "  }\n" +
+            "  test: Single\n" +
+            "  {\n" +
+            "    data: 'moreThanData';\n" +
+            "    asserts:\n" +
+            "    [\n" +
+            "    ];\n" +
+            "  }\n" +
+            "}\n", "COMPILATION error at [4:11-19]: Can't find the profile 'NoProfile'");
+        // Faulty tagged value
+
+        test("###Mapping\n" +
+            "Mapping anything::somethingelse ()\n" +
+            "###Service\n" +
+            "Service { NoProfile.NoKey = 'something' } anything::class\n" +
+            "{\n" +
+            "  pattern: 'url/myUrl/';\n" +
+            "  owners: ['test'];\n" +
+            "  documentation: 'test';\n" +
+            "  autoActivateUpdates: true;\n" +
+            "  execution: Single\n" +
+            "  {\n" +
+            "    query: '';\n" +
+            "    mapping: anything::somethingelse;\n" +
+            "    runtime:\n" +
+            "    #{\n" +
+            "     connections: [];\n" +
+            "    }#;\n" +
+            "  }\n" +
+            "  test: Single\n" +
+            "  {\n" +
+            "    data: 'moreThanData';\n" +
+            "    asserts:\n" +
+            "    [\n" +
+            "    ];\n" +
+            "  }\n" +
+            "}\n", "COMPILATION error at [4:11-19]: Can't find the profile 'NoProfile'");
+    }
+
+    @Test
     public void testServiceWithSingleExecution()
     {
         String resource = "Class test::class\n" +

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
@@ -22,7 +22,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     public void testService()
     {
         test("###Service\n" +
-                "Service meta::pure::myServiceSingle\n" +
+                "Service <<meta::pure::profiles::typemodifiers.abstract>> {doc.doc = 'something'} meta::pure::myServiceSingle\n" +
                 "{\n" +
                 "  pattern: 'url/myUrl/';\n" +
                 "  owners:\n" +

--- a/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainParserGrammar.g4
+++ b/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainParserGrammar.g4
@@ -14,7 +14,8 @@ identifier:                                     VALID_STRING | STRING
                                                 | ALL | LET | ALL_VERSIONS | ALL_VERSIONS_IN_RANGE      // from M3Parser
                                                 | IMPORT
                                                 | CLASS | FUNCTION | PROFILE | ASSOCIATION | ENUM | MEASURE
-                                                | EXTENDS | STEREOTYPES | TAGS
+                                                | EXTENDS
+                                                | STEREOTYPES | TAGS
                                                 | NATIVE | PROJECTS | AS
                                                 | CONSTRAINT_ENFORCEMENT_LEVEL_ERROR | CONSTRAINT_ENFORCEMENT_LEVEL_WARN
                                                 | AGGREGATION_TYPE_COMPOSITE | AGGREGATION_TYPE_SHARED | AGGREGATION_TYPE_NONE
@@ -41,6 +42,18 @@ elementDefinition:                              (
                                                     | instance
                                                     | measureDefinition
                                                 )
+;
+
+
+// -------------------------------------- SHARED --------------------------------------
+
+stereotypes:                                    LESS_THAN LESS_THAN stereotype (COMMA stereotype)* GREATER_THAN GREATER_THAN
+;
+stereotype:                                     qualifiedName DOT identifier
+;
+taggedValues:                                   BRACE_OPEN taggedValue (COMMA taggedValue)* BRACE_CLOSE
+;
+taggedValue:                                    qualifiedName DOT identifier EQUAL STRING
 ;
 
 
@@ -107,14 +120,6 @@ profile:                                        PROFILE qualifiedName
 stereotypeDefinitions:                          (STEREOTYPES COLON BRACKET_OPEN (identifier (COMMA identifier)*)? BRACKET_CLOSE SEMI_COLON)
 ;
 tagDefinitions:                                 (TAGS COLON BRACKET_OPEN (identifier (COMMA identifier)*)? BRACKET_CLOSE SEMI_COLON)
-;
-stereotypes:                                    LESS_THAN LESS_THAN stereotype (COMMA stereotype)* GREATER_THAN GREATER_THAN
-;
-stereotype:                                     qualifiedName DOT identifier
-;
-taggedValues:                                   BRACE_OPEN taggedValue (COMMA taggedValue)* BRACE_CLOSE
-;
-taggedValue:                                    qualifiedName DOT identifier EQUAL STRING
 ;
 
 

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -22,7 +22,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     @Test
     public void testClass()
     {
-        test("Class <<temporal.businesstemporal>> {doc.doc = 'bla'} A extends B\n" +
+        test("Class <<temporal.businesstemporal>> {doc.doc = 'something'} A extends B\n" +
                 "{\n" +
                 "  <<equality.Key>> {doc.doc = 'bla'} name: e::R[*];\n" +
                 "  {doc.doc = 'bla'} ok: Integer[1..2];\n" +


### PR DESCRIPTION
- [x] Fix a small issue with Query API not splitting the maven coordinate properly due to wrong delimiter usage
- [x] Add support for tagged values and stereotypes in Service and DataSpace (related to https://github.com/finos/legend-studio/issues/448): this will facilitate a lot more new features and extend the capabilities of these models (we're thinking about a bigger move towards supporting annotations in **all** packageable element types, but this is the first step.