### PR TITLE
Enable ErrorProne analysis tool and fix initial set of build errors

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/blockConnection/BlockConnection.java
+++ b/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/blockConnection/BlockConnection.java
@@ -229,7 +229,7 @@ public class BlockConnection implements Connection
     @Override
     public int getHoldability() throws SQLException
     {
-        return this.getHoldability();
+        return this.conn.getHoldability();
     }
 
     @Override
@@ -349,7 +349,7 @@ public class BlockConnection implements Connection
     @Override
     public Array createArrayOf(String typeName, Object[] elements) throws SQLException
     {
-        return this.createArrayOf(typeName, elements);
+        return this.conn.createArrayOf(typeName, elements);
     }
 
     @Override

--- a/legend-engine-shared-core/src/test/java/org/finos/legend/engine/shared/core/util/test/TestLimitedByteArrayOutputStream.java
+++ b/legend-engine-shared-core/src/test/java/org/finos/legend/engine/shared/core/util/test/TestLimitedByteArrayOutputStream.java
@@ -18,13 +18,15 @@ import org.finos.legend.engine.shared.core.util.LimitedByteArrayOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 public class TestLimitedByteArrayOutputStream
 {
     @Test
     public void belowLimit()
     {
         LimitedByteArrayOutputStream stream = new LimitedByteArrayOutputStream(10);
-        stream.write("abcdefg".getBytes(), 0, 7);
+        stream.write("abcdefg".getBytes(StandardCharsets.UTF_8), 0, 7);
         Assert.assertEquals("abcdefg", stream.toString());
     }
 
@@ -32,7 +34,7 @@ public class TestLimitedByteArrayOutputStream
     public void atLimit()
     {
         LimitedByteArrayOutputStream stream = new LimitedByteArrayOutputStream(10);
-        stream.write("abcdefghij".getBytes(), 0, 10);
+        stream.write("abcdefghij".getBytes(StandardCharsets.UTF_8), 0, 10);
         Assert.assertEquals("abcdefghij", stream.toString());
     }
 
@@ -40,7 +42,7 @@ public class TestLimitedByteArrayOutputStream
     public void beyondLimit()
     {
         LimitedByteArrayOutputStream stream = new LimitedByteArrayOutputStream(10);
-        stream.write("abcdefghijklmnopq".getBytes(), 0, 17);
+        stream.write("abcdefghijklmnopq".getBytes(StandardCharsets.UTF_8), 0, 17);
         Assert.assertEquals("abcdefghij...", stream.toString());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                  <source>11</source>
+                  <target>8</target>
+                  <encoding>UTF-8</encoding>
+                  <compilerArgs>
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>-Xplugin:ErrorProne -Xep:NullTernary:WARN -Xep:DefaultCharset:ERROR</arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                   <path>
+                     <groupId>com.google.errorprone</groupId>
+                     <artifactId>error_prone_core</artifactId>
+                     <version>2.9.0</version>
+                   </path>
+                  </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This enables the [ErrorProne](https://errorprone.info) analysis tool to catch common mistakes. 
In particular, the initial configuration here sets the DefaultCharSet analysis (https://errorprone.info/bugpattern/DefaultCharset) to throw an error and fail the build if the default charset is implicitly used (for example this fix is related https://github.com/finos/legend-engine/pull/396).

In this case, using ErrorProne we fail the build rather than allow the implicit use of default charset to propagate and cause issues in downstream projects. 

I have tuned the settings to allow [NullTernary](https://errorprone.info/bugpattern/NullTernary) analysis to not block the builds, as the FlatData code generation uses null ternary expressions in it's implementation.

We could finetune and switch off some warnings, in particular [MissingOverride](https://errorprone.info/bugpattern/MissingOverride) throws a lot of warnings in the generated Java code. 

