### PR TITLE
Ensure processor extensions don't do package adding twice

### DIFF
--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/BindingCompiler.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/BindingCompiler.java
@@ -60,11 +60,8 @@ public class BindingCompiler
     // First pass - create and index schemas
     private PackageableElement firstPass(Binding srcSchemaOp, CompileContext context)
     {
-        org.finos.legend.pure.m3.coreinstance.Package pack = context.pureModel.getOrCreatePackage(srcSchemaOp._package);
-
         Root_meta_external_shared_format_binding_Binding binding = new Root_meta_external_shared_format_binding_Binding_Impl(srcSchemaOp.name)
                 ._name(srcSchemaOp.name)
-                ._package(pack)
                 ._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("")._rawType(context.pureModel.getType("meta::external::shared::format::binding::Binding")));
 
         String path = context.pureModel.buildPackageString(srcSchemaOp._package, srcSchemaOp.name);

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ExternalFormatConnectionCompilerExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ExternalFormatConnectionCompilerExtension.java
@@ -30,10 +30,9 @@ import org.finos.legend.pure.generated.Root_meta_external_shared_format_executio
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_ExternalFormatConnection_Impl;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_ExternalSource;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_UrlStreamExternalSource_Impl;
-import org.finos.legend.pure.generated.Root_meta_pure_mapping_modelToModel_ModelStore_Impl;
-import org.finos.legend.pure.generated.Root_meta_relational_metamodel_Database_Impl;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 
+import java.util.Collections;
 import java.util.List;
 
 public class ExternalFormatConnectionCompilerExtension implements IExternalFormatCompilerExtension
@@ -48,7 +47,7 @@ public class ExternalFormatConnectionCompilerExtension implements IExternalForma
     @Override
     public List<Function2<Connection, CompileContext, org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Connection>> getExtraConnectionValueProcessors()
     {
-        return Lists.mutable.with(
+        return Collections.singletonList(
                 (connectionValue, context) ->
                 {
                     if (connectionValue instanceof ExternalFormatConnection)
@@ -63,7 +62,7 @@ public class ExternalFormatConnectionCompilerExtension implements IExternalForma
     @Override
     public List<Procedure3<Connection, org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Connection, CompileContext>> getExtraConnectionSecondPassProcessors()
     {
-        return Lists.mutable.with(
+        return Collections.singletonList(
                 (connectionValue, pureConnection, context) ->
                 {
                     if (connectionValue instanceof ExternalFormatConnection)
@@ -93,7 +92,8 @@ public class ExternalFormatConnectionCompilerExtension implements IExternalForma
     @Override
     public List<Function2<ExternalSource, CompileContext, Root_meta_external_shared_format_executionPlan_ExternalSource>> getExtraExternalSourceSpecificationProcessors()
     {
-        return Lists.mutable.with((spec, context) -> {
+        return Collections.singletonList((spec, context) ->
+        {
             if (spec instanceof UrlStreamExternalSource)
             {
                 UrlStreamExternalSource urlStreamExternalSource = (UrlStreamExternalSource) spec;

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SchemaSetCompiler.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SchemaSetCompiler.java
@@ -21,10 +21,7 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.engine.external.shared.format.model.ExternalFormatExtension;
 import org.finos.legend.engine.external.shared.format.model.ExternalSchemaCompileContext;
 import org.finos.legend.engine.external.shared.format.model.compile.ExternalFormatSchemaException;
-import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
-import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
-import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalFormatSchema;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalFormatSchemaSet;
@@ -69,10 +66,8 @@ public class SchemaSetCompiler
             throw new EngineException("Unknown schema format: " + srcSchemaSet.format, srcSchemaSet.formatSourceInformation, EngineErrorType.COMPILATION);
         }
 
-        org.finos.legend.pure.m3.coreinstance.Package pack = context.pureModel.getOrCreatePackage(srcSchemaSet._package);
         Root_meta_external_shared_format_metamodel_SchemaSet schemaSet = new Root_meta_external_shared_format_metamodel_SchemaSet_Impl(srcSchemaSet.name)
                 ._name(srcSchemaSet.name)
-                ._package(pack)
                 ._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("")._rawType(context.pureModel.getType("meta::external::shared::format::metamodel::SchemaSet")))
                 ._format(srcSchemaSet.format);
 

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtension.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtension.java
@@ -20,7 +20,6 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
-import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
@@ -31,6 +30,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.Funct
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.FunctionHandlerRegistrationInfo;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.Handlers;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.AssociationMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
@@ -40,14 +40,12 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSp
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.executionContext.ExecutionContext;
 import org.finos.legend.engine.shared.core.function.Function4;
 import org.finos.legend.engine.shared.core.function.Procedure3;
-import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
 import org.finos.legend.pure.generated.Root_meta_pure_executionPlan_ExecutionOption;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.AssociationImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EmbeddedSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Connection;
 
 import java.util.Collections;

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/Processor.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/Processor.java
@@ -15,7 +15,9 @@
 package org.finos.legend.engine.language.pure.compiler.toPureGraph.extension;
 
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.m3.coreinstance.Package;
 
 import java.util.Collection;
@@ -36,7 +38,13 @@ public abstract class Processor<T extends PackageableElement>
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pureElement = processElementFirstPass(castElement(element), context);
         pureElement._name(element.name);
+
         Package pack = context.pureModel.getOrCreatePackage(element._package);
+        if (pack._children().anySatisfy(c -> element.name.equals(c._name())))
+        {
+            throw new EngineException("An element named '" + element.name + "' already exists in the package '" + element._package + "'", element.sourceInformation, EngineErrorType.COMPILATION);
+        }
+
         pureElement._package(pack);
         pack._childrenAdd(pureElement);
         return pureElement;

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
@@ -33,23 +33,17 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
     {
         return Collections.singletonList(Processor.newProcessor(
                 Service.class,
-                Lists.mutable.of(PackageableConnection.class, PackageableRuntime.class),
-                (service, context) -> 
+                Lists.fixedSize.with(PackageableConnection.class, PackageableRuntime.class),
+                (service, context) -> new Root_meta_legend_service_metamodel_Service_Impl("")
+                        ._name(service.name)
+                        ._stereotypes(ListIterate.collect(service.stereotypes, s -> context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
+                        ._taggedValues(ListIterate.collect(service.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("")._tag(context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value)))
+                        ._pattern(service.pattern)
+                        ._owners(Lists.mutable.withAll(service.owners))
+                        ._documentation(service.documentation),
+                (service, context) ->
                 {
-                    org.finos.legend.pure.m3.coreinstance.Package pack = context.pureModel.getOrCreatePackage(service._package);
-                    Root_meta_legend_service_metamodel_Service pureService = new Root_meta_legend_service_metamodel_Service_Impl("")
-                            ._package(pack)
-                            ._name(service.name)
-                            ._stereotypes(ListIterate.collect(service.stereotypes, s -> context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
-                            ._taggedValues(ListIterate.collect(service.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("")._tag(context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value)))
-                            ._pattern(service.pattern)
-                            ._owners(Lists.mutable.withAll(service.owners))
-                            ._documentation(service.documentation);
-                    pack._childrenAdd(pureService);
-                    return pureService;
-                }, 
-                (service, context) -> {
-                    Root_meta_legend_service_metamodel_Service pureService = (Root_meta_legend_service_metamodel_Service)context.pureModel.getOrCreatePackage(service._package)._children().detect(c -> c._name().equals(service.name));
+                    Root_meta_legend_service_metamodel_Service pureService = (Root_meta_legend_service_metamodel_Service) context.pureModel.getOrCreatePackage(service._package)._children().detect(c -> service.name.equals(c._name()));
                     pureService._execution(HelperServiceBuilder.processServiceExecution(service.execution, context))
                             ._test(HelperServiceBuilder.processServiceTest(service.test, context, service.execution));
                 }));

--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
@@ -18,16 +18,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.finos.legend.engine.language.pure.compiler.toPureGraph.PackageableElementFirstPassBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.dsl.service.generation.ServicePlanGenerator;
+import org.finos.legend.engine.language.pure.dsl.service.generation.extension.ServiceExecutionExtension;
 import org.finos.legend.engine.language.pure.grammar.to.DEPRECATED_PureGrammarComposerCore;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.execution.nodes.helpers.ExecutionNodeTDSResultHelper;
@@ -50,7 +49,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.LegacyRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Execution;
-import org.finos.legend.engine.language.pure.dsl.service.generation.extension.ServiceExecutionExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedSingleExecutionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.MultiExecutionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureExecution;
@@ -68,12 +66,14 @@ import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.shared.javaCompiler.EngineJavaCompiler;
 import org.finos.legend.engine.shared.javaCompiler.JavaCompileException;
 import org.finos.legend.engine.shared.javaCompiler.StringJavaSource;
+import org.finos.legend.engine.test.runner.shared.TestResult;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_Service;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_SingleExecutionTest;
 import org.finos.legend.pure.generated.Root_meta_pure_router_extension_RouterExtension;
 import org.finos.legend.pure.generated.core_relational_relational_helperFunctions_helperFunctions;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -87,45 +87,52 @@ import java.util.ServiceLoader;
 
 public class ServiceTestRunner
 {
-    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger("Legend Execution Server: Service Test Runner");
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTestRunner.class);
 
-    private final Pair<Service, Root_meta_legend_service_metamodel_Service> pureServicePairs;
-    private final Pair<PureModelContextData, PureModel> pureModelPairs;
+    private final Service service;
+    private final Root_meta_legend_service_metamodel_Service pureService;
+    private final PureModelContextData pureModelContextData;
+    private final PureModel pureModel;
     private final ObjectMapper objectMapper;
     private final PlanExecutor executor;
     private final RichIterable<? extends Root_meta_pure_router_extension_RouterExtension> extensions;
     private final MutableList<PlanTransformer> transformers;
     private final String pureVersion;
 
-    public ServiceTestRunner(Pair<Service, Root_meta_legend_service_metamodel_Service> pureServicePairs, Pair<PureModelContextData, PureModel> pureModelPairs, ObjectMapper objectMapper, PlanExecutor executor, RichIterable<? extends Root_meta_pure_router_extension_RouterExtension> extensions, MutableList<PlanTransformer> transformers, String pureVersion)
+    public ServiceTestRunner(Service service, Root_meta_legend_service_metamodel_Service pureService, PureModelContextData pureModelContextData, PureModel pureModel, ObjectMapper objectMapper, PlanExecutor executor, RichIterable<? extends Root_meta_pure_router_extension_RouterExtension> extensions, MutableList<PlanTransformer> transformers, String pureVersion)
     {
-        this.pureServicePairs = pureServicePairs;
-        this.pureModelPairs = pureModelPairs;
-        this.objectMapper = objectMapper;
+        this.service = service;
+        this.pureService = (pureService == null) ? findPureService(service, pureModel) : pureService;
+        this.pureModelContextData = pureModelContextData;
+        this.pureModel = pureModel;
+        this.objectMapper = (objectMapper == null) ? ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports() : objectMapper;
         this.executor = executor;
         this.extensions = extensions;
         this.transformers = transformers;
         this.pureVersion = pureVersion;
     }
 
+    @Deprecated
+    public ServiceTestRunner(Pair<Service, Root_meta_legend_service_metamodel_Service> pureServicePairs, Pair<PureModelContextData, PureModel> pureModelPairs, ObjectMapper objectMapper, PlanExecutor executor, RichIterable<? extends Root_meta_pure_router_extension_RouterExtension> extensions, MutableList<PlanTransformer> transformers, String pureVersion)
+    {
+        this(pureServicePairs.getOne(), pureServicePairs.getTwo(), pureModelPairs.getOne(), pureModelPairs.getTwo(), objectMapper, executor, extensions, transformers, pureVersion);
+    }
+
+    @Deprecated
     public ServiceTestRunner(Service service, Pair<PureModelContextData, PureModel> pureModelPairs, PlanExecutor executor, RichIterable<? extends Root_meta_pure_router_extension_RouterExtension> extensions, MutableList<PlanTransformer> transformers, String pureVersion)
     {
-        this(Tuples.pair(service,(Root_meta_legend_service_metamodel_Service) service.accept(new PackageableElementFirstPassBuilder(pureModelPairs.getTwo().getContext(service)))), pureModelPairs, ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports(), executor, extensions, transformers, pureVersion);
+        this(service, null, pureModelPairs.getOne(), pureModelPairs.getTwo(), null, executor, extensions, transformers, pureVersion);
     }
 
     public List<RichServiceTestResult> executeTests() throws IOException, JavaCompileException
     {
-        Service service = pureServicePairs.getOne();
-        Root_meta_legend_service_metamodel_Service pureService = pureServicePairs.getTwo();
-        PureModelContextData pureModelContextData = pureModelPairs.getOne();
-        PureModel pureModel = pureModelPairs.getTwo();
-        Execution serviceExecution = service.execution;
+        Execution serviceExecution = this.service.execution;
         if (serviceExecution instanceof PureMultiExecution)
         {
-            List<RichServiceTestResult> results = org.eclipse.collections.api.factory.Lists.mutable.empty();
+            List<RichServiceTestResult> results = Lists.mutable.empty();
             try (Scope scope = GlobalTracer.get().buildSpan("Generate Tests And Run For MultiExecution Service").startActive(true))
             {
-                Map<String, Runtime> runtimeMap = ServiceTestGenerationHelper.buildMultiExecutionTestRuntime((PureMultiExecution)serviceExecution, (MultiExecutionTest) service.test, pureModelContextData, pureModel);
+                Map<String, Runtime> runtimeMap = ServiceTestGenerationHelper.buildMultiExecutionTestRuntime((PureMultiExecution) serviceExecution, (MultiExecutionTest) this.service.test, this.pureModelContextData, this.pureModel);
                 Map<String, MutableList<String>> sqlStatementsByKey = Maps.mutable.empty();
                 runtimeMap.forEach((key, runtime) ->
                 {
@@ -135,14 +142,14 @@ public class ServiceTestRunner
                         sqlStatementsByKey.put(key, sql);
                     }
                 });
-                CompositeExecutionPlan compositeExecutionPlan = ServiceTestGenerationHelper.buildCompositeExecutionTestPlan(service, runtimeMap, pureModel, pureVersion, PlanPlatform.JAVA, extensions, transformers);
+                CompositeExecutionPlan compositeExecutionPlan = ServiceTestGenerationHelper.buildCompositeExecutionTestPlan(this.service, runtimeMap, this.pureModel, this.pureVersion, PlanPlatform.JAVA, this.extensions, this.transformers);
                 Map<String, SingleExecutionPlan> plansByKey = compositeExecutionPlan.executionPlans;
                 for (SingleExecutionPlan plan : plansByKey.values())
                 {
                     JavaHelper.compilePlan(plan, null);
                 }
 
-                for (KeyedSingleExecutionTest es : ((MultiExecutionTest) service.test).tests)
+                for (KeyedSingleExecutionTest es : ((MultiExecutionTest) this.service.test).tests)
                 {
                     SingleExecutionPlan executionPlan = plansByKey.get(es.key);
                     List<TestContainer> asserts = es.asserts;
@@ -158,27 +165,28 @@ public class ServiceTestRunner
         {
             try (Scope scope = GlobalTracer.get().buildSpan("Generate Single Pure Tests And Run").startActive(true))
             {
-                PureSingleExecution pureSingleExecution = (PureSingleExecution) service.execution;
-                Runtime testRuntime = ServiceTestGenerationHelper.buildSingleExecutionTestRuntime((PureSingleExecution) service.execution, (SingleExecutionTest) service.test, pureModelContextData, pureModel);
+                PureSingleExecution pureSingleExecution = (PureSingleExecution) this.service.execution;
+                Runtime testRuntime = ServiceTestGenerationHelper.buildSingleExecutionTestRuntime((PureSingleExecution) this.service.execution, (SingleExecutionTest) this.service.test, this.pureModelContextData, this.pureModel);
                 RichIterable<? extends String> sqlStatements = extractSetUpSQLFromTestRuntime(testRuntime);
                 PureSingleExecution testPureSingleExecution = shallowCopySingleExecution(pureSingleExecution);
                 testPureSingleExecution.runtime = testRuntime;
-                ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(testPureSingleExecution, null, pureModel, pureVersion, PlanPlatform.JAVA, null, extensions, transformers);
+                ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(testPureSingleExecution, null, this.pureModel, this.pureVersion, PlanPlatform.JAVA, null, this.extensions, this.transformers);
                 SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
                 JavaHelper.compilePlan(singleExecutionPlan, null);
-                List<TestContainer> asserts = ((SingleExecutionTest) service.test).asserts;
+                List<TestContainer> asserts = ((SingleExecutionTest) this.service.test).asserts;
                 return Collections.singletonList(executeTestAsserts(singleExecutionPlan, asserts, sqlStatements, scope));
             }
         }
-        else {
+        else
+        {
             try (Scope scope = GlobalTracer.get().buildSpan("Generate Extra Service Execution Tests and Run").startActive(true))
             {
-                MutableList<ServiceExecutionExtension> serviceExecutionExtensions = org.eclipse.collections.api.factory.Lists.mutable.withAll(ServiceLoader.load(ServiceExecutionExtension.class));
-                Pair<ExecutionPlan, RichIterable<? extends  String>> testExecutor = getExtraServiceExecutionPlan(serviceExecutionExtensions, serviceExecution, ((Root_meta_legend_service_metamodel_SingleExecutionTest) pureService._test())._data());
+                MutableList<ServiceExecutionExtension> serviceExecutionExtensions = Lists.mutable.withAll(ServiceLoader.load(ServiceExecutionExtension.class));
+                Pair<ExecutionPlan, RichIterable<? extends String>> testExecutor = getExtraServiceExecutionPlan(serviceExecutionExtensions, serviceExecution, ((Root_meta_legend_service_metamodel_SingleExecutionTest) this.pureService._test())._data());
                 ExecutionPlan executionPlan = testExecutor.getOne();
                 Assert.assertTrue(executionPlan instanceof SingleExecutionPlan, () -> "Only Single Execution Plan supported");
                 List<TestContainer> containers = getExtraServiceTestContainers(serviceExecutionExtensions, service.test);
-                return Collections.singletonList(executeTestAsserts((SingleExecutionPlan)executionPlan, containers, testExecutor.getTwo(), scope));
+                return Collections.singletonList(executeTestAsserts((SingleExecutionPlan) executionPlan, containers, testExecutor.getTwo(), scope));
             }
         }
     }
@@ -186,7 +194,7 @@ public class ServiceTestRunner
     private Pair<ExecutionPlan, RichIterable<? extends String>> getExtraServiceExecutionPlan(MutableList<ServiceExecutionExtension> extensions, Execution execution, String testData)
     {
         return extensions
-                .collect(f -> f.tryToBuildTestExecutorContext(execution, testData, this.objectMapper, this.pureModelPairs.getTwo(), this.extensions, this.transformers, this.pureVersion))
+                .collect(f -> f.tryToBuildTestExecutorContext(execution, testData, this.objectMapper, this.pureModel, this.extensions, this.transformers, this.pureVersion))
                 .select(Objects::nonNull)
                 .select(Optional::isPresent)
                 .collect(Optional::get)
@@ -197,7 +205,7 @@ public class ServiceTestRunner
     private List<TestContainer> getExtraServiceTestContainers(MutableList<ServiceExecutionExtension> extensions, ServiceTest test)
     {
         return extensions
-                .collect(f -> f.tryToBuildTestAsserts(test, this.objectMapper, this.pureModelPairs.getTwo()))
+                .collect(f -> f.tryToBuildTestAsserts(test, this.objectMapper, this.pureModel))
                 .select(Objects::nonNull)
                 .select(Optional::isPresent)
                 .collect(Optional::get)
@@ -216,14 +224,12 @@ public class ServiceTestRunner
 
     private RichServiceTestResult executeTestAsserts(SingleExecutionPlan executionPlan, List<TestContainer> asserts, RichIterable<? extends String> sqlStatements, Scope scope) throws IOException
     {
-        if (ExecutionNodeTDSResultHelper.isResultTDS(executionPlan.rootExecutionNode) || (executionPlan.rootExecutionNode.isResultPrimitiveType() && executionPlan.rootExecutionNode.getDataTypeResultType().equals("String")))
+        if (ExecutionNodeTDSResultHelper.isResultTDS(executionPlan.rootExecutionNode) || (executionPlan.rootExecutionNode.isResultPrimitiveType() && "String".equals(executionPlan.rootExecutionNode.getDataTypeResultType())))
         {
             // Java
             String packageName = "org.finos.legend.tests.generated";
             String className = "TestSuite";
-            Service service = pureServicePairs.getOne();
-            PureModel pureModel = pureModelPairs.getTwo();
-            String javaCode = ServiceTestGenerationHelper.generateJavaForAsserts(asserts, service, pureModel, packageName, className);
+            String javaCode = ServiceTestGenerationHelper.generateJavaForAsserts(asserts, this.service, this.pureModel, packageName, className);
             Class<?> assertsClass;
             RichServiceTestResult testRun;
             try
@@ -232,7 +238,7 @@ public class ServiceTestRunner
             }
             catch (JavaCompileException e)
             {
-                throw new RuntimeException("Error compiling test asserts for " + service.getPath(), e);
+                throw new RuntimeException("Error compiling test asserts for " + this.service.getPath(), e);
             }
 
             scope.span().log("Java asserts generated and compiled");
@@ -247,15 +253,15 @@ public class ServiceTestRunner
                 }
 
                 // Run tests
-                Map<String, org.finos.legend.engine.test.runner.shared.TestResult> results = org.eclipse.collections.api.factory.Maps.mutable.empty();
-                Map<String, Exception> assertExceptions = org.eclipse.collections.api.factory.Maps.mutable.empty();
+                Map<String, TestResult> results = Maps.mutable.empty();
+                Map<String, Exception> assertExceptions = Maps.mutable.empty();
                 for (Pair<TestContainer, Integer> tc : LazyIterate.zipWithIndex(asserts))
                 {
                     // Build Param Map
-                    Map<String, Result>  parameters = Maps.mutable.empty();
-                    if (service.execution instanceof PureExecution)
+                    Map<String, Result> parameters = Maps.mutable.empty();
+                    if (this.service.execution instanceof PureExecution)
                     {
-                        parameters = ListIterate.zip(((PureExecution) service.execution).func.parameters, tc.getOne().parametersValues).toMap(
+                        parameters = ListIterate.zip(((PureExecution) this.service.execution).func.parameters, tc.getOne().parametersValues).toMap(
                                 p -> p.getOne().name,
                                 p -> new ConstantResult(p.getTwo() instanceof PureList
                                         ? ListIterate.collect(((PureList) p.getTwo()).values, v -> v.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withValueSpecificationAsExternalParameter().build()))
@@ -267,18 +273,18 @@ public class ServiceTestRunner
                             Lists.mutable.withAll(executionPlan.templateFunctions),
                             Lists.mutable.with(new RelationalStoreExecutionState(new RelationalStoreState(execScope == null ? -1 : execScope.getPort())), new InMemoryStoreExecutionState(new InMemoryStoreState()))
                     );
-                    Result result = executor.execute(executionPlan, testExecutionState, null, null);
+                    Result result = this.executor.execute(executionPlan, testExecutionState, null, null);
 
                     org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Result<Object> pureResult = result.accept(new ResultToPureResultVisitor());
 
                     // Execute Assert
                     String testName = ServiceTestGenerationHelper.getAssertMethodName(tc.getTwo());
-                    scope.span().setTag(testName, resultToString(pureResult, pureModel.getExecutionSupport()));
-                    org.finos.legend.engine.test.runner.shared.TestResult testResult;
+                    scope.span().setTag(testName, resultToString(pureResult, this.pureModel.getExecutionSupport()));
+                    TestResult testResult;
                     try
                     {
                         Boolean assertResult = (Boolean) assertsClass.getMethod(testName, org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Result.class, ExecutionSupport.class).invoke(null, pureResult, pureModel.getExecutionSupport());
-                        testResult = assertResult ? org.finos.legend.engine.test.runner.shared.TestResult.SUCCESS : org.finos.legend.engine.test.runner.shared.TestResult.FAILURE;
+                        testResult = assertResult ? TestResult.SUCCESS : TestResult.FAILURE;
                         scope.span().setTag(testName + "_assert", assertResult);
                     }
                     catch (Exception e)
@@ -287,7 +293,7 @@ public class ServiceTestRunner
                         PrintWriter writer = new PrintWriter(out);
                         e.printStackTrace(writer);
                         e.printStackTrace();
-                        testResult = org.finos.legend.engine.test.runner.shared.TestResult.ERROR;
+                        testResult = TestResult.ERROR;
                         assertExceptions.put(testName, e);
                         scope.span().setTag(testName + "_assert", out.toString());
                     }
@@ -300,7 +306,7 @@ public class ServiceTestRunner
             catch (Exception e)
             {
                 LOGGER.error("Error running tests", e);
-                throw new RuntimeException(e);
+                throw (e instanceof RuntimeException) ? (RuntimeException) e : new RuntimeException(e);
             }
             finally
             {
@@ -314,7 +320,7 @@ public class ServiceTestRunner
         }
         else
         {
-            return new RichServiceTestResult(pureServicePairs.getOne().getPath(),Collections.emptyMap(), Collections.emptyMap(), null,   executionPlan, "");
+            return new RichServiceTestResult(this.service.getPath(), Collections.emptyMap(), Collections.emptyMap(), null, executionPlan, "");
         }
     }
 
@@ -344,10 +350,7 @@ public class ServiceTestRunner
         {
             return (String) value;
         }
-        else
-        {
-            throw new RuntimeException("To Code");
-        }
+        throw new RuntimeException("To Code");
     }
 
 
@@ -369,10 +372,10 @@ public class ServiceTestRunner
         MutableList<String> results = null;
         for (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection connection : connections)
         {
-            if(connection instanceof RelationalDatabaseConnection)
+            if (connection instanceof RelationalDatabaseConnection)
             {
                 RelationalDatabaseConnection relationalDatabaseConnection = (RelationalDatabaseConnection) connection;
-                if(relationalDatabaseConnection.datasourceSpecification instanceof LocalH2DatasourceSpecification)
+                if (relationalDatabaseConnection.datasourceSpecification instanceof LocalH2DatasourceSpecification)
                 {
                     LocalH2DatasourceSpecification localH2DatasourceSpecification = (LocalH2DatasourceSpecification) relationalDatabaseConnection.datasourceSpecification;
                     if (localH2DatasourceSpecification.testDataSetupSqls != null)
@@ -394,4 +397,8 @@ public class ServiceTestRunner
         return results;
     }
 
+    private static Root_meta_legend_service_metamodel_Service findPureService(Service service, PureModel pureModel)
+    {
+        return (Root_meta_legend_service_metamodel_Service) pureModel.getPackageableElement(service.getPath());
+    }
 }

--- a/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestServiceTestRunner.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.test.runner.service;
 
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransformers;
@@ -23,6 +22,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.engine.test.runner.shared.TestResult;
+import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_Service;
 import org.finos.legend.pure.generated.core_relational_relational_router_router_extension;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,24 +48,30 @@ public class TestServiceTestRunner
         Assert.assertEquals(1, testResults.size());
         RichServiceTestResult testResult = testResults.get(0);
         Assert.assertEquals(servicePath, testResult.getServicePath());
-        if(multiExecution){
+        if (multiExecution)
+        {
             Assert.assertNotNull(testResult.getOptionalMultiExecutionKey());
-        } else {
+        }
+        else
+        {
             Assert.assertNull(testResult.getOptionalMultiExecutionKey());
         }
         Assert.assertEquals(Collections.emptyMap(), testResult.getAssertExceptions());
         Assert.assertEquals(Collections.singletonMap("test0", expectedResult), testResult.getResults());
     }
 
-    private List<RichServiceTestResult> runTest(Service service, PureModel pureModel, PureModelContextData pureModelContextData) {
-        ServiceTestRunner serviceTestRunner = new ServiceTestRunner(service, Tuples.pair(pureModelContextData, pureModel), PlanExecutor.newPlanExecutorWithAvailableStoreExecutors(), core_relational_relational_router_router_extension.Root_meta_pure_router_extension_defaultRelationalExtensions__RouterExtension_MANY_(pureModel.getExecutionSupport()), LegendPlanTransformers.transformers, "vX_X_X");
-        try {
+    private List<RichServiceTestResult> runTest(Service service, PureModel pureModel, PureModelContextData pureModelContextData)
+    {
+        ServiceTestRunner serviceTestRunner = new ServiceTestRunner(service, (Root_meta_legend_service_metamodel_Service) pureModel.getPackageableElement(service.getPath()), pureModelContextData, pureModel, ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports(), PlanExecutor.newPlanExecutorWithAvailableStoreExecutors(), core_relational_relational_router_router_extension.Root_meta_pure_router_extension_defaultRelationalExtensions__RouterExtension_MANY_(pureModel.getExecutionSupport()), LegendPlanTransformers.transformers, "vX_X_X");
+        try
+        {
             return serviceTestRunner.executeTests();
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             throw new RuntimeException(e);
         }
     }
-
 
     @Test
     public void testSucceedingService() throws Exception
@@ -84,5 +90,4 @@ public class TestServiceTestRunner
     {
         test("legend-sdlc-test-services-multi-execution.json", "my::Service", TestResult.SUCCESS, true);
     }
-
 }


### PR DESCRIPTION
Some processor extensions were adding the compiled entities to their packages in addition to the common code that did the same. The result was that the entities were added twice to the package, which violates assumptions about name uniqueness among package children. This fixes those bugs plus adds a validation to make sure it doesn't happen again.