### PR TITLE
Remove extra white-space after parameters definition in service store

### DIFF
--- a/legend-engine-language-external-store-service/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperServiceStoreGrammarComposer.java
+++ b/legend-engine-language-external-store-service/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperServiceStoreGrammarComposer.java
@@ -76,7 +76,7 @@ public class HelperServiceStoreGrammarComposer
         builder.append(getTabString(baseIndentation + 1)).append("method : ").append(service.method).append(";\n");
         if (service.parameters != null)
         {
-            builder.append(getTabString(baseIndentation + 1)).append("parameters : \n")
+            builder.append(getTabString(baseIndentation + 1)).append("parameters :\n")
                     .append(getTabString(baseIndentation + 1)).append("(\n")
                     .append(String.join(",\n", ListIterate.collect(service.parameters, param -> renderServiceParameter(param, baseIndentation + 2))))
                     .append("\n")

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreCompilationFromGrammar.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreCompilationFromGrammar.java
@@ -57,7 +57,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -73,7 +73,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [String] ( location = query, style = simple, explode = true )\n" +
                 "    );\n" +
@@ -89,7 +89,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [Integer] ( location = query, style = simple, explode = true, enum = test::Enum )\n" +
                 "    );\n" +
@@ -105,7 +105,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "  (\n" +
                 "    path : '/testService/{param2}';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -123,7 +123,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    path : '/testService/{param2}';\n" +
                 "    requestBody : test::Person <- test::TestBinding;\n" +
                 "    method : POST;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -147,7 +147,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -167,7 +167,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -179,7 +179,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "      path : '/testService';\n" +
                 "      requestBody : test::Person <- test::TestBinding;\n" +
                 "      method : POST;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -201,7 +201,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    path : '/testService/{param2}';\n" +
                 "    requestBody : test::Person <- test::TestBinding;\n" +
                 "    method : POST;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -216,7 +216,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -238,7 +238,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    path : '/testService/{param2}';\n" +
                 "    requestBody : test::Person <- test::TestBinding;\n" +
                 "    method : POST;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -250,7 +250,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [Integer] ( location = query, style = simple, explode = true, enum = test::Enum )\n" +
                 "    );\n" +
@@ -264,7 +264,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -282,7 +282,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "      (\n" +
                 "        path : '/testService';\n" +
                 "        method : GET;\n" +
-                "        parameters : \n" +
+                "        parameters :\n" +
                 "        (\n" +
                 "          serializationFormat : String ( location = query )\n" +
                 "        );\n" +
@@ -298,7 +298,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -309,7 +309,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -331,7 +331,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -348,7 +348,7 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreMappingCompilationFromGrammar.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreMappingCompilationFromGrammar.java
@@ -55,7 +55,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -90,7 +90,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService/{param}';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param : String ( location = path )\n" +
                 "      );\n" +
@@ -123,7 +123,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService/{param}';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param : String ( location = path )\n" +
                 "      );\n" +
@@ -162,7 +162,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "      (\n" +
                 "        path : '/testService/{param}';\n" +
                 "        method : GET;\n" +
-                "        parameters : \n" +
+                "        parameters :\n" +
                 "        (\n" +
                 "          param : String ( location = path )\n" +
                 "        );\n" +
@@ -199,7 +199,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "      (\n" +
                 "        path : '/testService/{param}';\n" +
                 "        method : GET;\n" +
-                "        parameters : \n" +
+                "        parameters :\n" +
                 "        (\n" +
                 "          param : String ( location = path ),\n" +
                 "          param2 : Integer ( location = query )\n" +
@@ -241,7 +241,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService1';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param : String ( location = query ),\n" +
                 "        param2 : Integer ( location = query )\n" +
@@ -253,7 +253,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService2';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param1 : Boolean ( location = query )\n" +
                 "      );\n" +
@@ -300,7 +300,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService1';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param : String ( location = query ),\n" +
                 "        param2 : Integer ( location = query )\n" +
@@ -312,7 +312,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService2';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param1 : Boolean ( location = query )\n" +
                 "      );\n" +
@@ -357,7 +357,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService1';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param : String ( location = query ),\n" +
                 "        param2 : Integer ( location = query )\n" +
@@ -369,7 +369,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    (\n" +
                 "      path : '/testService2';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        param1 : Boolean ( location = query )\n" +
                 "      );\n" +
@@ -419,7 +419,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "      (\n" +
                 "        path : '/testService1/{param}';\n" +
                 "        method : GET;\n" +
-                "        parameters : \n" +
+                "        parameters :\n" +
                 "        (\n" +
                 "          param : String ( location = path ),\n" +
                 "          param1 : Integer ( location = query )\n" +
@@ -431,7 +431,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "      (\n" +
                 "        path : '/testService2/{param}';\n" +
                 "        method : GET;\n" +
-                "        parameters : \n" +
+                "        parameters :\n" +
                 "        (\n" +
                 "          param : Boolean ( location = path ),\n" +
                 "          param1 : Float ( location = query )\n" +
@@ -482,7 +482,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -514,7 +514,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -547,7 +547,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param : Float ( location = query )\n" +
                 "    );\n" +
@@ -577,7 +577,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -620,7 +620,7 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query, enum = test::SerializationFormat )\n" +
                 "    );\n" +

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarParser.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarParser.java
@@ -49,7 +49,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService/';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -66,7 +66,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : 'testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -83,7 +83,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [String] ( location = query )\n" +
                 "    );\n" +
@@ -100,7 +100,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [String] ( location = query, style = simple )\n" +
                 "    );\n" +
@@ -117,7 +117,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query, style = simple, explode = true )\n" +
                 "    );\n" +
@@ -134,7 +134,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -145,7 +145,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -162,7 +162,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -176,7 +176,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -195,7 +195,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "    path : '/testService';\n" +
                 "    requestBody : ExampleClass <- tests::store::exampleBinding;\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -212,7 +212,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = path )\n" +
                 "    );\n" +
@@ -229,7 +229,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = path )\n" +
                 "    );\n" +
@@ -246,7 +246,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : PUT;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = path )\n" +
                 "    );\n" +
@@ -263,7 +263,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = requestBody )\n" +
                 "    );\n" +

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarRoundtrip.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarRoundtrip.java
@@ -37,7 +37,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : String ( location = query )\n" +
                 "    );\n" +
@@ -53,7 +53,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [String] ( location = query, style = simple, explode = true )\n" +
                 "    );\n" +
@@ -69,7 +69,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [Integer] ( location = query, style = simple, explode = true, enum = test::Enum )\n" +
                 "    );\n" +
@@ -85,7 +85,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "  (\n" +
                 "    path : '/testService/{param2}';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -103,7 +103,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    path : '/testService/{param2}';\n" +
                 "    requestBody : [ExampleClass <- tests::store::exampleBinding];\n" +
                 "    method : POST;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -139,7 +139,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -159,7 +159,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -171,7 +171,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "      path : '/testService';\n" +
                 "      requestBody : ExampleClass <- tests::store::exampleBinding;\n" +
                 "      method : POST;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -193,7 +193,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    path : '/testService/{param2}';\n" +
                 "    requestBody : [ExampleClass <- tests::store::exampleBinding];\n" +
                 "    method : POST;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -208,7 +208,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -230,7 +230,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    path : '/testService/{param2}';\n" +
                 "    requestBody : [ExampleClass <- tests::store::exampleBinding];\n" +
                 "    method : POST;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      param1 : String ( location = query ),\n" +
                 "      param2 : String ( location = path )\n" +
@@ -242,7 +242,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "  (\n" +
                 "    path : '/testService';\n" +
                 "    method : GET;\n" +
-                "    parameters : \n" +
+                "    parameters :\n" +
                 "    (\n" +
                 "      serializationFormat : [Integer] ( location = query, style = simple, explode = true, enum = test::Enum )\n" +
                 "    );\n" +
@@ -256,7 +256,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -274,7 +274,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "      (\n" +
                 "        path : '/testService';\n" +
                 "        method : GET;\n" +
-                "        parameters : \n" +
+                "        parameters :\n" +
                 "        (\n" +
                 "          serializationFormat : String ( location = query )\n" +
                 "        );\n" +
@@ -290,7 +290,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +
@@ -301,7 +301,7 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "    (\n" +
                 "      path : '/testService';\n" +
                 "      method : GET;\n" +
-                "      parameters : \n" +
+                "      parameters :\n" +
                 "      (\n" +
                 "        serializationFormat : String ( location = query )\n" +
                 "      );\n" +


### PR DESCRIPTION
Remove extra white-space after parameters definition in service store