### PR TITLE
exclude service test processing when no asserts provided

### DIFF
--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
@@ -21,7 +21,9 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -44,13 +46,13 @@ import org.finos.legend.engine.plan.execution.stores.service.plugin.ServiceStore
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.plan.platform.PlanPlatform;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
-import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.CompositeExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.EngineRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.LegacyRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Execution;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedExecutionParameter;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedSingleExecutionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.MultiExecutionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureExecution;
@@ -135,29 +137,21 @@ public class ServiceTestRunner
             List<RichServiceTestResult> results = Lists.mutable.empty();
             try (Scope scope = GlobalTracer.get().buildSpan("Generate Tests And Run For MultiExecution Service").startActive(true))
             {
-                Map<String, Runtime> runtimeMap = ServiceTestGenerationHelper.buildMultiExecutionTestRuntime((PureMultiExecution) serviceExecution, (MultiExecutionTest) this.service.test, this.pureModelContextData, this.pureModel);
-                Map<String, MutableList<String>> sqlStatementsByKey = Maps.mutable.empty();
-                runtimeMap.forEach((key, runtime) ->
+                MutableMap<String, KeyedExecutionParameter> executionsByKey = Iterate.groupByUniqueKey(((PureMultiExecution) serviceExecution).executionParameters, e -> e.key);
+                for (KeyedSingleExecutionTest es : ((MultiExecutionTest) service.test).tests)
                 {
-                    MutableList<String> sql = extractSetUpSQLFromTestRuntime(runtime);
-                    if (sql != null)
-                    {
-                        sqlStatementsByKey.put(key, sql);
-                    }
-                });
-                CompositeExecutionPlan compositeExecutionPlan = ServiceTestGenerationHelper.buildCompositeExecutionTestPlan(this.service, runtimeMap, this.pureModel, this.pureVersion, PlanPlatform.JAVA, this.extensions, this.transformers);
-                Map<String, SingleExecutionPlan> plansByKey = compositeExecutionPlan.executionPlans;
-                for (SingleExecutionPlan plan : plansByKey.values())
-                {
-                    JavaHelper.compilePlan(plan, null);
-                }
-
-                for (KeyedSingleExecutionTest es : ((MultiExecutionTest) this.service.test).tests)
-                {
-                    SingleExecutionPlan executionPlan = plansByKey.get(es.key);
                     List<TestContainer> asserts = es.asserts;
-                    RichIterable<? extends String> sqls = sqlStatementsByKey.get(es.key);
-                    RichServiceTestResult richServiceTestResult = executeTestAsserts(executionPlan, asserts, sqls, scope);
+                    KeyedExecutionParameter e = executionsByKey.get(es.key);
+
+                    PureMultiExecution pureExecution = (PureMultiExecution) service.execution;
+                    PureSingleExecution pureSingleExecution = new PureSingleExecution();
+                    pureSingleExecution.func = pureExecution.func;
+                    pureSingleExecution.mapping = e.mapping;
+                    pureSingleExecution.runtime = e.runtime;
+                    pureSingleExecution.executionOptions = e.executionOptions;
+
+                    String noAssertMessage = "No test assert found for key - " + es.key + "!!";
+                    RichServiceTestResult richServiceTestResult = executeSingleExecutionTest(pureSingleExecution, es.data, asserts, noAssertMessage, pureModelContextData, pureModel, scope);
                     richServiceTestResult.setOptionalMultiExecutionKey(es.key);
                     results.add(richServiceTestResult);
                 }
@@ -168,16 +162,9 @@ public class ServiceTestRunner
         {
             try (Scope scope = GlobalTracer.get().buildSpan("Generate Single Pure Tests And Run").startActive(true))
             {
-                PureSingleExecution pureSingleExecution = (PureSingleExecution) this.service.execution;
-                Runtime testRuntime = ServiceTestGenerationHelper.buildSingleExecutionTestRuntime((PureSingleExecution) this.service.execution, (SingleExecutionTest) this.service.test, this.pureModelContextData, this.pureModel);
-                RichIterable<? extends String> sqlStatements = extractSetUpSQLFromTestRuntime(testRuntime);
-                PureSingleExecution testPureSingleExecution = shallowCopySingleExecution(pureSingleExecution);
-                testPureSingleExecution.runtime = testRuntime;
-                ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(testPureSingleExecution, null, this.pureModel, this.pureVersion, PlanPlatform.JAVA, null, this.extensions, this.transformers);
-                SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
-                JavaHelper.compilePlan(singleExecutionPlan, null);
-                List<TestContainer> asserts = ((SingleExecutionTest) this.service.test).asserts;
-                return Collections.singletonList(executeTestAsserts(singleExecutionPlan, asserts, sqlStatements, scope));
+                List<TestContainer> asserts = ((SingleExecutionTest) service.test).asserts;
+                String noAssertMessage = "No test assert found !!";
+                return Collections.singletonList(executeSingleExecutionTest((PureSingleExecution) service.execution, ((SingleExecutionTest) service.test).data, asserts, noAssertMessage, pureModelContextData, pureModel, scope));
             }
         }
         else
@@ -191,6 +178,26 @@ public class ServiceTestRunner
                 List<TestContainer> containers = getExtraServiceTestContainers(serviceExecutionExtensions, service.test);
                 return Collections.singletonList(executeTestAsserts((SingleExecutionPlan) executionPlan, containers, testExecutor.getTwo(), scope));
             }
+        }
+    }
+
+    private RichServiceTestResult executeSingleExecutionTest(PureSingleExecution execution, String testData, List<TestContainer> asserts, String noAssertMessage, PureModelContextData pureModelContextData, PureModel pureModel, Scope scope) throws IOException, JavaCompileException
+    {
+        if (asserts == null || asserts.isEmpty())
+        {
+            scope.span().log(noAssertMessage);
+            return new RichServiceTestResult(service.getPath(), Collections.emptyMap(), Collections.emptyMap(), null, null, null);
+        }
+        else
+        {
+            Runtime testRuntime = ServiceTestGenerationHelper.buildTestRuntime(execution.runtime, execution.mapping, testData, pureModelContextData, pureModel);
+            RichIterable<? extends String> sqlStatements = extractSetUpSQLFromTestRuntime(testRuntime);
+            PureSingleExecution testPureSingleExecution = shallowCopySingleExecution(execution);
+            testPureSingleExecution.runtime = testRuntime;
+            ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(testPureSingleExecution, null, pureModel, pureVersion, PlanPlatform.JAVA, null, extensions, transformers);
+            SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
+            JavaHelper.compilePlan(singleExecutionPlan, null);
+            return executeTestAsserts(singleExecutionPlan, asserts, sqlStatements, scope);
         }
     }
 

--- a/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestServiceTestRunner.java
@@ -90,4 +90,46 @@ public class TestServiceTestRunner
     {
         test("legend-sdlc-test-services-multi-execution.json", "my::Service", TestResult.SUCCESS, true);
     }
+
+    @Test
+    public void testNoTestServiceFlow() throws Exception
+    {
+        URL url = Objects.requireNonNull(getClass().getClassLoader().getResource("legend-sdlc-test-services-without-tests.json"));
+        PureModelContextData pureModelContextData = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(url, PureModelContextData.class);
+        PureModel pureModel = new PureModel(pureModelContextData, null, Thread.currentThread().getContextClassLoader(), DeploymentMode.PROD);
+
+        Service service = pureModelContextData.getElementsOfType(Service.class).get(0);
+
+        List<RichServiceTestResult> testResults = this.runTest(service, pureModel, pureModelContextData);
+        Assert.assertNotNull(testResults);
+        Assert.assertEquals(1, testResults.size());
+        RichServiceTestResult testResult = testResults.get(0);
+        Assert.assertEquals("test::legend::service::execution::test::m2m::simpleServiceNoTest", testResult.getServicePath());
+        Assert.assertNull(testResult.getOptionalMultiExecutionKey());
+        Assert.assertNull(testResult.getExecutionPlan());
+        Assert.assertNull(testResult.getJavaCodeString());
+        Assert.assertEquals(Collections.emptyMap(), testResult.getAssertExceptions());
+        Assert.assertEquals(Collections.emptyMap(), testResult.getResults());
+    }
+
+    @Test
+    public void testMultiExecutionNoTestServiceFlow() throws Exception
+    {
+        URL url = Objects.requireNonNull(getClass().getClassLoader().getResource("legend-sdlc-test-services-multi-execution-without-tests.json"));
+        PureModelContextData pureModelContextData = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(url, PureModelContextData.class);
+        PureModel pureModel = new PureModel(pureModelContextData, null, Thread.currentThread().getContextClassLoader(), DeploymentMode.PROD);
+
+        Service service = pureModelContextData.getElementsOfType(Service.class).get(0);
+
+        List<RichServiceTestResult> testResults = this.runTest(service, pureModel, pureModelContextData);
+        Assert.assertNotNull(testResults);
+        Assert.assertEquals(1, testResults.size());
+        RichServiceTestResult testResult = testResults.get(0);
+        Assert.assertEquals("my::Service", testResult.getServicePath());
+        Assert.assertEquals("Env1", testResult.getOptionalMultiExecutionKey());
+        Assert.assertNull(testResult.getExecutionPlan());
+        Assert.assertNull(testResult.getJavaCodeString());
+        Assert.assertEquals(Collections.emptyMap(), testResult.getAssertExceptions());
+        Assert.assertEquals(Collections.emptyMap(), testResult.getResults());
+    }
 }

--- a/legend-engine-test-runner-service/src/test/resources/legend-sdlc-test-services-multi-execution-without-tests.json
+++ b/legend-engine-test-runner-service/src/test/resources/legend-sdlc-test-services-multi-execution-without-tests.json
@@ -1,0 +1,1563 @@
+{
+  "_type": "data",
+  "elements": [
+    {
+      "_type": "service",
+      "autoActivateUpdates": true,
+      "documentation": "",
+      "execution": {
+        "_type": "pureMultiExecution",
+        "executionKey": "env",
+        "executionParameters": [
+          {
+            "key": "Env1",
+            "mapping": "my::Map",
+            "mappingSourceInformation": {
+              "endColumn": 22,
+              "endLine": 13,
+              "sourceId": "",
+              "startColumn": 16,
+              "startLine": 13
+            },
+            "runtime": {
+              "_type": "engineRuntime",
+              "connections": [
+                {
+                  "sourceInformation": {
+                    "endColumn": 11,
+                    "endLine": 37,
+                    "sourceId": "",
+                    "startColumn": 11,
+                    "startLine": 22
+                  },
+                  "store": {
+                    "path": "my::DB",
+                    "sourceInformation": {
+                      "endColumn": 16,
+                      "endLine": 22,
+                      "sourceId": "",
+                      "startColumn": 11,
+                      "startLine": 22
+                    },
+                    "type": "STORE"
+                  },
+                  "storeConnections": [
+                    {
+                      "connection": {
+                        "_type": "RelationalDatabaseConnection",
+                        "authenticationStrategy": {
+                          "_type": "h2Default",
+                          "sourceInformation": {
+                            "endColumn": 32,
+                            "endLine": 34,
+                            "sourceId": "",
+                            "startColumn": 17,
+                            "startLine": 34
+                          }
+                        },
+                        "databaseType": "H2",
+                        "datasourceSpecification": {
+                          "_type": "h2Local",
+                          "sourceInformation": {
+                            "endColumn": 18,
+                            "endLine": 33,
+                            "sourceId": "",
+                            "startColumn": 17,
+                            "startLine": 30
+                          },
+                          "testDataSetupCsv": ""
+                        },
+                        "element": "my::DB",
+                        "elementSourceInformation": {
+                          "endColumn": 29,
+                          "endLine": 28,
+                          "sourceId": "",
+                          "startColumn": 24,
+                          "startLine": 28
+                        },
+                        "postProcessorWithParameter": [],
+                        "sourceInformation": {
+                          "endColumn": 15,
+                          "endLine": 35,
+                          "sourceId": "",
+                          "startColumn": 15,
+                          "startLine": 26
+                        },
+                        "type": "H2"
+                      },
+                      "id": "c1",
+                      "sourceInformation": {
+                        "endColumn": 14,
+                        "endLine": 36,
+                        "sourceId": "",
+                        "startColumn": 13,
+                        "startLine": 24
+                      }
+                    }
+                  ]
+                }
+              ],
+              "mappings": [
+                {
+                  "path": "my::Map",
+                  "sourceInformation": {
+                    "endColumn": 17,
+                    "endLine": 18,
+                    "sourceId": "",
+                    "startColumn": 11,
+                    "startLine": 18
+                  },
+                  "type": "MAPPING"
+                }
+              ],
+              "sourceInformation": {
+                "endColumn": 10,
+                "endLine": 38,
+                "sourceId": "",
+                "startColumn": 9,
+                "startLine": 16
+              }
+            },
+            "sourceInformation": {
+              "endColumn": 5,
+              "endLine": 40,
+              "sourceId": "",
+              "startColumn": 5,
+              "startLine": 11
+            }
+          }
+        ],
+        "func": {
+          "_type": "lambda",
+          "body": [
+            {
+              "_type": "func",
+              "function": "project",
+              "parameters": [
+                {
+                  "_type": "func",
+                  "function": "filter",
+                  "parameters": [
+                    {
+                      "_type": "func",
+                      "function": "getAll",
+                      "parameters": [
+                        {
+                          "_type": "class",
+                          "fullPath": "my::Person",
+                          "sourceInformation": {
+                            "endColumn": 22,
+                            "endLine": 9,
+                            "sourceId": "",
+                            "startColumn": 13,
+                            "startLine": 9
+                          }
+                        }
+                      ],
+                      "sourceInformation": {
+                        "endColumn": 28,
+                        "endLine": 9,
+                        "sourceId": "",
+                        "startColumn": 23,
+                        "startLine": 9
+                      }
+                    },
+                    {
+                      "_type": "lambda",
+                      "body": [
+                        {
+                          "_type": "func",
+                          "function": "in",
+                          "parameters": [
+                            {
+                              "_type": "property",
+                              "parameters": [
+                                {
+                                  "_type": "var",
+                                  "name": "x",
+                                  "sourceInformation": {
+                                    "endColumn": 41,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 40,
+                                    "startLine": 9
+                                  }
+                                }
+                              ],
+                              "property": "name",
+                              "sourceInformation": {
+                                "endColumn": 46,
+                                "endLine": 9,
+                                "sourceId": "",
+                                "startColumn": 43,
+                                "startLine": 9
+                              }
+                            },
+                            {
+                              "_type": "collection",
+                              "multiplicity": {
+                                "lowerBound": 51,
+                                "upperBound": 51
+                              },
+                              "sourceInformation": {
+                                "endColumn": 310,
+                                "endLine": 9,
+                                "sourceId": "",
+                                "startColumn": 52,
+                                "startLine": 9
+                              },
+                              "values": [
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 55,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 53,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 60,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 58,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 65,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 63,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 70,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 68,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 75,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 73,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 80,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 78,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 85,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 83,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 90,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 88,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 95,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 93,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 100,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 98,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 105,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 103,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 110,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 108,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 115,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 113,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 120,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 118,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 125,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 123,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 130,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 128,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 135,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 133,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 140,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 138,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 145,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 143,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 150,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 148,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 155,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 153,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 160,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 158,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 165,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 163,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 170,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 168,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 175,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 173,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 180,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 178,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 185,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 183,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 190,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 188,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 195,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 193,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 200,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 198,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 205,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 203,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 210,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 208,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 215,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 213,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 220,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 218,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 225,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 223,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 230,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 228,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 235,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 233,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 240,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 238,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 245,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 243,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 250,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 248,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 255,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 253,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 260,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 258,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 265,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 263,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 270,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 268,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 275,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 273,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 280,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 278,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 285,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 283,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 290,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 288,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 295,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 293,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 300,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 298,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "n"
+                                  ]
+                                },
+                                {
+                                  "_type": "string",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 309,
+                                    "endLine": 9,
+                                    "sourceId": "",
+                                    "startColumn": 303,
+                                    "startLine": 9
+                                  },
+                                  "values": [
+                                    "Hello"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sourceInformation": {
+                            "endColumn": 50,
+                            "endLine": 9,
+                            "sourceId": "",
+                            "startColumn": 49,
+                            "startLine": 9
+                          }
+                        }
+                      ],
+                      "parameters": [
+                        {
+                          "_type": "var",
+                          "name": "x"
+                        }
+                      ],
+                      "sourceInformation": {
+                        "endColumn": 311,
+                        "endLine": 9,
+                        "sourceId": "",
+                        "startColumn": 39,
+                        "startLine": 9
+                      }
+                    }
+                  ],
+                  "sourceInformation": {
+                    "endColumn": 36,
+                    "endLine": 9,
+                    "sourceId": "",
+                    "startColumn": 31,
+                    "startLine": 9
+                  }
+                },
+                {
+                  "_type": "func",
+                  "function": "col",
+                  "parameters": [
+                    {
+                      "_type": "lambda",
+                      "body": [
+                        {
+                          "_type": "property",
+                          "parameters": [
+                            {
+                              "_type": "var",
+                              "name": "x",
+                              "sourceInformation": {
+                                "endColumn": 330,
+                                "endLine": 9,
+                                "sourceId": "",
+                                "startColumn": 329,
+                                "startLine": 9
+                              }
+                            }
+                          ],
+                          "property": "name",
+                          "sourceInformation": {
+                            "endColumn": 335,
+                            "endLine": 9,
+                            "sourceId": "",
+                            "startColumn": 332,
+                            "startLine": 9
+                          }
+                        }
+                      ],
+                      "parameters": [
+                        {
+                          "_type": "var",
+                          "name": "x"
+                        }
+                      ],
+                      "sourceInformation": {
+                        "endColumn": 335,
+                        "endLine": 9,
+                        "sourceId": "",
+                        "startColumn": 328,
+                        "startLine": 9
+                      }
+                    },
+                    {
+                      "_type": "string",
+                      "multiplicity": {
+                        "lowerBound": 1,
+                        "upperBound": 1
+                      },
+                      "sourceInformation": {
+                        "endColumn": 343,
+                        "endLine": 9,
+                        "sourceId": "",
+                        "startColumn": 338,
+                        "startLine": 9
+                      },
+                      "values": [
+                        "Name"
+                      ]
+                    }
+                  ],
+                  "sourceInformation": {
+                    "endColumn": 325,
+                    "endLine": 9,
+                    "sourceId": "",
+                    "startColumn": 323,
+                    "startLine": 9
+                  }
+                }
+              ],
+              "sourceInformation": {
+                "endColumn": 321,
+                "endLine": 9,
+                "sourceId": "",
+                "startColumn": 315,
+                "startLine": 9
+              }
+            }
+          ],
+          "parameters": [],
+          "sourceInformation": {
+            "endColumn": 345,
+            "endLine": 9,
+            "sourceId": "",
+            "startColumn": 12,
+            "startLine": 9
+          }
+        },
+        "sourceInformation": {
+          "endColumn": 3,
+          "endLine": 41,
+          "sourceId": "",
+          "startColumn": 14,
+          "startLine": 7
+        }
+      },
+      "name": "Service",
+      "owners": [],
+      "package": "my",
+      "pattern": "/exampleService/{env}",
+      "sourceInformation": {
+        "endColumn": 1,
+        "endLine": 53,
+        "sourceId": "",
+        "startColumn": 1,
+        "startLine": 2
+      },
+      "test": {
+        "_type": "multiExecutionTest",
+        "sourceInformation": {
+          "endColumn": 3,
+          "endLine": 52,
+          "sourceId": "",
+          "startColumn": 9,
+          "startLine": 42
+        },
+        "tests": [
+          {
+            "asserts": [
+            ],
+            "data": "default\npersonTable\nname\nHello\n------",
+            "key": "Env1",
+            "sourceInformation": {
+              "endColumn": 5,
+              "endLine": 51,
+              "sourceId": "",
+              "startColumn": 5,
+              "startLine": 44
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_type": "relational",
+      "filters": [],
+      "includedStores": [],
+      "joins": [],
+      "name": "DB",
+      "package": "my",
+      "schemas": [
+        {
+          "name": "default",
+          "sourceInformation": {
+            "endColumn": 1,
+            "endLine": 63,
+            "sourceId": "",
+            "startColumn": 1,
+            "startLine": 57
+          },
+          "tables": [
+            {
+              "columns": [
+                {
+                  "name": "name",
+                  "nullable": false,
+                  "sourceInformation": {
+                    "endColumn": 34,
+                    "endLine": 61,
+                    "sourceId": "",
+                    "startColumn": 5,
+                    "startLine": 61
+                  },
+                  "type": {
+                    "_type": "Varchar",
+                    "size": 1000
+                  }
+                }
+              ],
+              "milestoning": [],
+              "name": "personTable",
+              "primaryKey": [
+                "name"
+              ],
+              "sourceInformation": {
+                "endColumn": 3,
+                "endLine": 62,
+                "sourceId": "",
+                "startColumn": 3,
+                "startLine": 59
+              }
+            }
+          ],
+          "views": []
+        }
+      ],
+      "sourceInformation": {
+        "endColumn": 1,
+        "endLine": 63,
+        "sourceId": "",
+        "startColumn": 1,
+        "startLine": 57
+      }
+    },
+    {
+      "_type": "class",
+      "constraints": [],
+      "name": "Person",
+      "originalMilestonedProperties": [],
+      "package": "my",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "name",
+          "propertyTypeSourceInformation": {
+            "endColumn": 14,
+            "endLine": 69,
+            "sourceId": "",
+            "startColumn": 9,
+            "startLine": 69
+          },
+          "sourceInformation": {
+            "endColumn": 18,
+            "endLine": 69,
+            "sourceId": "",
+            "startColumn": 3,
+            "startLine": 69
+          },
+          "stereotypes": [],
+          "taggedValues": [],
+          "type": "String"
+        }
+      ],
+      "qualifiedProperties": [],
+      "sourceInformation": {
+        "endColumn": 1,
+        "endLine": 70,
+        "sourceId": "",
+        "startColumn": 1,
+        "startLine": 67
+      },
+      "stereotypes": [],
+      "superTypes": [],
+      "taggedValues": []
+    },
+    {
+      "_type": "mapping",
+      "associationMappings": [],
+      "classMappings": [
+        {
+          "_type": "relational",
+          "class": "my::Person",
+          "classSourceInformation": {
+            "endColumn": 13,
+            "endLine": 76,
+            "sourceId": "",
+            "startColumn": 4,
+            "startLine": 76
+          },
+          "distinct": false,
+          "groupBy": [],
+          "mainTable": {
+            "_type": "Table",
+            "database": "my::DB",
+            "mainTableDb": "my::DB",
+            "schema": "default",
+            "sourceInformation": {
+              "endColumn": 34,
+              "endLine": 82,
+              "sourceId": "my::Map",
+              "startColumn": 24,
+              "startLine": 82
+            },
+            "table": "personTable"
+          },
+          "primaryKey": [
+            {
+              "_type": "column",
+              "column": "name",
+              "sourceInformation": {
+                "endColumn": 30,
+                "endLine": 80,
+                "sourceId": "my::Map",
+                "startColumn": 7,
+                "startLine": 80
+              },
+              "table": {
+                "_type": "Table",
+                "database": "my::DB",
+                "mainTableDb": "my::DB",
+                "schema": "default",
+                "sourceInformation": {
+                  "endColumn": 25,
+                  "endLine": 80,
+                  "sourceId": "my::Map",
+                  "startColumn": 15,
+                  "startLine": 80
+                },
+                "table": "personTable"
+              },
+              "tableAlias": "personTable"
+            }
+          ],
+          "propertyMappings": [
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "my::Person",
+                "property": "name",
+                "sourceInformation": {
+                  "endColumn": 8,
+                  "endLine": 83,
+                  "sourceId": "my::Map",
+                  "startColumn": 5,
+                  "startLine": 83
+                }
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "name",
+                "sourceInformation": {
+                  "endColumn": 34,
+                  "endLine": 83,
+                  "sourceId": "my::Map",
+                  "startColumn": 11,
+                  "startLine": 83
+                },
+                "table": {
+                  "_type": "Table",
+                  "database": "my::DB",
+                  "mainTableDb": "my::DB",
+                  "schema": "default",
+                  "sourceInformation": {
+                    "endColumn": 29,
+                    "endLine": 83,
+                    "sourceId": "my::Map",
+                    "startColumn": 19,
+                    "startLine": 83
+                  },
+                  "table": "personTable"
+                },
+                "tableAlias": "personTable"
+              },
+              "sourceInformation": {
+                "endColumn": 34,
+                "endLine": 83,
+                "sourceId": "my::Map",
+                "startColumn": 9,
+                "startLine": 83
+              }
+            }
+          ],
+          "root": true,
+          "sourceInformation": {
+            "endColumn": 3,
+            "endLine": 84,
+            "sourceId": "",
+            "startColumn": 3,
+            "startLine": 76
+          }
+        }
+      ],
+      "enumerationMappings": [],
+      "includedMappings": [],
+      "name": "Map",
+      "package": "my",
+      "sourceInformation": {
+        "endColumn": 1,
+        "endLine": 85,
+        "sourceId": "",
+        "startColumn": 1,
+        "startLine": 74
+      },
+      "tests": []
+    },
+    {
+      "_type": "sectionIndex",
+      "name": "SectionIndex",
+      "package": "__internal__",
+      "sections": [
+        {
+          "_type": "importAware",
+          "elements": [],
+          "imports": [],
+          "parserName": "Pure",
+          "sourceInformation": {
+            "endColumn": 8,
+            "endLine": 1,
+            "sourceId": "",
+            "startColumn": 1,
+            "startLine": 1
+          }
+        },
+        {
+          "_type": "importAware",
+          "elements": [
+            "my::Service"
+          ],
+          "imports": [],
+          "parserName": "Service",
+          "sourceInformation": {
+            "endColumn": 1,
+            "endLine": 56,
+            "sourceId": "",
+            "startColumn": 8,
+            "startLine": 2
+          }
+        },
+        {
+          "_type": "default",
+          "elements": [
+            "my::DB"
+          ],
+          "parserName": "Relational",
+          "sourceInformation": {
+            "endColumn": 1,
+            "endLine": 66,
+            "sourceId": "",
+            "startColumn": 1,
+            "startLine": 57
+          }
+        },
+        {
+          "_type": "importAware",
+          "elements": [
+            "my::Person"
+          ],
+          "imports": [],
+          "parserName": "Pure",
+          "sourceInformation": {
+            "endColumn": 1,
+            "endLine": 73,
+            "sourceId": "",
+            "startColumn": 1,
+            "startLine": 67
+          }
+        },
+        {
+          "_type": "importAware",
+          "elements": [
+            "my::Map"
+          ],
+          "imports": [],
+          "parserName": "Mapping",
+          "sourceInformation": {
+            "endColumn": 2,
+            "endLine": 87,
+            "sourceId": "",
+            "startColumn": 1,
+            "startLine": 74
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-test-runner-service/src/test/resources/legend-sdlc-test-services-without-tests.json
+++ b/legend-engine-test-runner-service/src/test/resources/legend-sdlc-test-services-without-tests.json
@@ -1,0 +1,7320 @@
+{
+  "_type": "data",
+  "cacheables": [],
+  "caches": [],
+  "connections": [],
+  "dataStoreSpecifications": [],
+  "diagrams": [],
+  "domain": {
+    "associations": [
+      {
+        "_type": "association",
+        "name": "Business_Employees",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Business"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employs",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "OrgStructures",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "parentOrg",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Organization"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "subOrgs",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Organization"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Parent_Children",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 2,
+              "upperBound": 2
+            },
+            "name": "parents",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "children",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Person_Accounts",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "acctOwner",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "accounts",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Account_AccountPnl",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "account",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "accountPnl",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::AccountPnl"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "AddressLocation",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "location",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Location"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "addresses",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Address"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "BridgeAsso1",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "bridge",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Bridge"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employees",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "BridgeAsso2",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "bridge",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Bridge"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Employment",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employees",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "FirmCEO",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "ceoFirm",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "ceo",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "FirmOrganizations",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "organizations",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Membership",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "organizations",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "members",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "PlacesOfInterest",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "location",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Location"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "placeOfInterest",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::PlaceOfInterest"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "ProdSynonym",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "synonyms",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Synonym"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "product",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Product"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "synonyms"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "s"
+                                  }
+                                ],
+                                "property": "type"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "type"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "s"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "synonymByType",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::ProductSynonymType",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "type"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Synonym",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "SubOrganization",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "parent",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "children",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Trade_Accounts",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "account",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "trades",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Trade"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Trade_Orders",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "account",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "orders",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Order"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "taggedValues": []
+      }
+    ],
+    "classes": [
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Business",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "address",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Organization",
+          "test::owl::tests::model::EntityWithLocation"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "EntityWithLocation",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "location",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::GeoLocation"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Executive",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "organization",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Business"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "seniorityLevel",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::OrgLevelType"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Professional"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "FemaleExecutive",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Executive",
+          "test::owl::tests::model::FemalePerson"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "FemalePerson",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Person"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "GeoLocation",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "engName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "MaleExecutive",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Executive",
+          "test::owl::tests::model::MalePerson"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "MalePerson",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Person"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Organization",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "officialName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Person",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "gender",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::GenderType"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 2
+            },
+            "name": "nicknames",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Professional",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Address",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "street",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 0
+            },
+            "name": "extension",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::AddressExtension"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "AddressExtension",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "stuff",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Firm",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "legalName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employees",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "addresses",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Address"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "count",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Person",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "addresses",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Address"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Firm"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Product2Simple",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "region",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Region"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "_Product2",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::src",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "subProductName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "bondDetailStatus",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "region",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Region"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "_S_Person",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::src",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "fullName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Account",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "createDate",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "in_Any_1__Any_MANY__Boolean_1_",
+                    "function": "in",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "name"
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 2,
+                          "upperBound": 2
+                        },
+                        "values": [
+                          "Account 1",
+                          "Account 2"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "A"
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "B"
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "accountCategory",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "contains_String_1__String_1__Boolean_1_",
+                    "function": "contains",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "name"
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "2"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "boolean",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          true
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "boolean",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          false
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "isTypeA",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Boolean",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "AccountPnl",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "pnl",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Address",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "street",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "comments",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "plus_String_MANY__String_1_",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 2,
+                      "upperBound": 2
+                    },
+                    "values": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "D:"
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "name"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "description",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::GeographicEntity"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Bridge",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Department",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Organization"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Division",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Organization"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "EntityWithAddress",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "address",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Address"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "EntityWithLocations",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "locations",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Location"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "locations"
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "exists_T_MANY__Function_1__Boolean_1_",
+                        "function": "exists",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "types"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "is_Any_1__Any_1__Boolean_1_",
+                                "function": "is",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "l"
+                                      }
+                                    ],
+                                    "property": "type"
+                                  },
+                                  {
+                                    "_type": "var",
+                                    "name": "type"
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "l"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "locationsByType",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::GeographicEntityType",
+                "multiplicity": {
+                  "lowerBound": 0
+                },
+                "name": "types"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Location",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Firm",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "legalName",
+            "stereotypes": [
+              {
+                "profile": "meta::pure::profiles::equality",
+                "value": "Key"
+              }
+            ],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "nickName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "times_Float_MANY__Float_1_",
+                "function": "times",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 2,
+                      "upperBound": 2
+                    },
+                    "values": [
+                      {
+                        "_type": "func",
+                        "fControl": "average_Integer_MANY__Float_1_",
+                        "function": "average",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "employees"
+                              }
+                            ],
+                            "property": "age"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "float",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          2.0
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "averageEmployeesAge",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Float",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "sum_Integer_MANY__Integer_1_",
+                "function": "sum",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      }
+                    ],
+                    "property": "age"
+                  }
+                ]
+              }
+            ],
+            "name": "sumEmployeesAge",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "max_Integer_MANY__Integer_$0_1$_",
+                "function": "max",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      }
+                    ],
+                    "property": "age"
+                  }
+                ]
+              }
+            ],
+            "name": "maxEmployeesAge",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "plus_String_MANY__String_1_",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    },
+                    "values": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "legalName"
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          ","
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "toOne_T_MANY__T_1_",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "address"
+                              }
+                            ]
+                          }
+                        ],
+                        "property": "name"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "nameAndAddress",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                    "function": "equal",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "fControl": "toOne_T_MANY__T_1_",
+                        "function": "toOne",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "legalName"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "Goldman Sachs"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "Yes"
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "No"
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "isGoldmanSachs",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                    "function": "equal",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "legalName"
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "Goldman Sachs"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "plus_String_MANY__String_1_",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 2,
+                              "upperBound": 2
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "legalName"
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  " , Top Secret"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "plus_String_MANY__String_1_",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "legalName"
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  ","
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "func",
+                                    "fControl": "toOne_T_MANY__T_1_",
+                                    "function": "toOne",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "address"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "property": "name"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "nameAndMaskedAddress",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ],
+                                "property": "lastName"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "lastName"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeeByLastName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastName"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "toOne_T_MANY__T_1_",
+                    "function": "toOne",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "employees"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "lastName"
+                                  },
+                                  {
+                                    "_type": "var",
+                                    "name": "lastName"
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "property": "firstName"
+              }
+            ],
+            "name": "employeeByLastNameFirstName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastName"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "lastName"
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ],
+                                "property": "lastName"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeeByLastNameWhereVarIsFirstEqualArg",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastName"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "employees"
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "lessThan_Number_1__Number_1__Boolean_1_",
+                        "function": "lessThan",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "toOne_T_MANY__T_1_",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ],
+                                "property": "age"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "var",
+                            "name": "age"
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeesByAge",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Integer",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "age"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "employees"
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "or_Boolean_1__Boolean_1__Boolean_1_",
+                        "function": "or",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "address"
+                                  }
+                                ],
+                                "property": "name"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "city"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "manager"
+                                  }
+                                ],
+                                "property": "name"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "managerName"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeesByCityOrManager",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "city"
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "managerName"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "and_Boolean_1__Boolean_1__Boolean_1_",
+                            "function": "and",
+                            "parameters": [
+                              {
+                                "_type": "func",
+                                "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "lastName"
+                                  },
+                                  {
+                                    "_type": "var",
+                                    "name": "name"
+                                  }
+                                ]
+                              },
+                              {
+                                "_type": "func",
+                                "fControl": "or_Boolean_1__Boolean_1__Boolean_1_",
+                                "function": "or",
+                                "parameters": [
+                                  {
+                                    "_type": "func",
+                                    "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                    "function": "equal",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "property",
+                                            "parameters": [
+                                              {
+                                                "_type": "var",
+                                                "name": "e"
+                                              }
+                                            ],
+                                            "property": "address"
+                                          }
+                                        ],
+                                        "property": "name"
+                                      },
+                                      {
+                                        "_type": "var",
+                                        "name": "city"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "_type": "func",
+                                    "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                    "function": "equal",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "property",
+                                            "parameters": [
+                                              {
+                                                "_type": "var",
+                                                "name": "e"
+                                              }
+                                            ],
+                                            "property": "manager"
+                                          }
+                                        ],
+                                        "property": "name"
+                                      },
+                                      {
+                                        "_type": "var",
+                                        "name": "managerName"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeesByCityOrManagerAndLastName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name"
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "city"
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "managerName"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "exists_T_MANY__Function_1__Boolean_1_",
+                "function": "exists",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "employees"
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "lessThan_Number_1__Number_1__Boolean_1_",
+                        "function": "lessThan",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "toOne_T_MANY__T_1_",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ],
+                                "property": "age"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "var",
+                            "name": "age"
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "hasEmployeeBelowAge",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Integer",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "age"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Boolean",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "first_T_MANY__T_$0_1$_",
+                "function": "first",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ],
+                                "property": "name"
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "address"
+                                  }
+                                ],
+                                "property": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeeWithFirmAddressName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "first_T_MANY__T_$0_1$_",
+                "function": "first",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "address"
+                                  }
+                                ],
+                                "property": "name"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeeWithAddressName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "joinStrings_String_MANY__String_1__String_1_",
+                "function": "joinStrings",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "fControl": "sortBy_T_m__Function_$0_1$__T_m_",
+                        "function": "sortBy",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                            "function": "filter",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "employees"
+                              },
+                              {
+                                "_type": "lambda",
+                                "body": [
+                                  {
+                                    "_type": "func",
+                                    "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                    "function": "equal",
+                                    "parameters": [
+                                      {
+                                        "_type": "func",
+                                        "fControl": "trim_String_1__String_1_",
+                                        "function": "trim",
+                                        "parameters": [
+                                          {
+                                            "_type": "func",
+                                            "fControl": "toOne_T_MANY__T_1_",
+                                            "function": "toOne",
+                                            "parameters": [
+                                              {
+                                                "_type": "property",
+                                                "parameters": [
+                                                  {
+                                                    "_type": "property",
+                                                    "parameters": [
+                                                      {
+                                                        "_type": "var",
+                                                        "name": "e"
+                                                      }
+                                                    ],
+                                                    "property": "address"
+                                                  }
+                                                ],
+                                                "property": "name"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "var",
+                                        "name": "name"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "path",
+                            "name": "",
+                            "path": [
+                              {
+                                "_type": "propertyPath",
+                                "parameters": [],
+                                "property": "lastName"
+                              }
+                            ],
+                            "startType": "test::pure::tests::model::simple::Person"
+                          }
+                        ]
+                      }
+                    ],
+                    "property": "lastName"
+                  },
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "values": [
+                      ""
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeesWithAddressNameSorted",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "map_T_MANY__Function_1__V_MANY_",
+                    "function": "map",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employees"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ],
+                            "property": "address"
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "and_Boolean_1__Boolean_1__Boolean_1_",
+                        "function": "and",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "name"
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "address"
+                                  }
+                                ],
+                                "property": "name"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "t"
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "x"
+                                  }
+                                ],
+                                "property": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeeAddressesWithFirmAddressName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name"
+              },
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::GeographicEntityType",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "t"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Address",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "in_Any_1__Any_MANY__Boolean_1_",
+                "function": "in",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "legalName"
+                  },
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    },
+                    "values": [
+                      "Goldman Sachs",
+                      "Goldman Sachs & Co.",
+                      "Goldman Sachs and Group"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "isGoldmanSachsGroup",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Boolean",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::EntityWithAddress"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "FirmExtension",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "establishedDate",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Date"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employeesExt",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::PersonExtension"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "year_Date_1__Integer_1_",
+                "function": "year",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "establishedDate"
+                  }
+                ]
+              }
+            ],
+            "name": "establishedYear",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "joinStrings_String_MANY__String_1__String_1_",
+                "function": "joinStrings",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "employeesExt"
+                      }
+                    ],
+                    "property": "lastName"
+                  },
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "values": [
+                      ","
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "allEmployeesLastName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Firm"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "GeographicEntity",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "type",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::GeographicEntityType"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Interaction",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "id",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "source",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "target",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "active",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "time",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "longestInteractionBetweenSourceAndTarget",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Location",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "place",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "censusdate",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Date"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::GeographicEntity"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Order",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "id",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "date",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "quantity",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "settlementDateTime",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "DateTime"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "pnl",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "pnlContact",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "zeroPnl",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "OrderPnl",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "pnl",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "supportContactName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "order",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Order"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Organization",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "letFunction_String_1__T_m__T_m_",
+                "function": "letFunction",
+                "parameters": [
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "values": [
+                      "parent"
+                    ]
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "parent"
+                  }
+                ]
+              },
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "isEmpty_Any_$0_1$__Boolean_1_",
+                    "function": "isEmpty",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "parent"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "collection",
+                        "multiplicity": {
+                          "lowerBound": 0,
+                          "upperBound": 0
+                        },
+                        "values": []
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "concatenate_T_MANY__T_MANY__T_MANY_",
+                        "function": "concatenate",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "parent"
+                          },
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "func",
+                                "fControl": "toOne_T_MANY__T_1_",
+                                "function": "toOne",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "parent"
+                                  }
+                                ]
+                              }
+                            ],
+                            "property": "superOrganizations"
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "superOrganizations",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "removeDuplicates_T_MANY__T_MANY_",
+                "function": "removeDuplicates",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "concatenate_T_MANY__T_MANY__T_MANY_",
+                    "function": "concatenate",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "children"
+                      },
+                      {
+                        "_type": "func",
+                        "fControl": "map_T_MANY__Function_1__V_MANY_",
+                        "function": "map",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "children"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "c"
+                                  }
+                                ],
+                                "property": "subOrganizations"
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "c"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "subOrganizations",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "children"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "c"
+                                  }
+                                ],
+                                "property": "name"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "name"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "c"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "child",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "removeDuplicates_T_MANY__T_MANY_",
+                "function": "removeDuplicates",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "concatenate_T_MANY__T_MANY__T_MANY_",
+                    "function": "concatenate",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "members"
+                      },
+                      {
+                        "_type": "func",
+                        "fControl": "map_T_MANY__Function_1__V_MANY_",
+                        "function": "map",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "subOrganizations"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "o"
+                                  }
+                                ],
+                                "property": "members"
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "o"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "allMembers",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Person",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "otherNames",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "extraInformation",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "manager",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "age",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "nickName",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "activeEmployment",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "plus_String_MANY__String_1_",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    },
+                    "values": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "firstName"
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          " "
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "lastName"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "name",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "plus_String_MANY__String_1_",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 5,
+                      "upperBound": 5
+                    },
+                    "values": [
+                      {
+                        "_type": "var",
+                        "name": "title"
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          " "
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "firstName"
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          " "
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "lastName"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "nameWithTitle",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "title"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "isEmpty_Any_$0_1$__Boolean_1_",
+                    "function": "isEmpty",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "prefix"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "isEmpty_Any_MANY__Boolean_1_",
+                            "function": "isEmpty",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "suffixes"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "plus_String_MANY__String_1_",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 3,
+                                      "upperBound": 3
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "firstName"
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "lastName"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": []
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "plus_String_MANY__String_1_",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 5,
+                                      "upperBound": 5
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "firstName"
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "lastName"
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "func",
+                                        "fControl": "joinStrings_String_MANY__String_1__String_1_",
+                                        "function": "joinStrings",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "suffixes"
+                                          },
+                                          {
+                                            "_type": "string",
+                                            "multiplicity": {
+                                              "lowerBound": 1,
+                                              "upperBound": 1
+                                            },
+                                            "values": [
+                                              ", "
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": []
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "isEmpty_Any_MANY__Boolean_1_",
+                            "function": "isEmpty",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "suffixes"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "plus_String_MANY__String_1_",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 5,
+                                      "upperBound": 5
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "func",
+                                        "fControl": "toOne_T_MANY__T_1_",
+                                        "function": "toOne",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "prefix"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "firstName"
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "lastName"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": []
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "plus_String_MANY__String_1_",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 7,
+                                      "upperBound": 7
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "func",
+                                        "fControl": "toOne_T_MANY__T_1_",
+                                        "function": "toOne",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "prefix"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "firstName"
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "lastName"
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "values": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "func",
+                                        "fControl": "joinStrings_String_MANY__String_1__String_1_",
+                                        "function": "joinStrings",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "suffixes"
+                                          },
+                                          {
+                                            "_type": "string",
+                                            "multiplicity": {
+                                              "lowerBound": 1,
+                                              "upperBound": 1
+                                            },
+                                            "values": [
+                                              ", "
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": []
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "nameWithPrefixAndSuffix",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 0,
+                  "upperBound": 1
+                },
+                "name": "prefix"
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 0
+                },
+                "name": "suffixes"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "name": "lastNameFirst"
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "plus_String_MANY__String_1_",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "lastName"
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "firstName"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "plus_String_MANY__String_1_",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "firstName"
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "lastName"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "fullName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Boolean",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastNameFirst"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "personNameParameter"
+                      }
+                    ],
+                    "property": "lastNameFirst"
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "plus_String_MANY__String_1_",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 5,
+                              "upperBound": 5
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "personNameParameter"
+                                      }
+                                    ],
+                                    "property": "nested"
+                                  }
+                                ],
+                                "property": "prefix"
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "lastName"
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "firstName"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "plus_String_MANY__String_1_",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "firstName"
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "lastName"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "parameterizedName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::PersonNameParameter",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "personNameParameter"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "removeDuplicates_T_MANY__T_MANY_",
+                "function": "removeDuplicates",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "concatenate_T_MANY__T_MANY__T_MANY_",
+                    "function": "concatenate",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "organizations"
+                      },
+                      {
+                        "_type": "func",
+                        "fControl": "map_T_MANY__Function_1__V_MANY_",
+                        "function": "map",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "organizations"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "o"
+                                  }
+                                ],
+                                "property": "superOrganizations"
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "o"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "allOrganizations",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "string",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "values": [
+                  "constant"
+                ]
+              }
+            ],
+            "name": "constant",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "concatenate_T_MANY__T_MANY__T_MANY_",
+                "function": "concatenate",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "address"
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "firm"
+                      }
+                    ],
+                    "property": "address"
+                  }
+                ]
+              }
+            ],
+            "name": "addresses",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Address",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::EntityWithAddress",
+          "test::pure::tests::model::simple::EntityWithLocations"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PersonExtension",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "birthdate",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Date"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "year_Date_$0_1$__Integer_$0_1$_",
+                "function": "year",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "birthdate"
+                  }
+                ]
+              }
+            ],
+            "name": "birthYear",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Person"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PersonNameParameter",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastNameFirst",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "nested",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::PersonNameParameterNested"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PersonNameParameterNested",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "prefix",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PlaceOfInterest",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Product",
+        "originalMilestonedProperties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "classification",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::ProductClassification"
+          }
+        ],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "classification",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::ProductClassification"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "enum",
+                            "fullPath": "test::pure::tests::model::simple::ProductSynonymType"
+                          }
+                        ],
+                        "property": "CUSIP"
+                      }
+                    ],
+                    "property": "synonymByType"
+                  }
+                ],
+                "property": "name"
+              }
+            ],
+            "name": "cusip",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "enum",
+                            "fullPath": "test::pure::tests::model::simple::ProductSynonymType"
+                          }
+                        ],
+                        "property": "ISIN"
+                      }
+                    ],
+                    "property": "synonymByType"
+                  }
+                ],
+                "property": "name"
+              }
+            ],
+            "name": "isin",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "name": "this"
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "enum",
+                        "fullPath": "test::pure::tests::model::simple::ProductSynonymType"
+                      }
+                    ],
+                    "property": "CUSIP"
+                  }
+                ],
+                "property": "synonymByType"
+              }
+            ],
+            "name": "cusipSynonym",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Synonym",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "name": "this"
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "enum",
+                        "fullPath": "test::pure::tests::model::simple::ProductSynonymType"
+                      }
+                    ],
+                    "property": "ISIN"
+                  }
+                ],
+                "property": "synonymByType"
+              }
+            ],
+            "name": "isinSynonym",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Synonym",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "ProductClassification",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "type",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "description",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [
+          {
+            "profile": "meta::pure::profiles::temporal",
+            "value": "businesstemporal"
+          }
+        ],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Synonym",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "typeAsString",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "type",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::ProductSynonymType"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Team",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Organization"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Trade",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "id",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "date",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "quantity",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "product",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Product"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "settlementDateTime",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "DateTime"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "latestEventDate",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "events",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::TradeEvent"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "isNotEmpty_Any_$0_1$__Boolean_1_",
+                    "function": "isNotEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "product"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "isNotEmpty_Any_$0_1$__Boolean_1_",
+                            "function": "isNotEmpty",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "product"
+                                  }
+                                ],
+                                "property": "cusip"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "toOne_T_MANY__T_1_",
+                                "function": "toOne",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "product"
+                                      }
+                                    ],
+                                    "property": "cusip"
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": []
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "func",
+                                    "fControl": "toOne_T_MANY__T_1_",
+                                    "function": "toOne",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "product"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "property": "name"
+                              }
+                            ],
+                            "parameters": []
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "Unknown"
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "productIdentifier",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "isEmpty_Any_$0_1$__Boolean_1_",
+                    "function": "isEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "product"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "Unknown"
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "toOne_T_MANY__T_1_",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "product"
+                              }
+                            ]
+                          }
+                        ],
+                        "property": "name"
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "productDescription",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "isNotEmpty_Any_$0_1$__Boolean_1_",
+                    "function": "isNotEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "account"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "toOne_T_MANY__T_1_",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "account"
+                              }
+                            ]
+                          }
+                        ],
+                        "property": "name"
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          "Unknown"
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "accountDescription",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "isNotEmpty_Any_$0_1$__Boolean_1_",
+                    "function": "isNotEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "product"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "if_Boolean_1__Function_1__Function_1__T_m_",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "fControl": "isNotEmpty_Any_$0_1$__Boolean_1_",
+                            "function": "isNotEmpty",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "product"
+                                  }
+                                ],
+                                "property": "cusip"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "product"
+                                  }
+                                ],
+                                "property": "cusip"
+                              }
+                            ],
+                            "parameters": []
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "product"
+                                  }
+                                ],
+                                "property": "name"
+                              }
+                            ],
+                            "parameters": []
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": []
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "collection",
+                        "multiplicity": {
+                          "lowerBound": 0,
+                          "upperBound": 0
+                        },
+                        "values": []
+                      }
+                    ],
+                    "parameters": []
+                  }
+                ]
+              }
+            ],
+            "name": "productIdentifierWithNull",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "minus_Float_MANY__Float_1_",
+                "function": "minus",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "quantity"
+                  }
+                ]
+              }
+            ],
+            "name": "customerQuantity",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Float",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "dateDiff_Date_1__Date_1__DurationUnit_1__Integer_1_",
+                "function": "dateDiff",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "toOne_T_MANY__T_1_",
+                    "function": "toOne",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "latestEventDate"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "date"
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "enum",
+                        "fullPath": "meta::pure::functions::date::DurationUnit"
+                      }
+                    ],
+                    "property": "DAYS"
+                  }
+                ]
+              }
+            ],
+            "name": "daysToLastEvent",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ],
+                        "property": "events"
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ],
+                                "property": "date"
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "latestEventDate"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "latestEvent",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::TradeEvent",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ],
+                    "property": "events"
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ],
+                            "property": "date"
+                          },
+                          {
+                            "_type": "var",
+                            "name": "date"
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "eventsByDate",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Date",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "date"
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::TradeEvent",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          },
+                          {
+                            "_type": "func",
+                            "fControl": "toOne_T_MANY__T_1_",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this"
+                                  }
+                                ],
+                                "property": "date"
+                              }
+                            ]
+                          }
+                        ],
+                        "property": "eventsByDate"
+                      }
+                    ],
+                    "property": "eventType"
+                  }
+                ]
+              }
+            ],
+            "name": "tradeDateEventType",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      },
+                      {
+                        "_type": "func",
+                        "fControl": "toOne_T_MANY__T_1_",
+                        "function": "toOne",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "date"
+                          }
+                        ]
+                      }
+                    ],
+                    "property": "eventsByDate"
+                  }
+                ]
+              }
+            ],
+            "name": "tradeDateEvent",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::TradeEvent",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "events"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "date"
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "date"
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "property": "eventType"
+                  }
+                ]
+              }
+            ],
+            "name": "tradeDateEventTypeInlined",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          },
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "date"
+                          }
+                        ],
+                        "property": "eventsByDate"
+                      }
+                    ],
+                    "property": "initiator"
+                  }
+                ]
+              }
+            ],
+            "name": "initiator",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOne_T_MANY__T_1_",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "events"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "date"
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this"
+                                      }
+                                    ],
+                                    "property": "date"
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "property": "initiator"
+                  }
+                ]
+              }
+            ],
+            "name": "initiatorInlined",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "fControl": "toOneMany_T_MANY__T_$1_MANY$_",
+                "function": "toOneMany",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "fControl": "filter_T_MANY__Function_1__T_MANY_",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ],
+                            "property": "events"
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "fControl": "equal_Any_MANY__Any_MANY__Boolean_1_",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e"
+                                      }
+                                    ],
+                                    "property": "eventType"
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this"
+                                          }
+                                        ],
+                                        "property": "product"
+                                      }
+                                    ],
+                                    "property": "name"
+                                  }
+                                ]
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "property": "initiator"
+                  }
+                ]
+              }
+            ],
+            "name": "initiatorInlinedByProductName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "TradeEvent",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "eventType",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "date",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "initiator",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "traderAddress",
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      }
+    ],
+    "enums": [
+      {
+        "_type": "Enumeration",
+        "name": "GenderType",
+        "package": "test::owl::tests::model",
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "MALE"
+          },
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "FEMALE"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "OrgLevelType",
+        "package": "test::owl::tests::model",
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "VP"
+          },
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "MD"
+          },
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "PMD"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "Region",
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "NewYork"
+          },
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "London"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "GeographicEntityType",
+        "package": "test::pure::tests::model::simple",
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "stereotypes": [],
+            "taggedValues": [
+              {
+                "tag": {
+                  "profile": "meta::pure::profiles::doc",
+                  "value": "doc"
+                },
+                "value": "A city, town, village, or other urban area."
+              }
+            ],
+            "value": "CITY"
+          },
+          {
+            "stereotypes": [
+              {
+                "profile": "meta::pure::profiles::doc",
+                "value": "deprecated"
+              }
+            ],
+            "taggedValues": [],
+            "value": "COUNTRY"
+          },
+          {
+            "stereotypes": [],
+            "taggedValues": [
+              {
+                "tag": {
+                  "profile": "meta::pure::profiles::doc",
+                  "value": "doc"
+                },
+                "value": "Any geographic entity other than a city or country."
+              }
+            ],
+            "value": "REGION"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "ProductSynonymType",
+        "package": "test::pure::tests::model::simple",
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "CUSIP"
+          },
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "ISIN"
+          },
+          {
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "GSN"
+          }
+        ]
+      }
+    ],
+    "functions": [],
+    "measures": [],
+    "profiles": []
+  },
+  "fileGenerations": [],
+  "flattenSpecifications": [],
+  "generationSpecifications": [],
+  "mappings": [
+    {
+      "_type": "mapping",
+      "associationMappings": [],
+      "classMappings": [
+        {
+          "_type": "pureInstance",
+          "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+          "id": "meta_pure_mapping_modelToModel_test_shared_dest_Person",
+          "propertyMappings": [
+            {
+              "_type": "purePropertyMapping",
+              "explodeProperty": false,
+              "property": {
+                "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                "property": "firstName"
+              },
+              "source": "meta_pure_mapping_modelToModel_test_shared_dest_Person",
+              "target": "",
+              "transform": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "func",
+                    "fControl": "substring_String_1__Integer_1__Integer_1__String_1_",
+                    "function": "substring",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "src"
+                          }
+                        ],
+                        "property": "fullName"
+                      },
+                      {
+                        "_type": "integer",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "values": [
+                          0
+                        ]
+                      },
+                      {
+                        "_type": "func",
+                        "fControl": "indexOf_String_1__String_1__Integer_1_",
+                        "function": "indexOf",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "src"
+                              }
+                            ],
+                            "property": "fullName"
+                          },
+                          {
+                            "_type": "string",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "values": [
+                              " "
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "class": "test::pure::mapping::modelToModel::test::shared::src::_S_Person",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "name": "src"
+                  }
+                ]
+              }
+            },
+            {
+              "_type": "purePropertyMapping",
+              "explodeProperty": false,
+              "property": {
+                "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                "property": "lastName"
+              },
+              "source": "meta_pure_mapping_modelToModel_test_shared_dest_Person",
+              "target": "",
+              "transform": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "func",
+                    "fControl": "substring_String_1__Integer_1__Integer_1__String_1_",
+                    "function": "substring",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "src"
+                          }
+                        ],
+                        "property": "fullName"
+                      },
+                      {
+                        "_type": "func",
+                        "fControl": "plus_Integer_MANY__Integer_1_",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 2,
+                              "upperBound": 2
+                            },
+                            "values": [
+                              {
+                                "_type": "func",
+                                "fControl": "indexOf_String_1__String_1__Integer_1_",
+                                "function": "indexOf",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "src"
+                                      }
+                                    ],
+                                    "property": "fullName"
+                                  },
+                                  {
+                                    "_type": "string",
+                                    "multiplicity": {
+                                      "lowerBound": 1,
+                                      "upperBound": 1
+                                    },
+                                    "values": [
+                                      " "
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "_type": "integer",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "values": [
+                                  1
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "func",
+                        "fControl": "length_String_1__Integer_1_",
+                        "function": "length",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "src"
+                              }
+                            ],
+                            "property": "fullName"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "class": "test::pure::mapping::modelToModel::test::shared::src::_S_Person",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "name": "src"
+                  }
+                ]
+              }
+            }
+          ],
+          "root": true,
+          "srcClass": "test::pure::mapping::modelToModel::test::shared::src::_S_Person"
+        },
+        {
+          "_type": "pureInstance",
+          "class": "test::pure::mapping::modelToModel::test::shared::dest::Product2Simple",
+          "id": "meta_pure_mapping_modelToModel_test_shared_dest_Product2Simple",
+          "propertyMappings": [
+            {
+              "_type": "purePropertyMapping",
+              "explodeProperty": false,
+              "property": {
+                "class": "test::pure::mapping::modelToModel::test::shared::dest::Product2Simple",
+                "property": "name"
+              },
+              "source": "meta_pure_mapping_modelToModel_test_shared_dest_Product2Simple",
+              "target": "",
+              "transform": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "src"
+                      }
+                    ],
+                    "property": "name"
+                  }
+                ],
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "class": "test::pure::mapping::modelToModel::test::shared::src::_Product2",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "name": "src"
+                  }
+                ]
+              }
+            },
+            {
+              "_type": "purePropertyMapping",
+              "explodeProperty": false,
+              "property": {
+                "class": "test::pure::mapping::modelToModel::test::shared::dest::Product2Simple",
+                "property": "region"
+              },
+              "source": "meta_pure_mapping_modelToModel_test_shared_dest_Product2Simple",
+              "target": "",
+              "transform": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "src"
+                      }
+                    ],
+                    "property": "region"
+                  }
+                ],
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "class": "test::pure::mapping::modelToModel::test::shared::src::_Product2",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "name": "src"
+                  }
+                ]
+              }
+            }
+          ],
+          "root": true,
+          "srcClass": "test::pure::mapping::modelToModel::test::shared::src::_Product2"
+        }
+      ],
+      "enumerationMappings": [],
+      "includedMappings": [],
+      "name": "simpleModelMapping",
+      "package": "test::pure::mapping::modelToModel::test::simple",
+      "tests": []
+    }
+  ],
+  "pipelines": [],
+  "runtimes": [],
+  "sectionIndices": [],
+  "serializableModelSpecifications": [],
+  "services": [
+    {
+      "_type": "service",
+      "autoActivateUpdates": true,
+      "documentation": "JsonModelConnection example M2M service",
+      "execution": {
+        "_type": "pureSingleExecution",
+        "func": {
+          "_type": "lambda",
+          "body": [
+            {
+              "_type": "func",
+              "fControl": "serialize_T_MANY__RootGraphFetchTree_1__String_1_",
+              "function": "serialize",
+              "parameters": [
+                {
+                  "_type": "func",
+                  "fControl": "graphFetch_T_MANY__RootGraphFetchTree_1__T_MANY_",
+                  "function": "graphFetch",
+                  "parameters": [
+                    {
+                      "_type": "func",
+                      "fControl": "getAll_Class_1__T_MANY_",
+                      "function": "getAll",
+                      "parameters": [
+                        {
+                          "_type": "class",
+                          "fullPath": "test::pure::mapping::modelToModel::test::shared::dest::Person"
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "rootGraphFetchTree",
+                      "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                      "subTrees": [
+                        {
+                          "_type": "propertyGraphFetchTree",
+                          "parameters": [],
+                          "property": "firstName",
+                          "subTrees": []
+                        },
+                        {
+                          "_type": "propertyGraphFetchTree",
+                          "parameters": [],
+                          "property": "lastName",
+                          "subTrees": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "_type": "rootGraphFetchTree",
+                  "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                  "subTrees": [
+                    {
+                      "_type": "propertyGraphFetchTree",
+                      "parameters": [],
+                      "property": "firstName",
+                      "subTrees": []
+                    },
+                    {
+                      "_type": "propertyGraphFetchTree",
+                      "parameters": [],
+                      "property": "lastName",
+                      "subTrees": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        },
+        "mapping": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+        "runtime": {
+          "_type": "legacyRuntime",
+          "connections": [
+            {
+              "_type": "JsonModelConnection",
+              "class": "test::pure::mapping::modelToModel::test::shared::src::_S_Person",
+              "element": "ModelStore",
+              "url": "executor:default"
+            }
+          ],
+          "mappings": []
+        }
+      },
+      "name": "simpleServiceNoTest",
+      "owners": [
+        "debelp",
+        "harted"
+      ],
+      "package": "test::legend::service::execution::test::m2m",
+      "pattern": "/simpleJson",
+      "test": {
+        "_type": "singleExecutionTest",
+        "asserts": [
+        ],
+        "data": ""
+      }
+    }
+  ],
+  "stores": [],
+  "texts": []
+}


### PR DESCRIPTION
Exclude service test processing when no asserts provided.
This will help with - 
1. Services depending on stores for which test strategy is not defined
2. Faster development flow as test plan generation & setup takes considerable amount of time

We can still add validation at earlier steps to stop service registration in prod without tests