### PR TITLE
Support inner join in the filter mapping in the Engine

### DIFF
--- a/legend-engine-language-pure-store-relational/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
+++ b/legend-engine-language-pure-store-relational/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
@@ -194,7 +194,7 @@ tableAliasColumnOperationWithScopeInfo:     relationalIdentifier (DOT scopeInfo)
 ;
 joinOperation:                              databasePointer? joinSequence (PIPE (booleanOperation | tableAliasColumnOperation))?
 ;
-joinSequence:                               joinPointer (GREATER_THAN joinPointerFull)*
+joinSequence:                               (PAREN_OPEN identifier PAREN_CLOSE)? joinPointer (GREATER_THAN joinPointerFull)*
 ;
 joinPointer:                                AT identifier
 ;

--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -880,8 +880,13 @@ public class RelationalParseTreeWalker
     // NOTE: right now, for join we only support sequence (line), not tree
     private List<JoinPointer> visitJoinSequence(RelationalParserGrammar.JoinSequenceContext ctx, String database, ScopeInfo scopeInfo)
     {
+        Token joinType = ctx.identifier() != null ? ctx.identifier().getStart() : null;
+        if (joinType != null && !JOIN_TYPES.contains(joinType.getText().toUpperCase()))
+        {
+            throw new EngineException("Unsupported join type '" + joinType.getText() + "'", this.walkerSourceInformation.getSourceInformation(ctx.identifier().getStart()), EngineErrorType.PARSER);
+        }
         List<JoinPointer> joins = new ArrayList<>();
-        joins.add(visitJoinPointer(ctx.joinPointer(), null, scopeInfo, database));
+        joins.add(visitJoinPointer(ctx.joinPointer(), joinType == null ? null : joinType.getText().toUpperCase(), scopeInfo, database));
         for (RelationalParserGrammar.JoinPointerFullContext joinPointerFullContext : ctx.joinPointerFull())
         {
             if (joinPointerFullContext.identifier() != null && !JOIN_TYPES.contains(PureGrammarParserUtility.fromIdentifier(joinPointerFullContext.identifier()).toUpperCase()))

--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
@@ -475,11 +475,23 @@ public class HelperRelationalGrammarComposer
         return "[" + database + "]";
     }
 
+    private static String renderJoinPointerForTheFirstFilterJoin(JoinPointer joinPointer)
+    {
+        return (joinPointer.db != null ? renderDatabasePointer(joinPointer.db) : "") + " " +
+                (joinPointer.joinType != null ? ("(" + joinPointer.joinType.toUpperCase() + ") ") : "") +
+                "@" + PureGrammarComposerUtility.convertIdentifier(joinPointer.name);
+    }
+
     public static String renderFilterMapping(FilterMapping filterMapping)
     {
-        return "~filter " + (filterMapping.filter.db != null
-                ? (LazyIterate.collect(filterMapping.joins, HelperRelationalGrammarComposer::renderJoinPointer).makeString(" > ") + (!filterMapping.joins.isEmpty() ? " | " : "") + renderDatabasePointer(filterMapping.filter.db))
-                : "") +
+        int joinSize = filterMapping.joins.size();
+        String firstJoin = joinSize > 0 ? renderJoinPointerForTheFirstFilterJoin(filterMapping.joins.get(0)) : "";
+        List<JoinPointer> otherJoins = joinSize > 1 ? filterMapping.joins.subList(1, joinSize) : null;
+        String body = firstJoin +
+                (otherJoins != null ? " > " + LazyIterate.collect(otherJoins, HelperRelationalGrammarComposer::renderJoinPointer).makeString(" > "): "" ) +
+                (!filterMapping.joins.isEmpty() ? " | " : "") + renderDatabasePointer(filterMapping.filter.db);
+
+        return "~filter " + (filterMapping.filter.db != null ? body : "") +
                 PureGrammarComposerUtility.convertIdentifier(filterMapping.filter.name);
     }
 

--- a/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarParser.java
+++ b/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarParser.java
@@ -189,4 +189,54 @@ public class TestRelationalMappingGrammarParser extends TestGrammarParser.TestGr
                 ")\n", "PARSER error at [9:48-53]: Mapping test relational input data does not support format 'RANDOM'. Possible values: SQL, CSV");
     }
 
+    @Test
+    public void testClassMappingFilterWithInnerJoin()
+    {
+        test("import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    firstName:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    employees:Person[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table personTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    firstName VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Table firmTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    legalName VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   View personFirmView\n"+
+                        "   (\n" +
+                        "    id : personTable.id,\n" +
+                        "    firstName : personTable.firstName,\n" +
+                        "    firmId : personTable.firmId\n" +
+                        "   )\n" +
+                        "   Filter FirmFilter(firmTable.legalName = 'A')\n" +
+                        "   Join Firm_Person(firmTable.id = personTable.firmId)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Person: Relational\n" +
+                        "    {\n" +
+                        "        ~filter [mapping::db] (INNER) @Firm_Person | [mapping::db] FirmFilter \n" +
+                        "        firstName : [db]personTable.firstName\n" +
+                        "    }\n" +
+                        ")\n");
+    }
 }

--- a/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
+++ b/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
@@ -41,4 +41,18 @@ public class TestRelationalMappingGrammarRoundtrip extends TestGrammarRoundtrip.
                 "  }\n" +
                 ")\n");
     }
+
+    @Test
+    public void testClassMappingFilterWithInnerJoin()
+    {
+        test("###Mapping\n" +
+                "Mapping mappingPackage::myMapping\n" +
+                "(\n" +
+                "  Person: Relational\n" +
+                "  {\n" +
+                "    ~filter [mapping::db] (INNER) @Firm_Person | [mapping::db]FirmFilter\n" +
+                "    firstName: [db]personTable.firstName\n" +
+                "  }\n" +
+                ")\n");
+    }
 }


### PR DESCRIPTION
Support inner join in the filter mapping in the Engine
The grammar is: ~filter [mapping::db] (INNER) @Firm_Person | [mapping::db] FirmFilter