### PR TITLE
Allow configuration of graphFetch batch memory limit in ServiceRunner API

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/PlanExecutor.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/PlanExecutor.java
@@ -59,7 +59,7 @@ public class PlanExecutor
     private final boolean isJavaCompilationAllowed;
     private final ImmutableList<StoreExecutor> extraExecutors;
     private final PlanExecutorInfo planExecutorInfo;
-    private final long graphFetchBatchMemoryLimit;
+    private long graphFetchBatchMemoryLimit;
 
     private PlanExecutor(boolean isJavaCompilationAllowed, ImmutableList<StoreExecutor> extraExecutors, long graphFetchBatchMemoryLimit)
     {
@@ -192,6 +192,11 @@ public class PlanExecutor
             // execute
             return singleExecutionPlan.rootExecutionNode.accept(new ExecutionNodeExecutor(profiles, state));
         }
+    }
+
+    public void setGraphFetchBatchMemoryLimit(long graphFetchBatchMemoryLimit)
+    {
+        this.graphFetchBatchMemoryLimit = graphFetchBatchMemoryLimit;
     }
 
     private EngineJavaCompiler possiblyCompilePlan(SingleExecutionPlan plan, ExecutionState state, MutableList<CommonProfile> profiles)

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
@@ -146,6 +146,12 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
     }
 
     @Override
+    public void setGraphFetchBatchMemoryLimit(long graphFetchBatchMemoryLimit)
+    {
+        this.executor.setGraphFetchBatchMemoryLimit(graphFetchBatchMemoryLimit);
+    }
+
+    @Override
     public String toString()
     {
         return "<" + getClass().getSimpleName() + " " + getServicePath() + ">";

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/OperationalContext.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/OperationalContext.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-/* Work in progress, do not use */
-
 public class OperationalContext
 {
     private Map<GraphFetchCrossAssociationKeys, ExecutionCache<GraphFetchCacheKey, List<Object>>> graphFetchCrossAssociationKeysCacheConfig;

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
@@ -22,8 +22,6 @@ import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
 
-/* Work in progress, do not use */
-
 public interface ServiceRunner
 {
     /**
@@ -80,4 +78,11 @@ public interface ServiceRunner
     {
         return Collections.emptyList();
     }
+
+    /**
+     * Set the memory limit for one batch of a graph fetch execution for this instance of ServiceRunner
+     *
+     * @param graphFetchBatchMemoryLimit limit in bytes for one batch of a graph fetch execution
+     */
+    void setGraphFetchBatchMemoryLimit(long graphFetchBatchMemoryLimit);
 }

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunnerInput.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunnerInput.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-/* Work in progress, do not use */
-
 public class ServiceRunnerInput
 {
     private List<Object> args = Collections.emptyList();

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunnerInput.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunnerInput.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+/* Work in progress, do not use */
+
 public class ServiceRunnerInput
 {
     private List<Object> args = Collections.emptyList();

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure
@@ -28,6 +28,11 @@ function test::function(input: String[1]): String[1]
    test::Person.all()->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#)
 }
 
+function test::functionWithBatchSize(input: String[1]): String[1]
+{
+   test::Person.all()->graphFetch(#{test::Person{firstName,lastName}}#, 10)->serialize(#{test::Person{firstName,lastName}}#)
+}
+
 
 ###Mapping
 Mapping test::Map


### PR DESCRIPTION
This PR allows configuration of graphFetch batch memory limit when executing services using service-execution JAR.

Benefits:

1. Allow graph fetch executions with large objects in JAR execution flow (which exceed 50MB limit)
2. Improve query performance by using large batch sizes when executing in a dedicated runtime