### PR TITLE
Add milestone column validations to ensure they exists on table definition

### DIFF
--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -824,14 +824,24 @@ public class HelperRelationalBuilder
                 columns, context);
     }
 
+    public static RichIterable<Column> getMilestoneColumn(String colName, Multimap<String, Column> columns, SourceInformation sourceInformation)
+    {
+        RichIterable<Column> c = columns.get(colName);
+        if (c == null || c.isEmpty())
+        {
+            throw new EngineException(String.format("Milestone column '%s' not found on table definition", colName), sourceInformation, EngineErrorType.COMPILATION);
+        }
+        return c;
+    }
+
     public static org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.Milestoning visitMilestoning(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.Milestoning milestoning, CompileContext context, Multimap<String, Column> columns)
     {
         if (milestoning instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.BusinessMilestoning)
         {
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.BusinessMilestoning businessMilestoning = (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.BusinessMilestoning) milestoning;
             Root_meta_relational_metamodel_relation_BusinessMilestoning_Impl pureBm = new Root_meta_relational_metamodel_relation_BusinessMilestoning_Impl("");
-            pureBm._from(columns.get(businessMilestoning.from));
-            pureBm._thru(columns.get(businessMilestoning.thru));
+            pureBm._from(getMilestoneColumn(businessMilestoning.from, columns, milestoning.sourceInformation));
+            pureBm._thru(getMilestoneColumn(businessMilestoning.thru, columns, milestoning.sourceInformation));
             if (businessMilestoning.infinityDate != null)
             {
                 pureBm._infinityDate((PureDate) ((Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl) businessMilestoning.infinityDate.accept(new ValueSpecificationBuilder(context, Lists.mutable.empty(), new ProcessingContext("TO REMOVE!"))))._values.getFirst());
@@ -843,15 +853,15 @@ public class HelperRelationalBuilder
         {
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.BusinessSnapshotMilestoning businessSnapshotMilestoning = (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.BusinessSnapshotMilestoning) milestoning;
             Root_meta_relational_metamodel_relation_BusinessSnapshotMilestoning_Impl pureBsm = new Root_meta_relational_metamodel_relation_BusinessSnapshotMilestoning_Impl("");
-            pureBsm._snapshotDate(columns.get(businessSnapshotMilestoning.snapshotDate));
+            pureBsm._snapshotDate(getMilestoneColumn(businessSnapshotMilestoning.snapshotDate, columns, milestoning.sourceInformation));
             return pureBsm;
         }
         else if (milestoning instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.ProcessingMilestoning)
         {
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.ProcessingMilestoning processingMilestoning = (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.ProcessingMilestoning) milestoning;
             Root_meta_relational_metamodel_relation_ProcessingMilestoning_Impl purePm = new Root_meta_relational_metamodel_relation_ProcessingMilestoning_Impl("");
-            purePm._in(columns.get(processingMilestoning.in));
-            purePm._out(columns.get(processingMilestoning.out));
+            purePm._in(getMilestoneColumn(processingMilestoning.in, columns, milestoning.sourceInformation));
+            purePm._out(getMilestoneColumn(processingMilestoning.out, columns, milestoning.sourceInformation));
             if (processingMilestoning.infinityDate != null)
             {
                 purePm._infinityDate((PureDate) ((Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl) processingMilestoning.infinityDate.accept(new ValueSpecificationBuilder(context, Lists.mutable.empty(), new ProcessingContext("TO REMOVE!"))))._values.getFirst());

--- a/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -245,6 +245,75 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
     }
 
     @Test
+    public void testMissingColumnOnMilestoning()
+    {
+        // PROCESSING_IN missing
+        test("###Relational\n" +
+                "Database app::db\n" +
+                "(\n" +
+                "    Table personTable" +
+                "    (" +
+                "       milestoning(processing(PROCESSING_IN = dummyIn, PROCESSING_OUT = dummyOut))" +
+                "       ID INT PRIMARY KEY, MANAGERID INT, dummyOut TIMESTAMP\n" +
+                "    )\n" +
+                ")",
+                "COMPILATION error at [4:47-108]: Milestone column 'dummyIn' not found on table definition"
+            );
+
+        // PROCESSING_OUT missing
+        test("###Relational\n" +
+                        "Database app::db\n" +
+                        "(\n" +
+                        "    Table personTable" +
+                        "    (" +
+                        "       milestoning(processing(PROCESSING_IN = dummyIn, PROCESSING_OUT = dummyOut))" +
+                        "       ID INT PRIMARY KEY, MANAGERID INT, dummyIn TIMESTAMP\n" +
+                        "    )\n" +
+                        ")",
+                "COMPILATION error at [4:47-108]: Milestone column 'dummyOut' not found on table definition"
+        );
+
+        // BUS_FROM missing
+        test("###Relational\n" +
+                        "Database app::db\n" +
+                        "(\n" +
+                        "    Table personTable" +
+                        "    (" +
+                        "       milestoning(business(BUS_FROM = dummyIn, BUS_THRU = dummyOut))" +
+                        "       ID INT PRIMARY KEY, MANAGERID INT, dummyOut DATE\n" +
+                        "    )\n" +
+                        ")",
+                "COMPILATION error at [4:56-94]: Milestone column 'dummyIn' not found on table definition"
+        );
+
+        // BUS_THRU missing
+        test("###Relational\n" +
+                        "Database app::db\n" +
+                        "(\n" +
+                        "    Table personTable" +
+                        "    (" +
+                        "       milestoning(business(BUS_FROM = dummyIn, BUS_THRU = dummyOut))" +
+                        "       ID INT PRIMARY KEY, MANAGERID INT, dummyIn DATE\n" +
+                        "    )\n" +
+                        ")",
+                "COMPILATION error at [4:56-94]: Milestone column 'dummyOut' not found on table definition"
+        );
+
+        // BUS_SNAPSHOT_DATE missing
+        test("###Relational\n" +
+                        "Database app::db\n" +
+                        "(\n" +
+                        "    Table personTable" +
+                        "    (" +
+                        "       milestoning(business(BUS_SNAPSHOT_DATE = dummy))" +
+                        "       ID INT PRIMARY KEY, MANAGERID INT\n" +
+                        "    )\n" +
+                        ")",
+                "COMPILATION error at [4:56-80]: Milestone column 'dummy' not found on table definition"
+        );
+    }
+
+    @Test
     public void testMissingJoin()
     {
         test("###Relational\n" +


### PR DESCRIPTION
The columns referenced on the milestone details needs to exists on the table schema definition.  If a user forgets to define it, they could get cryptic errors inside pureToSql.  This bugfix ensure we throw early, on the compilation phase, and that the error is meaningful to the user to understand how to action it.