### PR TITLE
generate test Runtime for runtime pointer provided in service spec

### DIFF
--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestGenerationHelper.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestGenerationHelper.java
@@ -90,6 +90,11 @@ public class ServiceTestGenerationHelper
             EngineRuntime engineRuntime = resolveRuntime(runtime, pureModelContextData);
             return buildMultipleConnectionRuntime(mappingPath, testData, engineRuntime, pureModelContextData, pureModel);
         }
+        if (runtime instanceof RuntimePointer)
+        {
+            EngineRuntime engineRuntime = resolveRuntime(runtime, pureModelContextData);
+            return buildRelationalTestRuntime(engineRuntime, mappingPath, testData, pureModel);
+        }
         return buildRelationalTestRuntime(runtime, mappingPath, testData, pureModel);
     }
 


### PR DESCRIPTION
Currently If Runtime path is provided is service spec, while generating H2 runtime for testing , it returns the original runtime instead of generating a new H2 runtime. Handled this case with this commit