### PR TITLE
corrected SchemaTo field being dropped in postprocessing mappers in toGrammar Api

### DIFF
--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
@@ -714,9 +714,7 @@ public class HelperRelationalGrammarComposer
                 "from: '" + nameMapper.from + "'; " +
                 "to: '" + nameMapper.to + "'; " +
                 "schemaFrom: '" + nameMapper.schema.from + "';" +
-                (nameMapper.schema.from.equals(nameMapper.schema.to)
-                        ? ""
-                        : " schemaTo: '" + nameMapper.schema.to + "';") +
+                " schemaTo: '" + nameMapper.schema.to + "';" +
                 "}";
     }
 

--- a/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalConnectionGrammarRoundtrip.java
+++ b/legend-engine-language-pure-store-relational/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalConnectionGrammarRoundtrip.java
@@ -286,6 +286,20 @@ public class TestRelationalConnectionGrammarRoundtrip extends TestGrammarRoundtr
     }
 
     @Test
+    public void testSingleMapperPostProcessorsWithTableMappingWithinSameSchema()
+    {
+        testPostProcessor(
+                "    mapper\n" +
+                        "    {\n" +
+                        "      mappers:\n" +
+                        "      [\n" +
+                        "        table {from: 'a'; to: 'A'; schemaFrom: 'B'; schemaTo: 'B';},\n" +
+                        "        schema {from: 'c'; to: 'C';}\n" +
+                        "      ];\n" +
+                        "    }");
+    }
+
+    @Test
     public void testMultipleMapperPostProcessors()
     {
         testPostProcessor(


### PR DESCRIPTION
SchemaTo field in postprocessing mappers was being dropped if SchemaTo=SchemaFrom. It was causing failures in Studio when switching to text mode . As Studio tried to fetch grammar from Legend-sdlc but this 'schemaTo' field was being dropped , causing failure in compilation. Added Round trip test for same case