### PR TITLE
Service Test Parameters - multiple parameters fix

### DIFF
--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
@@ -298,10 +298,10 @@ public class ServiceTestRunner
                                 p -> p.getOne().name,
                                 p -> p.getTwo() instanceof Collection   // Condition evoked in case of studio-flow
                                     ? new ConstantResult(
-                                    ListIterate.collect(( (Collection) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor())))
+                                    ListIterate.collect(( (Collection) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor()).getValue()))
                                     : p.getTwo() instanceof PureList   // Condition evoked in case of pureIDE-flow
                                     ? new ConstantResult(
-                                    ListIterate.collect(( (PureList) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor())))
+                                    ListIterate.collect(( (PureList) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor()).getValue()))
                                     : p.getTwo().accept(new ValueSpecificationToResultVisitor()));
                     }
 


### PR DESCRIPTION
The service registration fix was added for parameters of list type, which was breaking in the earlier release.