### PR TITLE
Fix processing of multiple service test parameters

### DIFF
--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
@@ -298,10 +298,10 @@ public class ServiceTestRunner
                                 p -> p.getOne().name,
                                 p -> p.getTwo() instanceof Collection   // Condition evoked in case of studio-flow
                                     ? new ConstantResult(
-                                    ListIterate.collect(( (Collection) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor())))
+                                    ListIterate.collect(( (Collection) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor()).getValue()))
                                     : p.getTwo() instanceof PureList   // Condition evoked in case of pureIDE-flow
                                     ? new ConstantResult(
-                                    ListIterate.collect(( (PureList) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor())))
+                                    ListIterate.collect(( (PureList) p.getTwo()).values, v -> v.accept(new ValueSpecificationToResultVisitor()).getValue()))
                                     : p.getTwo().accept(new ValueSpecificationToResultVisitor()));
                     }
 

--- a/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestServiceTestRunner.java
@@ -80,6 +80,12 @@ public class TestServiceTestRunner
     }
 
     @Test
+    public void testSucceedingServiceWithMultiParam() throws Exception
+    {
+        test("legend-sdlc-test-services-with-multi-param.json","test::legend::service::execution::test::m2m::simpleJsonServiceMultiParam", TestResult.SUCCESS, false);
+    }
+
+    @Test
     public void testFailingService() throws Exception
     {
         test("legend-sdlc-test-services-with-tests.json", "test::legend::service::execution::test::m2m::simpleFailingJsonService", TestResult.FAILURE, false);

--- a/legend-engine-test-runner-service/src/test/resources/legend-sdlc-test-services-with-multi-param.json
+++ b/legend-engine-test-runner-service/src/test/resources/legend-sdlc-test-services-with-multi-param.json
@@ -1,0 +1,16019 @@
+{
+    "_type": "data",
+    "elements": [
+      {
+        "_type": "service",
+        "autoActivateUpdates": true,
+        "documentation": "JsonModelConnection example M2M service",
+        "execution": {
+          "_type": "pureSingleExecution",
+          "func": {
+            "_type": "lambda",
+            "body": [
+              {
+                "_type": "func",
+                "function": "serialize",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "graphFetch",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "getAll",
+                        "parameters": [
+                          {
+                            "_type": "packageableElementPtr",
+                            "fullPath": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                            "sourceInformation": {
+                              "endColumn": 73,
+                              "endLine": 14,
+                              "sourceId": "",
+                              "startColumn": 13,
+                              "startLine": 14
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 79,
+                          "endLine": 14,
+                          "sourceId": "",
+                          "startColumn": 74,
+                          "startLine": 14
+                        }
+                      },
+                      {
+                        "_type": "rootGraphFetchTree",
+                        "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                        "sourceInformation": {
+                          "endColumn": 155,
+                          "endLine": 14,
+                          "sourceId": "",
+                          "startColumn": 95,
+                          "startLine": 14
+                        },
+                        "subTrees": [
+                          {
+                            "_type": "propertyGraphFetchTree",
+                            "parameters": [],
+                            "property": "firstName",
+                            "sourceInformation": {
+                              "endColumn": 165,
+                              "endLine": 14,
+                              "sourceId": "",
+                              "startColumn": 157,
+                              "startLine": 14
+                            },
+                            "subTrees": []
+                          },
+                          {
+                            "_type": "propertyGraphFetchTree",
+                            "parameters": [],
+                            "property": "lastName",
+                            "sourceInformation": {
+                              "endColumn": 174,
+                              "endLine": 14,
+                              "sourceId": "",
+                              "startColumn": 167,
+                              "startLine": 14
+                            },
+                            "subTrees": []
+                          }
+                        ]
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 91,
+                      "endLine": 14,
+                      "sourceId": "",
+                      "startColumn": 82,
+                      "startLine": 14
+                    }
+                  },
+                  {
+                    "_type": "rootGraphFetchTree",
+                    "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                    "sourceInformation": {
+                      "endColumn": 253,
+                      "endLine": 14,
+                      "sourceId": "",
+                      "startColumn": 193,
+                      "startLine": 14
+                    },
+                    "subTrees": [
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "firstName",
+                        "sourceInformation": {
+                          "endColumn": 263,
+                          "endLine": 14,
+                          "sourceId": "",
+                          "startColumn": 255,
+                          "startLine": 14
+                        },
+                        "subTrees": []
+                      },
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "lastName",
+                        "sourceInformation": {
+                          "endColumn": 272,
+                          "endLine": 14,
+                          "sourceId": "",
+                          "startColumn": 265,
+                          "startLine": 14
+                        },
+                        "subTrees": []
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 189,
+                  "endLine": 14,
+                  "sourceId": "",
+                  "startColumn": 181,
+                  "startLine": 14
+                }
+              }
+            ],
+            "parameters": [],
+            "sourceInformation": {
+              "endColumn": 276,
+              "endLine": 14,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 14
+            }
+          },
+          "mapping": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+          "mappingSourceInformation": {
+            "endColumn": 80,
+            "endLine": 15,
+            "sourceId": "",
+            "startColumn": 14,
+            "startLine": 15
+          },
+          "runtime": {
+            "_type": "engineRuntime",
+            "connections": [
+              {
+                "sourceInformation": {
+                  "endColumn": 9,
+                  "endLine": 30,
+                  "sourceId": "",
+                  "startColumn": 9,
+                  "startLine": 20
+                },
+                "store": {
+                  "path": "ModelStore",
+                  "sourceInformation": {
+                    "endColumn": 18,
+                    "endLine": 20,
+                    "sourceId": "",
+                    "startColumn": 9,
+                    "startLine": 20
+                  },
+                  "type": "STORE"
+                },
+                "storeConnections": [
+                  {
+                    "connection": {
+                      "_type": "JsonModelConnection",
+                      "class": "test::pure::mapping::modelToModel::test::shared::src::_S_Person",
+                      "classSourceInformation": {
+                        "endColumn": 84,
+                        "endLine": 26,
+                        "sourceId": "",
+                        "startColumn": 22,
+                        "startLine": 26
+                      },
+                      "sourceInformation": {
+                        "endColumn": 13,
+                        "endLine": 28,
+                        "sourceId": "",
+                        "startColumn": 13,
+                        "startLine": 24
+                      },
+                      "url": "executor:default"
+                    },
+                    "id": "connection_1",
+                    "sourceInformation": {
+                      "endColumn": 12,
+                      "endLine": 29,
+                      "sourceId": "",
+                      "startColumn": 11,
+                      "startLine": 22
+                    }
+                  }
+                ]
+              }
+            ],
+            "mappings": [],
+            "sourceInformation": {
+              "endColumn": 8,
+              "endLine": 31,
+              "sourceId": "",
+              "startColumn": 7,
+              "startLine": 18
+            }
+          },
+          "sourceInformation": {
+            "endColumn": 3,
+            "endLine": 33,
+            "sourceId": "",
+            "startColumn": 14,
+            "startLine": 12
+          }
+        },
+        "name": "simpleFailingJsonService",
+        "owners": [
+          "debelp",
+          "harted"
+        ],
+        "package": "test::legend::service::execution::test::m2m",
+        "pattern": "/simpleJson",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 42,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 2
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "test": {
+          "_type": "singleExecutionTest",
+          "asserts": [
+            {
+              "assert": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "func",
+                    "function": "and",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "size",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "res",
+                                    "sourceInformation": {
+                                      "endColumn": 53,
+                                      "endLine": 39,
+                                      "sourceId": "",
+                                      "startColumn": 50,
+                                      "startLine": 39
+                                    }
+                                  }
+                                ],
+                                "property": "values",
+                                "sourceInformation": {
+                                  "endColumn": 60,
+                                  "endLine": 39,
+                                  "sourceId": "",
+                                  "startColumn": 55,
+                                  "startLine": 39
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 66,
+                              "endLine": 39,
+                              "sourceId": "",
+                              "startColumn": 63,
+                              "startLine": 39
+                            }
+                          },
+                          {
+                            "_type": "integer",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 73,
+                              "endLine": 39,
+                              "sourceId": "",
+                              "startColumn": 73,
+                              "startLine": 39
+                            },
+                            "values": [
+                              1
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 71,
+                          "endLine": 39,
+                          "sourceId": "",
+                          "startColumn": 70,
+                          "startLine": 39
+                        }
+                      },
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "cast",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "res",
+                                    "sourceInformation": {
+                                      "endColumn": 83,
+                                      "endLine": 39,
+                                      "sourceId": "",
+                                      "startColumn": 80,
+                                      "startLine": 39
+                                    }
+                                  }
+                                ],
+                                "property": "values",
+                                "sourceInformation": {
+                                  "endColumn": 90,
+                                  "endLine": 39,
+                                  "sourceId": "",
+                                  "startColumn": 85,
+                                  "startLine": 39
+                                }
+                              },
+                              {
+                                "_type": "hackedClass",
+                                "fullPath": "String",
+                                "sourceInformation": {
+                                  "endColumn": 104,
+                                  "endLine": 39,
+                                  "sourceId": "",
+                                  "startColumn": 99,
+                                  "startLine": 39
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 96,
+                              "endLine": 39,
+                              "sourceId": "",
+                              "startColumn": 93,
+                              "startLine": 39
+                            }
+                          },
+                          {
+                            "_type": "string",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 213,
+                              "endLine": 39,
+                              "sourceId": "",
+                              "startColumn": 110,
+                              "startLine": 39
+                            },
+                            "values": [
+                              "[{\"firstName\":\"Pierre\",\"lastName\":\"DeBelen\"},{\"firstName\":\"Dave\",\"lastName\":\"Wathen\"}]"
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 108,
+                          "endLine": 39,
+                          "sourceId": "",
+                          "startColumn": 107,
+                          "startLine": 39
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 77,
+                      "endLine": 39,
+                      "sourceId": "",
+                      "startColumn": 76,
+                      "startLine": 39
+                    }
+                  }
+                ],
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "class": "meta::pure::mapping::Result",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "name": "res",
+                    "sourceInformation": {
+                      "endColumn": 44,
+                      "endLine": 39,
+                      "sourceId": "",
+                      "startColumn": 18,
+                      "startLine": 39
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 214,
+                  "endLine": 39,
+                  "sourceId": "",
+                  "startColumn": 48,
+                  "startLine": 39
+                }
+              },
+              "parametersValues": [],
+              "sourceInformation": {
+                "endColumn": 216,
+                "endLine": 39,
+                "sourceId": "",
+                "startColumn": 7,
+                "startLine": 39
+              }
+            }
+          ],
+          "data": "[{\"fullName\":\"Pierre DeBelen\"},{\"fullName\":\"Teddy Zhang\"}]",
+          "sourceInformation": {
+            "endColumn": 3,
+            "endLine": 41,
+            "sourceId": "",
+            "startColumn": 9,
+            "startLine": 34
+          }
+        }
+      },
+      {
+        "_type": "service",
+        "autoActivateUpdates": true,
+        "documentation": "JsonModelConnection example M2M service",
+        "execution": {
+          "_type": "pureSingleExecution",
+          "func": {
+            "_type": "lambda",
+            "body": [
+              {
+                "_type": "func",
+                "function": "serialize",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "graphFetch",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "getAll",
+                        "parameters": [
+                          {
+                            "_type": "packageableElementPtr",
+                            "fullPath": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                            "sourceInformation": {
+                              "endColumn": 73,
+                              "endLine": 57,
+                              "sourceId": "",
+                              "startColumn": 13,
+                              "startLine": 57
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 79,
+                          "endLine": 57,
+                          "sourceId": "",
+                          "startColumn": 74,
+                          "startLine": 57
+                        }
+                      },
+                      {
+                        "_type": "rootGraphFetchTree",
+                        "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                        "sourceInformation": {
+                          "endColumn": 155,
+                          "endLine": 57,
+                          "sourceId": "",
+                          "startColumn": 95,
+                          "startLine": 57
+                        },
+                        "subTrees": [
+                          {
+                            "_type": "propertyGraphFetchTree",
+                            "parameters": [],
+                            "property": "firstName",
+                            "sourceInformation": {
+                              "endColumn": 165,
+                              "endLine": 57,
+                              "sourceId": "",
+                              "startColumn": 157,
+                              "startLine": 57
+                            },
+                            "subTrees": []
+                          },
+                          {
+                            "_type": "propertyGraphFetchTree",
+                            "parameters": [],
+                            "property": "lastName",
+                            "sourceInformation": {
+                              "endColumn": 174,
+                              "endLine": 57,
+                              "sourceId": "",
+                              "startColumn": 167,
+                              "startLine": 57
+                            },
+                            "subTrees": []
+                          }
+                        ]
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 91,
+                      "endLine": 57,
+                      "sourceId": "",
+                      "startColumn": 82,
+                      "startLine": 57
+                    }
+                  },
+                  {
+                    "_type": "rootGraphFetchTree",
+                    "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                    "sourceInformation": {
+                      "endColumn": 253,
+                      "endLine": 57,
+                      "sourceId": "",
+                      "startColumn": 193,
+                      "startLine": 57
+                    },
+                    "subTrees": [
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "firstName",
+                        "sourceInformation": {
+                          "endColumn": 263,
+                          "endLine": 57,
+                          "sourceId": "",
+                          "startColumn": 255,
+                          "startLine": 57
+                        },
+                        "subTrees": []
+                      },
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "lastName",
+                        "sourceInformation": {
+                          "endColumn": 272,
+                          "endLine": 57,
+                          "sourceId": "",
+                          "startColumn": 265,
+                          "startLine": 57
+                        },
+                        "subTrees": []
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 189,
+                  "endLine": 57,
+                  "sourceId": "",
+                  "startColumn": 181,
+                  "startLine": 57
+                }
+              }
+            ],
+            "parameters": [],
+            "sourceInformation": {
+              "endColumn": 276,
+              "endLine": 57,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 57
+            }
+          },
+          "mapping": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+          "mappingSourceInformation": {
+            "endColumn": 80,
+            "endLine": 58,
+            "sourceId": "",
+            "startColumn": 14,
+            "startLine": 58
+          },
+          "runtime": {
+            "_type": "engineRuntime",
+            "connections": [
+              {
+                "sourceInformation": {
+                  "endColumn": 9,
+                  "endLine": 73,
+                  "sourceId": "",
+                  "startColumn": 9,
+                  "startLine": 63
+                },
+                "store": {
+                  "path": "ModelStore",
+                  "sourceInformation": {
+                    "endColumn": 18,
+                    "endLine": 63,
+                    "sourceId": "",
+                    "startColumn": 9,
+                    "startLine": 63
+                  },
+                  "type": "STORE"
+                },
+                "storeConnections": [
+                  {
+                    "connection": {
+                      "_type": "JsonModelConnection",
+                      "class": "test::pure::mapping::modelToModel::test::shared::src::_S_Person",
+                      "classSourceInformation": {
+                        "endColumn": 84,
+                        "endLine": 69,
+                        "sourceId": "",
+                        "startColumn": 22,
+                        "startLine": 69
+                      },
+                      "sourceInformation": {
+                        "endColumn": 13,
+                        "endLine": 71,
+                        "sourceId": "",
+                        "startColumn": 13,
+                        "startLine": 67
+                      },
+                      "url": "executor:default"
+                    },
+                    "id": "connection_1",
+                    "sourceInformation": {
+                      "endColumn": 12,
+                      "endLine": 72,
+                      "sourceId": "",
+                      "startColumn": 11,
+                      "startLine": 65
+                    }
+                  }
+                ]
+              }
+            ],
+            "mappings": [],
+            "sourceInformation": {
+              "endColumn": 8,
+              "endLine": 74,
+              "sourceId": "",
+              "startColumn": 7,
+              "startLine": 61
+            }
+          },
+          "sourceInformation": {
+            "endColumn": 3,
+            "endLine": 76,
+            "sourceId": "",
+            "startColumn": 14,
+            "startLine": 55
+          }
+        },
+        "name": "simpleJsonService",
+        "owners": [
+          "debelp",
+          "harted",
+          "ponodm"
+        ],
+        "package": "test::legend::service::execution::test::m2m",
+        "pattern": "/simpleJson",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 85,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 44
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "test": {
+          "_type": "singleExecutionTest",
+          "asserts": [
+            {
+              "assert": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "func",
+                    "function": "and",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "size",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "res",
+                                    "sourceInformation": {
+                                      "endColumn": 53,
+                                      "endLine": 82,
+                                      "sourceId": "",
+                                      "startColumn": 50,
+                                      "startLine": 82
+                                    }
+                                  }
+                                ],
+                                "property": "values",
+                                "sourceInformation": {
+                                  "endColumn": 60,
+                                  "endLine": 82,
+                                  "sourceId": "",
+                                  "startColumn": 55,
+                                  "startLine": 82
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 66,
+                              "endLine": 82,
+                              "sourceId": "",
+                              "startColumn": 63,
+                              "startLine": 82
+                            }
+                          },
+                          {
+                            "_type": "integer",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 73,
+                              "endLine": 82,
+                              "sourceId": "",
+                              "startColumn": 73,
+                              "startLine": 82
+                            },
+                            "values": [
+                              1
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 71,
+                          "endLine": 82,
+                          "sourceId": "",
+                          "startColumn": 70,
+                          "startLine": 82
+                        }
+                      },
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "cast",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "res",
+                                    "sourceInformation": {
+                                      "endColumn": 83,
+                                      "endLine": 82,
+                                      "sourceId": "",
+                                      "startColumn": 80,
+                                      "startLine": 82
+                                    }
+                                  }
+                                ],
+                                "property": "values",
+                                "sourceInformation": {
+                                  "endColumn": 90,
+                                  "endLine": 82,
+                                  "sourceId": "",
+                                  "startColumn": 85,
+                                  "startLine": 82
+                                }
+                              },
+                              {
+                                "_type": "hackedClass",
+                                "fullPath": "String",
+                                "sourceInformation": {
+                                  "endColumn": 104,
+                                  "endLine": 82,
+                                  "sourceId": "",
+                                  "startColumn": 99,
+                                  "startLine": 82
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 96,
+                              "endLine": 82,
+                              "sourceId": "",
+                              "startColumn": 93,
+                              "startLine": 82
+                            }
+                          },
+                          {
+                            "_type": "string",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 213,
+                              "endLine": 82,
+                              "sourceId": "",
+                              "startColumn": 110,
+                              "startLine": 82
+                            },
+                            "values": [
+                              "[{\"firstName\":\"Pierre\",\"lastName\":\"DeBelen\"},{\"firstName\":\"Dave\",\"lastName\":\"Wathen\"}]"
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 108,
+                          "endLine": 82,
+                          "sourceId": "",
+                          "startColumn": 107,
+                          "startLine": 82
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 77,
+                      "endLine": 82,
+                      "sourceId": "",
+                      "startColumn": 76,
+                      "startLine": 82
+                    }
+                  }
+                ],
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "class": "meta::pure::mapping::Result",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "name": "res",
+                    "sourceInformation": {
+                      "endColumn": 44,
+                      "endLine": 82,
+                      "sourceId": "",
+                      "startColumn": 18,
+                      "startLine": 82
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 214,
+                  "endLine": 82,
+                  "sourceId": "",
+                  "startColumn": 48,
+                  "startLine": 82
+                }
+              },
+              "parametersValues": [],
+              "sourceInformation": {
+                "endColumn": 216,
+                "endLine": 82,
+                "sourceId": "",
+                "startColumn": 7,
+                "startLine": 82
+              }
+            }
+          ],
+          "data": "[{\"fullName\":\"Pierre DeBelen\"},{\"fullName\":\"Dave Wathen\"}]",
+          "sourceInformation": {
+            "endColumn": 3,
+            "endLine": 84,
+            "sourceId": "",
+            "startColumn": 9,
+            "startLine": 77
+          }
+        }
+      },
+      {
+        "_type": "service",
+        "autoActivateUpdates": true,
+        "documentation": "JsonModelConnection example M2M service",
+        "execution": {
+          "_type": "pureSingleExecution",
+          "func": {
+            "_type": "lambda",
+            "body": [
+              {
+                "_type": "func",
+                "function": "serialize",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "graphFetch",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "getAll",
+                            "parameters": [
+                              {
+                                "_type": "packageableElementPtr",
+                                "fullPath": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                                "sourceInformation": {
+                                  "endColumn": 89,
+                                  "endLine": 100,
+                                  "sourceId": "",
+                                  "startColumn": 29,
+                                  "startLine": 100
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 95,
+                              "endLine": 100,
+                              "sourceId": "",
+                              "startColumn": 90,
+                              "startLine": 100
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "in",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "p",
+                                        "sourceInformation": {
+                                          "endColumn": 108,
+                                          "endLine": 100,
+                                          "sourceId": "",
+                                          "startColumn": 107,
+                                          "startLine": 100
+                                        }
+                                      }
+                                    ],
+                                    "property": "firstName",
+                                    "sourceInformation": {
+                                      "endColumn": 118,
+                                      "endLine": 100,
+                                      "sourceId": "",
+                                      "startColumn": 110,
+                                      "startLine": 100
+                                    }
+                                  },
+                                  {
+                                    "_type": "var",
+                                    "name": "names",
+                                    "sourceInformation": {
+                                      "endColumn": 129,
+                                      "endLine": 100,
+                                      "sourceId": "",
+                                      "startColumn": 124,
+                                      "startLine": 100
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 122,
+                                  "endLine": 100,
+                                  "sourceId": "",
+                                  "startColumn": 121,
+                                  "startLine": 100
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "p"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 130,
+                              "endLine": 100,
+                              "sourceId": "",
+                              "startColumn": 106,
+                              "startLine": 100
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 103,
+                          "endLine": 100,
+                          "sourceId": "",
+                          "startColumn": 98,
+                          "startLine": 100
+                        }
+                      },
+                      {
+                        "_type": "rootGraphFetchTree",
+                        "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                        "sourceInformation": {
+                          "endColumn": 207,
+                          "endLine": 100,
+                          "sourceId": "",
+                          "startColumn": 147,
+                          "startLine": 100
+                        },
+                        "subTrees": [
+                          {
+                            "_type": "propertyGraphFetchTree",
+                            "parameters": [],
+                            "property": "firstName",
+                            "sourceInformation": {
+                              "endColumn": 217,
+                              "endLine": 100,
+                              "sourceId": "",
+                              "startColumn": 209,
+                              "startLine": 100
+                            },
+                            "subTrees": []
+                          },
+                          {
+                            "_type": "propertyGraphFetchTree",
+                            "parameters": [],
+                            "property": "lastName",
+                            "sourceInformation": {
+                              "endColumn": 226,
+                              "endLine": 100,
+                              "sourceId": "",
+                              "startColumn": 219,
+                              "startLine": 100
+                            },
+                            "subTrees": []
+                          }
+                        ]
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 143,
+                      "endLine": 100,
+                      "sourceId": "",
+                      "startColumn": 134,
+                      "startLine": 100
+                    }
+                  },
+                  {
+                    "_type": "rootGraphFetchTree",
+                    "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                    "sourceInformation": {
+                      "endColumn": 305,
+                      "endLine": 100,
+                      "sourceId": "",
+                      "startColumn": 245,
+                      "startLine": 100
+                    },
+                    "subTrees": [
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "firstName",
+                        "sourceInformation": {
+                          "endColumn": 315,
+                          "endLine": 100,
+                          "sourceId": "",
+                          "startColumn": 307,
+                          "startLine": 100
+                        },
+                        "subTrees": []
+                      },
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "lastName",
+                        "sourceInformation": {
+                          "endColumn": 324,
+                          "endLine": 100,
+                          "sourceId": "",
+                          "startColumn": 317,
+                          "startLine": 100
+                        },
+                        "subTrees": []
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 241,
+                  "endLine": 100,
+                  "sourceId": "",
+                  "startColumn": 233,
+                  "startLine": 100
+                }
+              }
+            ],
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 0
+                },
+                "name": "names",
+                "sourceInformation": {
+                  "endColumn": 24,
+                  "endLine": 100,
+                  "sourceId": "",
+                  "startColumn": 19,
+                  "startLine": 100
+                }
+              }
+            ],
+            "sourceInformation": {
+              "endColumn": 328,
+              "endLine": 100,
+              "sourceId": "",
+              "startColumn": 28,
+              "startLine": 100
+            }
+          },
+          "mapping": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+          "mappingSourceInformation": {
+            "endColumn": 80,
+            "endLine": 101,
+            "sourceId": "",
+            "startColumn": 14,
+            "startLine": 101
+          },
+          "runtime": {
+            "_type": "engineRuntime",
+            "connections": [
+              {
+                "sourceInformation": {
+                  "endColumn": 9,
+                  "endLine": 116,
+                  "sourceId": "",
+                  "startColumn": 9,
+                  "startLine": 106
+                },
+                "store": {
+                  "path": "ModelStore",
+                  "sourceInformation": {
+                    "endColumn": 18,
+                    "endLine": 106,
+                    "sourceId": "",
+                    "startColumn": 9,
+                    "startLine": 106
+                  },
+                  "type": "STORE"
+                },
+                "storeConnections": [
+                  {
+                    "connection": {
+                      "_type": "JsonModelConnection",
+                      "class": "test::pure::mapping::modelToModel::test::shared::src::_S_Person",
+                      "classSourceInformation": {
+                        "endColumn": 84,
+                        "endLine": 112,
+                        "sourceId": "",
+                        "startColumn": 22,
+                        "startLine": 112
+                      },
+                      "sourceInformation": {
+                        "endColumn": 13,
+                        "endLine": 114,
+                        "sourceId": "",
+                        "startColumn": 13,
+                        "startLine": 110
+                      },
+                      "url": "executor:default"
+                    },
+                    "id": "connection_1",
+                    "sourceInformation": {
+                      "endColumn": 12,
+                      "endLine": 115,
+                      "sourceId": "",
+                      "startColumn": 11,
+                      "startLine": 108
+                    }
+                  }
+                ]
+              }
+            ],
+            "mappings": [],
+            "sourceInformation": {
+              "endColumn": 8,
+              "endLine": 117,
+              "sourceId": "",
+              "startColumn": 7,
+              "startLine": 104
+            }
+          },
+          "sourceInformation": {
+            "endColumn": 3,
+            "endLine": 119,
+            "sourceId": "",
+            "startColumn": 14,
+            "startLine": 98
+          }
+        },
+        "name": "simpleJsonServiceMultiParam",
+        "owners": [
+          "debelp",
+          "harted",
+          "ponodm"
+        ],
+        "package": "test::legend::service::execution::test::m2m",
+        "pattern": "/simpleJson",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 128,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 87
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "test": {
+          "_type": "singleExecutionTest",
+          "asserts": [
+            {
+              "assert": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "func",
+                    "function": "and",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "size",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "res",
+                                    "sourceInformation": {
+                                      "endColumn": 53,
+                                      "endLine": 125,
+                                      "sourceId": "",
+                                      "startColumn": 50,
+                                      "startLine": 125
+                                    }
+                                  }
+                                ],
+                                "property": "values",
+                                "sourceInformation": {
+                                  "endColumn": 60,
+                                  "endLine": 125,
+                                  "sourceId": "",
+                                  "startColumn": 55,
+                                  "startLine": 125
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 66,
+                              "endLine": 125,
+                              "sourceId": "",
+                              "startColumn": 63,
+                              "startLine": 125
+                            }
+                          },
+                          {
+                            "_type": "integer",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 73,
+                              "endLine": 125,
+                              "sourceId": "",
+                              "startColumn": 73,
+                              "startLine": 125
+                            },
+                            "values": [
+                              1
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 71,
+                          "endLine": 125,
+                          "sourceId": "",
+                          "startColumn": 70,
+                          "startLine": 125
+                        }
+                      },
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "cast",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "res",
+                                    "sourceInformation": {
+                                      "endColumn": 83,
+                                      "endLine": 125,
+                                      "sourceId": "",
+                                      "startColumn": 80,
+                                      "startLine": 125
+                                    }
+                                  }
+                                ],
+                                "property": "values",
+                                "sourceInformation": {
+                                  "endColumn": 90,
+                                  "endLine": 125,
+                                  "sourceId": "",
+                                  "startColumn": 85,
+                                  "startLine": 125
+                                }
+                              },
+                              {
+                                "_type": "hackedClass",
+                                "fullPath": "String",
+                                "sourceInformation": {
+                                  "endColumn": 104,
+                                  "endLine": 125,
+                                  "sourceId": "",
+                                  "startColumn": 99,
+                                  "startLine": 125
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 96,
+                              "endLine": 125,
+                              "sourceId": "",
+                              "startColumn": 93,
+                              "startLine": 125
+                            }
+                          },
+                          {
+                            "_type": "string",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 213,
+                              "endLine": 125,
+                              "sourceId": "",
+                              "startColumn": 110,
+                              "startLine": 125
+                            },
+                            "values": [
+                              "[{\"firstName\":\"Pierre\",\"lastName\":\"DeBelen\"},{\"firstName\":\"Dave\",\"lastName\":\"Wathen\"}]"
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 108,
+                          "endLine": 125,
+                          "sourceId": "",
+                          "startColumn": 107,
+                          "startLine": 125
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 77,
+                      "endLine": 125,
+                      "sourceId": "",
+                      "startColumn": 76,
+                      "startLine": 125
+                    }
+                  }
+                ],
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "class": "meta::pure::mapping::Result",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "name": "res",
+                    "sourceInformation": {
+                      "endColumn": 44,
+                      "endLine": 125,
+                      "sourceId": "",
+                      "startColumn": 18,
+                      "startLine": 125
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 214,
+                  "endLine": 125,
+                  "sourceId": "",
+                  "startColumn": 48,
+                  "startLine": 125
+                }
+              },
+              "parametersValues": [{
+                "_type": "listInstance",
+                "values": [
+                  {
+                    "_type": "string",
+                    "values": ["Pierre"],
+                    "multiplicity": {"lowerBound": 1, "upperBound": 1}
+                  },
+                  {
+                    "_type": "string",
+                    "values": ["Dave"],
+                    "multiplicity": {"lowerBound": 1, "upperBound": 1}
+                  }
+                ]
+              }],
+              "sourceInformation": {
+                "endColumn": 216,
+                "endLine": 125,
+                "sourceId": "",
+                "startColumn": 7,
+                "startLine": 125
+              }
+            }
+          ],
+          "data": "[{\"fullName\":\"Pierre DeBelen\"},{\"fullName\":\"Dave Wathen\"}]",
+          "sourceInformation": {
+            "endColumn": 3,
+            "endLine": 127,
+            "sourceId": "",
+            "startColumn": 9,
+            "startLine": 120
+          }
+        }
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Business",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "address",
+            "propertyTypeSourceInformation": {
+              "endColumn": 17,
+              "endLine": 134,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 134
+            },
+            "sourceInformation": {
+              "endColumn": 24,
+              "endLine": 134,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 134
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 135,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 132
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Organization",
+          "test::owl::tests::model::EntityWithLocation"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "EntityWithLocation",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "location",
+            "propertyTypeSourceInformation": {
+              "endColumn": 48,
+              "endLine": 139,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 139
+            },
+            "sourceInformation": {
+              "endColumn": 55,
+              "endLine": 139,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 139
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::GeoLocation"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 140,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 137
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Executive",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "organization",
+            "propertyTypeSourceInformation": {
+              "endColumn": 49,
+              "endLine": 144,
+              "sourceId": "",
+              "startColumn": 17,
+              "startLine": 144
+            },
+            "sourceInformation": {
+              "endColumn": 56,
+              "endLine": 144,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 144
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Business"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "seniorityLevel",
+            "propertyTypeSourceInformation": {
+              "endColumn": 55,
+              "endLine": 145,
+              "sourceId": "",
+              "startColumn": 19,
+              "startLine": 145
+            },
+            "sourceInformation": {
+              "endColumn": 62,
+              "endLine": 145,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 145
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::OrgLevelType"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 146,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 142
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Professional"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "FemaleExecutive",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 150,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 148
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Executive",
+          "test::owl::tests::model::FemalePerson"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "FemalePerson",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 154,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 152
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Person"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "GeoLocation",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "engName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 17,
+              "endLine": 158,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 158
+            },
+            "sourceInformation": {
+              "endColumn": 24,
+              "endLine": 158,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 158
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 159,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 156
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "MaleExecutive",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 163,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 161
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Executive",
+          "test::owl::tests::model::MalePerson"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "MalePerson",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 167,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 165
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::owl::tests::model::Person"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Organization",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "officialName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 22,
+              "endLine": 171,
+              "sourceId": "",
+              "startColumn": 17,
+              "startLine": 171
+            },
+            "sourceInformation": {
+              "endColumn": 29,
+              "endLine": 171,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 171
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 172,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 169
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Person",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 19,
+              "endLine": 176,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 176
+            },
+            "sourceInformation": {
+              "endColumn": 23,
+              "endLine": 176,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 176
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 177,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 177
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 177,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 177
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "gender",
+            "propertyTypeSourceInformation": {
+              "endColumn": 45,
+              "endLine": 178,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 178
+            },
+            "sourceInformation": {
+              "endColumn": 49,
+              "endLine": 178,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 178
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::GenderType"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 2
+            },
+            "name": "nicknames",
+            "propertyTypeSourceInformation": {
+              "endColumn": 19,
+              "endLine": 179,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 179
+            },
+            "sourceInformation": {
+              "endColumn": 26,
+              "endLine": 179,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 179
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 180,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 174
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Professional",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 184,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 182
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Address",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "street",
+            "propertyTypeSourceInformation": {
+              "endColumn": 16,
+              "endLine": 188,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 188
+            },
+            "sourceInformation": {
+              "endColumn": 20,
+              "endLine": 188,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 188
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 0
+            },
+            "name": "extension",
+            "propertyTypeSourceInformation": {
+              "endColumn": 84,
+              "endLine": 189,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 189
+            },
+            "sourceInformation": {
+              "endColumn": 91,
+              "endLine": 189,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 189
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::AddressExtension"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 190,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 186
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "AddressExtension",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "stuff",
+            "propertyTypeSourceInformation": {
+              "endColumn": 15,
+              "endLine": 194,
+              "sourceId": "",
+              "startColumn": 10,
+              "startLine": 194
+            },
+            "sourceInformation": {
+              "endColumn": 19,
+              "endLine": 194,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 194
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 195,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 192
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Firm",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "legalName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 19,
+              "endLine": 199,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 199
+            },
+            "sourceInformation": {
+              "endColumn": 23,
+              "endLine": 199,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 199
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employees",
+            "propertyTypeSourceInformation": {
+              "endColumn": 74,
+              "endLine": 200,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 200
+            },
+            "sourceInformation": {
+              "endColumn": 78,
+              "endLine": 200,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 200
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "addresses",
+            "propertyTypeSourceInformation": {
+              "endColumn": 75,
+              "endLine": 201,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 201
+            },
+            "sourceInformation": {
+              "endColumn": 79,
+              "endLine": 201,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 201
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Address"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "count",
+            "propertyTypeSourceInformation": {
+              "endColumn": 16,
+              "endLine": 202,
+              "sourceId": "",
+              "startColumn": 10,
+              "startLine": 202
+            },
+            "sourceInformation": {
+              "endColumn": 20,
+              "endLine": 202,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 202
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 203,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 197
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Person",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 19,
+              "endLine": 207,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 207
+            },
+            "sourceInformation": {
+              "endColumn": 23,
+              "endLine": 207,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 207
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 208,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 208
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 208,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 208
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "addresses",
+            "propertyTypeSourceInformation": {
+              "endColumn": 75,
+              "endLine": 209,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 209
+            },
+            "sourceInformation": {
+              "endColumn": 79,
+              "endLine": 209,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 209
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Address"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "propertyTypeSourceInformation": {
+              "endColumn": 67,
+              "endLine": 210,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 210
+            },
+            "sourceInformation": {
+              "endColumn": 74,
+              "endLine": 210,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 210
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Firm"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 211,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 205
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Product2Simple",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 215,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 215
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 215,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 215
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "region",
+            "propertyTypeSourceInformation": {
+              "endColumn": 71,
+              "endLine": 216,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 216
+            },
+            "sourceInformation": {
+              "endColumn": 78,
+              "endLine": 216,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 216
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Region"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 217,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 213
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "_Product2",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::src",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 221,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 221
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 221,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 221
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "subProductName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 24,
+              "endLine": 222,
+              "sourceId": "",
+              "startColumn": 19,
+              "startLine": 222
+            },
+            "sourceInformation": {
+              "endColumn": 28,
+              "endLine": 222,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 222
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "bondDetailStatus",
+            "propertyTypeSourceInformation": {
+              "endColumn": 26,
+              "endLine": 223,
+              "sourceId": "",
+              "startColumn": 21,
+              "startLine": 223
+            },
+            "sourceInformation": {
+              "endColumn": 30,
+              "endLine": 223,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 223
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "region",
+            "propertyTypeSourceInformation": {
+              "endColumn": 71,
+              "endLine": 224,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 224
+            },
+            "sourceInformation": {
+              "endColumn": 78,
+              "endLine": 224,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 224
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::mapping::modelToModel::test::shared::dest::Region"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 225,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 219
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "_S_Person",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::mapping::modelToModel::test::shared::src",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "fullName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 229,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 229
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 229,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 229
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 230,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 227
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Account",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 234,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 234
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 234,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 234
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "createDate",
+            "propertyTypeSourceInformation": {
+              "endColumn": 24,
+              "endLine": 235,
+              "sourceId": "",
+              "startColumn": 15,
+              "startLine": 235
+            },
+            "sourceInformation": {
+              "endColumn": 28,
+              "endLine": 235,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 235
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "in",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 29,
+                              "endLine": 236,
+                              "sourceId": "",
+                              "startColumn": 25,
+                              "startLine": 236
+                            }
+                          }
+                        ],
+                        "property": "name",
+                        "sourceInformation": {
+                          "endColumn": 34,
+                          "endLine": 236,
+                          "sourceId": "",
+                          "startColumn": 31,
+                          "startLine": 236
+                        }
+                      },
+                      {
+                        "_type": "collection",
+                        "multiplicity": {
+                          "lowerBound": 2,
+                          "upperBound": 2
+                        },
+                        "sourceInformation": {
+                          "endColumn": 65,
+                          "endLine": 236,
+                          "sourceId": "",
+                          "startColumn": 40,
+                          "startLine": 236
+                        },
+                        "values": [
+                          {
+                            "_type": "string",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 51,
+                              "endLine": 236,
+                              "sourceId": "",
+                              "startColumn": 41,
+                              "startLine": 236
+                            },
+                            "values": [
+                              "Account 1"
+                            ]
+                          },
+                          {
+                            "_type": "string",
+                            "multiplicity": {
+                              "lowerBound": 1,
+                              "upperBound": 1
+                            },
+                            "sourceInformation": {
+                              "endColumn": 64,
+                              "endLine": 236,
+                              "sourceId": "",
+                              "startColumn": 54,
+                              "startLine": 236
+                            },
+                            "values": [
+                              "Account 2"
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 38,
+                      "endLine": 236,
+                      "sourceId": "",
+                      "startColumn": 37,
+                      "startLine": 236
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 72,
+                          "endLine": 236,
+                          "sourceId": "",
+                          "startColumn": 70,
+                          "startLine": 236
+                        },
+                        "values": [
+                          "A"
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 72,
+                      "endLine": 236,
+                      "sourceId": "",
+                      "startColumn": 69,
+                      "startLine": 236
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 78,
+                          "endLine": 236,
+                          "sourceId": "",
+                          "startColumn": 76,
+                          "startLine": 236
+                        },
+                        "values": [
+                          "B"
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 78,
+                      "endLine": 236,
+                      "sourceId": "",
+                      "startColumn": 75,
+                      "startLine": 236
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 23,
+                  "endLine": 236,
+                  "sourceId": "",
+                  "startColumn": 22,
+                  "startLine": 236
+                }
+              }
+            ],
+            "name": "accountCategory",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 92,
+              "endLine": 236,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 236
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "contains",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 21,
+                              "endLine": 237,
+                              "sourceId": "",
+                              "startColumn": 17,
+                              "startLine": 237
+                            }
+                          }
+                        ],
+                        "property": "name",
+                        "sourceInformation": {
+                          "endColumn": 26,
+                          "endLine": 237,
+                          "sourceId": "",
+                          "startColumn": 23,
+                          "startLine": 237
+                        }
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 40,
+                          "endLine": 237,
+                          "sourceId": "",
+                          "startColumn": 38,
+                          "startLine": 237
+                        },
+                        "values": [
+                          "2"
+                        ]
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 36,
+                      "endLine": 237,
+                      "sourceId": "",
+                      "startColumn": 29,
+                      "startLine": 237
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "boolean",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 48,
+                          "endLine": 237,
+                          "sourceId": "",
+                          "startColumn": 45,
+                          "startLine": 237
+                        },
+                        "values": [
+                          true
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 48,
+                      "endLine": 237,
+                      "sourceId": "",
+                      "startColumn": 44,
+                      "startLine": 237
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "boolean",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 56,
+                          "endLine": 237,
+                          "sourceId": "",
+                          "startColumn": 52,
+                          "startLine": 237
+                        },
+                        "values": [
+                          false
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 56,
+                      "endLine": 237,
+                      "sourceId": "",
+                      "startColumn": 51,
+                      "startLine": 237
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 15,
+                  "endLine": 237,
+                  "sourceId": "",
+                  "startColumn": 14,
+                  "startLine": 237
+                }
+              }
+            ],
+            "name": "isTypeA",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Boolean",
+            "sourceInformation": {
+              "endColumn": 71,
+              "endLine": 237,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 237
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 238,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 232
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "AccountPnl",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "pnl",
+            "propertyTypeSourceInformation": {
+              "endColumn": 12,
+              "endLine": 242,
+              "sourceId": "",
+              "startColumn": 8,
+              "startLine": 242
+            },
+            "sourceInformation": {
+              "endColumn": 16,
+              "endLine": 242,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 242
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 243,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 240
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Address",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 247,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 247
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 247,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 247
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "street",
+            "propertyTypeSourceInformation": {
+              "endColumn": 16,
+              "endLine": 248,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 248
+            },
+            "sourceInformation": {
+              "endColumn": 23,
+              "endLine": 248,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 248
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "comments",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 249,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 249
+            },
+            "sourceInformation": {
+              "endColumn": 25,
+              "endLine": 249,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 249
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 2,
+                      "upperBound": 2
+                    },
+                    "sourceInformation": {
+                      "endColumn": 34,
+                      "endLine": 250,
+                      "sourceId": "",
+                      "startColumn": 23,
+                      "startLine": 250
+                    },
+                    "values": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 21,
+                          "endLine": 250,
+                          "sourceId": "",
+                          "startColumn": 18,
+                          "startLine": 250
+                        },
+                        "values": [
+                          "D:"
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 29,
+                              "endLine": 250,
+                              "sourceId": "",
+                              "startColumn": 25,
+                              "startLine": 250
+                            }
+                          }
+                        ],
+                        "property": "name",
+                        "sourceInformation": {
+                          "endColumn": 34,
+                          "endLine": 250,
+                          "sourceId": "",
+                          "startColumn": 31,
+                          "startLine": 250
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 34,
+                  "endLine": 250,
+                  "sourceId": "",
+                  "startColumn": 23,
+                  "startLine": 250
+                }
+              }
+            ],
+            "name": "description",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 47,
+              "endLine": 250,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 250
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 251,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 245
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::GeographicEntity"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Bridge",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 255,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 253
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Department",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 259,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 257
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Organization"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Division",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 263,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 261
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Organization"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "EntityWithAddress",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "address",
+            "propertyTypeSourceInformation": {
+              "endColumn": 52,
+              "endLine": 267,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 267
+            },
+            "sourceInformation": {
+              "endColumn": 59,
+              "endLine": 267,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 267
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Address"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 268,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 265
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "EntityWithLocations",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "locations",
+            "propertyTypeSourceInformation": {
+              "endColumn": 55,
+              "endLine": 272,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 272
+            },
+            "sourceInformation": {
+              "endColumn": 59,
+              "endLine": 272,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 272
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Location"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 90,
+                          "endLine": 273,
+                          "sourceId": "",
+                          "startColumn": 86,
+                          "startLine": 273
+                        }
+                      }
+                    ],
+                    "property": "locations",
+                    "sourceInformation": {
+                      "endColumn": 100,
+                      "endLine": 273,
+                      "sourceId": "",
+                      "startColumn": 92,
+                      "startLine": 273
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "exists",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "types",
+                            "sourceInformation": {
+                              "endColumn": 117,
+                              "endLine": 273,
+                              "sourceId": "",
+                              "startColumn": 112,
+                              "startLine": 273
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "is",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "l",
+                                        "sourceInformation": {
+                                          "endColumn": 133,
+                                          "endLine": 273,
+                                          "sourceId": "",
+                                          "startColumn": 132,
+                                          "startLine": 273
+                                        }
+                                      }
+                                    ],
+                                    "property": "type",
+                                    "sourceInformation": {
+                                      "endColumn": 138,
+                                      "endLine": 273,
+                                      "sourceId": "",
+                                      "startColumn": 135,
+                                      "startLine": 273
+                                    }
+                                  },
+                                  {
+                                    "_type": "var",
+                                    "name": "type",
+                                    "sourceInformation": {
+                                      "endColumn": 148,
+                                      "endLine": 273,
+                                      "sourceId": "",
+                                      "startColumn": 144,
+                                      "startLine": 273
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 142,
+                                  "endLine": 273,
+                                  "sourceId": "",
+                                  "startColumn": 141,
+                                  "startLine": 273
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "type"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 149,
+                              "endLine": 273,
+                              "sourceId": "",
+                              "startColumn": 131,
+                              "startLine": 273
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 125,
+                          "endLine": 273,
+                          "sourceId": "",
+                          "startColumn": 120,
+                          "startLine": 273
+                        }
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "l"
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 150,
+                      "endLine": 273,
+                      "sourceId": "",
+                      "startColumn": 111,
+                      "startLine": 273
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 108,
+                  "endLine": 273,
+                  "sourceId": "",
+                  "startColumn": 103,
+                  "startLine": 273
+                }
+              }
+            ],
+            "name": "locationsByType",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::GeographicEntityType",
+                "multiplicity": {
+                  "lowerBound": 0
+                },
+                "name": "types",
+                "sourceInformation": {
+                  "endColumn": 82,
+                  "endLine": 273,
+                  "sourceId": "",
+                  "startColumn": 19,
+                  "startLine": 273
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Location",
+            "sourceInformation": {
+              "endColumn": 200,
+              "endLine": 273,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 273
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 274,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 270
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Firm",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "legalName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 58,
+              "endLine": 278,
+              "sourceId": "",
+              "startColumn": 53,
+              "startLine": 278
+            },
+            "sourceInformation": {
+              "endColumn": 62,
+              "endLine": 278,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 278
+            },
+            "stereotypes": [
+              {
+                "profile": "meta::pure::profiles::equality",
+                "profileSourceInformation": {
+                  "endColumn": 34,
+                  "endLine": 278,
+                  "sourceId": "",
+                  "startColumn": 5,
+                  "startLine": 278
+                },
+                "sourceInformation": {
+                  "endColumn": 38,
+                  "endLine": 278,
+                  "sourceId": "",
+                  "startColumn": 5,
+                  "startLine": 278
+                },
+                "value": "Key"
+              }
+            ],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "nickName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 279,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 279
+            },
+            "sourceInformation": {
+              "endColumn": 25,
+              "endLine": 279,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 279
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "times",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 2,
+                      "upperBound": 2
+                    },
+                    "sourceInformation": {
+                      "endColumn": 63,
+                      "endLine": 280,
+                      "sourceId": "",
+                      "startColumn": 59,
+                      "startLine": 280
+                    },
+                    "values": [
+                      {
+                        "_type": "func",
+                        "function": "average",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 31,
+                                      "endLine": 280,
+                                      "sourceId": "",
+                                      "startColumn": 27,
+                                      "startLine": 280
+                                    }
+                                  }
+                                ],
+                                "property": "employees",
+                                "sourceInformation": {
+                                  "endColumn": 41,
+                                  "endLine": 280,
+                                  "sourceId": "",
+                                  "startColumn": 33,
+                                  "startLine": 280
+                                }
+                              }
+                            ],
+                            "property": "age",
+                            "sourceInformation": {
+                              "endColumn": 45,
+                              "endLine": 280,
+                              "sourceId": "",
+                              "startColumn": 43,
+                              "startLine": 280
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 54,
+                          "endLine": 280,
+                          "sourceId": "",
+                          "startColumn": 48,
+                          "startLine": 280
+                        }
+                      },
+                      {
+                        "_type": "float",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 63,
+                          "endLine": 280,
+                          "sourceId": "",
+                          "startColumn": 61,
+                          "startLine": 280
+                        },
+                        "values": [
+                          2.0
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 63,
+                  "endLine": 280,
+                  "sourceId": "",
+                  "startColumn": 59,
+                  "startLine": 280
+                }
+              }
+            ],
+            "name": "averageEmployeesAge",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Float",
+            "sourceInformation": {
+              "endColumn": 75,
+              "endLine": 280,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 280
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "sum",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 26,
+                              "endLine": 281,
+                              "sourceId": "",
+                              "startColumn": 22,
+                              "startLine": 281
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 36,
+                          "endLine": 281,
+                          "sourceId": "",
+                          "startColumn": 28,
+                          "startLine": 281
+                        }
+                      }
+                    ],
+                    "property": "age",
+                    "sourceInformation": {
+                      "endColumn": 40,
+                      "endLine": 281,
+                      "sourceId": "",
+                      "startColumn": 38,
+                      "startLine": 281
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 45,
+                  "endLine": 281,
+                  "sourceId": "",
+                  "startColumn": 43,
+                  "startLine": 281
+                }
+              }
+            ],
+            "name": "sumEmployeesAge",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "sourceInformation": {
+              "endColumn": 61,
+              "endLine": 281,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 281
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "max",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 26,
+                              "endLine": 282,
+                              "sourceId": "",
+                              "startColumn": 22,
+                              "startLine": 282
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 36,
+                          "endLine": 282,
+                          "sourceId": "",
+                          "startColumn": 28,
+                          "startLine": 282
+                        }
+                      }
+                    ],
+                    "property": "age",
+                    "sourceInformation": {
+                      "endColumn": 40,
+                      "endLine": 282,
+                      "sourceId": "",
+                      "startColumn": 38,
+                      "startLine": 282
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 45,
+                  "endLine": 282,
+                  "sourceId": "",
+                  "startColumn": 43,
+                  "startLine": 282
+                }
+              }
+            ],
+            "name": "maxEmployeesAge",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "sourceInformation": {
+              "endColumn": 64,
+              "endLine": 282,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 282
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    },
+                    "sourceInformation": {
+                      "endColumn": 71,
+                      "endLine": 283,
+                      "sourceId": "",
+                      "startColumn": 37,
+                      "startLine": 283
+                    },
+                    "values": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 25,
+                              "endLine": 283,
+                              "sourceId": "",
+                              "startColumn": 21,
+                              "startLine": 283
+                            }
+                          }
+                        ],
+                        "property": "legalName",
+                        "sourceInformation": {
+                          "endColumn": 35,
+                          "endLine": 283,
+                          "sourceId": "",
+                          "startColumn": 27,
+                          "startLine": 283
+                        }
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 41,
+                          "endLine": 283,
+                          "sourceId": "",
+                          "startColumn": 39,
+                          "startLine": 283
+                        },
+                        "values": [
+                          ","
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 49,
+                                      "endLine": 283,
+                                      "sourceId": "",
+                                      "startColumn": 45,
+                                      "startLine": 283
+                                    }
+                                  }
+                                ],
+                                "property": "address",
+                                "sourceInformation": {
+                                  "endColumn": 57,
+                                  "endLine": 283,
+                                  "sourceId": "",
+                                  "startColumn": 51,
+                                  "startLine": 283
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 64,
+                              "endLine": 283,
+                              "sourceId": "",
+                              "startColumn": 60,
+                              "startLine": 283
+                            }
+                          }
+                        ],
+                        "property": "name",
+                        "sourceInformation": {
+                          "endColumn": 71,
+                          "endLine": 283,
+                          "sourceId": "",
+                          "startColumn": 68,
+                          "startLine": 283
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 71,
+                  "endLine": 283,
+                  "sourceId": "",
+                  "startColumn": 37,
+                  "startLine": 283
+                }
+              }
+            ],
+            "name": "nameAndAddress",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 84,
+              "endLine": 283,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 283
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "equal",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "toOne",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 28,
+                                  "endLine": 284,
+                                  "sourceId": "",
+                                  "startColumn": 24,
+                                  "startLine": 284
+                                }
+                              }
+                            ],
+                            "property": "legalName",
+                            "sourceInformation": {
+                              "endColumn": 38,
+                              "endLine": 284,
+                              "sourceId": "",
+                              "startColumn": 30,
+                              "startLine": 284
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 45,
+                          "endLine": 284,
+                          "sourceId": "",
+                          "startColumn": 41,
+                          "startLine": 284
+                        }
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 66,
+                          "endLine": 284,
+                          "sourceId": "",
+                          "startColumn": 52,
+                          "startLine": 284
+                        },
+                        "values": [
+                          "Goldman Sachs"
+                        ]
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 50,
+                      "endLine": 284,
+                      "sourceId": "",
+                      "startColumn": 49,
+                      "startLine": 284
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 74,
+                          "endLine": 284,
+                          "sourceId": "",
+                          "startColumn": 70,
+                          "startLine": 284
+                        },
+                        "values": [
+                          "Yes"
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 74,
+                      "endLine": 284,
+                      "sourceId": "",
+                      "startColumn": 69,
+                      "startLine": 284
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 81,
+                          "endLine": 284,
+                          "sourceId": "",
+                          "startColumn": 78,
+                          "startLine": 284
+                        },
+                        "values": [
+                          "No"
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 81,
+                      "endLine": 284,
+                      "sourceId": "",
+                      "startColumn": 77,
+                      "startLine": 284
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 22,
+                  "endLine": 284,
+                  "sourceId": "",
+                  "startColumn": 21,
+                  "startLine": 284
+                }
+              }
+            ],
+            "name": "isGoldmanSachs",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 95,
+              "endLine": 284,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 284
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "equal",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 34,
+                              "endLine": 285,
+                              "sourceId": "",
+                              "startColumn": 30,
+                              "startLine": 285
+                            }
+                          }
+                        ],
+                        "property": "legalName",
+                        "sourceInformation": {
+                          "endColumn": 44,
+                          "endLine": 285,
+                          "sourceId": "",
+                          "startColumn": 36,
+                          "startLine": 285
+                        }
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 63,
+                          "endLine": 285,
+                          "sourceId": "",
+                          "startColumn": 49,
+                          "startLine": 285
+                        },
+                        "values": [
+                          "Goldman Sachs"
+                        ]
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 47,
+                      "endLine": 285,
+                      "sourceId": "",
+                      "startColumn": 46,
+                      "startLine": 285
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 2,
+                              "upperBound": 2
+                            },
+                            "sourceInformation": {
+                              "endColumn": 99,
+                              "endLine": 285,
+                              "sourceId": "",
+                              "startColumn": 83,
+                              "startLine": 285
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 71,
+                                      "endLine": 285,
+                                      "sourceId": "",
+                                      "startColumn": 67,
+                                      "startLine": 285
+                                    }
+                                  }
+                                ],
+                                "property": "legalName",
+                                "sourceInformation": {
+                                  "endColumn": 81,
+                                  "endLine": 285,
+                                  "sourceId": "",
+                                  "startColumn": 73,
+                                  "startLine": 285
+                                }
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "sourceInformation": {
+                                  "endColumn": 99,
+                                  "endLine": 285,
+                                  "sourceId": "",
+                                  "startColumn": 85,
+                                  "startLine": 285
+                                },
+                                "values": [
+                                  " , Top Secret"
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 99,
+                          "endLine": 285,
+                          "sourceId": "",
+                          "startColumn": 83,
+                          "startLine": 285
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 99,
+                      "endLine": 285,
+                      "sourceId": "",
+                      "startColumn": 66,
+                      "startLine": 285
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "sourceInformation": {
+                              "endColumn": 153,
+                              "endLine": 285,
+                              "sourceId": "",
+                              "startColumn": 119,
+                              "startLine": 285
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 107,
+                                      "endLine": 285,
+                                      "sourceId": "",
+                                      "startColumn": 103,
+                                      "startLine": 285
+                                    }
+                                  }
+                                ],
+                                "property": "legalName",
+                                "sourceInformation": {
+                                  "endColumn": 117,
+                                  "endLine": 285,
+                                  "sourceId": "",
+                                  "startColumn": 109,
+                                  "startLine": 285
+                                }
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "sourceInformation": {
+                                  "endColumn": 123,
+                                  "endLine": 285,
+                                  "sourceId": "",
+                                  "startColumn": 121,
+                                  "startLine": 285
+                                },
+                                "values": [
+                                  ","
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "func",
+                                    "function": "toOne",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 131,
+                                              "endLine": 285,
+                                              "sourceId": "",
+                                              "startColumn": 127,
+                                              "startLine": 285
+                                            }
+                                          }
+                                        ],
+                                        "property": "address",
+                                        "sourceInformation": {
+                                          "endColumn": 139,
+                                          "endLine": 285,
+                                          "sourceId": "",
+                                          "startColumn": 133,
+                                          "startLine": 285
+                                        }
+                                      }
+                                    ],
+                                    "sourceInformation": {
+                                      "endColumn": 146,
+                                      "endLine": 285,
+                                      "sourceId": "",
+                                      "startColumn": 142,
+                                      "startLine": 285
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 153,
+                                  "endLine": 285,
+                                  "sourceId": "",
+                                  "startColumn": 150,
+                                  "startLine": 285
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 153,
+                          "endLine": 285,
+                          "sourceId": "",
+                          "startColumn": 119,
+                          "startLine": 285
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 153,
+                      "endLine": 285,
+                      "sourceId": "",
+                      "startColumn": 102,
+                      "startLine": 285
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 28,
+                  "endLine": 285,
+                  "sourceId": "",
+                  "startColumn": 27,
+                  "startLine": 285
+                }
+              }
+            ],
+            "name": "nameAndMaskedAddress",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 167,
+              "endLine": 285,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 285
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 48,
+                              "endLine": 286,
+                              "sourceId": "",
+                              "startColumn": 44,
+                              "startLine": 286
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 58,
+                          "endLine": 286,
+                          "sourceId": "",
+                          "startColumn": 50,
+                          "startLine": 286
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e",
+                                    "sourceInformation": {
+                                      "endColumn": 71,
+                                      "endLine": 286,
+                                      "sourceId": "",
+                                      "startColumn": 70,
+                                      "startLine": 286
+                                    }
+                                  }
+                                ],
+                                "property": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 80,
+                                  "endLine": 286,
+                                  "sourceId": "",
+                                  "startColumn": 73,
+                                  "startLine": 286
+                                }
+                              },
+                              {
+                                "_type": "var",
+                                "name": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 93,
+                                  "endLine": 286,
+                                  "sourceId": "",
+                                  "startColumn": 85,
+                                  "startLine": 286
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 83,
+                              "endLine": 286,
+                              "sourceId": "",
+                              "startColumn": 82,
+                              "startLine": 286
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 93,
+                          "endLine": 286,
+                          "sourceId": "",
+                          "startColumn": 69,
+                          "startLine": 286
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 66,
+                      "endLine": 286,
+                      "sourceId": "",
+                      "startColumn": 61,
+                      "startLine": 286
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 101,
+                  "endLine": 286,
+                  "sourceId": "",
+                  "startColumn": 97,
+                  "startLine": 286
+                }
+              }
+            ],
+            "name": "employeeByLastName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastName",
+                "sourceInformation": {
+                  "endColumn": 40,
+                  "endLine": 286,
+                  "sourceId": "",
+                  "startColumn": 22,
+                  "startLine": 286
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 153,
+              "endLine": 286,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 286
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "toOne",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 57,
+                                  "endLine": 287,
+                                  "sourceId": "",
+                                  "startColumn": 53,
+                                  "startLine": 287
+                                }
+                              }
+                            ],
+                            "property": "employees",
+                            "sourceInformation": {
+                              "endColumn": 67,
+                              "endLine": 287,
+                              "sourceId": "",
+                              "startColumn": 59,
+                              "startLine": 287
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 80,
+                                          "endLine": 287,
+                                          "sourceId": "",
+                                          "startColumn": 79,
+                                          "startLine": 287
+                                        }
+                                      }
+                                    ],
+                                    "property": "lastName",
+                                    "sourceInformation": {
+                                      "endColumn": 89,
+                                      "endLine": 287,
+                                      "sourceId": "",
+                                      "startColumn": 82,
+                                      "startLine": 287
+                                    }
+                                  },
+                                  {
+                                    "_type": "var",
+                                    "name": "lastName",
+                                    "sourceInformation": {
+                                      "endColumn": 102,
+                                      "endLine": 287,
+                                      "sourceId": "",
+                                      "startColumn": 94,
+                                      "startLine": 287
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 92,
+                                  "endLine": 287,
+                                  "sourceId": "",
+                                  "startColumn": 91,
+                                  "startLine": 287
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 102,
+                              "endLine": 287,
+                              "sourceId": "",
+                              "startColumn": 78,
+                              "startLine": 287
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 75,
+                          "endLine": 287,
+                          "sourceId": "",
+                          "startColumn": 70,
+                          "startLine": 287
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 110,
+                      "endLine": 287,
+                      "sourceId": "",
+                      "startColumn": 106,
+                      "startLine": 287
+                    }
+                  }
+                ],
+                "property": "firstName",
+                "sourceInformation": {
+                  "endColumn": 122,
+                  "endLine": 287,
+                  "sourceId": "",
+                  "startColumn": 114,
+                  "startLine": 287
+                }
+              }
+            ],
+            "name": "employeeByLastNameFirstName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastName",
+                "sourceInformation": {
+                  "endColumn": 49,
+                  "endLine": 287,
+                  "sourceId": "",
+                  "startColumn": 31,
+                  "startLine": 287
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 138,
+              "endLine": 287,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 287
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 71,
+                              "endLine": 288,
+                              "sourceId": "",
+                              "startColumn": 67,
+                              "startLine": 288
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 81,
+                          "endLine": 288,
+                          "sourceId": "",
+                          "startColumn": 73,
+                          "startLine": 288
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 101,
+                                  "endLine": 288,
+                                  "sourceId": "",
+                                  "startColumn": 93,
+                                  "startLine": 288
+                                }
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e",
+                                    "sourceInformation": {
+                                      "endColumn": 107,
+                                      "endLine": 288,
+                                      "sourceId": "",
+                                      "startColumn": 106,
+                                      "startLine": 288
+                                    }
+                                  }
+                                ],
+                                "property": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 116,
+                                  "endLine": 288,
+                                  "sourceId": "",
+                                  "startColumn": 109,
+                                  "startLine": 288
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 104,
+                              "endLine": 288,
+                              "sourceId": "",
+                              "startColumn": 103,
+                              "startLine": 288
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 116,
+                          "endLine": 288,
+                          "sourceId": "",
+                          "startColumn": 92,
+                          "startLine": 288
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 89,
+                      "endLine": 288,
+                      "sourceId": "",
+                      "startColumn": 84,
+                      "startLine": 288
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 124,
+                  "endLine": 288,
+                  "sourceId": "",
+                  "startColumn": 120,
+                  "startLine": 288
+                }
+              }
+            ],
+            "name": "employeeByLastNameWhereVarIsFirstEqualArg",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastName",
+                "sourceInformation": {
+                  "endColumn": 63,
+                  "endLine": 288,
+                  "sourceId": "",
+                  "startColumn": 45,
+                  "startLine": 288
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 176,
+              "endLine": 288,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 288
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 40,
+                          "endLine": 289,
+                          "sourceId": "",
+                          "startColumn": 36,
+                          "startLine": 289
+                        }
+                      }
+                    ],
+                    "property": "employees",
+                    "sourceInformation": {
+                      "endColumn": 50,
+                      "endLine": 289,
+                      "sourceId": "",
+                      "startColumn": 42,
+                      "startLine": 289
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "lessThan",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e",
+                                    "sourceInformation": {
+                                      "endColumn": 63,
+                                      "endLine": 289,
+                                      "sourceId": "",
+                                      "startColumn": 62,
+                                      "startLine": 289
+                                    }
+                                  }
+                                ],
+                                "property": "age",
+                                "sourceInformation": {
+                                  "endColumn": 67,
+                                  "endLine": 289,
+                                  "sourceId": "",
+                                  "startColumn": 65,
+                                  "startLine": 289
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 74,
+                              "endLine": 289,
+                              "sourceId": "",
+                              "startColumn": 70,
+                              "startLine": 289
+                            }
+                          },
+                          {
+                            "_type": "var",
+                            "name": "age",
+                            "sourceInformation": {
+                              "endColumn": 83,
+                              "endLine": 289,
+                              "sourceId": "",
+                              "startColumn": 80,
+                              "startLine": 289
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 83,
+                          "endLine": 289,
+                          "sourceId": "",
+                          "startColumn": 78,
+                          "startLine": 289
+                        }
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 83,
+                      "endLine": 289,
+                      "sourceId": "",
+                      "startColumn": 61,
+                      "startLine": 289
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 58,
+                  "endLine": 289,
+                  "sourceId": "",
+                  "startColumn": 53,
+                  "startLine": 289
+                }
+              }
+            ],
+            "name": "employeesByAge",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Integer",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "age",
+                "sourceInformation": {
+                  "endColumn": 32,
+                  "endLine": 289,
+                  "sourceId": "",
+                  "startColumn": 18,
+                  "startLine": 289
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 131,
+              "endLine": 289,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 289
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 73,
+                          "endLine": 290,
+                          "sourceId": "",
+                          "startColumn": 69,
+                          "startLine": 290
+                        }
+                      }
+                    ],
+                    "property": "employees",
+                    "sourceInformation": {
+                      "endColumn": 83,
+                      "endLine": 290,
+                      "sourceId": "",
+                      "startColumn": 75,
+                      "startLine": 290
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "or",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 97,
+                                          "endLine": 290,
+                                          "sourceId": "",
+                                          "startColumn": 96,
+                                          "startLine": 290
+                                        }
+                                      }
+                                    ],
+                                    "property": "address",
+                                    "sourceInformation": {
+                                      "endColumn": 105,
+                                      "endLine": 290,
+                                      "sourceId": "",
+                                      "startColumn": 99,
+                                      "startLine": 290
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 110,
+                                  "endLine": 290,
+                                  "sourceId": "",
+                                  "startColumn": 107,
+                                  "startLine": 290
+                                }
+                              },
+                              {
+                                "_type": "var",
+                                "name": "city",
+                                "sourceInformation": {
+                                  "endColumn": 119,
+                                  "endLine": 290,
+                                  "sourceId": "",
+                                  "startColumn": 115,
+                                  "startLine": 290
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 113,
+                              "endLine": 290,
+                              "sourceId": "",
+                              "startColumn": 112,
+                              "startLine": 290
+                            }
+                          },
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 127,
+                                          "endLine": 290,
+                                          "sourceId": "",
+                                          "startColumn": 126,
+                                          "startLine": 290
+                                        }
+                                      }
+                                    ],
+                                    "property": "manager",
+                                    "sourceInformation": {
+                                      "endColumn": 135,
+                                      "endLine": 290,
+                                      "sourceId": "",
+                                      "startColumn": 129,
+                                      "startLine": 290
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 140,
+                                  "endLine": 290,
+                                  "sourceId": "",
+                                  "startColumn": 137,
+                                  "startLine": 290
+                                }
+                              },
+                              {
+                                "_type": "var",
+                                "name": "managerName",
+                                "sourceInformation": {
+                                  "endColumn": 156,
+                                  "endLine": 290,
+                                  "sourceId": "",
+                                  "startColumn": 145,
+                                  "startLine": 290
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 143,
+                              "endLine": 290,
+                              "sourceId": "",
+                              "startColumn": 142,
+                              "startLine": 290
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 123,
+                          "endLine": 290,
+                          "sourceId": "",
+                          "startColumn": 122,
+                          "startLine": 290
+                        }
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 157,
+                      "endLine": 290,
+                      "sourceId": "",
+                      "startColumn": 94,
+                      "startLine": 290
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 91,
+                  "endLine": 290,
+                  "sourceId": "",
+                  "startColumn": 86,
+                  "startLine": 290
+                }
+              }
+            ],
+            "name": "employeesByCityOrManager",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "city",
+                "sourceInformation": {
+                  "endColumn": 42,
+                  "endLine": 290,
+                  "sourceId": "",
+                  "startColumn": 28,
+                  "startLine": 290
+                }
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "managerName",
+                "sourceInformation": {
+                  "endColumn": 65,
+                  "endLine": 290,
+                  "sourceId": "",
+                  "startColumn": 44,
+                  "startLine": 290
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 205,
+              "endLine": 290,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 290
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 100,
+                              "endLine": 291,
+                              "sourceId": "",
+                              "startColumn": 96,
+                              "startLine": 291
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 110,
+                          "endLine": 291,
+                          "sourceId": "",
+                          "startColumn": 102,
+                          "startLine": 291
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "and",
+                            "parameters": [
+                              {
+                                "_type": "func",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 124,
+                                          "endLine": 291,
+                                          "sourceId": "",
+                                          "startColumn": 123,
+                                          "startLine": 291
+                                        }
+                                      }
+                                    ],
+                                    "property": "lastName",
+                                    "sourceInformation": {
+                                      "endColumn": 133,
+                                      "endLine": 291,
+                                      "sourceId": "",
+                                      "startColumn": 126,
+                                      "startLine": 291
+                                    }
+                                  },
+                                  {
+                                    "_type": "var",
+                                    "name": "name",
+                                    "sourceInformation": {
+                                      "endColumn": 142,
+                                      "endLine": 291,
+                                      "sourceId": "",
+                                      "startColumn": 138,
+                                      "startLine": 291
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 136,
+                                  "endLine": 291,
+                                  "sourceId": "",
+                                  "startColumn": 135,
+                                  "startLine": 291
+                                }
+                              },
+                              {
+                                "_type": "func",
+                                "function": "or",
+                                "parameters": [
+                                  {
+                                    "_type": "func",
+                                    "function": "equal",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "property",
+                                            "parameters": [
+                                              {
+                                                "_type": "var",
+                                                "name": "e",
+                                                "sourceInformation": {
+                                                  "endColumn": 151,
+                                                  "endLine": 291,
+                                                  "sourceId": "",
+                                                  "startColumn": 150,
+                                                  "startLine": 291
+                                                }
+                                              }
+                                            ],
+                                            "property": "address",
+                                            "sourceInformation": {
+                                              "endColumn": 159,
+                                              "endLine": 291,
+                                              "sourceId": "",
+                                              "startColumn": 153,
+                                              "startLine": 291
+                                            }
+                                          }
+                                        ],
+                                        "property": "name",
+                                        "sourceInformation": {
+                                          "endColumn": 164,
+                                          "endLine": 291,
+                                          "sourceId": "",
+                                          "startColumn": 161,
+                                          "startLine": 291
+                                        }
+                                      },
+                                      {
+                                        "_type": "var",
+                                        "name": "city",
+                                        "sourceInformation": {
+                                          "endColumn": 173,
+                                          "endLine": 291,
+                                          "sourceId": "",
+                                          "startColumn": 169,
+                                          "startLine": 291
+                                        }
+                                      }
+                                    ],
+                                    "sourceInformation": {
+                                      "endColumn": 167,
+                                      "endLine": 291,
+                                      "sourceId": "",
+                                      "startColumn": 166,
+                                      "startLine": 291
+                                    }
+                                  },
+                                  {
+                                    "_type": "func",
+                                    "function": "equal",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "property",
+                                            "parameters": [
+                                              {
+                                                "_type": "var",
+                                                "name": "e",
+                                                "sourceInformation": {
+                                                  "endColumn": 181,
+                                                  "endLine": 291,
+                                                  "sourceId": "",
+                                                  "startColumn": 180,
+                                                  "startLine": 291
+                                                }
+                                              }
+                                            ],
+                                            "property": "manager",
+                                            "sourceInformation": {
+                                              "endColumn": 189,
+                                              "endLine": 291,
+                                              "sourceId": "",
+                                              "startColumn": 183,
+                                              "startLine": 291
+                                            }
+                                          }
+                                        ],
+                                        "property": "name",
+                                        "sourceInformation": {
+                                          "endColumn": 194,
+                                          "endLine": 291,
+                                          "sourceId": "",
+                                          "startColumn": 191,
+                                          "startLine": 291
+                                        }
+                                      },
+                                      {
+                                        "_type": "var",
+                                        "name": "managerName",
+                                        "sourceInformation": {
+                                          "endColumn": 210,
+                                          "endLine": 291,
+                                          "sourceId": "",
+                                          "startColumn": 199,
+                                          "startLine": 291
+                                        }
+                                      }
+                                    ],
+                                    "sourceInformation": {
+                                      "endColumn": 197,
+                                      "endLine": 291,
+                                      "sourceId": "",
+                                      "startColumn": 196,
+                                      "startLine": 291
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 177,
+                                  "endLine": 291,
+                                  "sourceId": "",
+                                  "startColumn": 176,
+                                  "startLine": 291
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 146,
+                              "endLine": 291,
+                              "sourceId": "",
+                              "startColumn": 145,
+                              "startLine": 291
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 212,
+                          "endLine": 291,
+                          "sourceId": "",
+                          "startColumn": 121,
+                          "startLine": 291
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 118,
+                      "endLine": 291,
+                      "sourceId": "",
+                      "startColumn": 113,
+                      "startLine": 291
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 220,
+                  "endLine": 291,
+                  "sourceId": "",
+                  "startColumn": 216,
+                  "startLine": 291
+                }
+              }
+            ],
+            "name": "employeesByCityOrManagerAndLastName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name",
+                "sourceInformation": {
+                  "endColumn": 53,
+                  "endLine": 291,
+                  "sourceId": "",
+                  "startColumn": 39,
+                  "startLine": 291
+                }
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "city",
+                "sourceInformation": {
+                  "endColumn": 69,
+                  "endLine": 291,
+                  "sourceId": "",
+                  "startColumn": 55,
+                  "startLine": 291
+                }
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "managerName",
+                "sourceInformation": {
+                  "endColumn": 92,
+                  "endLine": 291,
+                  "sourceId": "",
+                  "startColumn": 71,
+                  "startLine": 291
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 269,
+              "endLine": 291,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 291
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "exists",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 45,
+                          "endLine": 292,
+                          "sourceId": "",
+                          "startColumn": 41,
+                          "startLine": 292
+                        }
+                      }
+                    ],
+                    "property": "employees",
+                    "sourceInformation": {
+                      "endColumn": 55,
+                      "endLine": 292,
+                      "sourceId": "",
+                      "startColumn": 47,
+                      "startLine": 292
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "lessThan",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e",
+                                    "sourceInformation": {
+                                      "endColumn": 68,
+                                      "endLine": 292,
+                                      "sourceId": "",
+                                      "startColumn": 67,
+                                      "startLine": 292
+                                    }
+                                  }
+                                ],
+                                "property": "age",
+                                "sourceInformation": {
+                                  "endColumn": 72,
+                                  "endLine": 292,
+                                  "sourceId": "",
+                                  "startColumn": 70,
+                                  "startLine": 292
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 79,
+                              "endLine": 292,
+                              "sourceId": "",
+                              "startColumn": 75,
+                              "startLine": 292
+                            }
+                          },
+                          {
+                            "_type": "var",
+                            "name": "age",
+                            "sourceInformation": {
+                              "endColumn": 88,
+                              "endLine": 292,
+                              "sourceId": "",
+                              "startColumn": 85,
+                              "startLine": 292
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 88,
+                          "endLine": 292,
+                          "sourceId": "",
+                          "startColumn": 83,
+                          "startLine": 292
+                        }
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 88,
+                      "endLine": 292,
+                      "sourceId": "",
+                      "startColumn": 66,
+                      "startLine": 292
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 63,
+                  "endLine": 292,
+                  "sourceId": "",
+                  "startColumn": 58,
+                  "startLine": 292
+                }
+              }
+            ],
+            "name": "hasEmployeeBelowAge",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Integer",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "age",
+                "sourceInformation": {
+                  "endColumn": 37,
+                  "endLine": 292,
+                  "sourceId": "",
+                  "startColumn": 23,
+                  "startLine": 292
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Boolean",
+            "sourceInformation": {
+              "endColumn": 103,
+              "endLine": 292,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 292
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "first",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 38,
+                              "endLine": 293,
+                              "sourceId": "",
+                              "startColumn": 34,
+                              "startLine": 293
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 48,
+                          "endLine": 293,
+                          "sourceId": "",
+                          "startColumn": 40,
+                          "startLine": 293
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e",
+                                    "sourceInformation": {
+                                      "endColumn": 61,
+                                      "endLine": 293,
+                                      "sourceId": "",
+                                      "startColumn": 60,
+                                      "startLine": 293
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 66,
+                                  "endLine": 293,
+                                  "sourceId": "",
+                                  "startColumn": 63,
+                                  "startLine": 293
+                                }
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 75,
+                                          "endLine": 293,
+                                          "sourceId": "",
+                                          "startColumn": 71,
+                                          "startLine": 293
+                                        }
+                                      }
+                                    ],
+                                    "property": "address",
+                                    "sourceInformation": {
+                                      "endColumn": 83,
+                                      "endLine": 293,
+                                      "sourceId": "",
+                                      "startColumn": 77,
+                                      "startLine": 293
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 88,
+                                  "endLine": 293,
+                                  "sourceId": "",
+                                  "startColumn": 85,
+                                  "startLine": 293
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 69,
+                              "endLine": 293,
+                              "sourceId": "",
+                              "startColumn": 68,
+                              "startLine": 293
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 88,
+                          "endLine": 293,
+                          "sourceId": "",
+                          "startColumn": 59,
+                          "startLine": 293
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 56,
+                      "endLine": 293,
+                      "sourceId": "",
+                      "startColumn": 51,
+                      "startLine": 293
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 96,
+                  "endLine": 293,
+                  "sourceId": "",
+                  "startColumn": 92,
+                  "startLine": 293
+                }
+              }
+            ],
+            "name": "employeeWithFirmAddressName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 148,
+              "endLine": 293,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 293
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "first",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 49,
+                              "endLine": 294,
+                              "sourceId": "",
+                              "startColumn": 45,
+                              "startLine": 294
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 59,
+                          "endLine": 294,
+                          "sourceId": "",
+                          "startColumn": 51,
+                          "startLine": 294
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 72,
+                                          "endLine": 294,
+                                          "sourceId": "",
+                                          "startColumn": 71,
+                                          "startLine": 294
+                                        }
+                                      }
+                                    ],
+                                    "property": "address",
+                                    "sourceInformation": {
+                                      "endColumn": 80,
+                                      "endLine": 294,
+                                      "sourceId": "",
+                                      "startColumn": 74,
+                                      "startLine": 294
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 85,
+                                  "endLine": 294,
+                                  "sourceId": "",
+                                  "startColumn": 82,
+                                  "startLine": 294
+                                }
+                              },
+                              {
+                                "_type": "var",
+                                "name": "name",
+                                "sourceInformation": {
+                                  "endColumn": 94,
+                                  "endLine": 294,
+                                  "sourceId": "",
+                                  "startColumn": 90,
+                                  "startLine": 294
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 88,
+                              "endLine": 294,
+                              "sourceId": "",
+                              "startColumn": 87,
+                              "startLine": 294
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 94,
+                          "endLine": 294,
+                          "sourceId": "",
+                          "startColumn": 70,
+                          "startLine": 294
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 67,
+                      "endLine": 294,
+                      "sourceId": "",
+                      "startColumn": 62,
+                      "startLine": 294
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 102,
+                  "endLine": 294,
+                  "sourceId": "",
+                  "startColumn": 98,
+                  "startLine": 294
+                }
+              }
+            ],
+            "name": "employeeWithAddressName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name",
+                "sourceInformation": {
+                  "endColumn": 41,
+                  "endLine": 294,
+                  "sourceId": "",
+                  "startColumn": 27,
+                  "startLine": 294
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 154,
+              "endLine": 294,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 294
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "joinStrings",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "sortBy",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "filter",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 56,
+                                      "endLine": 295,
+                                      "sourceId": "",
+                                      "startColumn": 52,
+                                      "startLine": 295
+                                    }
+                                  }
+                                ],
+                                "property": "employees",
+                                "sourceInformation": {
+                                  "endColumn": 66,
+                                  "endLine": 295,
+                                  "sourceId": "",
+                                  "startColumn": 58,
+                                  "startLine": 295
+                                }
+                              },
+                              {
+                                "_type": "lambda",
+                                "body": [
+                                  {
+                                    "_type": "func",
+                                    "function": "equal",
+                                    "parameters": [
+                                      {
+                                        "_type": "func",
+                                        "function": "trim",
+                                        "parameters": [
+                                          {
+                                            "_type": "func",
+                                            "function": "toOne",
+                                            "parameters": [
+                                              {
+                                                "_type": "property",
+                                                "parameters": [
+                                                  {
+                                                    "_type": "property",
+                                                    "parameters": [
+                                                      {
+                                                        "_type": "var",
+                                                        "name": "e",
+                                                        "sourceInformation": {
+                                                          "endColumn": 79,
+                                                          "endLine": 295,
+                                                          "sourceId": "",
+                                                          "startColumn": 78,
+                                                          "startLine": 295
+                                                        }
+                                                      }
+                                                    ],
+                                                    "property": "address",
+                                                    "sourceInformation": {
+                                                      "endColumn": 87,
+                                                      "endLine": 295,
+                                                      "sourceId": "",
+                                                      "startColumn": 81,
+                                                      "startLine": 295
+                                                    }
+                                                  }
+                                                ],
+                                                "property": "name",
+                                                "sourceInformation": {
+                                                  "endColumn": 92,
+                                                  "endLine": 295,
+                                                  "sourceId": "",
+                                                  "startColumn": 89,
+                                                  "startLine": 295
+                                                }
+                                              }
+                                            ],
+                                            "sourceInformation": {
+                                              "endColumn": 99,
+                                              "endLine": 295,
+                                              "sourceId": "",
+                                              "startColumn": 95,
+                                              "startLine": 295
+                                            }
+                                          }
+                                        ],
+                                        "sourceInformation": {
+                                          "endColumn": 107,
+                                          "endLine": 295,
+                                          "sourceId": "",
+                                          "startColumn": 104,
+                                          "startLine": 295
+                                        }
+                                      },
+                                      {
+                                        "_type": "var",
+                                        "name": "name",
+                                        "sourceInformation": {
+                                          "endColumn": 118,
+                                          "endLine": 295,
+                                          "sourceId": "",
+                                          "startColumn": 114,
+                                          "startLine": 295
+                                        }
+                                      }
+                                    ],
+                                    "sourceInformation": {
+                                      "endColumn": 112,
+                                      "endLine": 295,
+                                      "sourceId": "",
+                                      "startColumn": 111,
+                                      "startLine": 295
+                                    }
+                                  }
+                                ],
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e"
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 118,
+                                  "endLine": 295,
+                                  "sourceId": "",
+                                  "startColumn": 77,
+                                  "startLine": 295
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 74,
+                              "endLine": 295,
+                              "sourceId": "",
+                              "startColumn": 69,
+                              "startLine": 295
+                            }
+                          },
+                          {
+                            "_type": "path",
+                            "path": [
+                              {
+                                "_type": "propertyPath",
+                                "parameters": [],
+                                "property": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 230,
+                                  "endLine": 295,
+                                  "sourceId": "",
+                                  "startColumn": 222,
+                                  "startLine": 295
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 235,
+                              "endLine": 295,
+                              "sourceId": "",
+                              "startColumn": 181,
+                              "startLine": 295
+                            },
+                            "startType": "test::pure::tests::model::simple::Person"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 127,
+                          "endLine": 295,
+                          "sourceId": "",
+                          "startColumn": 122,
+                          "startLine": 295
+                        }
+                      }
+                    ],
+                    "property": "lastName",
+                    "sourceInformation": {
+                      "endColumn": 190,
+                      "endLine": 295,
+                      "sourceId": "",
+                      "startColumn": 183,
+                      "startLine": 295
+                    }
+                  },
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "sourceInformation": {
+                      "endColumn": 206,
+                      "endLine": 295,
+                      "sourceId": "",
+                      "startColumn": 205,
+                      "startLine": 295
+                    },
+                    "values": [
+                      ""
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 203,
+                  "endLine": 295,
+                  "sourceId": "",
+                  "startColumn": 193,
+                  "startLine": 295
+                }
+              }
+            ],
+            "name": "employeesWithAddressNameSorted",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name",
+                "sourceInformation": {
+                  "endColumn": 48,
+                  "endLine": 295,
+                  "sourceId": "",
+                  "startColumn": 34,
+                  "startLine": 295
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 223,
+              "endLine": 295,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 295
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "map",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 123,
+                              "endLine": 296,
+                              "sourceId": "",
+                              "startColumn": 119,
+                              "startLine": 296
+                            }
+                          }
+                        ],
+                        "property": "employees",
+                        "sourceInformation": {
+                          "endColumn": 133,
+                          "endLine": 296,
+                          "sourceId": "",
+                          "startColumn": 125,
+                          "startLine": 296
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e",
+                                "sourceInformation": {
+                                  "endColumn": 143,
+                                  "endLine": 296,
+                                  "sourceId": "",
+                                  "startColumn": 142,
+                                  "startLine": 296
+                                }
+                              }
+                            ],
+                            "property": "address",
+                            "sourceInformation": {
+                              "endColumn": 151,
+                              "endLine": 296,
+                              "sourceId": "",
+                              "startColumn": 145,
+                              "startLine": 296
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 151,
+                          "endLine": 296,
+                          "sourceId": "",
+                          "startColumn": 141,
+                          "startLine": 296
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 138,
+                      "endLine": 296,
+                      "sourceId": "",
+                      "startColumn": 136,
+                      "startLine": 296
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "and",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "name",
+                                "sourceInformation": {
+                                  "endColumn": 169,
+                                  "endLine": 296,
+                                  "sourceId": "",
+                                  "startColumn": 165,
+                                  "startLine": 296
+                                }
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 178,
+                                          "endLine": 296,
+                                          "sourceId": "",
+                                          "startColumn": 174,
+                                          "startLine": 296
+                                        }
+                                      }
+                                    ],
+                                    "property": "address",
+                                    "sourceInformation": {
+                                      "endColumn": 186,
+                                      "endLine": 296,
+                                      "sourceId": "",
+                                      "startColumn": 180,
+                                      "startLine": 296
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 191,
+                                  "endLine": 296,
+                                  "sourceId": "",
+                                  "startColumn": 188,
+                                  "startLine": 296
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 172,
+                              "endLine": 296,
+                              "sourceId": "",
+                              "startColumn": 171,
+                              "startLine": 296
+                            }
+                          },
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "t",
+                                "sourceInformation": {
+                                  "endColumn": 199,
+                                  "endLine": 296,
+                                  "sourceId": "",
+                                  "startColumn": 198,
+                                  "startLine": 296
+                                }
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "x",
+                                    "sourceInformation": {
+                                      "endColumn": 205,
+                                      "endLine": 296,
+                                      "sourceId": "",
+                                      "startColumn": 204,
+                                      "startLine": 296
+                                    }
+                                  }
+                                ],
+                                "property": "type",
+                                "sourceInformation": {
+                                  "endColumn": 210,
+                                  "endLine": 296,
+                                  "sourceId": "",
+                                  "startColumn": 207,
+                                  "startLine": 296
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 202,
+                              "endLine": 296,
+                              "sourceId": "",
+                              "startColumn": 201,
+                              "startLine": 296
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 195,
+                          "endLine": 296,
+                          "sourceId": "",
+                          "startColumn": 194,
+                          "startLine": 296
+                        }
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 211,
+                      "endLine": 296,
+                      "sourceId": "",
+                      "startColumn": 163,
+                      "startLine": 296
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 160,
+                  "endLine": 296,
+                  "sourceId": "",
+                  "startColumn": 155,
+                  "startLine": 296
+                }
+              }
+            ],
+            "name": "employeeAddressesWithFirmAddressName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name",
+                "sourceInformation": {
+                  "endColumn": 54,
+                  "endLine": 296,
+                  "sourceId": "",
+                  "startColumn": 40,
+                  "startLine": 296
+                }
+              },
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::GeographicEntityType",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "t",
+                "sourceInformation": {
+                  "endColumn": 115,
+                  "endLine": 296,
+                  "sourceId": "",
+                  "startColumn": 56,
+                  "startLine": 296
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Address",
+            "sourceInformation": {
+              "endColumn": 260,
+              "endLine": 296,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 296
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "in",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 30,
+                          "endLine": 297,
+                          "sourceId": "",
+                          "startColumn": 26,
+                          "startLine": 297
+                        }
+                      }
+                    ],
+                    "property": "legalName",
+                    "sourceInformation": {
+                      "endColumn": 40,
+                      "endLine": 297,
+                      "sourceId": "",
+                      "startColumn": 32,
+                      "startLine": 297
+                    }
+                  },
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    },
+                    "sourceInformation": {
+                      "endColumn": 112,
+                      "endLine": 297,
+                      "sourceId": "",
+                      "startColumn": 46,
+                      "startLine": 297
+                    },
+                    "values": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 61,
+                          "endLine": 297,
+                          "sourceId": "",
+                          "startColumn": 47,
+                          "startLine": 297
+                        },
+                        "values": [
+                          "Goldman Sachs"
+                        ]
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 84,
+                          "endLine": 297,
+                          "sourceId": "",
+                          "startColumn": 64,
+                          "startLine": 297
+                        },
+                        "values": [
+                          "Goldman Sachs & Co."
+                        ]
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 111,
+                          "endLine": 297,
+                          "sourceId": "",
+                          "startColumn": 87,
+                          "startLine": 297
+                        },
+                        "values": [
+                          "Goldman Sachs and Group"
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 44,
+                  "endLine": 297,
+                  "sourceId": "",
+                  "startColumn": 43,
+                  "startLine": 297
+                }
+              }
+            ],
+            "name": "isGoldmanSachsGroup",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Boolean",
+            "sourceInformation": {
+              "endColumn": 127,
+              "endLine": 297,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 297
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 298,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 276
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::EntityWithAddress"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "FirmExtension",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "establishedDate",
+            "propertyTypeSourceInformation": {
+              "endColumn": 23,
+              "endLine": 302,
+              "sourceId": "",
+              "startColumn": 20,
+              "startLine": 302
+            },
+            "sourceInformation": {
+              "endColumn": 27,
+              "endLine": 302,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 302
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Date"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employeesExt",
+            "propertyTypeSourceInformation": {
+              "endColumn": 65,
+              "endLine": 303,
+              "sourceId": "",
+              "startColumn": 17,
+              "startLine": 303
+            },
+            "sourceInformation": {
+              "endColumn": 69,
+              "endLine": 303,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 303
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::PersonExtension"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "year",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 26,
+                          "endLine": 304,
+                          "sourceId": "",
+                          "startColumn": 22,
+                          "startLine": 304
+                        }
+                      }
+                    ],
+                    "property": "establishedDate",
+                    "sourceInformation": {
+                      "endColumn": 42,
+                      "endLine": 304,
+                      "sourceId": "",
+                      "startColumn": 28,
+                      "startLine": 304
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 48,
+                  "endLine": 304,
+                  "sourceId": "",
+                  "startColumn": 45,
+                  "startLine": 304
+                }
+              }
+            ],
+            "name": "establishedYear",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "sourceInformation": {
+              "endColumn": 64,
+              "endLine": 304,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 304
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "joinStrings",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 31,
+                              "endLine": 305,
+                              "sourceId": "",
+                              "startColumn": 27,
+                              "startLine": 305
+                            }
+                          }
+                        ],
+                        "property": "employeesExt",
+                        "sourceInformation": {
+                          "endColumn": 44,
+                          "endLine": 305,
+                          "sourceId": "",
+                          "startColumn": 33,
+                          "startLine": 305
+                        }
+                      }
+                    ],
+                    "property": "lastName",
+                    "sourceInformation": {
+                      "endColumn": 53,
+                      "endLine": 305,
+                      "sourceId": "",
+                      "startColumn": 46,
+                      "startLine": 305
+                    }
+                  },
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "sourceInformation": {
+                      "endColumn": 70,
+                      "endLine": 305,
+                      "sourceId": "",
+                      "startColumn": 68,
+                      "startLine": 305
+                    },
+                    "values": [
+                      ","
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 66,
+                  "endLine": 305,
+                  "sourceId": "",
+                  "startColumn": 56,
+                  "startLine": 305
+                }
+              }
+            ],
+            "name": "allEmployeesLastName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 87,
+              "endLine": 305,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 305
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 306,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 300
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Firm"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "GeographicEntity",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "type",
+            "propertyTypeSourceInformation": {
+              "endColumn": 62,
+              "endLine": 310,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 310
+            },
+            "sourceInformation": {
+              "endColumn": 66,
+              "endLine": 310,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 310
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::GeographicEntityType"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 311,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 308
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Interaction",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "id",
+            "propertyTypeSourceInformation": {
+              "endColumn": 12,
+              "endLine": 315,
+              "sourceId": "",
+              "startColumn": 7,
+              "startLine": 315
+            },
+            "sourceInformation": {
+              "endColumn": 16,
+              "endLine": 315,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 315
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "source",
+            "propertyTypeSourceInformation": {
+              "endColumn": 50,
+              "endLine": 316,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 316
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 316,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 316
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "target",
+            "propertyTypeSourceInformation": {
+              "endColumn": 50,
+              "endLine": 317,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 317
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 317,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 317
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "active",
+            "propertyTypeSourceInformation": {
+              "endColumn": 17,
+              "endLine": 318,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 318
+            },
+            "sourceInformation": {
+              "endColumn": 21,
+              "endLine": 318,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 318
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "time",
+            "propertyTypeSourceInformation": {
+              "endColumn": 15,
+              "endLine": 319,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 319
+            },
+            "sourceInformation": {
+              "endColumn": 19,
+              "endLine": 319,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 319
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "longestInteractionBetweenSourceAndTarget",
+            "propertyTypeSourceInformation": {
+              "endColumn": 51,
+              "endLine": 320,
+              "sourceId": "",
+              "startColumn": 45,
+              "startLine": 320
+            },
+            "sourceInformation": {
+              "endColumn": 55,
+              "endLine": 320,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 320
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 321,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 313
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Location",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "place",
+            "propertyTypeSourceInformation": {
+              "endColumn": 15,
+              "endLine": 325,
+              "sourceId": "",
+              "startColumn": 10,
+              "startLine": 325
+            },
+            "sourceInformation": {
+              "endColumn": 19,
+              "endLine": 325,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 325
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "censusdate",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 326,
+              "sourceId": "",
+              "startColumn": 15,
+              "startLine": 326
+            },
+            "sourceInformation": {
+              "endColumn": 25,
+              "endLine": 326,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 326
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Date"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 327,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 323
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::GeographicEntity"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Order",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "id",
+            "propertyTypeSourceInformation": {
+              "endColumn": 13,
+              "endLine": 331,
+              "sourceId": "",
+              "startColumn": 7,
+              "startLine": 331
+            },
+            "sourceInformation": {
+              "endColumn": 17,
+              "endLine": 331,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 331
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "date",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 332,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 332
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 332,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 332
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "quantity",
+            "propertyTypeSourceInformation": {
+              "endColumn": 17,
+              "endLine": 333,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 333
+            },
+            "sourceInformation": {
+              "endColumn": 21,
+              "endLine": 333,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 333
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "settlementDateTime",
+            "propertyTypeSourceInformation": {
+              "endColumn": 30,
+              "endLine": 334,
+              "sourceId": "",
+              "startColumn": 23,
+              "startLine": 334
+            },
+            "sourceInformation": {
+              "endColumn": 37,
+              "endLine": 334,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 334
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "DateTime"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "pnl",
+            "propertyTypeSourceInformation": {
+              "endColumn": 12,
+              "endLine": 335,
+              "sourceId": "",
+              "startColumn": 8,
+              "startLine": 335
+            },
+            "sourceInformation": {
+              "endColumn": 19,
+              "endLine": 335,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 335
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "pnlContact",
+            "propertyTypeSourceInformation": {
+              "endColumn": 54,
+              "endLine": 336,
+              "sourceId": "",
+              "startColumn": 15,
+              "startLine": 336
+            },
+            "sourceInformation": {
+              "endColumn": 61,
+              "endLine": 336,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 336
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "zeroPnl",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 337,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 337
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 337,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 337
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 338,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 329
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "OrderPnl",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "pnl",
+            "propertyTypeSourceInformation": {
+              "endColumn": 12,
+              "endLine": 342,
+              "sourceId": "",
+              "startColumn": 8,
+              "startLine": 342
+            },
+            "sourceInformation": {
+              "endColumn": 16,
+              "endLine": 342,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 342
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "supportContactName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 28,
+              "endLine": 343,
+              "sourceId": "",
+              "startColumn": 23,
+              "startLine": 343
+            },
+            "sourceInformation": {
+              "endColumn": 32,
+              "endLine": 343,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 343
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "order",
+            "propertyTypeSourceInformation": {
+              "endColumn": 48,
+              "endLine": 344,
+              "sourceId": "",
+              "startColumn": 10,
+              "startLine": 344
+            },
+            "sourceInformation": {
+              "endColumn": 52,
+              "endLine": 344,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 344
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Order"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 345,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 340
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Organization",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 349,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 349
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 349,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 349
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "letFunction",
+                "parameters": [
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "values": [
+                      "parent"
+                    ]
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 42,
+                          "endLine": 350,
+                          "sourceId": "",
+                          "startColumn": 38,
+                          "startLine": 350
+                        }
+                      }
+                    ],
+                    "property": "parent",
+                    "sourceInformation": {
+                      "endColumn": 49,
+                      "endLine": 350,
+                      "sourceId": "",
+                      "startColumn": 25,
+                      "startLine": 350
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 49,
+                  "endLine": 350,
+                  "sourceId": "",
+                  "startColumn": 25,
+                  "startLine": 350
+                }
+              },
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "isEmpty",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "parent",
+                        "sourceInformation": {
+                          "endColumn": 10,
+                          "endLine": 351,
+                          "sourceId": "",
+                          "startColumn": 4,
+                          "startLine": 351
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 19,
+                      "endLine": 351,
+                      "sourceId": "",
+                      "startColumn": 13,
+                      "startLine": 351
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "collection",
+                        "multiplicity": {
+                          "lowerBound": 0,
+                          "upperBound": 0
+                        },
+                        "sourceInformation": {
+                          "endColumn": 26,
+                          "endLine": 351,
+                          "sourceId": "",
+                          "startColumn": 25,
+                          "startLine": 351
+                        },
+                        "values": []
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 26,
+                      "endLine": 351,
+                      "sourceId": "",
+                      "startColumn": 24,
+                      "startLine": 351
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "concatenate",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "parent",
+                            "sourceInformation": {
+                              "endColumn": 36,
+                              "endLine": 351,
+                              "sourceId": "",
+                              "startColumn": 30,
+                              "startLine": 351
+                            }
+                          },
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "func",
+                                "function": "toOne",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "parent",
+                                    "sourceInformation": {
+                                      "endColumn": 57,
+                                      "endLine": 351,
+                                      "sourceId": "",
+                                      "startColumn": 51,
+                                      "startLine": 351
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 64,
+                                  "endLine": 351,
+                                  "sourceId": "",
+                                  "startColumn": 60,
+                                  "startLine": 351
+                                }
+                              }
+                            ],
+                            "property": "superOrganizations",
+                            "sourceInformation": {
+                              "endColumn": 85,
+                              "endLine": 351,
+                              "sourceId": "",
+                              "startColumn": 68,
+                              "startLine": 351
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 49,
+                          "endLine": 351,
+                          "sourceId": "",
+                          "startColumn": 39,
+                          "startLine": 351
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 86,
+                      "endLine": 351,
+                      "sourceId": "",
+                      "startColumn": 29,
+                      "startLine": 351
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 2,
+                  "endLine": 351,
+                  "sourceId": "",
+                  "startColumn": 1,
+                  "startLine": 351
+                }
+              }
+            ],
+            "name": "superOrganizations",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "sourceInformation": {
+              "endColumn": 141,
+              "endLine": 351,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 350
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "removeDuplicates",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "concatenate",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 27,
+                              "endLine": 352,
+                              "sourceId": "",
+                              "startColumn": 23,
+                              "startLine": 352
+                            }
+                          }
+                        ],
+                        "property": "children",
+                        "sourceInformation": {
+                          "endColumn": 36,
+                          "endLine": 352,
+                          "sourceId": "",
+                          "startColumn": 29,
+                          "startLine": 352
+                        }
+                      },
+                      {
+                        "_type": "func",
+                        "function": "map",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 55,
+                                  "endLine": 352,
+                                  "sourceId": "",
+                                  "startColumn": 51,
+                                  "startLine": 352
+                                }
+                              }
+                            ],
+                            "property": "children",
+                            "sourceInformation": {
+                              "endColumn": 64,
+                              "endLine": 352,
+                              "sourceId": "",
+                              "startColumn": 57,
+                              "startLine": 352
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "c",
+                                    "sourceInformation": {
+                                      "endColumn": 74,
+                                      "endLine": 352,
+                                      "sourceId": "",
+                                      "startColumn": 73,
+                                      "startLine": 352
+                                    }
+                                  }
+                                ],
+                                "property": "subOrganizations",
+                                "sourceInformation": {
+                                  "endColumn": 91,
+                                  "endLine": 352,
+                                  "sourceId": "",
+                                  "startColumn": 76,
+                                  "startLine": 352
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "c"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 91,
+                              "endLine": 352,
+                              "sourceId": "",
+                              "startColumn": 72,
+                              "startLine": 352
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 69,
+                          "endLine": 352,
+                          "sourceId": "",
+                          "startColumn": 67,
+                          "startLine": 352
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 49,
+                      "endLine": 352,
+                      "sourceId": "",
+                      "startColumn": 39,
+                      "startLine": 352
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 111,
+                  "endLine": 352,
+                  "sourceId": "",
+                  "startColumn": 96,
+                  "startLine": 352
+                }
+              }
+            ],
+            "name": "subOrganizations",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "sourceInformation": {
+              "endColumn": 166,
+              "endLine": 352,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 352
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 31,
+                              "endLine": 353,
+                              "sourceId": "",
+                              "startColumn": 27,
+                              "startLine": 353
+                            }
+                          }
+                        ],
+                        "property": "children",
+                        "sourceInformation": {
+                          "endColumn": 40,
+                          "endLine": 353,
+                          "sourceId": "",
+                          "startColumn": 33,
+                          "startLine": 353
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "c",
+                                    "sourceInformation": {
+                                      "endColumn": 53,
+                                      "endLine": 353,
+                                      "sourceId": "",
+                                      "startColumn": 52,
+                                      "startLine": 353
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 58,
+                                  "endLine": 353,
+                                  "sourceId": "",
+                                  "startColumn": 55,
+                                  "startLine": 353
+                                }
+                              },
+                              {
+                                "_type": "var",
+                                "name": "name",
+                                "sourceInformation": {
+                                  "endColumn": 67,
+                                  "endLine": 353,
+                                  "sourceId": "",
+                                  "startColumn": 63,
+                                  "startLine": 353
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 61,
+                              "endLine": 353,
+                              "sourceId": "",
+                              "startColumn": 60,
+                              "startLine": 353
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "c"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 67,
+                          "endLine": 353,
+                          "sourceId": "",
+                          "startColumn": 51,
+                          "startLine": 353
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 48,
+                      "endLine": 353,
+                      "sourceId": "",
+                      "startColumn": 43,
+                      "startLine": 353
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 75,
+                  "endLine": 353,
+                  "sourceId": "",
+                  "startColumn": 71,
+                  "startLine": 353
+                }
+              }
+            ],
+            "name": "child",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "name",
+                "sourceInformation": {
+                  "endColumn": 23,
+                  "endLine": 353,
+                  "sourceId": "",
+                  "startColumn": 9,
+                  "startLine": 353
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "sourceInformation": {
+              "endColumn": 130,
+              "endLine": 353,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 353
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "removeDuplicates",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "concatenate",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 21,
+                              "endLine": 354,
+                              "sourceId": "",
+                              "startColumn": 17,
+                              "startLine": 354
+                            }
+                          }
+                        ],
+                        "property": "members",
+                        "sourceInformation": {
+                          "endColumn": 29,
+                          "endLine": 354,
+                          "sourceId": "",
+                          "startColumn": 23,
+                          "startLine": 354
+                        }
+                      },
+                      {
+                        "_type": "func",
+                        "function": "map",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 48,
+                                  "endLine": 354,
+                                  "sourceId": "",
+                                  "startColumn": 44,
+                                  "startLine": 354
+                                }
+                              }
+                            ],
+                            "property": "subOrganizations",
+                            "sourceInformation": {
+                              "endColumn": 65,
+                              "endLine": 354,
+                              "sourceId": "",
+                              "startColumn": 50,
+                              "startLine": 354
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "o",
+                                    "sourceInformation": {
+                                      "endColumn": 75,
+                                      "endLine": 354,
+                                      "sourceId": "",
+                                      "startColumn": 74,
+                                      "startLine": 354
+                                    }
+                                  }
+                                ],
+                                "property": "members",
+                                "sourceInformation": {
+                                  "endColumn": 83,
+                                  "endLine": 354,
+                                  "sourceId": "",
+                                  "startColumn": 77,
+                                  "startLine": 354
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "o"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 83,
+                              "endLine": 354,
+                              "sourceId": "",
+                              "startColumn": 73,
+                              "startLine": 354
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 70,
+                          "endLine": 354,
+                          "sourceId": "",
+                          "startColumn": 68,
+                          "startLine": 354
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 42,
+                      "endLine": 354,
+                      "sourceId": "",
+                      "startColumn": 32,
+                      "startLine": 354
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 103,
+                  "endLine": 354,
+                  "sourceId": "",
+                  "startColumn": 88,
+                  "startLine": 354
+                }
+              }
+            ],
+            "name": "allMembers",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 152,
+              "endLine": 354,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 354
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 355,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 347
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Person",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 19,
+              "endLine": 359,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 359
+            },
+            "sourceInformation": {
+              "endColumn": 23,
+              "endLine": 359,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 359
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 360,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 360
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 360,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 360
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "otherNames",
+            "propertyTypeSourceInformation": {
+              "endColumn": 20,
+              "endLine": 361,
+              "sourceId": "",
+              "startColumn": 15,
+              "startLine": 361
+            },
+            "sourceInformation": {
+              "endColumn": 24,
+              "endLine": 361,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 361
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "extraInformation",
+            "propertyTypeSourceInformation": {
+              "endColumn": 26,
+              "endLine": 362,
+              "sourceId": "",
+              "startColumn": 21,
+              "startLine": 362
+            },
+            "sourceInformation": {
+              "endColumn": 33,
+              "endLine": 362,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 362
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "manager",
+            "propertyTypeSourceInformation": {
+              "endColumn": 51,
+              "endLine": 363,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 363
+            },
+            "sourceInformation": {
+              "endColumn": 58,
+              "endLine": 363,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 363
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "age",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 364,
+              "sourceId": "",
+              "startColumn": 8,
+              "startLine": 364
+            },
+            "sourceInformation": {
+              "endColumn": 21,
+              "endLine": 364,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 364
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "nickName",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 365,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 365
+            },
+            "sourceInformation": {
+              "endColumn": 25,
+              "endLine": 365,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 365
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "activeEmployment",
+            "propertyTypeSourceInformation": {
+              "endColumn": 27,
+              "endLine": 366,
+              "sourceId": "",
+              "startColumn": 21,
+              "startLine": 366
+            },
+            "sourceInformation": {
+              "endColumn": 34,
+              "endLine": 366,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 366
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    },
+                    "sourceInformation": {
+                      "endColumn": 48,
+                      "endLine": 367,
+                      "sourceId": "",
+                      "startColumn": 27,
+                      "startLine": 367
+                    },
+                    "values": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 15,
+                              "endLine": 367,
+                              "sourceId": "",
+                              "startColumn": 11,
+                              "startLine": 367
+                            }
+                          }
+                        ],
+                        "property": "firstName",
+                        "sourceInformation": {
+                          "endColumn": 25,
+                          "endLine": 367,
+                          "sourceId": "",
+                          "startColumn": 17,
+                          "startLine": 367
+                        }
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 31,
+                          "endLine": 367,
+                          "sourceId": "",
+                          "startColumn": 29,
+                          "startLine": 367
+                        },
+                        "values": [
+                          " "
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 39,
+                              "endLine": 367,
+                              "sourceId": "",
+                              "startColumn": 35,
+                              "startLine": 367
+                            }
+                          }
+                        ],
+                        "property": "lastName",
+                        "sourceInformation": {
+                          "endColumn": 48,
+                          "endLine": 367,
+                          "sourceId": "",
+                          "startColumn": 41,
+                          "startLine": 367
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 48,
+                  "endLine": 367,
+                  "sourceId": "",
+                  "startColumn": 27,
+                  "startLine": 367
+                }
+              }
+            ],
+            "name": "name",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 61,
+              "endLine": 367,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 367
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "multiplicity": {
+                      "lowerBound": 5,
+                      "upperBound": 5
+                    },
+                    "sourceInformation": {
+                      "endColumn": 88,
+                      "endLine": 368,
+                      "sourceId": "",
+                      "startColumn": 43,
+                      "startLine": 368
+                    },
+                    "values": [
+                      {
+                        "_type": "var",
+                        "name": "title",
+                        "sourceInformation": {
+                          "endColumn": 41,
+                          "endLine": 368,
+                          "sourceId": "",
+                          "startColumn": 36,
+                          "startLine": 368
+                        }
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 47,
+                          "endLine": 368,
+                          "sourceId": "",
+                          "startColumn": 45,
+                          "startLine": 368
+                        },
+                        "values": [
+                          " "
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 55,
+                              "endLine": 368,
+                              "sourceId": "",
+                              "startColumn": 51,
+                              "startLine": 368
+                            }
+                          }
+                        ],
+                        "property": "firstName",
+                        "sourceInformation": {
+                          "endColumn": 65,
+                          "endLine": 368,
+                          "sourceId": "",
+                          "startColumn": 57,
+                          "startLine": 368
+                        }
+                      },
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 71,
+                          "endLine": 368,
+                          "sourceId": "",
+                          "startColumn": 69,
+                          "startLine": 368
+                        },
+                        "values": [
+                          " "
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 79,
+                              "endLine": 368,
+                              "sourceId": "",
+                              "startColumn": 75,
+                              "startLine": 368
+                            }
+                          }
+                        ],
+                        "property": "lastName",
+                        "sourceInformation": {
+                          "endColumn": 88,
+                          "endLine": 368,
+                          "sourceId": "",
+                          "startColumn": 81,
+                          "startLine": 368
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 88,
+                  "endLine": 368,
+                  "sourceId": "",
+                  "startColumn": 43,
+                  "startLine": 368
+                }
+              }
+            ],
+            "name": "nameWithTitle",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "title",
+                "sourceInformation": {
+                  "endColumn": 32,
+                  "endLine": 368,
+                  "sourceId": "",
+                  "startColumn": 17,
+                  "startLine": 368
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 101,
+              "endLine": 368,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 368
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "isEmpty",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "prefix",
+                        "sourceInformation": {
+                          "endColumn": 79,
+                          "endLine": 369,
+                          "sourceId": "",
+                          "startColumn": 73,
+                          "startLine": 369
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 88,
+                      "endLine": 369,
+                      "sourceId": "",
+                      "startColumn": 82,
+                      "startLine": 369
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "isEmpty",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "suffixes",
+                                "sourceInformation": {
+                                  "endColumn": 105,
+                                  "endLine": 369,
+                                  "sourceId": "",
+                                  "startColumn": 97,
+                                  "startLine": 369
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 114,
+                              "endLine": 369,
+                              "sourceId": "",
+                              "startColumn": 108,
+                              "startLine": 369
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 3,
+                                      "upperBound": 3
+                                    },
+                                    "sourceInformation": {
+                                      "endColumn": 157,
+                                      "endLine": 369,
+                                      "sourceId": "",
+                                      "startColumn": 136,
+                                      "startLine": 369
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 124,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 120,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "firstName",
+                                        "sourceInformation": {
+                                          "endColumn": 134,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 126,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 140,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 138,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 148,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 144,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "lastName",
+                                        "sourceInformation": {
+                                          "endColumn": 157,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 150,
+                                          "startLine": 369
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 157,
+                                  "endLine": 369,
+                                  "sourceId": "",
+                                  "startColumn": 136,
+                                  "startLine": 369
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 157,
+                              "endLine": 369,
+                              "sourceId": "",
+                              "startColumn": 119,
+                              "startLine": 369
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 5,
+                                      "upperBound": 5
+                                    },
+                                    "sourceInformation": {
+                                      "endColumn": 236,
+                                      "endLine": 369,
+                                      "sourceId": "",
+                                      "startColumn": 177,
+                                      "startLine": 369
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 165,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 161,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "firstName",
+                                        "sourceInformation": {
+                                          "endColumn": 175,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 167,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 181,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 179,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 189,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 185,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "lastName",
+                                        "sourceInformation": {
+                                          "endColumn": 198,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 191,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 205,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 202,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "func",
+                                        "function": "joinStrings",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "suffixes",
+                                            "sourceInformation": {
+                                              "endColumn": 217,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 209,
+                                              "startLine": 369
+                                            }
+                                          },
+                                          {
+                                            "_type": "string",
+                                            "multiplicity": {
+                                              "lowerBound": 1,
+                                              "upperBound": 1
+                                            },
+                                            "sourceInformation": {
+                                              "endColumn": 235,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 232,
+                                              "startLine": 369
+                                            },
+                                            "values": [
+                                              ", "
+                                            ]
+                                          }
+                                        ],
+                                        "sourceInformation": {
+                                          "endColumn": 230,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 220,
+                                          "startLine": 369
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 236,
+                                  "endLine": 369,
+                                  "sourceId": "",
+                                  "startColumn": 177,
+                                  "startLine": 369
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 236,
+                              "endLine": 369,
+                              "sourceId": "",
+                              "startColumn": 160,
+                              "startLine": 369
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 95,
+                          "endLine": 369,
+                          "sourceId": "",
+                          "startColumn": 94,
+                          "startLine": 369
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 237,
+                      "endLine": 369,
+                      "sourceId": "",
+                      "startColumn": 93,
+                      "startLine": 369
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "isEmpty",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "suffixes",
+                                "sourceInformation": {
+                                  "endColumn": 252,
+                                  "endLine": 369,
+                                  "sourceId": "",
+                                  "startColumn": 244,
+                                  "startLine": 369
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 261,
+                              "endLine": 369,
+                              "sourceId": "",
+                              "startColumn": 255,
+                              "startLine": 369
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 5,
+                                      "upperBound": 5
+                                    },
+                                    "sourceInformation": {
+                                      "endColumn": 329,
+                                      "endLine": 369,
+                                      "sourceId": "",
+                                      "startColumn": 284,
+                                      "startLine": 369
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "func",
+                                        "function": "toOne",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "prefix",
+                                            "sourceInformation": {
+                                              "endColumn": 273,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 267,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "sourceInformation": {
+                                          "endColumn": 280,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 276,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 288,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 286,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 296,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 292,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "firstName",
+                                        "sourceInformation": {
+                                          "endColumn": 306,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 298,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 312,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 310,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 320,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 316,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "lastName",
+                                        "sourceInformation": {
+                                          "endColumn": 329,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 322,
+                                          "startLine": 369
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 329,
+                                  "endLine": 369,
+                                  "sourceId": "",
+                                  "startColumn": 284,
+                                  "startLine": 369
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 329,
+                              "endLine": 369,
+                              "sourceId": "",
+                              "startColumn": 266,
+                              "startLine": 369
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "plus",
+                                "parameters": [
+                                  {
+                                    "_type": "collection",
+                                    "multiplicity": {
+                                      "lowerBound": 7,
+                                      "upperBound": 7
+                                    },
+                                    "sourceInformation": {
+                                      "endColumn": 433,
+                                      "endLine": 369,
+                                      "sourceId": "",
+                                      "startColumn": 350,
+                                      "startLine": 369
+                                    },
+                                    "values": [
+                                      {
+                                        "_type": "func",
+                                        "function": "toOne",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "prefix",
+                                            "sourceInformation": {
+                                              "endColumn": 339,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 333,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "sourceInformation": {
+                                          "endColumn": 346,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 342,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 354,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 352,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 362,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 358,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "firstName",
+                                        "sourceInformation": {
+                                          "endColumn": 372,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 364,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 378,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 376,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 386,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 382,
+                                              "startLine": 369
+                                            }
+                                          }
+                                        ],
+                                        "property": "lastName",
+                                        "sourceInformation": {
+                                          "endColumn": 395,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 388,
+                                          "startLine": 369
+                                        }
+                                      },
+                                      {
+                                        "_type": "string",
+                                        "multiplicity": {
+                                          "lowerBound": 1,
+                                          "upperBound": 1
+                                        },
+                                        "sourceInformation": {
+                                          "endColumn": 402,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 399,
+                                          "startLine": 369
+                                        },
+                                        "values": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "_type": "func",
+                                        "function": "joinStrings",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "suffixes",
+                                            "sourceInformation": {
+                                              "endColumn": 414,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 406,
+                                              "startLine": 369
+                                            }
+                                          },
+                                          {
+                                            "_type": "string",
+                                            "multiplicity": {
+                                              "lowerBound": 1,
+                                              "upperBound": 1
+                                            },
+                                            "sourceInformation": {
+                                              "endColumn": 432,
+                                              "endLine": 369,
+                                              "sourceId": "",
+                                              "startColumn": 429,
+                                              "startLine": 369
+                                            },
+                                            "values": [
+                                              ", "
+                                            ]
+                                          }
+                                        ],
+                                        "sourceInformation": {
+                                          "endColumn": 427,
+                                          "endLine": 369,
+                                          "sourceId": "",
+                                          "startColumn": 417,
+                                          "startLine": 369
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 433,
+                                  "endLine": 369,
+                                  "sourceId": "",
+                                  "startColumn": 350,
+                                  "startLine": 369
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 433,
+                              "endLine": 369,
+                              "sourceId": "",
+                              "startColumn": 332,
+                              "startLine": 369
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 242,
+                          "endLine": 369,
+                          "sourceId": "",
+                          "startColumn": 241,
+                          "startLine": 369
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 434,
+                      "endLine": 369,
+                      "sourceId": "",
+                      "startColumn": 240,
+                      "startLine": 369
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 71,
+                  "endLine": 369,
+                  "sourceId": "",
+                  "startColumn": 70,
+                  "startLine": 369
+                }
+              }
+            ],
+            "name": "nameWithPrefixAndSuffix",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 0,
+                  "upperBound": 1
+                },
+                "name": "prefix",
+                "sourceInformation": {
+                  "endColumn": 46,
+                  "endLine": 369,
+                  "sourceId": "",
+                  "startColumn": 27,
+                  "startLine": 369
+                }
+              },
+              {
+                "_type": "var",
+                "class": "String",
+                "multiplicity": {
+                  "lowerBound": 0
+                },
+                "name": "suffixes",
+                "sourceInformation": {
+                  "endColumn": 66,
+                  "endLine": 369,
+                  "sourceId": "",
+                  "startColumn": 48,
+                  "startLine": 369
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 448,
+              "endLine": 369,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 369
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "name": "lastNameFirst",
+                    "sourceInformation": {
+                      "endColumn": 56,
+                      "endLine": 370,
+                      "sourceId": "",
+                      "startColumn": 43,
+                      "startLine": 370
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "sourceInformation": {
+                              "endColumn": 98,
+                              "endLine": 370,
+                              "sourceId": "",
+                              "startColumn": 75,
+                              "startLine": 370
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 64,
+                                      "endLine": 370,
+                                      "sourceId": "",
+                                      "startColumn": 60,
+                                      "startLine": 370
+                                    }
+                                  }
+                                ],
+                                "property": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 73,
+                                  "endLine": 370,
+                                  "sourceId": "",
+                                  "startColumn": 66,
+                                  "startLine": 370
+                                }
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "sourceInformation": {
+                                  "endColumn": 80,
+                                  "endLine": 370,
+                                  "sourceId": "",
+                                  "startColumn": 77,
+                                  "startLine": 370
+                                },
+                                "values": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 88,
+                                      "endLine": 370,
+                                      "sourceId": "",
+                                      "startColumn": 84,
+                                      "startLine": 370
+                                    }
+                                  }
+                                ],
+                                "property": "firstName",
+                                "sourceInformation": {
+                                  "endColumn": 98,
+                                  "endLine": 370,
+                                  "sourceId": "",
+                                  "startColumn": 90,
+                                  "startLine": 370
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 98,
+                          "endLine": 370,
+                          "sourceId": "",
+                          "startColumn": 75,
+                          "startLine": 370
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 98,
+                      "endLine": 370,
+                      "sourceId": "",
+                      "startColumn": 59,
+                      "startLine": 370
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "sourceInformation": {
+                              "endColumn": 139,
+                              "endLine": 370,
+                              "sourceId": "",
+                              "startColumn": 118,
+                              "startLine": 370
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 106,
+                                      "endLine": 370,
+                                      "sourceId": "",
+                                      "startColumn": 102,
+                                      "startLine": 370
+                                    }
+                                  }
+                                ],
+                                "property": "firstName",
+                                "sourceInformation": {
+                                  "endColumn": 116,
+                                  "endLine": 370,
+                                  "sourceId": "",
+                                  "startColumn": 108,
+                                  "startLine": 370
+                                }
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "sourceInformation": {
+                                  "endColumn": 122,
+                                  "endLine": 370,
+                                  "sourceId": "",
+                                  "startColumn": 120,
+                                  "startLine": 370
+                                },
+                                "values": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 130,
+                                      "endLine": 370,
+                                      "sourceId": "",
+                                      "startColumn": 126,
+                                      "startLine": 370
+                                    }
+                                  }
+                                ],
+                                "property": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 139,
+                                  "endLine": 370,
+                                  "sourceId": "",
+                                  "startColumn": 132,
+                                  "startLine": 370
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 139,
+                          "endLine": 370,
+                          "sourceId": "",
+                          "startColumn": 118,
+                          "startLine": 370
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 139,
+                      "endLine": 370,
+                      "sourceId": "",
+                      "startColumn": 101,
+                      "startLine": 370
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 41,
+                  "endLine": 370,
+                  "sourceId": "",
+                  "startColumn": 40,
+                  "startLine": 370
+                }
+              }
+            ],
+            "name": "fullName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Boolean",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "lastNameFirst",
+                "sourceInformation": {
+                  "endColumn": 36,
+                  "endLine": 370,
+                  "sourceId": "",
+                  "startColumn": 12,
+                  "startLine": 370
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 153,
+              "endLine": 370,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 370
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "personNameParameter",
+                        "sourceInformation": {
+                          "endColumn": 123,
+                          "endLine": 371,
+                          "sourceId": "",
+                          "startColumn": 104,
+                          "startLine": 371
+                        }
+                      }
+                    ],
+                    "property": "lastNameFirst",
+                    "sourceInformation": {
+                      "endColumn": 137,
+                      "endLine": 371,
+                      "sourceId": "",
+                      "startColumn": 125,
+                      "startLine": 371
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 5,
+                              "upperBound": 5
+                            },
+                            "sourceInformation": {
+                              "endColumn": 222,
+                              "endLine": 371,
+                              "sourceId": "",
+                              "startColumn": 176,
+                              "startLine": 371
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "personNameParameter",
+                                        "sourceInformation": {
+                                          "endColumn": 160,
+                                          "endLine": 371,
+                                          "sourceId": "",
+                                          "startColumn": 141,
+                                          "startLine": 371
+                                        }
+                                      }
+                                    ],
+                                    "property": "nested",
+                                    "sourceInformation": {
+                                      "endColumn": 167,
+                                      "endLine": 371,
+                                      "sourceId": "",
+                                      "startColumn": 162,
+                                      "startLine": 371
+                                    }
+                                  }
+                                ],
+                                "property": "prefix",
+                                "sourceInformation": {
+                                  "endColumn": 174,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 169,
+                                  "startLine": 371
+                                }
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "sourceInformation": {
+                                  "endColumn": 180,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 178,
+                                  "startLine": 371
+                                },
+                                "values": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 188,
+                                      "endLine": 371,
+                                      "sourceId": "",
+                                      "startColumn": 184,
+                                      "startLine": 371
+                                    }
+                                  }
+                                ],
+                                "property": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 197,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 190,
+                                  "startLine": 371
+                                }
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "sourceInformation": {
+                                  "endColumn": 204,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 201,
+                                  "startLine": 371
+                                },
+                                "values": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 212,
+                                      "endLine": 371,
+                                      "sourceId": "",
+                                      "startColumn": 208,
+                                      "startLine": 371
+                                    }
+                                  }
+                                ],
+                                "property": "firstName",
+                                "sourceInformation": {
+                                  "endColumn": 222,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 214,
+                                  "startLine": 371
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 222,
+                          "endLine": 371,
+                          "sourceId": "",
+                          "startColumn": 176,
+                          "startLine": 371
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 222,
+                      "endLine": 371,
+                      "sourceId": "",
+                      "startColumn": 140,
+                      "startLine": 371
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "plus",
+                        "parameters": [
+                          {
+                            "_type": "collection",
+                            "multiplicity": {
+                              "lowerBound": 3,
+                              "upperBound": 3
+                            },
+                            "sourceInformation": {
+                              "endColumn": 263,
+                              "endLine": 371,
+                              "sourceId": "",
+                              "startColumn": 242,
+                              "startLine": 371
+                            },
+                            "values": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 230,
+                                      "endLine": 371,
+                                      "sourceId": "",
+                                      "startColumn": 226,
+                                      "startLine": 371
+                                    }
+                                  }
+                                ],
+                                "property": "firstName",
+                                "sourceInformation": {
+                                  "endColumn": 240,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 232,
+                                  "startLine": 371
+                                }
+                              },
+                              {
+                                "_type": "string",
+                                "multiplicity": {
+                                  "lowerBound": 1,
+                                  "upperBound": 1
+                                },
+                                "sourceInformation": {
+                                  "endColumn": 246,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 244,
+                                  "startLine": 371
+                                },
+                                "values": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 254,
+                                      "endLine": 371,
+                                      "sourceId": "",
+                                      "startColumn": 250,
+                                      "startLine": 371
+                                    }
+                                  }
+                                ],
+                                "property": "lastName",
+                                "sourceInformation": {
+                                  "endColumn": 263,
+                                  "endLine": 371,
+                                  "sourceId": "",
+                                  "startColumn": 256,
+                                  "startLine": 371
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 263,
+                          "endLine": 371,
+                          "sourceId": "",
+                          "startColumn": 242,
+                          "startLine": 371
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 263,
+                      "endLine": 371,
+                      "sourceId": "",
+                      "startColumn": 225,
+                      "startLine": 371
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 102,
+                  "endLine": 371,
+                  "sourceId": "",
+                  "startColumn": 101,
+                  "startLine": 371
+                }
+              }
+            ],
+            "name": "parameterizedName",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::PersonNameParameter",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "personNameParameter",
+                "sourceInformation": {
+                  "endColumn": 97,
+                  "endLine": 371,
+                  "sourceId": "",
+                  "startColumn": 21,
+                  "startLine": 371
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 277,
+              "endLine": 371,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 371
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "removeDuplicates",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "concatenate",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 27,
+                              "endLine": 372,
+                              "sourceId": "",
+                              "startColumn": 23,
+                              "startLine": 372
+                            }
+                          }
+                        ],
+                        "property": "organizations",
+                        "sourceInformation": {
+                          "endColumn": 41,
+                          "endLine": 372,
+                          "sourceId": "",
+                          "startColumn": 29,
+                          "startLine": 372
+                        }
+                      },
+                      {
+                        "_type": "func",
+                        "function": "map",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 60,
+                                  "endLine": 372,
+                                  "sourceId": "",
+                                  "startColumn": 56,
+                                  "startLine": 372
+                                }
+                              }
+                            ],
+                            "property": "organizations",
+                            "sourceInformation": {
+                              "endColumn": 74,
+                              "endLine": 372,
+                              "sourceId": "",
+                              "startColumn": 62,
+                              "startLine": 372
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "o",
+                                    "sourceInformation": {
+                                      "endColumn": 84,
+                                      "endLine": 372,
+                                      "sourceId": "",
+                                      "startColumn": 83,
+                                      "startLine": 372
+                                    }
+                                  }
+                                ],
+                                "property": "superOrganizations",
+                                "sourceInformation": {
+                                  "endColumn": 103,
+                                  "endLine": 372,
+                                  "sourceId": "",
+                                  "startColumn": 86,
+                                  "startLine": 372
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "o"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 103,
+                              "endLine": 372,
+                              "sourceId": "",
+                              "startColumn": 82,
+                              "startLine": 372
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 79,
+                          "endLine": 372,
+                          "sourceId": "",
+                          "startColumn": 77,
+                          "startLine": 372
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 54,
+                      "endLine": 372,
+                      "sourceId": "",
+                      "startColumn": 44,
+                      "startLine": 372
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 123,
+                  "endLine": 372,
+                  "sourceId": "",
+                  "startColumn": 108,
+                  "startLine": 372
+                }
+              }
+            ],
+            "name": "allOrganizations",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Organization",
+            "sourceInformation": {
+              "endColumn": 178,
+              "endLine": 372,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 372
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "string",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "sourceInformation": {
+                  "endColumn": 24,
+                  "endLine": 373,
+                  "sourceId": "",
+                  "startColumn": 15,
+                  "startLine": 373
+                },
+                "values": [
+                  "constant"
+                ]
+              }
+            ],
+            "name": "constant",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 37,
+              "endLine": 373,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 373
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "concatenate",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 20,
+                          "endLine": 374,
+                          "sourceId": "",
+                          "startColumn": 16,
+                          "startLine": 374
+                        }
+                      }
+                    ],
+                    "property": "address",
+                    "sourceInformation": {
+                      "endColumn": 28,
+                      "endLine": 374,
+                      "sourceId": "",
+                      "startColumn": 22,
+                      "startLine": 374
+                    }
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 47,
+                              "endLine": 374,
+                              "sourceId": "",
+                              "startColumn": 43,
+                              "startLine": 374
+                            }
+                          }
+                        ],
+                        "property": "firm",
+                        "sourceInformation": {
+                          "endColumn": 52,
+                          "endLine": 374,
+                          "sourceId": "",
+                          "startColumn": 49,
+                          "startLine": 374
+                        }
+                      }
+                    ],
+                    "property": "address",
+                    "sourceInformation": {
+                      "endColumn": 60,
+                      "endLine": 374,
+                      "sourceId": "",
+                      "startColumn": 54,
+                      "startLine": 374
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 41,
+                  "endLine": 374,
+                  "sourceId": "",
+                  "startColumn": 31,
+                  "startLine": 374
+                }
+              }
+            ],
+            "name": "addresses",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::Address",
+            "sourceInformation": {
+              "endColumn": 109,
+              "endLine": 374,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 374
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 375,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 357
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::EntityWithAddress",
+          "test::pure::tests::model::simple::EntityWithLocations"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PersonExtension",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "birthdate",
+            "propertyTypeSourceInformation": {
+              "endColumn": 17,
+              "endLine": 379,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 379
+            },
+            "sourceInformation": {
+              "endColumn": 24,
+              "endLine": 379,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 379
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Date"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "year",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 20,
+                          "endLine": 380,
+                          "sourceId": "",
+                          "startColumn": 16,
+                          "startLine": 380
+                        }
+                      }
+                    ],
+                    "property": "birthdate",
+                    "sourceInformation": {
+                      "endColumn": 30,
+                      "endLine": 380,
+                      "sourceId": "",
+                      "startColumn": 22,
+                      "startLine": 380
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 36,
+                  "endLine": 380,
+                  "sourceId": "",
+                  "startColumn": 33,
+                  "startLine": 380
+                }
+              }
+            ],
+            "name": "birthYear",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "sourceInformation": {
+              "endColumn": 55,
+              "endLine": 380,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 380
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 381,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 377
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Person"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PersonNameParameter",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastNameFirst",
+            "propertyTypeSourceInformation": {
+              "endColumn": 24,
+              "endLine": 385,
+              "sourceId": "",
+              "startColumn": 18,
+              "startLine": 385
+            },
+            "sourceInformation": {
+              "endColumn": 28,
+              "endLine": 385,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 385
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "nested",
+            "propertyTypeSourceInformation": {
+              "endColumn": 69,
+              "endLine": 386,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 386
+            },
+            "sourceInformation": {
+              "endColumn": 73,
+              "endLine": 386,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 386
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::PersonNameParameterNested"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 387,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 383
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PersonNameParameterNested",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "prefix",
+            "propertyTypeSourceInformation": {
+              "endColumn": 16,
+              "endLine": 391,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 391
+            },
+            "sourceInformation": {
+              "endColumn": 20,
+              "endLine": 391,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 391
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 392,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 389
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "PlaceOfInterest",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 396,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 396
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 396,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 396
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 397,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 394
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Product",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 401,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 401
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 401,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 401
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "classification",
+            "propertyTypeSourceInformation": {
+              "endColumn": 73,
+              "endLine": 402,
+              "sourceId": "",
+              "startColumn": 19,
+              "startLine": 402
+            },
+            "sourceInformation": {
+              "endColumn": 80,
+              "endLine": 402,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 402
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::ProductClassification"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 16,
+                          "endLine": 403,
+                          "sourceId": "",
+                          "startColumn": 12,
+                          "startLine": 403
+                        }
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "packageableElementPtr",
+                            "fullPath": "test::pure::tests::model::simple::ProductSynonymType",
+                            "sourceInformation": {
+                              "endColumn": 83,
+                              "endLine": 403,
+                              "sourceId": "",
+                              "startColumn": 32,
+                              "startLine": 403
+                            }
+                          }
+                        ],
+                        "property": "CUSIP",
+                        "sourceInformation": {
+                          "endColumn": 89,
+                          "endLine": 403,
+                          "sourceId": "",
+                          "startColumn": 85,
+                          "startLine": 403
+                        }
+                      }
+                    ],
+                    "property": "synonymByType",
+                    "sourceInformation": {
+                      "endColumn": 30,
+                      "endLine": 403,
+                      "sourceId": "",
+                      "startColumn": 18,
+                      "startLine": 403
+                    }
+                  }
+                ],
+                "property": "name",
+                "sourceInformation": {
+                  "endColumn": 95,
+                  "endLine": 403,
+                  "sourceId": "",
+                  "startColumn": 92,
+                  "startLine": 403
+                }
+              }
+            ],
+            "name": "cusip",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 108,
+              "endLine": 403,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 403
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 15,
+                          "endLine": 404,
+                          "sourceId": "",
+                          "startColumn": 11,
+                          "startLine": 404
+                        }
+                      },
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "packageableElementPtr",
+                            "fullPath": "test::pure::tests::model::simple::ProductSynonymType",
+                            "sourceInformation": {
+                              "endColumn": 82,
+                              "endLine": 404,
+                              "sourceId": "",
+                              "startColumn": 31,
+                              "startLine": 404
+                            }
+                          }
+                        ],
+                        "property": "ISIN",
+                        "sourceInformation": {
+                          "endColumn": 87,
+                          "endLine": 404,
+                          "sourceId": "",
+                          "startColumn": 84,
+                          "startLine": 404
+                        }
+                      }
+                    ],
+                    "property": "synonymByType",
+                    "sourceInformation": {
+                      "endColumn": 29,
+                      "endLine": 404,
+                      "sourceId": "",
+                      "startColumn": 17,
+                      "startLine": 404
+                    }
+                  }
+                ],
+                "property": "name",
+                "sourceInformation": {
+                  "endColumn": 93,
+                  "endLine": 404,
+                  "sourceId": "",
+                  "startColumn": 90,
+                  "startLine": 404
+                }
+              }
+            ],
+            "name": "isin",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 106,
+              "endLine": 404,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 404
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "name": "this",
+                    "sourceInformation": {
+                      "endColumn": 23,
+                      "endLine": 405,
+                      "sourceId": "",
+                      "startColumn": 19,
+                      "startLine": 405
+                    }
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "packageableElementPtr",
+                        "fullPath": "test::pure::tests::model::simple::ProductSynonymType",
+                        "sourceInformation": {
+                          "endColumn": 90,
+                          "endLine": 405,
+                          "sourceId": "",
+                          "startColumn": 39,
+                          "startLine": 405
+                        }
+                      }
+                    ],
+                    "property": "CUSIP",
+                    "sourceInformation": {
+                      "endColumn": 96,
+                      "endLine": 405,
+                      "sourceId": "",
+                      "startColumn": 92,
+                      "startLine": 405
+                    }
+                  }
+                ],
+                "property": "synonymByType",
+                "sourceInformation": {
+                  "endColumn": 37,
+                  "endLine": 405,
+                  "sourceId": "",
+                  "startColumn": 25,
+                  "startLine": 405
+                }
+              }
+            ],
+            "name": "cusipSynonym",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Synonym",
+            "sourceInformation": {
+              "endColumn": 145,
+              "endLine": 405,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 405
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "property",
+                "parameters": [
+                  {
+                    "_type": "var",
+                    "name": "this",
+                    "sourceInformation": {
+                      "endColumn": 22,
+                      "endLine": 406,
+                      "sourceId": "",
+                      "startColumn": 18,
+                      "startLine": 406
+                    }
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "packageableElementPtr",
+                        "fullPath": "test::pure::tests::model::simple::ProductSynonymType",
+                        "sourceInformation": {
+                          "endColumn": 89,
+                          "endLine": 406,
+                          "sourceId": "",
+                          "startColumn": 38,
+                          "startLine": 406
+                        }
+                      }
+                    ],
+                    "property": "ISIN",
+                    "sourceInformation": {
+                      "endColumn": 94,
+                      "endLine": 406,
+                      "sourceId": "",
+                      "startColumn": 91,
+                      "startLine": 406
+                    }
+                  }
+                ],
+                "property": "synonymByType",
+                "sourceInformation": {
+                  "endColumn": 36,
+                  "endLine": 406,
+                  "sourceId": "",
+                  "startColumn": 24,
+                  "startLine": 406
+                }
+              }
+            ],
+            "name": "isinSynonym",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Synonym",
+            "sourceInformation": {
+              "endColumn": 143,
+              "endLine": 406,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 406
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 407,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 399
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "ProductClassification",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "type",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 411,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 411
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 411,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 411
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "description",
+            "propertyTypeSourceInformation": {
+              "endColumn": 21,
+              "endLine": 412,
+              "sourceId": "",
+              "startColumn": 16,
+              "startLine": 412
+            },
+            "sourceInformation": {
+              "endColumn": 25,
+              "endLine": 412,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 412
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 413,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 409
+        },
+        "stereotypes": [
+          {
+            "profile": "meta::pure::profiles::temporal",
+            "profileSourceInformation": {
+              "endColumn": 38,
+              "endLine": 409,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 409
+            },
+            "sourceInformation": {
+              "endColumn": 55,
+              "endLine": 409,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 409
+            },
+            "value": "businesstemporal"
+          }
+        ],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Synonym",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "typeAsString",
+            "propertyTypeSourceInformation": {
+              "endColumn": 22,
+              "endLine": 417,
+              "sourceId": "",
+              "startColumn": 17,
+              "startLine": 417
+            },
+            "sourceInformation": {
+              "endColumn": 26,
+              "endLine": 417,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 417
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "type",
+            "propertyTypeSourceInformation": {
+              "endColumn": 60,
+              "endLine": 418,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 418
+            },
+            "sourceInformation": {
+              "endColumn": 64,
+              "endLine": 418,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 418
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::ProductSynonymType"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name",
+            "propertyTypeSourceInformation": {
+              "endColumn": 14,
+              "endLine": 419,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 419
+            },
+            "sourceInformation": {
+              "endColumn": 18,
+              "endLine": 419,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 419
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 420,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 415
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Team",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 424,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 422
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "test::pure::tests::model::simple::Organization"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "Trade",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "id",
+            "propertyTypeSourceInformation": {
+              "endColumn": 13,
+              "endLine": 428,
+              "sourceId": "",
+              "startColumn": 7,
+              "startLine": 428
+            },
+            "sourceInformation": {
+              "endColumn": 17,
+              "endLine": 428,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 428
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "date",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 429,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 429
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 429,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 429
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "quantity",
+            "propertyTypeSourceInformation": {
+              "endColumn": 17,
+              "endLine": 430,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 430
+            },
+            "sourceInformation": {
+              "endColumn": 21,
+              "endLine": 430,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 430
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "product",
+            "propertyTypeSourceInformation": {
+              "endColumn": 52,
+              "endLine": 431,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 431
+            },
+            "sourceInformation": {
+              "endColumn": 59,
+              "endLine": 431,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 431
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Product"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "settlementDateTime",
+            "propertyTypeSourceInformation": {
+              "endColumn": 30,
+              "endLine": 432,
+              "sourceId": "",
+              "startColumn": 23,
+              "startLine": 432
+            },
+            "sourceInformation": {
+              "endColumn": 37,
+              "endLine": 432,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 432
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "DateTime"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "latestEventDate",
+            "propertyTypeSourceInformation": {
+              "endColumn": 29,
+              "endLine": 433,
+              "sourceId": "",
+              "startColumn": 20,
+              "startLine": 433
+            },
+            "sourceInformation": {
+              "endColumn": 36,
+              "endLine": 433,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 433
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "events",
+            "propertyTypeSourceInformation": {
+              "endColumn": 54,
+              "endLine": 434,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 434
+            },
+            "sourceInformation": {
+              "endColumn": 58,
+              "endLine": 434,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 434
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::TradeEvent"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "isNotEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 31,
+                              "endLine": 435,
+                              "sourceId": "",
+                              "startColumn": 27,
+                              "startLine": 435
+                            }
+                          }
+                        ],
+                        "property": "product",
+                        "sourceInformation": {
+                          "endColumn": 39,
+                          "endLine": 435,
+                          "sourceId": "",
+                          "startColumn": 33,
+                          "startLine": 435
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 51,
+                      "endLine": 435,
+                      "sourceId": "",
+                      "startColumn": 42,
+                      "startLine": 435
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "isNotEmpty",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 64,
+                                          "endLine": 435,
+                                          "sourceId": "",
+                                          "startColumn": 60,
+                                          "startLine": 435
+                                        }
+                                      }
+                                    ],
+                                    "property": "product",
+                                    "sourceInformation": {
+                                      "endColumn": 72,
+                                      "endLine": 435,
+                                      "sourceId": "",
+                                      "startColumn": 66,
+                                      "startLine": 435
+                                    }
+                                  }
+                                ],
+                                "property": "cusip",
+                                "sourceInformation": {
+                                  "endColumn": 78,
+                                  "endLine": 435,
+                                  "sourceId": "",
+                                  "startColumn": 74,
+                                  "startLine": 435
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 90,
+                              "endLine": 435,
+                              "sourceId": "",
+                              "startColumn": 81,
+                              "startLine": 435
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "toOne",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 100,
+                                              "endLine": 435,
+                                              "sourceId": "",
+                                              "startColumn": 96,
+                                              "startLine": 435
+                                            }
+                                          }
+                                        ],
+                                        "property": "product",
+                                        "sourceInformation": {
+                                          "endColumn": 108,
+                                          "endLine": 435,
+                                          "sourceId": "",
+                                          "startColumn": 102,
+                                          "startLine": 435
+                                        }
+                                      }
+                                    ],
+                                    "property": "cusip",
+                                    "sourceInformation": {
+                                      "endColumn": 114,
+                                      "endLine": 435,
+                                      "sourceId": "",
+                                      "startColumn": 110,
+                                      "startLine": 435
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 121,
+                                  "endLine": 435,
+                                  "sourceId": "",
+                                  "startColumn": 117,
+                                  "startLine": 435
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 123,
+                              "endLine": 435,
+                              "sourceId": "",
+                              "startColumn": 95,
+                              "startLine": 435
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "func",
+                                    "function": "toOne",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 131,
+                                              "endLine": 435,
+                                              "sourceId": "",
+                                              "startColumn": 127,
+                                              "startLine": 435
+                                            }
+                                          }
+                                        ],
+                                        "property": "product",
+                                        "sourceInformation": {
+                                          "endColumn": 139,
+                                          "endLine": 435,
+                                          "sourceId": "",
+                                          "startColumn": 133,
+                                          "startLine": 435
+                                        }
+                                      }
+                                    ],
+                                    "sourceInformation": {
+                                      "endColumn": 146,
+                                      "endLine": 435,
+                                      "sourceId": "",
+                                      "startColumn": 142,
+                                      "startLine": 435
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 153,
+                                  "endLine": 435,
+                                  "sourceId": "",
+                                  "startColumn": 150,
+                                  "startLine": 435
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 153,
+                              "endLine": 435,
+                              "sourceId": "",
+                              "startColumn": 126,
+                              "startLine": 435
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 58,
+                          "endLine": 435,
+                          "sourceId": "",
+                          "startColumn": 57,
+                          "startLine": 435
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 154,
+                      "endLine": 435,
+                      "sourceId": "",
+                      "startColumn": 56,
+                      "startLine": 435
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 166,
+                          "endLine": 435,
+                          "sourceId": "",
+                          "startColumn": 158,
+                          "startLine": 435
+                        },
+                        "values": [
+                          "Unknown"
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 166,
+                      "endLine": 435,
+                      "sourceId": "",
+                      "startColumn": 157,
+                      "startLine": 435
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 25,
+                  "endLine": 435,
+                  "sourceId": "",
+                  "startColumn": 24,
+                  "startLine": 435
+                }
+              }
+            ],
+            "name": "productIdentifier",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 180,
+              "endLine": 435,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 435
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "isEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 32,
+                              "endLine": 436,
+                              "sourceId": "",
+                              "startColumn": 28,
+                              "startLine": 436
+                            }
+                          }
+                        ],
+                        "property": "product",
+                        "sourceInformation": {
+                          "endColumn": 40,
+                          "endLine": 436,
+                          "sourceId": "",
+                          "startColumn": 34,
+                          "startLine": 436
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 49,
+                      "endLine": 436,
+                      "sourceId": "",
+                      "startColumn": 43,
+                      "startLine": 436
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 63,
+                          "endLine": 436,
+                          "sourceId": "",
+                          "startColumn": 55,
+                          "startLine": 436
+                        },
+                        "values": [
+                          "Unknown"
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 63,
+                      "endLine": 436,
+                      "sourceId": "",
+                      "startColumn": 54,
+                      "startLine": 436
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 71,
+                                      "endLine": 436,
+                                      "sourceId": "",
+                                      "startColumn": 67,
+                                      "startLine": 436
+                                    }
+                                  }
+                                ],
+                                "property": "product",
+                                "sourceInformation": {
+                                  "endColumn": 79,
+                                  "endLine": 436,
+                                  "sourceId": "",
+                                  "startColumn": 73,
+                                  "startLine": 436
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 86,
+                              "endLine": 436,
+                              "sourceId": "",
+                              "startColumn": 82,
+                              "startLine": 436
+                            }
+                          }
+                        ],
+                        "property": "name",
+                        "sourceInformation": {
+                          "endColumn": 93,
+                          "endLine": 436,
+                          "sourceId": "",
+                          "startColumn": 90,
+                          "startLine": 436
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 93,
+                      "endLine": 436,
+                      "sourceId": "",
+                      "startColumn": 66,
+                      "startLine": 436
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 26,
+                  "endLine": 436,
+                  "sourceId": "",
+                  "startColumn": 25,
+                  "startLine": 436
+                }
+              }
+            ],
+            "name": "productDescription",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 107,
+              "endLine": 436,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 436
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "isNotEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 32,
+                              "endLine": 437,
+                              "sourceId": "",
+                              "startColumn": 28,
+                              "startLine": 437
+                            }
+                          }
+                        ],
+                        "property": "account",
+                        "sourceInformation": {
+                          "endColumn": 40,
+                          "endLine": 437,
+                          "sourceId": "",
+                          "startColumn": 34,
+                          "startLine": 437
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 52,
+                      "endLine": 437,
+                      "sourceId": "",
+                      "startColumn": 43,
+                      "startLine": 437
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 62,
+                                      "endLine": 437,
+                                      "sourceId": "",
+                                      "startColumn": 58,
+                                      "startLine": 437
+                                    }
+                                  }
+                                ],
+                                "property": "account",
+                                "sourceInformation": {
+                                  "endColumn": 70,
+                                  "endLine": 437,
+                                  "sourceId": "",
+                                  "startColumn": 64,
+                                  "startLine": 437
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 77,
+                              "endLine": 437,
+                              "sourceId": "",
+                              "startColumn": 73,
+                              "startLine": 437
+                            }
+                          }
+                        ],
+                        "property": "name",
+                        "sourceInformation": {
+                          "endColumn": 84,
+                          "endLine": 437,
+                          "sourceId": "",
+                          "startColumn": 81,
+                          "startLine": 437
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 84,
+                      "endLine": 437,
+                      "sourceId": "",
+                      "startColumn": 57,
+                      "startLine": 437
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "string",
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        },
+                        "sourceInformation": {
+                          "endColumn": 96,
+                          "endLine": 437,
+                          "sourceId": "",
+                          "startColumn": 88,
+                          "startLine": 437
+                        },
+                        "values": [
+                          "Unknown"
+                        ]
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 96,
+                      "endLine": 437,
+                      "sourceId": "",
+                      "startColumn": 87,
+                      "startLine": 437
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 26,
+                  "endLine": 437,
+                  "sourceId": "",
+                  "startColumn": 25,
+                  "startLine": 437
+                }
+              }
+            ],
+            "name": "accountDescription",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 110,
+              "endLine": 437,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 437
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "if",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "isNotEmpty",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 39,
+                              "endLine": 438,
+                              "sourceId": "",
+                              "startColumn": 35,
+                              "startLine": 438
+                            }
+                          }
+                        ],
+                        "property": "product",
+                        "sourceInformation": {
+                          "endColumn": 47,
+                          "endLine": 438,
+                          "sourceId": "",
+                          "startColumn": 41,
+                          "startLine": 438
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 59,
+                      "endLine": 438,
+                      "sourceId": "",
+                      "startColumn": 50,
+                      "startLine": 438
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "isNotEmpty",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 72,
+                                          "endLine": 438,
+                                          "sourceId": "",
+                                          "startColumn": 68,
+                                          "startLine": 438
+                                        }
+                                      }
+                                    ],
+                                    "property": "product",
+                                    "sourceInformation": {
+                                      "endColumn": 80,
+                                      "endLine": 438,
+                                      "sourceId": "",
+                                      "startColumn": 74,
+                                      "startLine": 438
+                                    }
+                                  }
+                                ],
+                                "property": "cusip",
+                                "sourceInformation": {
+                                  "endColumn": 86,
+                                  "endLine": 438,
+                                  "sourceId": "",
+                                  "startColumn": 82,
+                                  "startLine": 438
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 98,
+                              "endLine": 438,
+                              "sourceId": "",
+                              "startColumn": 89,
+                              "startLine": 438
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 108,
+                                          "endLine": 438,
+                                          "sourceId": "",
+                                          "startColumn": 104,
+                                          "startLine": 438
+                                        }
+                                      }
+                                    ],
+                                    "property": "product",
+                                    "sourceInformation": {
+                                      "endColumn": 116,
+                                      "endLine": 438,
+                                      "sourceId": "",
+                                      "startColumn": 110,
+                                      "startLine": 438
+                                    }
+                                  }
+                                ],
+                                "property": "cusip",
+                                "sourceInformation": {
+                                  "endColumn": 122,
+                                  "endLine": 438,
+                                  "sourceId": "",
+                                  "startColumn": 118,
+                                  "startLine": 438
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 122,
+                              "endLine": 438,
+                              "sourceId": "",
+                              "startColumn": 103,
+                              "startLine": 438
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 130,
+                                          "endLine": 438,
+                                          "sourceId": "",
+                                          "startColumn": 126,
+                                          "startLine": 438
+                                        }
+                                      }
+                                    ],
+                                    "property": "product",
+                                    "sourceInformation": {
+                                      "endColumn": 138,
+                                      "endLine": 438,
+                                      "sourceId": "",
+                                      "startColumn": 132,
+                                      "startLine": 438
+                                    }
+                                  }
+                                ],
+                                "property": "name",
+                                "sourceInformation": {
+                                  "endColumn": 143,
+                                  "endLine": 438,
+                                  "sourceId": "",
+                                  "startColumn": 140,
+                                  "startLine": 438
+                                }
+                              }
+                            ],
+                            "parameters": [],
+                            "sourceInformation": {
+                              "endColumn": 143,
+                              "endLine": 438,
+                              "sourceId": "",
+                              "startColumn": 125,
+                              "startLine": 438
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 66,
+                          "endLine": 438,
+                          "sourceId": "",
+                          "startColumn": 65,
+                          "startLine": 438
+                        }
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 144,
+                      "endLine": 438,
+                      "sourceId": "",
+                      "startColumn": 64,
+                      "startLine": 438
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "collection",
+                        "multiplicity": {
+                          "lowerBound": 0,
+                          "upperBound": 0
+                        },
+                        "sourceInformation": {
+                          "endColumn": 149,
+                          "endLine": 438,
+                          "sourceId": "",
+                          "startColumn": 148,
+                          "startLine": 438
+                        },
+                        "values": []
+                      }
+                    ],
+                    "parameters": [],
+                    "sourceInformation": {
+                      "endColumn": 149,
+                      "endLine": 438,
+                      "sourceId": "",
+                      "startColumn": 147,
+                      "startLine": 438
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 33,
+                  "endLine": 438,
+                  "sourceId": "",
+                  "startColumn": 32,
+                  "startLine": 438
+                }
+              }
+            ],
+            "name": "productIdentifierWithNull",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 166,
+              "endLine": 438,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 438
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "minus",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 27,
+                          "endLine": 439,
+                          "sourceId": "",
+                          "startColumn": 23,
+                          "startLine": 439
+                        }
+                      }
+                    ],
+                    "property": "quantity",
+                    "sourceInformation": {
+                      "endColumn": 36,
+                      "endLine": 439,
+                      "sourceId": "",
+                      "startColumn": 29,
+                      "startLine": 439
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 43,
+                  "endLine": 439,
+                  "sourceId": "",
+                  "startColumn": 39,
+                  "startLine": 439
+                }
+              }
+            ],
+            "name": "customerQuantity",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Float",
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 439,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 439
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "dateDiff",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "toOne",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 26,
+                              "endLine": 440,
+                              "sourceId": "",
+                              "startColumn": 22,
+                              "startLine": 440
+                            }
+                          }
+                        ],
+                        "property": "latestEventDate",
+                        "sourceInformation": {
+                          "endColumn": 42,
+                          "endLine": 440,
+                          "sourceId": "",
+                          "startColumn": 28,
+                          "startLine": 440
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 49,
+                      "endLine": 440,
+                      "sourceId": "",
+                      "startColumn": 45,
+                      "startLine": 440
+                    }
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 67,
+                          "endLine": 440,
+                          "sourceId": "",
+                          "startColumn": 63,
+                          "startLine": 440
+                        }
+                      }
+                    ],
+                    "property": "date",
+                    "sourceInformation": {
+                      "endColumn": 72,
+                      "endLine": 440,
+                      "sourceId": "",
+                      "startColumn": 69,
+                      "startLine": 440
+                    }
+                  },
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "packageableElementPtr",
+                        "fullPath": "meta::pure::functions::date::DurationUnit",
+                        "sourceInformation": {
+                          "endColumn": 115,
+                          "endLine": 440,
+                          "sourceId": "",
+                          "startColumn": 75,
+                          "startLine": 440
+                        }
+                      }
+                    ],
+                    "property": "DAYS",
+                    "sourceInformation": {
+                      "endColumn": 120,
+                      "endLine": 440,
+                      "sourceId": "",
+                      "startColumn": 117,
+                      "startLine": 440
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 61,
+                  "endLine": 440,
+                  "sourceId": "",
+                  "startColumn": 54,
+                  "startLine": 440
+                }
+              }
+            ],
+            "name": "daysToLastEvent",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Integer",
+            "sourceInformation": {
+              "endColumn": 135,
+              "endLine": 440,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 440
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 22,
+                              "endLine": 441,
+                              "sourceId": "",
+                              "startColumn": 18,
+                              "startLine": 441
+                            }
+                          }
+                        ],
+                        "property": "events",
+                        "sourceInformation": {
+                          "endColumn": 29,
+                          "endLine": 441,
+                          "sourceId": "",
+                          "startColumn": 24,
+                          "startLine": 441
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "e",
+                                    "sourceInformation": {
+                                      "endColumn": 42,
+                                      "endLine": 441,
+                                      "sourceId": "",
+                                      "startColumn": 41,
+                                      "startLine": 441
+                                    }
+                                  }
+                                ],
+                                "property": "date",
+                                "sourceInformation": {
+                                  "endColumn": 47,
+                                  "endLine": 441,
+                                  "sourceId": "",
+                                  "startColumn": 44,
+                                  "startLine": 441
+                                }
+                              },
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 56,
+                                      "endLine": 441,
+                                      "sourceId": "",
+                                      "startColumn": 52,
+                                      "startLine": 441
+                                    }
+                                  }
+                                ],
+                                "property": "latestEventDate",
+                                "sourceInformation": {
+                                  "endColumn": 72,
+                                  "endLine": 441,
+                                  "sourceId": "",
+                                  "startColumn": 58,
+                                  "startLine": 441
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 50,
+                              "endLine": 441,
+                              "sourceId": "",
+                              "startColumn": 49,
+                              "startLine": 441
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "e"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 72,
+                          "endLine": 441,
+                          "sourceId": "",
+                          "startColumn": 40,
+                          "startLine": 441
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 37,
+                      "endLine": 441,
+                      "sourceId": "",
+                      "startColumn": 32,
+                      "startLine": 441
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 80,
+                  "endLine": 441,
+                  "sourceId": "",
+                  "startColumn": 76,
+                  "startLine": 441
+                }
+              }
+            ],
+            "name": "latestEvent",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::TradeEvent",
+            "sourceInformation": {
+              "endColumn": 133,
+              "endLine": 441,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 441
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 36,
+                          "endLine": 442,
+                          "sourceId": "",
+                          "startColumn": 32,
+                          "startLine": 442
+                        }
+                      }
+                    ],
+                    "property": "events",
+                    "sourceInformation": {
+                      "endColumn": 43,
+                      "endLine": 442,
+                      "sourceId": "",
+                      "startColumn": 38,
+                      "startLine": 442
+                    }
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e",
+                                "sourceInformation": {
+                                  "endColumn": 56,
+                                  "endLine": 442,
+                                  "sourceId": "",
+                                  "startColumn": 55,
+                                  "startLine": 442
+                                }
+                              }
+                            ],
+                            "property": "date",
+                            "sourceInformation": {
+                              "endColumn": 61,
+                              "endLine": 442,
+                              "sourceId": "",
+                              "startColumn": 58,
+                              "startLine": 442
+                            }
+                          },
+                          {
+                            "_type": "var",
+                            "name": "date",
+                            "sourceInformation": {
+                              "endColumn": 70,
+                              "endLine": 442,
+                              "sourceId": "",
+                              "startColumn": 66,
+                              "startLine": 442
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 64,
+                          "endLine": 442,
+                          "sourceId": "",
+                          "startColumn": 63,
+                          "startLine": 442
+                        }
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "e"
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 70,
+                      "endLine": 442,
+                      "sourceId": "",
+                      "startColumn": 54,
+                      "startLine": 442
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 51,
+                  "endLine": 442,
+                  "sourceId": "",
+                  "startColumn": 46,
+                  "startLine": 442
+                }
+              }
+            ],
+            "name": "eventsByDate",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "Date",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "date",
+                "sourceInformation": {
+                  "endColumn": 28,
+                  "endLine": 442,
+                  "sourceId": "",
+                  "startColumn": 16,
+                  "startLine": 442
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 0
+            },
+            "returnType": "test::pure::tests::model::simple::TradeEvent",
+            "sourceInformation": {
+              "endColumn": 122,
+              "endLine": 442,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 442
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 29,
+                              "endLine": 443,
+                              "sourceId": "",
+                              "startColumn": 25,
+                              "startLine": 443
+                            }
+                          },
+                          {
+                            "_type": "func",
+                            "function": "toOne",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "this",
+                                    "sourceInformation": {
+                                      "endColumn": 48,
+                                      "endLine": 443,
+                                      "sourceId": "",
+                                      "startColumn": 44,
+                                      "startLine": 443
+                                    }
+                                  }
+                                ],
+                                "property": "date",
+                                "sourceInformation": {
+                                  "endColumn": 53,
+                                  "endLine": 443,
+                                  "sourceId": "",
+                                  "startColumn": 50,
+                                  "startLine": 443
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 60,
+                              "endLine": 443,
+                              "sourceId": "",
+                              "startColumn": 56,
+                              "startLine": 443
+                            }
+                          }
+                        ],
+                        "property": "eventsByDate",
+                        "sourceInformation": {
+                          "endColumn": 42,
+                          "endLine": 443,
+                          "sourceId": "",
+                          "startColumn": 31,
+                          "startLine": 443
+                        }
+                      }
+                    ],
+                    "property": "eventType",
+                    "sourceInformation": {
+                      "endColumn": 73,
+                      "endLine": 443,
+                      "sourceId": "",
+                      "startColumn": 65,
+                      "startLine": 443
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 80,
+                  "endLine": 443,
+                  "sourceId": "",
+                  "startColumn": 76,
+                  "startLine": 443
+                }
+              }
+            ],
+            "name": "tradeDateEventType",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 95,
+              "endLine": 443,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 443
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this",
+                        "sourceInformation": {
+                          "endColumn": 25,
+                          "endLine": 444,
+                          "sourceId": "",
+                          "startColumn": 21,
+                          "startLine": 444
+                        }
+                      },
+                      {
+                        "_type": "func",
+                        "function": "toOne",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 44,
+                                  "endLine": 444,
+                                  "sourceId": "",
+                                  "startColumn": 40,
+                                  "startLine": 444
+                                }
+                              }
+                            ],
+                            "property": "date",
+                            "sourceInformation": {
+                              "endColumn": 49,
+                              "endLine": 444,
+                              "sourceId": "",
+                              "startColumn": 46,
+                              "startLine": 444
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 56,
+                          "endLine": 444,
+                          "sourceId": "",
+                          "startColumn": 52,
+                          "startLine": 444
+                        }
+                      }
+                    ],
+                    "property": "eventsByDate",
+                    "sourceInformation": {
+                      "endColumn": 38,
+                      "endLine": 444,
+                      "sourceId": "",
+                      "startColumn": 27,
+                      "startLine": 444
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 66,
+                  "endLine": 444,
+                  "sourceId": "",
+                  "startColumn": 62,
+                  "startLine": 444
+                }
+              }
+            ],
+            "name": "tradeDateEvent",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::TradeEvent",
+            "sourceInformation": {
+              "endColumn": 119,
+              "endLine": 444,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 444
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 36,
+                                  "endLine": 445,
+                                  "sourceId": "",
+                                  "startColumn": 32,
+                                  "startLine": 445
+                                }
+                              }
+                            ],
+                            "property": "events",
+                            "sourceInformation": {
+                              "endColumn": 43,
+                              "endLine": 445,
+                              "sourceId": "",
+                              "startColumn": 38,
+                              "startLine": 445
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 56,
+                                          "endLine": 445,
+                                          "sourceId": "",
+                                          "startColumn": 55,
+                                          "startLine": 445
+                                        }
+                                      }
+                                    ],
+                                    "property": "date",
+                                    "sourceInformation": {
+                                      "endColumn": 61,
+                                      "endLine": 445,
+                                      "sourceId": "",
+                                      "startColumn": 58,
+                                      "startLine": 445
+                                    }
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 70,
+                                          "endLine": 445,
+                                          "sourceId": "",
+                                          "startColumn": 66,
+                                          "startLine": 445
+                                        }
+                                      }
+                                    ],
+                                    "property": "date",
+                                    "sourceInformation": {
+                                      "endColumn": 75,
+                                      "endLine": 445,
+                                      "sourceId": "",
+                                      "startColumn": 72,
+                                      "startLine": 445
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 64,
+                                  "endLine": 445,
+                                  "sourceId": "",
+                                  "startColumn": 63,
+                                  "startLine": 445
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 75,
+                              "endLine": 445,
+                              "sourceId": "",
+                              "startColumn": 54,
+                              "startLine": 445
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 51,
+                          "endLine": 445,
+                          "sourceId": "",
+                          "startColumn": 46,
+                          "startLine": 445
+                        }
+                      }
+                    ],
+                    "property": "eventType",
+                    "sourceInformation": {
+                      "endColumn": 86,
+                      "endLine": 445,
+                      "sourceId": "",
+                      "startColumn": 78,
+                      "startLine": 445
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 93,
+                  "endLine": 445,
+                  "sourceId": "",
+                  "startColumn": 89,
+                  "startLine": 445
+                }
+              }
+            ],
+            "name": "tradeDateEventTypeInlined",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String",
+            "sourceInformation": {
+              "endColumn": 108,
+              "endLine": 445,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 445
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 20,
+                              "endLine": 446,
+                              "sourceId": "",
+                              "startColumn": 16,
+                              "startLine": 446
+                            }
+                          },
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 39,
+                                  "endLine": 446,
+                                  "sourceId": "",
+                                  "startColumn": 35,
+                                  "startLine": 446
+                                }
+                              }
+                            ],
+                            "property": "date",
+                            "sourceInformation": {
+                              "endColumn": 44,
+                              "endLine": 446,
+                              "sourceId": "",
+                              "startColumn": 41,
+                              "startLine": 446
+                            }
+                          }
+                        ],
+                        "property": "eventsByDate",
+                        "sourceInformation": {
+                          "endColumn": 33,
+                          "endLine": 446,
+                          "sourceId": "",
+                          "startColumn": 22,
+                          "startLine": 446
+                        }
+                      }
+                    ],
+                    "property": "initiator",
+                    "sourceInformation": {
+                      "endColumn": 55,
+                      "endLine": 446,
+                      "sourceId": "",
+                      "startColumn": 47,
+                      "startLine": 446
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 62,
+                  "endLine": 446,
+                  "sourceId": "",
+                  "startColumn": 58,
+                  "startLine": 446
+                }
+              }
+            ],
+            "name": "initiator",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 114,
+              "endLine": 446,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 446
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 27,
+                                  "endLine": 447,
+                                  "sourceId": "",
+                                  "startColumn": 23,
+                                  "startLine": 447
+                                }
+                              }
+                            ],
+                            "property": "events",
+                            "sourceInformation": {
+                              "endColumn": 34,
+                              "endLine": 447,
+                              "sourceId": "",
+                              "startColumn": 29,
+                              "startLine": 447
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 47,
+                                          "endLine": 447,
+                                          "sourceId": "",
+                                          "startColumn": 46,
+                                          "startLine": 447
+                                        }
+                                      }
+                                    ],
+                                    "property": "date",
+                                    "sourceInformation": {
+                                      "endColumn": 52,
+                                      "endLine": 447,
+                                      "sourceId": "",
+                                      "startColumn": 49,
+                                      "startLine": 447
+                                    }
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "this",
+                                        "sourceInformation": {
+                                          "endColumn": 61,
+                                          "endLine": 447,
+                                          "sourceId": "",
+                                          "startColumn": 57,
+                                          "startLine": 447
+                                        }
+                                      }
+                                    ],
+                                    "property": "date",
+                                    "sourceInformation": {
+                                      "endColumn": 66,
+                                      "endLine": 447,
+                                      "sourceId": "",
+                                      "startColumn": 63,
+                                      "startLine": 447
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 55,
+                                  "endLine": 447,
+                                  "sourceId": "",
+                                  "startColumn": 54,
+                                  "startLine": 447
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 66,
+                              "endLine": 447,
+                              "sourceId": "",
+                              "startColumn": 45,
+                              "startLine": 447
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 42,
+                          "endLine": 447,
+                          "sourceId": "",
+                          "startColumn": 37,
+                          "startLine": 447
+                        }
+                      }
+                    ],
+                    "property": "initiator",
+                    "sourceInformation": {
+                      "endColumn": 77,
+                      "endLine": 447,
+                      "sourceId": "",
+                      "startColumn": 69,
+                      "startLine": 447
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 84,
+                  "endLine": 447,
+                  "sourceId": "",
+                  "startColumn": 80,
+                  "startLine": 447
+                }
+              }
+            ],
+            "name": "initiatorInlined",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 136,
+              "endLine": 447,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 447
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          },
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOneMany",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "filter",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this",
+                                "sourceInformation": {
+                                  "endColumn": 40,
+                                  "endLine": 448,
+                                  "sourceId": "",
+                                  "startColumn": 36,
+                                  "startLine": 448
+                                }
+                              }
+                            ],
+                            "property": "events",
+                            "sourceInformation": {
+                              "endColumn": 47,
+                              "endLine": 448,
+                              "sourceId": "",
+                              "startColumn": 42,
+                              "startLine": 448
+                            }
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "func",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "var",
+                                        "name": "e",
+                                        "sourceInformation": {
+                                          "endColumn": 60,
+                                          "endLine": 448,
+                                          "sourceId": "",
+                                          "startColumn": 59,
+                                          "startLine": 448
+                                        }
+                                      }
+                                    ],
+                                    "property": "eventType",
+                                    "sourceInformation": {
+                                      "endColumn": 70,
+                                      "endLine": 448,
+                                      "sourceId": "",
+                                      "startColumn": 62,
+                                      "startLine": 448
+                                    }
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "property",
+                                        "parameters": [
+                                          {
+                                            "_type": "var",
+                                            "name": "this",
+                                            "sourceInformation": {
+                                              "endColumn": 79,
+                                              "endLine": 448,
+                                              "sourceId": "",
+                                              "startColumn": 75,
+                                              "startLine": 448
+                                            }
+                                          }
+                                        ],
+                                        "property": "product",
+                                        "sourceInformation": {
+                                          "endColumn": 87,
+                                          "endLine": 448,
+                                          "sourceId": "",
+                                          "startColumn": 81,
+                                          "startLine": 448
+                                        }
+                                      }
+                                    ],
+                                    "property": "name",
+                                    "sourceInformation": {
+                                      "endColumn": 92,
+                                      "endLine": 448,
+                                      "sourceId": "",
+                                      "startColumn": 89,
+                                      "startLine": 448
+                                    }
+                                  }
+                                ],
+                                "sourceInformation": {
+                                  "endColumn": 73,
+                                  "endLine": 448,
+                                  "sourceId": "",
+                                  "startColumn": 72,
+                                  "startLine": 448
+                                }
+                              }
+                            ],
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "e"
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 92,
+                              "endLine": 448,
+                              "sourceId": "",
+                              "startColumn": 58,
+                              "startLine": 448
+                            }
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 55,
+                          "endLine": 448,
+                          "sourceId": "",
+                          "startColumn": 50,
+                          "startLine": 448
+                        }
+                      }
+                    ],
+                    "property": "initiator",
+                    "sourceInformation": {
+                      "endColumn": 103,
+                      "endLine": 448,
+                      "sourceId": "",
+                      "startColumn": 95,
+                      "startLine": 448
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 114,
+                  "endLine": 448,
+                  "sourceId": "",
+                  "startColumn": 106,
+                  "startLine": 448
+                }
+              }
+            ],
+            "name": "initiatorInlinedByProductName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Person",
+            "sourceInformation": {
+              "endColumn": 166,
+              "endLine": 448,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 448
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 449,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 426
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "class",
+        "constraints": [],
+        "name": "TradeEvent",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "eventType",
+            "propertyTypeSourceInformation": {
+              "endColumn": 19,
+              "endLine": 453,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 453
+            },
+            "sourceInformation": {
+              "endColumn": 26,
+              "endLine": 453,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 453
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "date",
+            "propertyTypeSourceInformation": {
+              "endColumn": 18,
+              "endLine": 454,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 454
+            },
+            "sourceInformation": {
+              "endColumn": 22,
+              "endLine": 454,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 454
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "initiator",
+            "propertyTypeSourceInformation": {
+              "endColumn": 53,
+              "endLine": 455,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 455
+            },
+            "sourceInformation": {
+              "endColumn": 60,
+              "endLine": 455,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 455
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "traderAddress",
+            "propertyTypeSourceInformation": {
+              "endColumn": 23,
+              "endLine": 456,
+              "sourceId": "",
+              "startColumn": 18,
+              "startLine": 456
+            },
+            "sourceInformation": {
+              "endColumn": 30,
+              "endLine": 456,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 456
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "String"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 457,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 451
+        },
+        "stereotypes": [],
+        "superTypes": [
+          "meta::pure::metamodel::type::Any"
+        ],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Business_Employees",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "propertyTypeSourceInformation": {
+              "endColumn": 41,
+              "endLine": 461,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 461
+            },
+            "sourceInformation": {
+              "endColumn": 48,
+              "endLine": 461,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 461
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Business"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employs",
+            "propertyTypeSourceInformation": {
+              "endColumn": 42,
+              "endLine": 462,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 462
+            },
+            "sourceInformation": {
+              "endColumn": 46,
+              "endLine": 462,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 462
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 463,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 459
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "OrgStructures",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "parentOrg",
+            "propertyTypeSourceInformation": {
+              "endColumn": 50,
+              "endLine": 467,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 467
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 467,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 467
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Organization"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "subOrgs",
+            "propertyTypeSourceInformation": {
+              "endColumn": 48,
+              "endLine": 468,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 468
+            },
+            "sourceInformation": {
+              "endColumn": 52,
+              "endLine": 468,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 468
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Organization"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 469,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 465
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Parent_Children",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 2,
+              "upperBound": 2
+            },
+            "name": "parents",
+            "propertyTypeSourceInformation": {
+              "endColumn": 42,
+              "endLine": 473,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 473
+            },
+            "sourceInformation": {
+              "endColumn": 46,
+              "endLine": 473,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 473
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "children",
+            "propertyTypeSourceInformation": {
+              "endColumn": 43,
+              "endLine": 474,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 474
+            },
+            "sourceInformation": {
+              "endColumn": 47,
+              "endLine": 474,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 474
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 475,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 471
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Person_Accounts",
+        "originalMilestonedProperties": [],
+        "package": "test::owl::tests::model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "acctOwner",
+            "propertyTypeSourceInformation": {
+              "endColumn": 44,
+              "endLine": 479,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 479
+            },
+            "sourceInformation": {
+              "endColumn": 51,
+              "endLine": 479,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 479
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::owl::tests::model::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "accounts",
+            "propertyTypeSourceInformation": {
+              "endColumn": 53,
+              "endLine": 480,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 480
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 480,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 480
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 481,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 477
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Account_AccountPnl",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "account",
+            "propertyTypeSourceInformation": {
+              "endColumn": 52,
+              "endLine": 485,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 485
+            },
+            "sourceInformation": {
+              "endColumn": 59,
+              "endLine": 485,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 485
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "accountPnl",
+            "propertyTypeSourceInformation": {
+              "endColumn": 58,
+              "endLine": 486,
+              "sourceId": "",
+              "startColumn": 15,
+              "startLine": 486
+            },
+            "sourceInformation": {
+              "endColumn": 65,
+              "endLine": 486,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 486
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::AccountPnl"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 487,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 483
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "AddressLocation",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "location",
+            "propertyTypeSourceInformation": {
+              "endColumn": 54,
+              "endLine": 491,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 491
+            },
+            "sourceInformation": {
+              "endColumn": 61,
+              "endLine": 491,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 491
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Location"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "addresses",
+            "propertyTypeSourceInformation": {
+              "endColumn": 54,
+              "endLine": 492,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 492
+            },
+            "sourceInformation": {
+              "endColumn": 58,
+              "endLine": 492,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 492
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Address"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 493,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 489
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "BridgeAsso1",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "bridge",
+            "propertyTypeSourceInformation": {
+              "endColumn": 50,
+              "endLine": 497,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 497
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 497,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 497
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Bridge"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employees",
+            "propertyTypeSourceInformation": {
+              "endColumn": 53,
+              "endLine": 498,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 498
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 498,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 498
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 499,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 495
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "BridgeAsso2",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "bridge",
+            "propertyTypeSourceInformation": {
+              "endColumn": 50,
+              "endLine": 503,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 503
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 503,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 503
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Bridge"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "propertyTypeSourceInformation": {
+              "endColumn": 46,
+              "endLine": 504,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 504
+            },
+            "sourceInformation": {
+              "endColumn": 53,
+              "endLine": 504,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 504
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 505,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 501
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Employment",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "propertyTypeSourceInformation": {
+              "endColumn": 46,
+              "endLine": 509,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 509
+            },
+            "sourceInformation": {
+              "endColumn": 53,
+              "endLine": 509,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 509
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "employees",
+            "propertyTypeSourceInformation": {
+              "endColumn": 53,
+              "endLine": 510,
+              "sourceId": "",
+              "startColumn": 14,
+              "startLine": 510
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 510,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 510
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 511,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 507
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "FirmCEO",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "ceoFirm",
+            "propertyTypeSourceInformation": {
+              "endColumn": 49,
+              "endLine": 515,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 515
+            },
+            "sourceInformation": {
+              "endColumn": 56,
+              "endLine": 515,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 515
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "ceo",
+            "propertyTypeSourceInformation": {
+              "endColumn": 47,
+              "endLine": 516,
+              "sourceId": "",
+              "startColumn": 8,
+              "startLine": 516
+            },
+            "sourceInformation": {
+              "endColumn": 54,
+              "endLine": 516,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 516
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 517,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 513
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "FirmOrganizations",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firm",
+            "propertyTypeSourceInformation": {
+              "endColumn": 46,
+              "endLine": 521,
+              "sourceId": "",
+              "startColumn": 9,
+              "startLine": 521
+            },
+            "sourceInformation": {
+              "endColumn": 50,
+              "endLine": 521,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 521
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Firm"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "organizations",
+            "propertyTypeSourceInformation": {
+              "endColumn": 63,
+              "endLine": 522,
+              "sourceId": "",
+              "startColumn": 18,
+              "startLine": 522
+            },
+            "sourceInformation": {
+              "endColumn": 67,
+              "endLine": 522,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 522
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 523,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 519
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Membership",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "organizations",
+            "propertyTypeSourceInformation": {
+              "endColumn": 63,
+              "endLine": 527,
+              "sourceId": "",
+              "startColumn": 18,
+              "startLine": 527
+            },
+            "sourceInformation": {
+              "endColumn": 67,
+              "endLine": 527,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 527
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "members",
+            "propertyTypeSourceInformation": {
+              "endColumn": 51,
+              "endLine": 528,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 528
+            },
+            "sourceInformation": {
+              "endColumn": 55,
+              "endLine": 528,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 528
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Person"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 529,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 525
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "PlacesOfInterest",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "location",
+            "propertyTypeSourceInformation": {
+              "endColumn": 54,
+              "endLine": 533,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 533
+            },
+            "sourceInformation": {
+              "endColumn": 58,
+              "endLine": 533,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 533
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Location"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "placeOfInterest",
+            "propertyTypeSourceInformation": {
+              "endColumn": 68,
+              "endLine": 534,
+              "sourceId": "",
+              "startColumn": 20,
+              "startLine": 534
+            },
+            "sourceInformation": {
+              "endColumn": 72,
+              "endLine": 534,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 534
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::PlaceOfInterest"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 535,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 531
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "ProdSynonym",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "synonyms",
+            "propertyTypeSourceInformation": {
+              "endColumn": 53,
+              "endLine": 539,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 539
+            },
+            "sourceInformation": {
+              "endColumn": 57,
+              "endLine": 539,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 539
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Synonym"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "product",
+            "propertyTypeSourceInformation": {
+              "endColumn": 52,
+              "endLine": 540,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 540
+            },
+            "sourceInformation": {
+              "endColumn": 56,
+              "endLine": 540,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 540
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Product"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "toOne",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this",
+                            "sourceInformation": {
+                              "endColumn": 85,
+                              "endLine": 541,
+                              "sourceId": "",
+                              "startColumn": 81,
+                              "startLine": 541
+                            }
+                          }
+                        ],
+                        "property": "synonyms",
+                        "sourceInformation": {
+                          "endColumn": 94,
+                          "endLine": 541,
+                          "sourceId": "",
+                          "startColumn": 87,
+                          "startLine": 541
+                        }
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "s",
+                                    "sourceInformation": {
+                                      "endColumn": 107,
+                                      "endLine": 541,
+                                      "sourceId": "",
+                                      "startColumn": 106,
+                                      "startLine": 541
+                                    }
+                                  }
+                                ],
+                                "property": "type",
+                                "sourceInformation": {
+                                  "endColumn": 112,
+                                  "endLine": 541,
+                                  "sourceId": "",
+                                  "startColumn": 109,
+                                  "startLine": 541
+                                }
+                              },
+                              {
+                                "_type": "var",
+                                "name": "type",
+                                "sourceInformation": {
+                                  "endColumn": 121,
+                                  "endLine": 541,
+                                  "sourceId": "",
+                                  "startColumn": 117,
+                                  "startLine": 541
+                                }
+                              }
+                            ],
+                            "sourceInformation": {
+                              "endColumn": 115,
+                              "endLine": 541,
+                              "sourceId": "",
+                              "startColumn": 114,
+                              "startLine": 541
+                            }
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "s"
+                          }
+                        ],
+                        "sourceInformation": {
+                          "endColumn": 121,
+                          "endLine": 541,
+                          "sourceId": "",
+                          "startColumn": 105,
+                          "startLine": 541
+                        }
+                      }
+                    ],
+                    "sourceInformation": {
+                      "endColumn": 102,
+                      "endLine": 541,
+                      "sourceId": "",
+                      "startColumn": 97,
+                      "startLine": 541
+                    }
+                  }
+                ],
+                "sourceInformation": {
+                  "endColumn": 129,
+                  "endLine": 541,
+                  "sourceId": "",
+                  "startColumn": 125,
+                  "startLine": 541
+                }
+              }
+            ],
+            "name": "synonymByType",
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "test::pure::tests::model::simple::ProductSynonymType",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "type",
+                "sourceInformation": {
+                  "endColumn": 77,
+                  "endLine": 541,
+                  "sourceId": "",
+                  "startColumn": 17,
+                  "startLine": 541
+                }
+              }
+            ],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "test::pure::tests::model::simple::Synonym",
+            "sourceInformation": {
+              "endColumn": 179,
+              "endLine": 541,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 541
+            },
+            "stereotypes": [],
+            "taggedValues": []
+          }
+        ],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 542,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 537
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "SubOrganization",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "parent",
+            "propertyTypeSourceInformation": {
+              "endColumn": 56,
+              "endLine": 546,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 546
+            },
+            "sourceInformation": {
+              "endColumn": 63,
+              "endLine": 546,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 546
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "children",
+            "propertyTypeSourceInformation": {
+              "endColumn": 58,
+              "endLine": 547,
+              "sourceId": "",
+              "startColumn": 13,
+              "startLine": 547
+            },
+            "sourceInformation": {
+              "endColumn": 62,
+              "endLine": 547,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 547
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Organization"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 548,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 544
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Trade_Accounts",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "account",
+            "propertyTypeSourceInformation": {
+              "endColumn": 52,
+              "endLine": 552,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 552
+            },
+            "sourceInformation": {
+              "endColumn": 59,
+              "endLine": 552,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 552
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "trades",
+            "propertyTypeSourceInformation": {
+              "endColumn": 49,
+              "endLine": 553,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 553
+            },
+            "sourceInformation": {
+              "endColumn": 53,
+              "endLine": 553,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 553
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Trade"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 554,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 550
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "association",
+        "name": "Trade_Orders",
+        "originalMilestonedProperties": [],
+        "package": "test::pure::tests::model::simple",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "account",
+            "propertyTypeSourceInformation": {
+              "endColumn": 52,
+              "endLine": 558,
+              "sourceId": "",
+              "startColumn": 12,
+              "startLine": 558
+            },
+            "sourceInformation": {
+              "endColumn": 59,
+              "endLine": 558,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 558
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Account"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0
+            },
+            "name": "orders",
+            "propertyTypeSourceInformation": {
+              "endColumn": 49,
+              "endLine": 559,
+              "sourceId": "",
+              "startColumn": 11,
+              "startLine": 559
+            },
+            "sourceInformation": {
+              "endColumn": 53,
+              "endLine": 559,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 559
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "type": "test::pure::tests::model::simple::Order"
+          }
+        ],
+        "qualifiedProperties": [],
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 560,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 556
+        },
+        "stereotypes": [],
+        "taggedValues": []
+      },
+      {
+        "_type": "Enumeration",
+        "name": "GenderType",
+        "package": "test::owl::tests::model",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 566,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 562
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "sourceInformation": {
+              "endColumn": 6,
+              "endLine": 564,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 564
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "MALE"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 8,
+              "endLine": 565,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 565
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "FEMALE"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "OrgLevelType",
+        "package": "test::owl::tests::model",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 573,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 568
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "sourceInformation": {
+              "endColumn": 4,
+              "endLine": 570,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 570
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "VP"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 4,
+              "endLine": 571,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 571
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "MD"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 5,
+              "endLine": 572,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 572
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "PMD"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "Region",
+        "package": "test::pure::mapping::modelToModel::test::shared::dest",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 579,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 575
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "sourceInformation": {
+              "endColumn": 9,
+              "endLine": 577,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 577
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "NewYork"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 8,
+              "endLine": 578,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 578
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "London"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "GeographicEntityType",
+        "package": "test::pure::tests::model::simple",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 586,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 581
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "sourceInformation": {
+              "endColumn": 86,
+              "endLine": 583,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 583
+            },
+            "stereotypes": [],
+            "taggedValues": [
+              {
+                "sourceInformation": {
+                  "endColumn": 80,
+                  "endLine": 583,
+                  "sourceId": "",
+                  "startColumn": 4,
+                  "startLine": 583
+                },
+                "tag": {
+                  "profile": "meta::pure::profiles::doc",
+                  "profileSourceInformation": {
+                    "endColumn": 28,
+                    "endLine": 583,
+                    "sourceId": "",
+                    "startColumn": 4,
+                    "startLine": 583
+                  },
+                  "sourceInformation": {
+                    "endColumn": 32,
+                    "endLine": 583,
+                    "sourceId": "",
+                    "startColumn": 30,
+                    "startLine": 583
+                  },
+                  "value": "doc"
+                },
+                "value": "A city, town, village, or other urban area."
+              }
+            ],
+            "value": "CITY"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 50,
+              "endLine": 584,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 584
+            },
+            "stereotypes": [
+              {
+                "profile": "meta::pure::profiles::doc",
+                "profileSourceInformation": {
+                  "endColumn": 29,
+                  "endLine": 584,
+                  "sourceId": "",
+                  "startColumn": 5,
+                  "startLine": 584
+                },
+                "sourceInformation": {
+                  "endColumn": 40,
+                  "endLine": 584,
+                  "sourceId": "",
+                  "startColumn": 5,
+                  "startLine": 584
+                },
+                "value": "deprecated"
+              }
+            ],
+            "taggedValues": [],
+            "value": "COUNTRY"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 96,
+              "endLine": 585,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 585
+            },
+            "stereotypes": [],
+            "taggedValues": [
+              {
+                "sourceInformation": {
+                  "endColumn": 88,
+                  "endLine": 585,
+                  "sourceId": "",
+                  "startColumn": 4,
+                  "startLine": 585
+                },
+                "tag": {
+                  "profile": "meta::pure::profiles::doc",
+                  "profileSourceInformation": {
+                    "endColumn": 28,
+                    "endLine": 585,
+                    "sourceId": "",
+                    "startColumn": 4,
+                    "startLine": 585
+                  },
+                  "sourceInformation": {
+                    "endColumn": 32,
+                    "endLine": 585,
+                    "sourceId": "",
+                    "startColumn": 30,
+                    "startLine": 585
+                  },
+                  "value": "doc"
+                },
+                "value": "Any geographic entity other than a city or country."
+              }
+            ],
+            "value": "REGION"
+          }
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "ProductSynonymType",
+        "package": "test::pure::tests::model::simple",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 593,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 588
+        },
+        "stereotypes": [],
+        "taggedValues": [],
+        "values": [
+          {
+            "sourceInformation": {
+              "endColumn": 7,
+              "endLine": 590,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 590
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "CUSIP"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 6,
+              "endLine": 591,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 591
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "ISIN"
+          },
+          {
+            "sourceInformation": {
+              "endColumn": 5,
+              "endLine": 592,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 592
+            },
+            "stereotypes": [],
+            "taggedValues": [],
+            "value": "GSN"
+          }
+        ]
+      },
+      {
+        "_type": "mapping",
+        "associationMappings": [],
+        "classMappings": [
+          {
+            "_type": "pureInstance",
+            "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+            "classSourceInformation": {
+              "endColumn": 64,
+              "endLine": 599,
+              "sourceId": "",
+              "startColumn": 4,
+              "startLine": 599
+            },
+            "id": "meta_pure_mapping_modelToModel_test_shared_dest_Person",
+            "propertyMappings": [
+              {
+                "_type": "purePropertyMapping",
+                "explodeProperty": false,
+                "property": {
+                  "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                  "property": "firstName",
+                  "sourceInformation": {
+                    "endColumn": 13,
+                    "endLine": 602,
+                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                    "startColumn": 5,
+                    "startLine": 602
+                  }
+                },
+                "source": "meta_pure_mapping_modelToModel_test_shared_dest_Person",
+                "sourceInformation": {
+                  "endColumn": 71,
+                  "endLine": 602,
+                  "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                  "startColumn": 5,
+                  "startLine": 602
+                },
+                "transform": {
+                  "_type": "lambda",
+                  "body": [
+                    {
+                      "_type": "func",
+                      "function": "substring",
+                      "parameters": [
+                        {
+                          "_type": "property",
+                          "parameters": [
+                            {
+                              "_type": "var",
+                              "name": "src",
+                              "sourceInformation": {
+                                "endColumn": 19,
+                                "endLine": 602,
+                                "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                "startColumn": 16,
+                                "startLine": 602
+                              }
+                            }
+                          ],
+                          "property": "fullName",
+                          "sourceInformation": {
+                            "endColumn": 28,
+                            "endLine": 602,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 21,
+                            "startLine": 602
+                          }
+                        },
+                        {
+                          "_type": "integer",
+                          "multiplicity": {
+                            "lowerBound": 1,
+                            "upperBound": 1
+                          },
+                          "sourceInformation": {
+                            "endColumn": 41,
+                            "endLine": 602,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 41,
+                            "startLine": 602
+                          },
+                          "values": [
+                            0
+                          ]
+                        },
+                        {
+                          "_type": "func",
+                          "function": "indexOf",
+                          "parameters": [
+                            {
+                              "_type": "property",
+                              "parameters": [
+                                {
+                                  "_type": "var",
+                                  "name": "src",
+                                  "sourceInformation": {
+                                    "endColumn": 47,
+                                    "endLine": 602,
+                                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                    "startColumn": 44,
+                                    "startLine": 602
+                                  }
+                                }
+                              ],
+                              "property": "fullName",
+                              "sourceInformation": {
+                                "endColumn": 56,
+                                "endLine": 602,
+                                "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                "startColumn": 49,
+                                "startLine": 602
+                              }
+                            },
+                            {
+                              "_type": "string",
+                              "multiplicity": {
+                                "lowerBound": 1,
+                                "upperBound": 1
+                              },
+                              "sourceInformation": {
+                                "endColumn": 69,
+                                "endLine": 602,
+                                "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                "startColumn": 67,
+                                "startLine": 602
+                              },
+                              "values": [
+                                " "
+                              ]
+                            }
+                          ],
+                          "sourceInformation": {
+                            "endColumn": 65,
+                            "endLine": 602,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 59,
+                            "startLine": 602
+                          }
+                        }
+                      ],
+                      "sourceInformation": {
+                        "endColumn": 39,
+                        "endLine": 602,
+                        "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                        "startColumn": 31,
+                        "startLine": 602
+                      }
+                    }
+                  ],
+                  "parameters": []
+                }
+              },
+              {
+                "_type": "purePropertyMapping",
+                "explodeProperty": false,
+                "property": {
+                  "class": "test::pure::mapping::modelToModel::test::shared::dest::Person",
+                  "property": "lastName",
+                  "sourceInformation": {
+                    "endColumn": 12,
+                    "endLine": 603,
+                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                    "startColumn": 5,
+                    "startLine": 603
+                  }
+                },
+                "source": "meta_pure_mapping_modelToModel_test_shared_dest_Person",
+                "sourceInformation": {
+                  "endColumn": 96,
+                  "endLine": 603,
+                  "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                  "startColumn": 5,
+                  "startLine": 603
+                },
+                "transform": {
+                  "_type": "lambda",
+                  "body": [
+                    {
+                      "_type": "func",
+                      "function": "substring",
+                      "parameters": [
+                        {
+                          "_type": "property",
+                          "parameters": [
+                            {
+                              "_type": "var",
+                              "name": "src",
+                              "sourceInformation": {
+                                "endColumn": 18,
+                                "endLine": 603,
+                                "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                "startColumn": 15,
+                                "startLine": 603
+                              }
+                            }
+                          ],
+                          "property": "fullName",
+                          "sourceInformation": {
+                            "endColumn": 27,
+                            "endLine": 603,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 20,
+                            "startLine": 603
+                          }
+                        },
+                        {
+                          "_type": "func",
+                          "function": "plus",
+                          "parameters": [
+                            {
+                              "_type": "collection",
+                              "multiplicity": {
+                                "lowerBound": 2,
+                                "upperBound": 2
+                              },
+                              "sourceInformation": {
+                                "endColumn": 70,
+                                "endLine": 603,
+                                "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                "startColumn": 68,
+                                "startLine": 603
+                              },
+                              "values": [
+                                {
+                                  "_type": "func",
+                                  "function": "indexOf",
+                                  "parameters": [
+                                    {
+                                      "_type": "property",
+                                      "parameters": [
+                                        {
+                                          "_type": "var",
+                                          "name": "src",
+                                          "sourceInformation": {
+                                            "endColumn": 43,
+                                            "endLine": 603,
+                                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                            "startColumn": 40,
+                                            "startLine": 603
+                                          }
+                                        }
+                                      ],
+                                      "property": "fullName",
+                                      "sourceInformation": {
+                                        "endColumn": 52,
+                                        "endLine": 603,
+                                        "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                        "startColumn": 45,
+                                        "startLine": 603
+                                      }
+                                    },
+                                    {
+                                      "_type": "string",
+                                      "multiplicity": {
+                                        "lowerBound": 1,
+                                        "upperBound": 1
+                                      },
+                                      "sourceInformation": {
+                                        "endColumn": 65,
+                                        "endLine": 603,
+                                        "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                        "startColumn": 63,
+                                        "startLine": 603
+                                      },
+                                      "values": [
+                                        " "
+                                      ]
+                                    }
+                                  ],
+                                  "sourceInformation": {
+                                    "endColumn": 61,
+                                    "endLine": 603,
+                                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                    "startColumn": 55,
+                                    "startLine": 603
+                                  }
+                                },
+                                {
+                                  "_type": "integer",
+                                  "multiplicity": {
+                                    "lowerBound": 1,
+                                    "upperBound": 1
+                                  },
+                                  "sourceInformation": {
+                                    "endColumn": 70,
+                                    "endLine": 603,
+                                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                    "startColumn": 70,
+                                    "startLine": 603
+                                  },
+                                  "values": [
+                                    1
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sourceInformation": {
+                            "endColumn": 70,
+                            "endLine": 603,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 68,
+                            "startLine": 603
+                          }
+                        },
+                        {
+                          "_type": "func",
+                          "function": "length",
+                          "parameters": [
+                            {
+                              "_type": "property",
+                              "parameters": [
+                                {
+                                  "_type": "var",
+                                  "name": "src",
+                                  "sourceInformation": {
+                                    "endColumn": 76,
+                                    "endLine": 603,
+                                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                    "startColumn": 73,
+                                    "startLine": 603
+                                  }
+                                }
+                              ],
+                              "property": "fullName",
+                              "sourceInformation": {
+                                "endColumn": 85,
+                                "endLine": 603,
+                                "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                                "startColumn": 78,
+                                "startLine": 603
+                              }
+                            }
+                          ],
+                          "sourceInformation": {
+                            "endColumn": 93,
+                            "endLine": 603,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 88,
+                            "startLine": 603
+                          }
+                        }
+                      ],
+                      "sourceInformation": {
+                        "endColumn": 38,
+                        "endLine": 603,
+                        "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                        "startColumn": 30,
+                        "startLine": 603
+                      }
+                    }
+                  ],
+                  "parameters": []
+                }
+              }
+            ],
+            "root": true,
+            "sourceClassSourceInformation": {
+              "endColumn": 72,
+              "endLine": 601,
+              "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+              "startColumn": 10,
+              "startLine": 601
+            },
+            "sourceInformation": {
+              "endColumn": 3,
+              "endLine": 604,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 599
+            },
+            "srcClass": "test::pure::mapping::modelToModel::test::shared::src::_S_Person"
+          },
+          {
+            "_type": "pureInstance",
+            "class": "test::pure::mapping::modelToModel::test::shared::dest::Product2Simple",
+            "classSourceInformation": {
+              "endColumn": 72,
+              "endLine": 605,
+              "sourceId": "",
+              "startColumn": 4,
+              "startLine": 605
+            },
+            "id": "meta_pure_mapping_modelToModel_test_shared_dest_Product2Simple",
+            "propertyMappings": [
+              {
+                "_type": "purePropertyMapping",
+                "explodeProperty": false,
+                "property": {
+                  "class": "test::pure::mapping::modelToModel::test::shared::dest::Product2Simple",
+                  "property": "name",
+                  "sourceInformation": {
+                    "endColumn": 8,
+                    "endLine": 608,
+                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                    "startColumn": 5,
+                    "startLine": 608
+                  }
+                },
+                "source": "meta_pure_mapping_modelToModel_test_shared_dest_Product2Simple",
+                "sourceInformation": {
+                  "endColumn": 19,
+                  "endLine": 608,
+                  "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                  "startColumn": 5,
+                  "startLine": 608
+                },
+                "transform": {
+                  "_type": "lambda",
+                  "body": [
+                    {
+                      "_type": "property",
+                      "parameters": [
+                        {
+                          "_type": "var",
+                          "name": "src",
+                          "sourceInformation": {
+                            "endColumn": 14,
+                            "endLine": 608,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 11,
+                            "startLine": 608
+                          }
+                        }
+                      ],
+                      "property": "name",
+                      "sourceInformation": {
+                        "endColumn": 19,
+                        "endLine": 608,
+                        "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                        "startColumn": 16,
+                        "startLine": 608
+                      }
+                    }
+                  ],
+                  "parameters": []
+                }
+              },
+              {
+                "_type": "purePropertyMapping",
+                "explodeProperty": false,
+                "property": {
+                  "class": "test::pure::mapping::modelToModel::test::shared::dest::Product2Simple",
+                  "property": "region",
+                  "sourceInformation": {
+                    "endColumn": 10,
+                    "endLine": 609,
+                    "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                    "startColumn": 5,
+                    "startLine": 609
+                  }
+                },
+                "source": "meta_pure_mapping_modelToModel_test_shared_dest_Product2Simple",
+                "sourceInformation": {
+                  "endColumn": 23,
+                  "endLine": 609,
+                  "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                  "startColumn": 5,
+                  "startLine": 609
+                },
+                "transform": {
+                  "_type": "lambda",
+                  "body": [
+                    {
+                      "_type": "property",
+                      "parameters": [
+                        {
+                          "_type": "var",
+                          "name": "src",
+                          "sourceInformation": {
+                            "endColumn": 16,
+                            "endLine": 609,
+                            "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                            "startColumn": 13,
+                            "startLine": 609
+                          }
+                        }
+                      ],
+                      "property": "region",
+                      "sourceInformation": {
+                        "endColumn": 23,
+                        "endLine": 609,
+                        "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+                        "startColumn": 18,
+                        "startLine": 609
+                      }
+                    }
+                  ],
+                  "parameters": []
+                }
+              }
+            ],
+            "root": true,
+            "sourceClassSourceInformation": {
+              "endColumn": 72,
+              "endLine": 607,
+              "sourceId": "test::pure::mapping::modelToModel::test::simple::simpleModelMapping",
+              "startColumn": 10,
+              "startLine": 607
+            },
+            "sourceInformation": {
+              "endColumn": 3,
+              "endLine": 610,
+              "sourceId": "",
+              "startColumn": 3,
+              "startLine": 605
+            },
+            "srcClass": "test::pure::mapping::modelToModel::test::shared::src::_Product2"
+          }
+        ],
+        "enumerationMappings": [],
+        "includedMappings": [],
+        "name": "simpleModelMapping",
+        "package": "test::pure::mapping::modelToModel::test::simple",
+        "sourceInformation": {
+          "endColumn": 1,
+          "endLine": 611,
+          "sourceId": "",
+          "startColumn": 1,
+          "startLine": 597
+        },
+        "tests": []
+      },
+      {
+        "_type": "sectionIndex",
+        "name": "SectionIndex",
+        "package": "__internal__",
+        "sections": [
+          {
+            "_type": "importAware",
+            "elements": [],
+            "imports": [],
+            "parserName": "Pure",
+            "sourceInformation": {
+              "endColumn": 8,
+              "endLine": 1,
+              "sourceId": "",
+              "startColumn": 1,
+              "startLine": 1
+            }
+          },
+          {
+            "_type": "importAware",
+            "elements": [
+              "test::legend::service::execution::test::m2m::simpleFailingJsonService",
+              "test::legend::service::execution::test::m2m::simpleJsonService",
+              "test::legend::service::execution::test::m2m::simpleJsonServiceMultiParam"
+            ],
+            "imports": [],
+            "parserName": "Service",
+            "sourceInformation": {
+              "endColumn": 1,
+              "endLine": 131,
+              "sourceId": "",
+              "startColumn": 8,
+              "startLine": 2
+            }
+          },
+          {
+            "_type": "importAware",
+            "elements": [
+              "test::owl::tests::model::Business",
+              "test::owl::tests::model::EntityWithLocation",
+              "test::owl::tests::model::Executive",
+              "test::owl::tests::model::FemaleExecutive",
+              "test::owl::tests::model::FemalePerson",
+              "test::owl::tests::model::GeoLocation",
+              "test::owl::tests::model::MaleExecutive",
+              "test::owl::tests::model::MalePerson",
+              "test::owl::tests::model::Organization",
+              "test::owl::tests::model::Person",
+              "test::owl::tests::model::Professional",
+              "test::pure::mapping::modelToModel::test::shared::dest::Address",
+              "test::pure::mapping::modelToModel::test::shared::dest::AddressExtension",
+              "test::pure::mapping::modelToModel::test::shared::dest::Firm",
+              "test::pure::mapping::modelToModel::test::shared::dest::Person",
+              "test::pure::mapping::modelToModel::test::shared::dest::Product2Simple",
+              "test::pure::mapping::modelToModel::test::shared::src::_Product2",
+              "test::pure::mapping::modelToModel::test::shared::src::_S_Person",
+              "test::pure::tests::model::simple::Account",
+              "test::pure::tests::model::simple::AccountPnl",
+              "test::pure::tests::model::simple::Address",
+              "test::pure::tests::model::simple::Bridge",
+              "test::pure::tests::model::simple::Department",
+              "test::pure::tests::model::simple::Division",
+              "test::pure::tests::model::simple::EntityWithAddress",
+              "test::pure::tests::model::simple::EntityWithLocations",
+              "test::pure::tests::model::simple::Firm",
+              "test::pure::tests::model::simple::FirmExtension",
+              "test::pure::tests::model::simple::GeographicEntity",
+              "test::pure::tests::model::simple::Interaction",
+              "test::pure::tests::model::simple::Location",
+              "test::pure::tests::model::simple::Order",
+              "test::pure::tests::model::simple::OrderPnl",
+              "test::pure::tests::model::simple::Organization",
+              "test::pure::tests::model::simple::Person",
+              "test::pure::tests::model::simple::PersonExtension",
+              "test::pure::tests::model::simple::PersonNameParameter",
+              "test::pure::tests::model::simple::PersonNameParameterNested",
+              "test::pure::tests::model::simple::PlaceOfInterest",
+              "test::pure::tests::model::simple::Product",
+              "test::pure::tests::model::simple::ProductClassification",
+              "test::pure::tests::model::simple::Synonym",
+              "test::pure::tests::model::simple::Team",
+              "test::pure::tests::model::simple::Trade",
+              "test::pure::tests::model::simple::TradeEvent",
+              "test::owl::tests::model::Business_Employees",
+              "test::owl::tests::model::OrgStructures",
+              "test::owl::tests::model::Parent_Children",
+              "test::owl::tests::model::Person_Accounts",
+              "test::pure::tests::model::simple::Account_AccountPnl",
+              "test::pure::tests::model::simple::AddressLocation",
+              "test::pure::tests::model::simple::BridgeAsso1",
+              "test::pure::tests::model::simple::BridgeAsso2",
+              "test::pure::tests::model::simple::Employment",
+              "test::pure::tests::model::simple::FirmCEO",
+              "test::pure::tests::model::simple::FirmOrganizations",
+              "test::pure::tests::model::simple::Membership",
+              "test::pure::tests::model::simple::PlacesOfInterest",
+              "test::pure::tests::model::simple::ProdSynonym",
+              "test::pure::tests::model::simple::SubOrganization",
+              "test::pure::tests::model::simple::Trade_Accounts",
+              "test::pure::tests::model::simple::Trade_Orders",
+              "test::owl::tests::model::GenderType",
+              "test::owl::tests::model::OrgLevelType",
+              "test::pure::mapping::modelToModel::test::shared::dest::Region",
+              "test::pure::tests::model::simple::GeographicEntityType",
+              "test::pure::tests::model::simple::ProductSynonymType"
+            ],
+            "imports": [],
+            "parserName": "Pure",
+            "sourceInformation": {
+              "endColumn": 1,
+              "endLine": 596,
+              "sourceId": "",
+              "startColumn": 1,
+              "startLine": 132
+            }
+          },
+          {
+            "_type": "importAware",
+            "elements": [
+              "test::pure::mapping::modelToModel::test::simple::simpleModelMapping"
+            ],
+            "imports": [],
+            "parserName": "Mapping",
+            "sourceInformation": {
+              "endColumn": 1,
+              "endLine": 613,
+              "sourceId": "",
+              "startColumn": 1,
+              "startLine": 597
+            }
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
**Overview**
Process test parameters so that they are wrapped in a single ConstantResult. This fixes a bug where service test runs fail due to unexpectedly encountering parameters wrapped in nested ConstantResult objects.

**Testing**
Unit test added to test a service with multi-parameter tests and ensures the service test executes correctly.