### PR TITLE
add Docker snapshot build for integration testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build + Test
         if: (github.repository != 'finos/legend-engine') || (github.ref != 'refs/heads/master')
         run: mvn install javadoc:javadoc
-      - name: Build + Test + Sonar + Maven Deploy
+      - name: Build + Test + Maven Deploy + Sonar + Docker Snapshot
         if: (github.repository == 'finos/legend-engine') && (github.ref == 'refs/heads/master')
-        run: mvn javadoc:javadoc deploy -Psonar
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: mvn javadoc:javadoc deploy -P sonar,docker-snapshot

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -488,7 +488,6 @@
                     <plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>dockerfile-maven-plugin</artifactId>
-                        <version>1.4.13</version>
                         <inherited>false</inherited>
                         <executions>
                             <execution>
@@ -502,6 +501,34 @@
                         </executions>
                         <configuration>
                             <tag>${project.version}</tag>
+                            <username>${env.DOCKER_USERNAME}</username>
+                            <password>${env.DOCKER_PASSWORD}</password>
+                            <repository>registry.hub.docker.com/${env.DOCKER_USERNAME}/${project.artifactId}</repository>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker-snapshot</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>tag</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <tag>snapshot</tag>
                             <username>${env.DOCKER_USERNAME}</username>
                             <password>${env.DOCKER_PASSWORD}</password>
                             <repository>registry.hub.docker.com/${env.DOCKER_USERNAME}/${project.artifactId}</repository>


### PR DESCRIPTION
Add Docker snapshot build to be used for integration testing of Legend application stack. The immediate usage right now is for Studio E2E testing.

I have tested this. See my repo at https://github.com/akphi/legend-test-space/runs/4439338167?check_suite_focus=true