### PR TITLE
minor update to the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <hamcrest.core.version>1.3</hamcrest.core.version>
         <openjdk.jol.version>0.9</openjdk.jol.version>
         <json-smart.version>2.4.7</json-smart.version>
-
+        <byte-buddy.version>1.11.20</byte-buddy.version>
 
         <!-- Plugin versions -->
         <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
@@ -196,7 +196,7 @@
         <jacoco.maven.plugin.version>0.8.5</jacoco.maven.plugin.version>
         <exec.maven.plugin.version>3.0.0</exec.maven.plugin.version>
         <build-helper.maven.plugin.version>3.2.0</build-helper.maven.plugin.version>
-        <byte-buddy.version>1.11.20</byte-buddy.version>
+        <dockerfile.maven.plugin.version>1.4.13</dockerfile.maven.plugin.version>
     </properties>
 
     <scm>
@@ -291,6 +291,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${build-helper.maven.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <version>${dockerfile.maven.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
I'm trying to see if this fixes the problem with Docker snapshot publish. I don't think so since when I inspect the pipeline, the correct version of the plugin is downloaded anyway.

@maoo Could you reset the values of `DOCKER_USERNAME` and `DOCKER_PASSWORD` to be similar to what I have in SDLC? With the same configuration, SDLC is publishing snapshot to Docker now
https://github.com/finos/legend-sdlc/runs/4444460063?check_suite_focus=true
Not with Engine
https://github.com/finos/legend-engine/runs/4460971860?check_suite_focus=true

```
Error:  unauthorized: incorrect username or password
Warning:  An attempt failed, will retry 1 more times
...
Error:  toomanyrequests: too many failed login attempts for username or IP address
...
Error:  Failed to execute goal com.spotify:dockerfile-maven-plugin:1.4.13:push (default) on project legend-engine-server: Could not push image: toomanyrequests: too many failed login attempts for username or IP address -> [Help 1]
```

> I have tested this change on a clone of this repoository - see https://github.com/akphi/legend-test-space/runs/4462123324?check_suite_focus=true