### PR TITLE
Cache common imports instead of resolving them each time

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
@@ -58,6 +58,9 @@ public class CompileContext
     private static final ImmutableSet<String> SPECIAL_TYPES = _Package.SPECIAL_TYPES;
     private static final String PACKAGE_SEPARATOR = org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.DEFAULT_PATH_SEPARATOR;
     private static final String META_PACKAGE_NAME = "meta";
+    private static final MutableMap<String, String> commonMetaPaths = Maps.mutable.empty();
+    private static final int MAX_SIZE_COMMON_META_PATHS = 1000;
+
     // NOTE: this list is taken from m3.pure in PURE
     private static final ImmutableSet<String> META_IMPORTS = Sets.immutable.with(
             "meta::pure::metamodel",
@@ -159,6 +162,11 @@ public class CompileContext
         return getCompilerExtensions().getExtraProcessorOrThrow(element);
     }
 
+    public static MutableMap<String, String> getCommonMetaPaths()
+    {
+        return commonMetaPaths;
+    }
+
     public <T> T resolve(String path, SourceInformation sourceInformation, Function<String, T> resolver)
     {
         if (path == null)
@@ -176,6 +184,12 @@ public class CompileContext
         if (path.contains(PACKAGE_SEPARATOR))
         {
             return resolver.apply(path);
+        }
+
+        // Resolve import if available in commonMetaPaths and auto-imports were not added
+        if (this.imports.size() == META_IMPORTS.size() && commonMetaPaths.containsKey(path))
+        {
+            return resolver.apply(commonMetaPaths.get(path));
         }
 
         // NOTE: here we make the assumption that we have populated the indices properly so the same element
@@ -406,6 +420,12 @@ public class CompileContext
             return functionHandlerMap.get(extractedFunctionName);
         }
 
+        // Resolve import if available in commonMetaPaths and auto-imports were not added
+        if (this.imports.size() == META_IMPORTS.size() && commonMetaPaths.containsKey(extractedFunctionName))
+        {
+            return functionHandlerMap.get(commonMetaPaths.get(extractedFunctionName));
+        }
+
         MutableMap<String, FunctionExpressionBuilder> results = searchImports(extractedFunctionName, functionHandlerMap::get);
         switch (results.size())
         {
@@ -462,6 +482,10 @@ public class CompileContext
                 results.put(fullPath, result);
             }
         });
+        if (results.size() == 1 && results.keysView().getAny().startsWith("meta") && commonMetaPaths.size() < MAX_SIZE_COMMON_META_PATHS)
+        {
+            commonMetaPaths.put(name, results.keysView().getAny());
+        }
         return results;
     }
 }

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -115,9 +115,12 @@ public class PureModel implements IPureModel
     // this as part of `CompileContext`
     final CompilerExtensions extensions;
 
-    final Handlers handlers;
+    // NOTE: since we resolve the same types across different pure elements, we have to keep commonPaths local
+    // to `PureModel` rather than having this as part of `CompileContext`
     private final MutableMap<String, String> commonPaths = Maps.mutable.empty();
     private static final int MAX_SIZE_COMMON_PATHS = 1000;
+
+    final Handlers handlers;
 
     private final MutableSet<String> immutables = Sets.mutable.empty();
     private final MutableMap<String, Multiplicity> multiplicitiesIndex = Maps.mutable.empty();

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -116,6 +116,8 @@ public class PureModel implements IPureModel
     final CompilerExtensions extensions;
 
     final Handlers handlers;
+    private final MutableMap<String, String> commonPaths = Maps.mutable.empty();
+    private static final int MAX_SIZE_COMMON_PATHS = 1000;
 
     private final MutableSet<String> immutables = Sets.mutable.empty();
     private final MutableMap<String, Multiplicity> multiplicitiesIndex = Maps.mutable.empty();
@@ -933,6 +935,19 @@ public class PureModel implements IPureModel
     public CompileContext getContext(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
     {
         return new CompileContext.Builder(this).withElement(element).build();
+    }
+
+    public MutableMap<String, String> getCommonPaths()
+    {
+        return this.commonPaths;
+    }
+
+    public void addCommonPath(String key, String value)
+    {
+        if (this.commonPaths.size() < MAX_SIZE_COMMON_PATHS)
+        {
+            this.commonPaths.put(key, value);
+        }
     }
 
     public Section getSection(String fullPath)

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestCompilerContext.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestCompilerContext.java
@@ -1,0 +1,63 @@
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+import org.finos.legend.engine.language.pure.compiler.Compiler;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCompilerContext
+{
+    @Test
+    public void testCommonImportsCache()
+    {
+        PureModelContextData contextData = PureModelContextData.newPureModelContextData();
+        PureModel pureModel = Compiler.compile(contextData, null, null);
+
+        CompileContext compileContext = new CompileContext.Builder(pureModel).build();
+        compileContext.resolve("doc", null, path -> pureModel.getProfile(path, null));
+        Assert.assertTrue(CompileContext.getCommonMetaPaths().size() > 0);
+    }
+
+    @Test
+    public void testCommonImportsCache_withAutoImports()
+    {
+        PureModel pureModel = Compiler.compile(PureModelContextData.newPureModelContextData(), null, null);
+        CompileContext compileContext = new CompileContext.Builder(pureModel).build();
+        compileContext.resolve("doc", null, path -> pureModel.getProfile(path, null));
+        Assert.assertTrue(CompileContext.getCommonMetaPaths().size() > 0);
+
+        String grammar = "import test::*;\n" +
+                "\n" +
+                "Profile test::doc {}\n" +
+                "\n" +
+                "Class <<doc.doc>> test::mewo {\n" +
+                "}";
+        PureModelContextData contextData = PureGrammarParser.newInstance().parseModel(grammar);
+        try
+        {
+            Compiler.compile(contextData, null, null);
+            Assert.fail("Expected compilation error but no error occurred");
+        }
+        catch (EngineException e)
+        {
+            Assert.assertEquals("COMPILATION error at [5:9-11]: Can't resolve element with path 'doc' - multiple matches found [meta::pure::profiles::doc, test::doc]",
+                    EngineException.buildPrettyErrorMessage(e.getMessage(), e.getSourceInformation(), e.getErrorType()));
+        }
+    }
+
+    @Test
+    public void testCommonImportsCache_dontCacheProjectSpecificElements()
+    {
+        String grammar = "import test::*;\n" +
+                "\n" +
+                "Class test::one {}\n" +
+                "Class test::two {\n" +
+                "   prop1: one[1];\n" +
+                "}";
+        PureModelContextData contextData = PureGrammarParser.newInstance().parseModel(grammar);
+        Compiler.compile(contextData, null, null);
+        Assert.assertFalse(CompileContext.getCommonMetaPaths().contains("test::one"));
+    }
+}

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestCompilerContext.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestCompilerContext.java
@@ -17,7 +17,7 @@ public class TestCompilerContext
 
         CompileContext compileContext = new CompileContext.Builder(pureModel).build();
         compileContext.resolve("doc", null, path -> pureModel.getProfile(path, null));
-        Assert.assertTrue(CompileContext.getCommonMetaPaths().size() > 0);
+        Assert.assertEquals(1, pureModel.getCommonPaths().size());
     }
 
     @Test
@@ -26,7 +26,7 @@ public class TestCompilerContext
         PureModel pureModel = Compiler.compile(PureModelContextData.newPureModelContextData(), null, null);
         CompileContext compileContext = new CompileContext.Builder(pureModel).build();
         compileContext.resolve("doc", null, path -> pureModel.getProfile(path, null));
-        Assert.assertTrue(CompileContext.getCommonMetaPaths().size() > 0);
+        Assert.assertEquals(1, pureModel.getCommonPaths().size());
 
         String grammar = "import test::*;\n" +
                 "\n" +
@@ -57,7 +57,7 @@ public class TestCompilerContext
                 "   prop1: one[1];\n" +
                 "}";
         PureModelContextData contextData = PureGrammarParser.newInstance().parseModel(grammar);
-        Compiler.compile(contextData, null, null);
-        Assert.assertFalse(CompileContext.getCommonMetaPaths().contains("test::one"));
+        PureModel pureModel = Compiler.compile(contextData, null, null);
+        Assert.assertTrue(pureModel.getCommonPaths().contains("test::one"));
     }
 }


### PR DESCRIPTION
Unless user uses auto-imports
Also project specific import's resolutions won't be cached