### PR TITLE
Enhance service grammar to support execution options

### DIFF
--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
@@ -25,6 +25,7 @@ SERVICE_FUNCTION:                   'query';
 SERVICE_EXECUTION_KEY:              'key';
 SERVICE_MAPPING:                    'mapping';
 SERVICE_RUNTIME:                    'runtime';
+SERVICE_EXECUTION_OPTIONS:          'executionOptions';
 
 SERVICE_TEST:                       'test';
 SERVICE_TEST_TESTS:                 'tests';

--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
@@ -16,7 +16,7 @@ identifier:                             VALID_STRING | STRING
                                         | SERVICE | IMPORT
                                         | SERVICE_SINGLE | SERVICE_MULTI
                                         | SERVICE_PATTERN | SERVICE_OWNERS | SERVICE_DOCUMENTATION | SERVICE_AUTO_ACTIVATE_UPDATES
-                                        | SERVICE_EXECUTION | SERVICE_FUNCTION | SERVICE_EXECUTION_KEY | SERVICE_EXECUTION_EXECUTIONS | SERVICE_RUNTIME | SERVICE_MAPPING
+                                        | SERVICE_EXECUTION | SERVICE_FUNCTION | SERVICE_EXECUTION_KEY | SERVICE_EXECUTION_EXECUTIONS | SERVICE_RUNTIME | SERVICE_MAPPING | SERVICE_EXECUTION_OPTIONS
                                         | SERVICE_TEST | SERVICE_TEST_TESTS | SERVICE_DATA | SERVICE_ASSERTS
 ;
 
@@ -71,6 +71,14 @@ serviceFunc:                            SERVICE_FUNCTION COLON combinedExpressio
 ;
 serviceExec:                            SERVICE_EXECUTION COLON (singleExec|multiExec)
 ;
+
+executionOptions:                       SERVICE_EXECUTION_OPTIONS COLON
+                                            BRACKET_OPEN
+                                                (executionOption (COMMA executionOption)*)?
+                                            BRACKET_CLOSE
+                                            SEMI_COLON
+;
+
 singleExec:                             SERVICE_SINGLE
                                             BRACE_OPEN
                                                 (
@@ -78,6 +86,7 @@ singleExec:                             SERVICE_SINGLE
                                                     | serviceMapping
                                                     | serviceRuntime
                                                 )*
+                                                executionOptions?
                                             BRACE_CLOSE
 ;
 multiExec:                              SERVICE_MULTI
@@ -95,6 +104,7 @@ execParameter:                          execParameterSignature COLON
                                                     serviceMapping
                                                     | serviceRuntime
                                                 )*
+                                                executionOptions?
                                             BRACE_CLOSE
 ;
 execParameterSignature:                 SERVICE_EXECUTION_EXECUTIONS BRACKET_OPEN STRING BRACKET_CLOSE
@@ -107,9 +117,11 @@ serviceRuntime:                         SERVICE_RUNTIME COLON (runtimePointer | 
 ;
 runtimePointer:                         qualifiedName SEMI_COLON
 ;
-embeddedRuntime:                        ISLAND_OPEN (embeddedRuntimeContent)* SEMI_COLON
+embeddedRuntime:                        ISLAND_OPEN (islandSpecificationValue)* SEMI_COLON
 ;
-embeddedRuntimeContent:                 ISLAND_START | ISLAND_BRACE_OPEN | ISLAND_CONTENT | ISLAND_HASH | ISLAND_BRACE_CLOSE | ISLAND_END
+executionOption:                        ISLAND_OPEN ISLAND_CONTENT (islandSpecificationValue)*
+;
+islandSpecificationValue:               ISLAND_START | ISLAND_BRACE_OPEN | ISLAND_CONTENT | ISLAND_HASH | ISLAND_BRACE_CLOSE | ISLAND_END
 ;
 
 

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/IServiceParserExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/IServiceParserExtension.java
@@ -1,0 +1,36 @@
+package org.finos.legend.engine.language.pure.dsl.service.grammar.from;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.dsl.service.grammar.from.executionoption.ExecutionOptionSpecificationSourceCode;
+import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+
+public interface IServiceParserExtension extends PureGrammarParserExtension
+{
+    static List<IServiceParserExtension> getExtensions()
+    {
+        return Lists.mutable.withAll(ServiceLoader.load(IServiceParserExtension.class));
+    }
+
+    default List<Function<ExecutionOptionSpecificationSourceCode, ExecutionOption>> getExtraExecutionOptionParsers()
+    {
+        return Collections.emptyList();
+    }
+
+    static ExecutionOption process(ExecutionOptionSpecificationSourceCode code, List<Function<ExecutionOptionSpecificationSourceCode, ExecutionOption>> parsers) {
+        return ListIterate
+                .collect(parsers, parser -> parser.apply(code))
+                .select(Objects::nonNull)
+                .getFirstOptional()
+                .orElseThrow(() -> new EngineException("Unsupported Execution Option type '" + code.getType() + "'", code.getSourceInformation(), EngineErrorType.PARSER));
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParserExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParserExtension.java
@@ -22,13 +22,12 @@ import org.finos.legend.engine.language.pure.grammar.from.SectionSourceCode;
 import org.finos.legend.engine.language.pure.grammar.from.SourceCodeParserInfo;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.ServiceLexerGrammar;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.ServiceParserGrammar;
-import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension;
 import org.finos.legend.engine.language.pure.grammar.from.extension.SectionParser;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.ImportAwareCodeSection;
 
 import java.util.Collections;
 
-public class ServiceParserExtension implements PureGrammarParserExtension
+public class ServiceParserExtension implements IServiceParserExtension
 {
     public static final String NAME = "Service";
 

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/executionoption/ExecutionOptionSpecificationSourceCode.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/executionoption/ExecutionOptionSpecificationSourceCode.java
@@ -1,0 +1,39 @@
+package org.finos.legend.engine.language.pure.dsl.service.grammar.from.executionoption;
+
+import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+
+public class ExecutionOptionSpecificationSourceCode
+{
+    private final String code;
+    private final String type;
+    private final SourceInformation sourceInformation;
+    private final ParseTreeWalkerSourceInformation walkerSourceInformation;
+
+    public ExecutionOptionSpecificationSourceCode(String code, String type, SourceInformation sourceInformation, ParseTreeWalkerSourceInformation walkerSourceInformation) {
+        this.code = code;
+        this.type = type;
+        this.sourceInformation = sourceInformation;
+        this.walkerSourceInformation = walkerSourceInformation;
+    }
+
+    public String getCode()
+    {
+        return code;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public SourceInformation getSourceInformation()
+    {
+        return sourceInformation;
+    }
+
+    public ParseTreeWalkerSourceInformation getWalkerSourceInformation()
+    {
+        return walkerSourceInformation;
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/IServiceGrammarComposerExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/IServiceGrammarComposerExtension.java
@@ -1,0 +1,35 @@
+package org.finos.legend.engine.language.pure.dsl.service.grammar.to;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
+import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+
+import java.util.List;
+import java.util.Objects;
+
+public interface IServiceGrammarComposerExtension extends PureGrammarComposerExtension
+{
+    static List<IServiceGrammarComposerExtension> getExtensions(PureGrammarComposerContext context)
+    {
+        return ListIterate.selectInstancesOf(context.extensions, IServiceGrammarComposerExtension.class);
+    }
+
+    static String process(ExecutionOption executionOption, List<Function2<ExecutionOption, PureGrammarComposerContext, String>> processors, PureGrammarComposerContext context) {
+        return ListIterate
+                .collect(processors, processor -> processor.value(executionOption, context))
+                .select(Objects::nonNull)
+                .getFirstOptional()
+                .orElseThrow(() -> new EngineException("Unsupported Execution Option type '" + executionOption.getClass() + "'", executionOption.sourceInformation, EngineErrorType.PARSER));
+    }
+
+
+    default List<Function2<ExecutionOption, PureGrammarComposerContext, String>> getExtraExecutionOptionComposers()
+    {
+        return FastList.newList();
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
@@ -201,7 +201,34 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "    ];\n" +
                 "  }\n" +
                 "}\n", "COMPILATION error at [29:14-27]: Can't find mapping 'test::mapping2'");
-        // test service execution runtime pointer
+        // test unknown exec option
+        test(resource + "###Service\n" +
+                "Service test::Service\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  owners: ['ownerName', 'ownerName2'];\n" +
+                "  documentation: 'test';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Single\n" +
+                "  {\n" +
+                "    query: src: test::class[1]|$src.prop1;\n" +
+                "    mapping: test::mapping;\n" +
+                "    runtime: test::runtime;\n" +
+                "    executionOptions:\n" +
+                "    [\n" +
+                "       #{dummyExecOption}#,\n" +
+                "       #{dummyExecOptionWithParam {var1: 123}}#\n" +
+                "    ];\n" +
+                "  }\n" +
+                "  test: Single\n" +
+                "  {\n" +
+                "    data: 'moreThanData';\n" +
+                "    asserts:\n" +
+                "    [\n" +
+                "    ];\n" +
+                "  }\n" +
+                "}\n", "COMPILATION error at [34:8-47]: Unsupported execution option type 'class org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption.DummyExecOptionWithParameters'");
+        // test service execution runtime pointer00
         test(resource + "###Service\n" +
                 "Service test::Service\n" +
                 "{\n" +
@@ -479,6 +506,37 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "    }\n" +
                 "  }\n" +
                 "}\n", "COMPILATION error at [35:5-39:5]: Execution parameter with key 'PROD' already existed");
+        // check unknown exec option
+        test(resource + "###Service\n" +
+                "Service test::Service\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  owners: ['ownerName'];\n" +
+                "  documentation: 'test';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Multi\n" +
+                "  {\n" +
+                "    query: src:    test::class[1]|$src.prop1;\n" +
+                "    key: 'env';\n" +
+                "    executions['PROD']:\n" +
+                "    {\n" +
+                "      mapping: test::mapping;\n" +
+                "      runtime: test::runtime;\n" +
+                "      executionOptions:\n" +
+                "      [\n" +
+                "          #{dummyExecOption}#,\n" +
+                "          #{dummyExecOptionWithParam {var1: 123}}#\n" +
+                "      ];\n" +
+                "    }\n" +
+                "  }\n" +
+                "  test: Multi\n" +
+                "  {\n" +
+                "    tests['PROD']:\n" +
+                "    {\n" +
+                "      data: 'testData';\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n", "COMPILATION error at [37:11-50]: Unsupported execution option type 'class org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption.DummyExecOptionWithParameters'");
         // check duplicated test key values
         test(resource + "###Service\n" +
                 "Service test::Service\n" +

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarParser.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarParser.java
@@ -387,6 +387,48 @@ public class TestServiceGrammarParser extends TestGrammarParser.TestGrammarParse
                 "    asserts: [];\n" +
                 "  }\n" +
                 "}\n", "PARSER error at [12:9-17:3]: Field 'asserts' should be specified only once");
+        // unknown exec option
+        test("###Service\n" +
+                "Service meta::pure::myServiceSingle\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  execution: Single\n" +
+                "  {\n" +
+                "    query: src: meta::transform::tests::Address[1]|$src.a;\n" +
+                "    mapping: meta::myMapping;\n" +
+                "    runtime: meta::myRuntime;\n" +
+                "    executionOptions: [ \n" +
+                "         #{\n" +
+                "            unknownOption\n" +
+                "         }# ];\n" +
+                "  }\n" +
+                "  test: Single\n" +
+                "  {\n" +
+                "    data: 'moreThanData';\n" +
+                "  }\n" +
+                "}\n", "PARSER error at [12:10-14:11]: Unsupported Execution Option type 'unknownOption'");
+        // fail on exec option subparser (proper source info on error)
+        test("###Service\n" +
+                "Service meta::pure::myServiceSingle\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  execution: Single\n" +
+                "  {\n" +
+                "    query: src: meta::transform::tests::Address[1]|$src.a;\n" +
+                "    mapping: meta::myMapping;\n" +
+                "    runtime: meta::myRuntime;\n" +
+                "    executionOptions: [ \n" +
+                "         #{\n" +
+                "            failingDummyExecOption\n" +
+                "         }# ];\n" +
+                "  }\n" +
+                "  test: Single\n" +
+                "  {\n" +
+                "    data: 'moreThanData';\n" +
+                "  }\n" +
+                "}\n", "PARSER error at [13:13-34]: Error to check source info reported correctly from subparser");
     }
 
     @Test
@@ -649,6 +691,59 @@ public class TestServiceGrammarParser extends TestGrammarParser.TestGrammarParse
                 "    }\n" +
                 "  }\n" +
                 "}\n", "PARSER error at [18:5-23:5]: Field 'asserts' should be specified only once");
+        // unknown exec option
+        test("###Service\n" +
+                "Service meta::pure::myServiceMulti\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  execution: Multi\n" +
+                "  {\n" +
+                "    query: src: meta::transform::tests::Address[1]|$src.a;\n" +
+                "    key: 'env';\n" +
+                "    executions['QA']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping1;\n" +
+                "      runtime: test::runtime;\n" +
+                "      executionOptions: [ #{ unknownOption }# ];\n" +
+                "    }\n" +
+                "  }\n" +
+                "  test: Multi\n" +
+                "  {\n" +
+                "    tests['QA']:\n" +
+                "    {\n" +
+                "      data: 'moreData';\n" +
+                "      asserts: [];\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n", "PARSER error at [14:27-45]: Unsupported Execution Option type 'unknownOption'");
+
+        // fail on exec option subparser (proper source info on error)
+        test("###Service\n" +
+                "Service meta::pure::myServiceMulti\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  execution: Multi\n" +
+                "  {\n" +
+                "    query: src: meta::transform::tests::Address[1]|$src.a;\n" +
+                "    key: 'env';\n" +
+                "    executions['QA']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping1;\n" +
+                "      runtime: test::runtime;\n" +
+                "      executionOptions: [ #{ failingDummyExecOption }# ];\n" +
+                "    }\n" +
+                "  }\n" +
+                "  test: Multi\n" +
+                "  {\n" +
+                "    tests['QA']:\n" +
+                "    {\n" +
+                "      data: 'moreData';\n" +
+                "      asserts: [];\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n", "PARSER error at [14:30-51]: Error to check source info reported correctly from subparser");
     }
 
     @Test

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
@@ -360,4 +360,251 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "}\n"
         );
     }
+
+    @Test
+    public void testMultiServiceWithExecutionOptions()
+    {
+        // empty eliminated during formmatting
+        testFormat("###Service\n" +
+                        "Service meta::pure::myServiceSingle\n" +
+                        "{\n" +
+                        "  pattern: 'url/myUrl/';\n" +
+                        "  documentation: 'this is just for context';\n" +
+                        "  autoActivateUpdates: true;\n" +
+                        "  execution: Multi\n" +
+                        "  {\n" +
+                        "    query: |model::pure::mapping::modelToModel::test::shared::dest::Product.all()->graphFetchChecked(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#)->serialize(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#);\n" +
+                        "    key: 'env';\n" +
+                        "    executions['QA']:\n" +
+                        "    {\n" +
+                        "      mapping: meta::myMapping1;\n" +
+                        "      runtime: test::runtime;\n" +
+                        "    }\n" +
+                        "    executions['UAT']:\n" +
+                        "    {\n" +
+                        "      mapping: meta::myMapping2;\n" +
+                        "      runtime: meta::myRuntime;\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "  test: Multi\n" +
+                        "  {\n" +
+                        "    tests['QA']:\n" +
+                        "    {\n" +
+                        "      data: 'moreData';\n" +
+                        "      asserts:\n" +
+                        "      [\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                        "      ];\n" +
+                        "    }\n" +
+                        "    tests['UAT']:\n" +
+                        "    {\n" +
+                        "      data: 'moreData';\n" +
+                        "      asserts:\n" +
+                        "      [\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                        "      ];\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}\n",
+                "###Service\n" +
+                        "Service meta::pure::myServiceSingle\n" +
+                        "{\n" +
+                        "  pattern: 'url/myUrl/';\n" +
+                        "  documentation: 'this is just for context';\n" +
+                        "  autoActivateUpdates: true;\n" +
+                        "  execution: Multi\n" +
+                        "  {\n" +
+                        "    query: |model::pure::mapping::modelToModel::test::shared::dest::Product.all()->graphFetchChecked(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#)->serialize(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#);\n" +
+                        "    key: 'env';\n" +
+                        "    executions['QA']:\n" +
+                        "    {\n" +
+                        "      mapping: meta::myMapping1;\n" +
+                        "      runtime: test::runtime;\n" +
+                        "      executionOptions: [\n" +
+                        "      ];\n" +
+                        "    }\n" +
+                        "    executions['UAT']:\n" +
+                        "    {\n" +
+                        "      mapping: meta::myMapping2;\n" +
+                        "      runtime: meta::myRuntime;\n" +
+                        "      executionOptions: [\n" +
+                        "      ];\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "  test: Multi\n" +
+                        "  {\n" +
+                        "    tests['QA']:\n" +
+                        "    {\n" +
+                        "      data: 'moreData';\n" +
+                        "      asserts:\n" +
+                        "      [\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                        "      ];\n" +
+                        "    }\n" +
+                        "    tests['UAT']:\n" +
+                        "    {\n" +
+                        "      data: 'moreData';\n" +
+                        "      asserts:\n" +
+                        "      [\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                        "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                        "      ];\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}\n");
+
+        // test with some exec options
+        test("###Service\n" +
+                "Service meta::pure::myServiceSingle\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Multi\n" +
+                "  {\n" +
+                "    query: |model::pure::mapping::modelToModel::test::shared::dest::Product.all()->graphFetchChecked(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#)->serialize(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#);\n" +
+                "    key: 'env';\n" +
+                "    executions['QA']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping1;\n" +
+                "      runtime: test::runtime;\n" +
+                "      executionOptions:\n" +
+                "      [\n" +
+                "          #{\n" +
+                "            dummyExecOption\n" +
+                "          }#,\n" +
+                "          #{\n" +
+                "            dummyExecOptionWithParam\n" +
+                "              {\n" +
+                "                 var1: Hello;\n" +
+                "                 var2: 123;\n" +
+                "                 var3: [world, bye];\n" +
+                "                 var4: { name: Bobby };\n" +
+                "              }\n" +
+                "          }#\n" +
+                "      ];\n" +
+                "    }\n" +
+                "    executions['UAT']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping2;\n" +
+                "      runtime: meta::myRuntime;\n" +
+                "      executionOptions:\n" +
+                "      [\n" +
+                "          #{\n" +
+                "            dummyExecOption\n" +
+                "          }#\n" +
+                "      ];\n" +
+                "    }\n" +
+                "  }\n" +
+                "  test: Multi\n" +
+                "  {\n" +
+                "    tests['QA']:\n" +
+                "    {\n" +
+                "      data: 'moreData';\n" +
+                "      asserts:\n" +
+                "      [\n" +
+                "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                "      ];\n" +
+                "    }\n" +
+                "    tests['UAT']:\n" +
+                "    {\n" +
+                "      data: 'moreData';\n" +
+                "      asserts:\n" +
+                "      [\n" +
+                "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                "        { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                "      ];\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testSingleServiceWithExecutionOptions()
+    {
+        // empty eliminated during formmatting
+        testFormat("###Service\n" +
+                        "Service meta::pure::myServiceSingle\n" +
+                        "{\n" +
+                        "  pattern: 'url/myUrl/';\n" +
+                        "  documentation: 'this is just for context';\n" +
+                        "  autoActivateUpdates: true;\n" +
+                        "  execution: Single\n" +
+                        "  {\n" +
+                        "    query: src: meta::transform::tests::Address[1]|$src.a;\n" +
+                        "    mapping: mySimpleMapping;\n" +
+                        "    runtime: mySimpleRuntime;\n" +
+                        "  }\n" +
+                        "  test: Single\n" +
+                        "  {\n" +
+                        "    data: 'moreThanData';\n" +
+                        "    asserts:\n" +
+                        "    [\n" +
+                        "      { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                        "      { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                        "    ];\n" +
+                        "  }\n" +
+                        "}\n",
+                "###Service\n" +
+                "Service meta::pure::myServiceSingle\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Single\n" +
+                "  {\n" +
+                "    query: src: meta::transform::tests::Address[1]|$src.a;\n" +
+                "    mapping: mySimpleMapping;\n" +
+                "    runtime: mySimpleRuntime;\n" +
+                "    executionOptions: [\n" +
+                "    ];\n" +
+                "  }\n" +
+                "  test: Single\n" +
+                "  {\n" +
+                "    data: 'moreThanData';\n" +
+                "    asserts:\n" +
+                "    [\n" +
+                "      { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                "      { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                "    ];\n" +
+                "  }\n" +
+                "}\n");
+
+        // test with some exec options
+        test("###Service\n" +
+                "Service meta::pure::myServiceSingle\n" +
+                        "{\n" +
+                        "  pattern: 'url/myUrl/';\n" +
+                        "  documentation: 'this is just for context';\n" +
+                        "  autoActivateUpdates: true;\n" +
+                        "  execution: Single\n" +
+                        "  {\n" +
+                        "    query: src: meta::transform::tests::Address[1]|$src.a;\n" +
+                        "    mapping: mySimpleMapping;\n" +
+                        "    runtime: mySimpleRuntime;\n" +
+                        "    executionOptions:\n" +
+                        "    [\n" +
+                        "        #{\n" +
+                        "          dummyExecOption\n" +
+                        "        }#,\n" +
+                        "        #{\n" +
+                        "          dummyExecOptionWithParam {var1: Hello; var2: 123; var3: [world, bye]; var4: { name: Bobby };}\n" +
+                        "        }#\n" +
+                        "    ];\n" +
+                        "  }\n" +
+                        "  test: Single\n" +
+                        "  {\n" +
+                        "    data: 'moreThanData';\n" +
+                        "    asserts:\n" +
+                        "    [\n" +
+                        "      { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 },\n" +
+                        "      { [], res: Result<Any|*>[1]|$res.values->cast(@TabularDataSet).rows->size() == 1 }\n" +
+                        "    ];\n" +
+                        "  }\n" +
+                        "}\n");
+    }
 }

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyCompilerExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyCompilerExtension.java
@@ -1,0 +1,39 @@
+package org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+import org.finos.legend.pure.generated.Root_meta_pure_executionPlan_ExecutionOption;
+import org.finos.legend.pure.generated.Root_meta_pure_executionPlan_tests_DummyExecutionOption_Impl;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DummyCompilerExtension implements CompilerExtension
+{
+    @Override
+    public Iterable<? extends Processor<?>> getExtraProcessors()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Function2<ExecutionOption, CompileContext, Root_meta_pure_executionPlan_ExecutionOption>> getExtraExecutionOptionProcessors()
+    {
+        return Collections.singletonList(this::processExecOption);
+    }
+
+    private Root_meta_pure_executionPlan_ExecutionOption processExecOption(ExecutionOption executionOption, CompileContext context)
+    {
+        if (executionOption instanceof DummyExecOption)
+        {
+            return new Root_meta_pure_executionPlan_tests_DummyExecutionOption_Impl("");
+        }
+        else
+        {
+            return null;
+        }
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyExecOption.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyExecOption.java
@@ -1,0 +1,17 @@
+package org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption;
+
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+
+public class DummyExecOption extends ExecutionOption
+{
+    // for jackson
+    public DummyExecOption()
+    {
+    }
+
+    public DummyExecOption(SourceInformation sourceInformation)
+    {
+        this.sourceInformation = sourceInformation;
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyExecOptionWithParameters.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyExecOptionWithParameters.java
@@ -1,0 +1,20 @@
+package org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption;
+
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+
+public class DummyExecOptionWithParameters extends ExecutionOption
+{
+    public String code;
+
+    // for jackson
+    public DummyExecOptionWithParameters()
+    {
+    }
+
+    public DummyExecOptionWithParameters(String code, SourceInformation sourceInformation)
+    {
+        this.code = code;
+        this.sourceInformation = sourceInformation;
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyPureProtocolExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyPureProtocolExtension.java
@@ -1,0 +1,27 @@
+package org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption;
+
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
+import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+
+import java.util.List;
+
+public class DummyPureProtocolExtension implements PureProtocolExtension
+{
+    @Override
+    public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
+    {
+        return Lists.mutable.with(() -> Lists.mutable.with(
+                ProtocolSubTypeInfo.Builder
+                        .newInstance(ExecutionOption.class)
+                        .withSubtypes(FastList.newListWith(
+                                Tuples.pair(DummyExecOption.class, "dummyExecOption"),
+                                Tuples.pair(DummyExecOptionWithParameters.class, "dummyExecOptionWithParam")
+                        )).build()
+        ));
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyServiceGrammarComposerExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyServiceGrammarComposerExtension.java
@@ -1,0 +1,33 @@
+package org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.grammar.to.IServiceGrammarComposerExtension;
+import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+
+import java.util.List;
+
+public class DummyServiceGrammarComposerExtension implements IServiceGrammarComposerExtension
+{
+    @Override
+    public List<Function2<ExecutionOption, PureGrammarComposerContext, String>> getExtraExecutionOptionComposers()
+    {
+        return Lists.mutable.of(
+                (execOpt, context) ->{
+                    if (execOpt instanceof DummyExecOption)
+                    {
+                        return context.getIndentationString() + "dummyExecOption";
+                    }
+                    else if(execOpt instanceof DummyExecOptionWithParameters)
+                    {
+                        return context.getIndentationString() + ((DummyExecOptionWithParameters) execOpt).code.trim();
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+        );
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyServiceParserExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/org/finos/legend/engine/language/pure/dsl/service/test/executionoption/DummyServiceParserExtension.java
@@ -1,0 +1,45 @@
+package org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.grammar.from.IServiceParserExtension;
+import org.finos.legend.engine.language.pure.dsl.service.grammar.from.executionoption.ExecutionOptionSpecificationSourceCode;
+import org.finos.legend.engine.language.pure.grammar.from.antlr4.ServiceParserGrammar;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.executionOption.ExecutionOption;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Lexer;
+import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class DummyServiceParserExtension implements IServiceParserExtension
+{
+    @Override
+    public List<Function<ExecutionOptionSpecificationSourceCode, ExecutionOption>> getExtraExecutionOptionParsers()
+    {
+        return Lists.mutable.of(
+                DummyServiceParserExtension::parseDummyExecOption
+        );
+    }
+
+    private static ExecutionOption parseDummyExecOption(ExecutionOptionSpecificationSourceCode code)
+    {
+        switch (code.getType())
+        {
+            case "failingDummyExecOption":
+                M3Parser m3Parser = new M3Parser(new CommonTokenStream(new M3Lexer(CharStreams.fromString(code.getCode()))));
+                SourceInformation sourceInformation = code.getWalkerSourceInformation().getSourceInformation(m3Parser.getCurrentToken());
+                throw new EngineException("Error to check source info reported correctly from subparser", sourceInformation, EngineErrorType.PARSER);
+            case "dummyExecOptionWithParam":
+                return new DummyExecOptionWithParameters(code.getCode(), code.getSourceInformation());
+            case "dummyExecOption":
+                return new DummyExecOption(code.getSourceInformation());
+            default:
+                return null;
+        }
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
+++ b/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption.DummyCompilerExtension

--- a/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.service.grammar.from.IServiceParserExtension
+++ b/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.service.grammar.from.IServiceParserExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption.DummyServiceParserExtension

--- a/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension
+++ b/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption.DummyServiceGrammarComposerExtension

--- a/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension
+++ b/legend-engine-language-pure-dsl-service/src/test/resources/META-INF/services/org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.org.finos.legend.engine.language.pure.dsl.service.test.executionoption.DummyPureProtocolExtension

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionOption/ExecutionOption.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionOption/ExecutionOption.java
@@ -15,8 +15,10 @@
 package org.finos.legend.engine.protocol.pure.v1.model.executionOption;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type")
 public abstract class ExecutionOption
 {
+    public SourceInformation sourceInformation;
 }


### PR DESCRIPTION
This expose the service feature that legend-pure already supports.  Execution options are implemented as extensions that different DSL modules can implement, hence the grammar is done thru islands (#{...}#).