### PR TITLE
Fixes to allow usage of meta::pure::mapping::from on functions

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
@@ -257,7 +257,7 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     {
         // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
         org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(packageableRuntime._package);
-        PackageableElement stub = new Root_meta_pure_metamodel_PackageableElement_Impl("")._package(pack)._name(packageableRuntime.name);
+        PackageableElement stub = new Root_meta_pure_runtime_PackageableRuntime_Impl("")._package(pack)._name(packageableRuntime.name);
         pack._childrenAdd(stub);
         return stub;
     }
@@ -267,7 +267,7 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     {
         // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
         org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(packageableConnection._package);
-        PackageableElement stub = new Root_meta_pure_metamodel_PackageableElement_Impl("")._package(pack)._name(packageableConnection.name);
+        PackageableElement stub = new Root_meta_pure_runtime_PackageableConnection_Impl("")._package(pack)._name(packageableConnection.name);
         pack._childrenAdd(stub);
         // NOTE: the whole point of this processing is to put the Pure Connection in an index
         final org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Connection connection = packageableConnection.connectionValue.accept(new ConnectionFirstPassBuilder(this.context));

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -403,7 +403,6 @@ public class PureModel implements IPureModel
         // Fourth pass - qualifiers
         pure.classes.forEach(el -> visitWithErrorHandling(el, new PackageableElementFourthPassBuilder(this.getContext(el))));
         pure.associations.forEach(el -> visitWithErrorHandling(el, new PackageableElementThirdPassBuilder(this.getContext(el))));
-        pure.functions.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
     }
 
     private void loadStores(PureModelContextDataIndex pure)
@@ -439,6 +438,8 @@ public class PureModel implements IPureModel
 
     private void loadOtherElementsPostConnectionsAndRuntimes(PureModelContextDataIndex pure)
     {
+        // functions might reference runtime and connections
+        pure.functions.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
         loadOtherElements(pure, p -> p.getPrerequisiteClasses().contains(PackageableConnection.class) || p.getPrerequisiteClasses().contains(PackageableRuntime.class));
     }
 

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -80,12 +80,14 @@ import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_generics_Ge
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_PackageableRuntime;
 import org.finos.legend.pure.generated.Root_meta_pure_tds_AggregateValue_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_tds_BasicColumnSpecification_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_tds_SortInformation_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_tds_TdsOlapAggregation_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_tds_TdsOlapRank_Impl;
 import org.finos.legend.pure.generated.platform_pure_graph;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.AbstractProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
@@ -132,7 +134,18 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     @Override
     public ValueSpecification visit(org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.PackageableElementPtr packageableElementPtr)
     {
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement packageableElement = this.context.resolvePackageableElement(packageableElementPtr.fullPath, packageableElementPtr.sourceInformation);
+        PackageableElement packageableElement = this.context.resolvePackageableElement(packageableElementPtr.fullPath, packageableElementPtr.sourceInformation);
+        if (packageableElement instanceof Root_meta_pure_runtime_PackageableRuntime)
+        {
+            return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("")
+                    ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("")._rawType(this.context.resolveType("meta::pure::runtime::Runtime")))
+                    ._multiplicity(this.context.pureModel.getMultiplicity("one"))
+                    ._values(FastList.newListWith(this.context.resolveRuntime(packageableElementPtr.fullPath, packageableElementPtr.sourceInformation)));
+        }
+        else if(packageableElement._classifierGenericType() == null)
+        {
+            throw new EngineException("Not supported as a value specification: " + packageableElementPtr.fullPath, packageableElementPtr.sourceInformation, EngineErrorType.COMPILATION);
+        }
 
         return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("")
                 ._genericType(packageableElement._classifierGenericType())

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure
@@ -36,6 +36,12 @@ function test::fetch(ip: String[*]): String[1]
    test::Person.all()->filter(x|$x.firstName->in($ip))->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#)
 }
 
+function test::fetchWithFrom(ip: String[*]): String[1]
+{
+   test::Person.all()->filter(x|$x.firstName->in($ip))->from(test::Map, test::Runtime)->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#)
+}
+
+
 
 ###Mapping
 Mapping test::Map


### PR DESCRIPTION
To properly support meta::pure::mapping::from, the functions second pass needs to happen after connections and runtime to ensure these can be properly accessed while resolving function arguments.  

Also, given runtime are not really packaged, the stub needs to be converted to an actual runtime. 