### PR TITLE
Add support for function/service parameters as sources of external format connections [WIP]

### DIFF
--- a/legend-engine-external-format-flatdata-runtime/src/test/java/org/finos/legend/engine/external/format/flatdata/read/test/TestFlatDataQueries.java
+++ b/legend-engine-external-format-flatdata-runtime/src/test/java/org/finos/legend/engine/external/format/flatdata/read/test/TestFlatDataQueries.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.external.format.flatdata.read.test;
 
 import net.javacrumbs.jsonunit.JsonMatchers;
+import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.engine.external.format.flatdata.fromModel.ModelToFlatDataConfiguration;
 import org.finos.legend.engine.external.format.flatdata.toModel.FlatDataToModelConfiguration;
 import org.finos.legend.engine.external.shared.format.model.test.ModelToSchemaGenerationTest;
@@ -25,12 +26,7 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Objects;
+import java.io.InputStream;
 
 import static org.finos.legend.engine.external.shared.format.model.test.SchemaToModelGenerationTest.newExternalSchemaSetGrammarBuilder;
 
@@ -325,6 +321,34 @@ public class TestFlatDataQueries extends TestExternalFormatQueries
         MatcherAssert.assertThat(result, JsonMatchers.jsonEquals(resourceReader("queries/deserializeAndMapMultiSectionCsvResult.json")));
     }
 
+    @Test
+    public void testParameterInputFlatData()
+    {
+        String modelGrammar = firmModel();
+        PureModelContextData generated = ModelToSchemaGenerationTest.generateSchema(modelGrammar, toFlatDataConfig("test::firm::model::Person"));
+
+        String grammar = firmSelfMapping() + parameterRuntime("test::firm::mapping::SelfMapping", "test::gen::TestBinding", "flatDataInput");
+        String externalizeResult = runTest(generated,
+                grammar,
+                "{flatDataInput:String[1] | test::firm::model::Person.all()->graphFetch(" + personTree() + ")->externalize(test::gen::TestBinding)}",
+                "test::firm::mapping::SelfMapping",
+                "test::runtime",
+                (InputStream) null,
+                Maps.mutable.of("flatDataInput", resourceAsString("queries/peopleWithExactHeadings.csv")));
+
+        Assert.assertEquals(resourceAsString("queries/peopleWithExactHeadings.csv"), externalizeResult);
+
+        String serializeResult = runTest(generated,
+                grammar,
+                "{flatDataInput:String[1] | test::firm::model::Person.all()->graphFetchChecked(" + personTree() + ")->serialize(" + personTree() + ")}",
+                "test::firm::mapping::SelfMapping",
+                "test::runtime",
+                (InputStream) null,
+                Maps.mutable.of("flatDataInput", resourceAsString("queries/peopleWithExactHeadings.csv")));
+
+        MatcherAssert.assertThat(serializeResult, JsonMatchers.jsonEquals(resourceReader("queries/peopleCheckedResult.json")));
+    }
+
     private String tradeSelfMapping()
     {
         return "###Mapping\n" +
@@ -389,20 +413,5 @@ public class TestFlatDataQueries extends TestExternalFormatQueries
         config.purifyNames = true;
         config.schemaClassName = schemaClassName;
         return config;
-    }
-
-    private String resourceAsString(String path)
-    {
-        byte[] bytes;
-        try
-        {
-            bytes = Files.readAllBytes(Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(path), "Failed to get resource " + path).toURI()));
-        }
-        catch (IOException | URISyntaxException e)
-        {
-            throw new RuntimeException(e);
-        }
-        String string = new String(bytes, StandardCharsets.UTF_8);
-        return string.replaceAll("\\R", "\n");
     }
 }

--- a/legend-engine-external-format-xml-runtime/src/test/java/org/finos/legend/engine/external/format/xml/test/TestXmlQueries.java
+++ b/legend-engine-external-format-xml-runtime/src/test/java/org/finos/legend/engine/external/format/xml/test/TestXmlQueries.java
@@ -15,9 +15,9 @@
 package org.finos.legend.engine.external.format.xml.test;
 
 import net.javacrumbs.jsonunit.JsonMatchers;
+import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.engine.external.shared.runtime.test.TestExternalFormatQueries;
 import org.hamcrest.MatcherAssert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestXmlQueries extends TestExternalFormatQueries
@@ -145,6 +145,20 @@ public class TestXmlQueries extends TestExternalFormatQueries
                                 resource("queries/firmWithXsiNil.xml"));
 
         MatcherAssert.assertThat(result, JsonMatchers.jsonEquals(resourceReader("queries/firmWithXsiNilCheckedResult.json")));
+    }
+
+    @Test
+    public void testParameterInputXML()
+    {
+        String grammar = firmModel() + firmSelfMapping() + schemalessBinding() + parameterRuntime("test::firm::mapping::SelfMapping", "test::firm::Binding", "xmlInput");
+        String result = runTest(grammar,
+                "{xmlInput:String[1] | test::firm::model::Firm.all()->graphFetchChecked(" + firmTree() + ")->serialize(" + firmTree() + ")}",
+                "test::firm::mapping::SelfMapping",
+                "test::runtime",
+                null,
+                Maps.mutable.of("xmlInput", resourceAsString("queries/oneFirm.xml")));
+
+        MatcherAssert.assertThat(result, JsonMatchers.jsonEquals(resourceReader("queries/oneFirmCheckedResult.json")));
     }
 
     private String schemalessBinding()

--- a/legend-engine-external-shared-format-model/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/externalSource/ExternalSourceSpecificationLexerGrammar.g4
+++ b/legend-engine-external-shared-format-model/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/externalSource/ExternalSourceSpecificationLexerGrammar.g4
@@ -4,3 +4,6 @@ import CoreLexerGrammar;
 
 URL_STREAM_ESP:                             'UrlStream';
 URL:                                        'url';
+
+PARAMETER_ESP:                              'Parameter';
+NAME:                                       'name';

--- a/legend-engine-external-shared-format-model/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/externalSource/ExternalSourceSpecificationParserGrammar.g4
+++ b/legend-engine-external-shared-format-model/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/externalSource/ExternalSourceSpecificationParserGrammar.g4
@@ -7,7 +7,7 @@ options
     tokenVocab = ExternalSourceSpecificationLexerGrammar;
 }
 
-identifier:                      VALID_STRING
+identifier:                      VALID_STRING | STRING | URL_STREAM_ESP | URL | PARAMETER_ESP | NAME
 ;
 
 // ----------------------------- EXTERNAL FORMAT CONNECTION EXTERNAL SOURCE SPEC -----------------------------
@@ -18,4 +18,12 @@ urlStreamExternalSourceSpecification:           URL_STREAM_ESP
                                                 BRACE_CLOSE
 ;
 urlStreamUrl:                               URL COLON STRING SEMI_COLON
+;
+
+parameterExternalSourceSpecification:           PARAMETER_ESP
+                                                BRACE_OPEN
+                                                    parameterName*
+                                                BRACE_CLOSE
+;
+parameterName:                                  NAME COLON STRING SEMI_COLON
 ;

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ExternalFormatConnectionCompilerExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ExternalFormatConnectionCompilerExtension.java
@@ -22,6 +22,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalFormatConnection;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalSource;
+import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ParameterExternalSource;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.UrlStreamExternalSource;
 import org.finos.legend.engine.shared.core.function.Procedure3;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
@@ -30,6 +31,7 @@ import org.finos.legend.pure.generated.Root_meta_external_shared_format_executio
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_ExternalFormatConnection_Impl;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_ExternalSource;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_UrlStreamExternalSource_Impl;
+import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_ParameterExternalSource_Impl;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 
 import java.util.Collections;
@@ -99,6 +101,12 @@ public class ExternalFormatConnectionCompilerExtension implements IExternalForma
                 UrlStreamExternalSource urlStreamExternalSource = (UrlStreamExternalSource) spec;
                 return new Root_meta_external_shared_format_executionPlan_UrlStreamExternalSource_Impl("")
                         ._url(urlStreamExternalSource.url);
+            }
+            else if (spec instanceof ParameterExternalSource)
+            {
+                ParameterExternalSource parameterExternalSource = (ParameterExternalSource) spec;
+                return new Root_meta_external_shared_format_executionPlan_ParameterExternalSource_Impl("")
+                        ._name(parameterExternalSource.name);
             }
             return null;
         });

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ExternalFormatConnectionGrammarParserExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ExternalFormatConnectionGrammarParserExtension.java
@@ -72,6 +72,8 @@ public class ExternalFormatConnectionGrammarParserExtension implements IExternal
                                              {
                                                  case "UrlStream":
                                                      return parseDataSourceSpecification(code, p -> walker.visitUrlStreamExternalSourceSpecification(code, p.urlStreamExternalSourceSpecification()));
+                                                 case "Parameter":
+                                                     return parseDataSourceSpecification(code, p -> walker.visitParameterExternalSourceSpecification(code, p.parameterExternalSourceSpecification()));
                                                  default:
                                                      return null;
                                              }

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/externalSource/ExternalSourceSpecificationParseTreeWalker.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/externalSource/ExternalSourceSpecificationParseTreeWalker.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.language.pure.grammar.from.externalSource;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserUtility;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.connection.externalSource.ExternalSourceSpecificationParserGrammar;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalSource;
+import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ParameterExternalSource;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.UrlStreamExternalSource;
 
 public class ExternalSourceSpecificationParseTreeWalker
@@ -27,6 +28,15 @@ public class ExternalSourceSpecificationParseTreeWalker
         extSource.sourceInformation = code.getSourceInformation();
         ExternalSourceSpecificationParserGrammar.UrlStreamUrlContext urlCtx = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.urlStreamUrl(), "url", code.getSourceInformation());
         extSource.url = PureGrammarParserUtility.fromGrammarString(urlCtx.STRING().getText(), true);
+        return extSource;
+    }
+
+    public ExternalSource visitParameterExternalSourceSpecification(ExternalSourceSpecificationSourceCode code, ExternalSourceSpecificationParserGrammar.ParameterExternalSourceSpecificationContext ctx)
+    {
+        ParameterExternalSource extSource = new ParameterExternalSource();
+        extSource.sourceInformation = code.getSourceInformation();
+        ExternalSourceSpecificationParserGrammar.ParameterNameContext parameterNameContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.parameterName(), "name", code.getSourceInformation());
+        extSource.name = PureGrammarParserUtility.fromGrammarString(parameterNameContext.STRING().getText(), true);
         return extSource;
     }
 }

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/to/ExternalFormatGrammarComposerExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/to/ExternalFormatGrammarComposerExtension.java
@@ -32,6 +32,7 @@ import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shar
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalSource;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.Binding;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.UrlStreamExternalSource;
+import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ParameterExternalSource;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -108,6 +109,14 @@ public class ExternalFormatGrammarComposerExtension implements IExternalFormatGr
                 return "UrlStream\n" +
                         context.getIndentationString() + getTabString(1) + "{\n" +
                         context.getIndentationString() + getTabString(2) + "url: " + convertString(spec.url, true) + ";\n" +
+                        context.getIndentationString() + getTabString(1) + "}";
+            }
+            else if (specification instanceof ParameterExternalSource)
+            {
+                ParameterExternalSource spec = (ParameterExternalSource) specification;
+                return "Parameter\n" +
+                        context.getIndentationString() + getTabString(1) + "{\n" +
+                        context.getIndentationString() + getTabString(2) + "name: " + convertString(spec.name, true) + ";\n" +
                         context.getIndentationString() + getTabString(1) + "}";
             }
 

--- a/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestExternalFormatConnectionCompilation.java
+++ b/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestExternalFormatConnectionCompilation.java
@@ -19,6 +19,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_ExternalFormatConnection;
+import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_ParameterExternalSource;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_UrlStreamExternalSource;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Runtime;
 import org.junit.Assert;
@@ -131,5 +132,110 @@ public class TestExternalFormatConnectionCompilation
         Root_meta_external_shared_format_executionPlan_ExternalFormatConnection connection = (Root_meta_external_shared_format_executionPlan_ExternalFormatConnection) runtime._connections().toList().get(0);
         Assert.assertTrue(connection._externalSource() instanceof Root_meta_external_shared_format_executionPlan_UrlStreamExternalSource);
         Assert.assertEquals("executor:default", ((Root_meta_external_shared_format_executionPlan_UrlStreamExternalSource) connection._externalSource())._url());
+    }
+
+    @Test
+    public void testPackageableParameterExternalFormatConnection()
+    {
+        Pair<PureModelContextData, PureModel> compiledGraph = test(
+                "###Pure\n" +
+                        "Class meta::firm::Person\n" +
+                        "{\n" +
+                        "  fullName: String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "###ExternalFormat\n" +
+                        "SchemaSet meta::firm::SchemaSet\n" +
+                        "{\n" +
+                        "  format: Example;\n" +
+                        "  schemas: [ { content: 'example'; } ];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Binding meta::firm::Binding\n" +
+                        "{\n" +
+                        "  schemaSet: meta::firm::SchemaSet;\n" +
+                        "  contentType: 'text/example';\n" +
+                        "  modelIncludes: [\n" +
+                        "    meta::firm::Person\n" +
+                        "  ];\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Connection\n" +
+                        "ExternalFormatConnection simple::Connection\n" +
+                        "{\n" +
+                        "  store: meta::firm::Binding;\n" +
+                        "  source: Parameter\n" +
+                        "  {\n" +
+                        "    name: 'paramName';\n" +
+                        "  };\n" +
+                        "}\n");
+        Root_meta_external_shared_format_executionPlan_ExternalFormatConnection connection = (Root_meta_external_shared_format_executionPlan_ExternalFormatConnection) compiledGraph.getTwo().getConnection("simple::Connection", SourceInformation.getUnknownSourceInformation());
+        Assert.assertTrue(connection._externalSource() instanceof Root_meta_external_shared_format_executionPlan_ParameterExternalSource);
+        Assert.assertEquals("paramName", ((Root_meta_external_shared_format_executionPlan_ParameterExternalSource) connection._externalSource())._name());
+    }
+
+    @Test
+    public void testParameterExternalFormatConnectionInPackageableRuntime()
+    {
+        Pair<PureModelContextData, PureModel> compiledGraph = test(
+                "###Pure\n" +
+                        "Class meta::firm::Person\n" +
+                        "{\n" +
+                        "  fullName: String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "###ExternalFormat\n" +
+                        "SchemaSet meta::firm::SchemaSet\n" +
+                        "{\n" +
+                        "  format: Example;\n" +
+                        "  schemas: [ { content: 'example'; } ];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Binding meta::firm::Binding\n" +
+                        "{\n" +
+                        "  schemaSet: meta::firm::SchemaSet;\n" +
+                        "  contentType: 'text/example';\n" +
+                        "  modelIncludes: [\n" +
+                        "    meta::firm::Person\n" +
+                        "  ];\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "Mapping test::Mapping\n" +
+                        "(\n" +
+                        "  meta::firm::Person: Pure\n" +
+                        "  {\n" +
+                        "    ~src meta::firm::Person\n" +
+                        "    fullName: $src.fullName\n" +
+                        "  }\n" +
+                        ")\n" +
+                        "###Runtime\n" +
+                        "Runtime test::runtime\n" +
+                        "{\n" +
+                        "  mappings:\n" +
+                        "  [\n" +
+                        "    test::Mapping\n" +
+                        "  ];\n" +
+                        "  connections:\n" +
+                        "  [\n" +
+                        "    meta::firm::Binding:\n" +
+                        "    [\n" +
+                        "      c1:\n" +
+                        "      #{\n" +
+                        "        ExternalFormatConnection\n" +
+                        "        {\n" +
+                        "          source: Parameter\n" +
+                        "          {\n" +
+                        "            name: 'paramName';\n" +
+                        "          };\n" +
+                        "        }\n" +
+                        "      }#\n" +
+                        "    ]\n" +
+                        "  ];\n" +
+                        "}\n");
+        Runtime runtime = compiledGraph.getTwo().getRuntime("test::runtime");
+        Root_meta_external_shared_format_executionPlan_ExternalFormatConnection connection = (Root_meta_external_shared_format_executionPlan_ExternalFormatConnection) runtime._connections().toList().get(0);
+        Assert.assertTrue(connection._externalSource() instanceof Root_meta_external_shared_format_executionPlan_ParameterExternalSource);
+        Assert.assertEquals("paramName", ((Root_meta_external_shared_format_executionPlan_ParameterExternalSource) connection._externalSource())._name());
     }
 }

--- a/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestExternalFormatConnectionGrammarParser.java
+++ b/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestExternalFormatConnectionGrammarParser.java
@@ -112,4 +112,40 @@ public class TestExternalFormatConnectionGrammarParser extends TestGrammarParser
                      "  };\n" +
                      "}\n", "PARSER error at [5:3-9:4]: Field 'url' should be specified only once");
     }
+
+    @Test
+    public void testParameterExternalSource()
+    {
+        // Missing field
+        test("###Connection\n" +
+                "ExternalFormatConnection meta::mySimpleConnection\n" +
+                "{\n" +
+                "  store: domain::SchemaBinding1;\n" +
+                "  source: Parameter\n" +
+                "  {\n" +
+                "  };\n" +
+                "}\n", "PARSER error at [5:3-7:4]: Field 'name' is required");
+
+        //Duplicate field
+        test("###Connection\n" +
+                "ExternalFormatConnection meta::mySimpleConnection\n" +
+                "{\n" +
+                "  store: domain::SchemaBinding1;\n" +
+                "  source: Parameter\n" +
+                "  {\n" +
+                "     name: 'param1';\n" +
+                "     name: 'param2';\n" +
+                "  };\n" +
+                "}\n", "PARSER error at [5:3-9:4]: Field 'name' should be specified only once");
+
+        test("###Connection\n" +
+                "ExternalFormatConnection meta::mySimpleConnection\n" +
+                "{\n" +
+                "  store: domain::SchemaBinding1;\n" +
+                "  source: Parameter\n" +
+                "  {\n" +
+                "     name: 'paramName';\n" +
+                "  };\n" +
+                "}\n");
+    }
 }

--- a/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestExternalFormatConnectionGrammarRoundtrip.java
+++ b/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestExternalFormatConnectionGrammarRoundtrip.java
@@ -31,4 +31,18 @@ public class TestExternalFormatConnectionGrammarRoundtrip extends TestGrammarRou
                      "  };\n" +
                      "}\n");
     }
+
+    @Test
+    public void testParameterExternalConnection()
+    {
+        test("###Connection\n" +
+                "ExternalFormatConnection simple::Parameter\n" +
+                "{\n" +
+                "  store: test::SchemaBinding;\n" +
+                "  source: Parameter\n" +
+                "  {\n" +
+                "    name: 'paramName';\n" +
+                "  };\n" +
+                "}\n");
+    }
 }

--- a/legend-engine-external-shared-format-runtime/src/main/java/org/finos/legend/engine/external/shared/runtime/read/ExecutionHelper.java
+++ b/legend-engine-external-shared-format-runtime/src/main/java/org/finos/legend/engine/external/shared/runtime/read/ExecutionHelper.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.external.shared.runtime.read;
 import org.finos.legend.engine.plan.execution.result.InputStreamResult;
 import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNode;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.external.shared.ParameterExternalSourceExecutionNode;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.external.shared.UrlStreamExecutionNode;
 
 import java.io.InputStream;
@@ -40,6 +41,10 @@ public class ExecutionHelper
         if (executionNode instanceof UrlStreamExecutionNode)
         {
             return ((UrlStreamExecutionNode) executionNode).url;
+        }
+        else if (executionNode instanceof ParameterExternalSourceExecutionNode)
+        {
+            return "parameter:" + ((ParameterExternalSourceExecutionNode) executionNode).name;
         }
         else
         {

--- a/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/external/shared/ExternalFormatProtocolExtension.java
+++ b/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/external/shared/ExternalFormatProtocolExtension.java
@@ -22,6 +22,7 @@ import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNode;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.external.shared.DataQualityExecutionNode;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.external.shared.ParameterExternalSourceExecutionNode;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.external.shared.UrlStreamExecutionNode;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
@@ -30,6 +31,7 @@ import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shar
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalSource;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.Binding;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.UrlStreamExternalSource;
+import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ParameterExternalSource;
 
 import java.util.List;
 
@@ -51,12 +53,14 @@ public class ExternalFormatProtocolExtension implements PureProtocolExtension
 
                 ProtocolSubTypeInfo.Builder.newInstance(ExternalSource.class)
                         .withSubtypes(FastList.newListWith(
-                                Tuples.pair(UrlStreamExternalSource.class, "urlStream")
+                                Tuples.pair(UrlStreamExternalSource.class, "urlStream"),
+                                Tuples.pair(ParameterExternalSource.class, "parameter")
                         )).build(),
                 ProtocolSubTypeInfo.Builder.newInstance(ExecutionNode.class)
                                            .withSubtypes(FastList.newListWith(
                                                    Tuples.pair(DataQualityExecutionNode.class, "dataQuality"),
-                                                   Tuples.pair(UrlStreamExecutionNode.class, "urlStream")
+                                                   Tuples.pair(UrlStreamExecutionNode.class, "urlStream"),
+                                                   Tuples.pair(ParameterExternalSourceExecutionNode.class, "parameterExternalSource")
                                            )).build()
 
         ));

--- a/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/external/shared/ParameterExternalSourceExecutionNode.java
+++ b/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/external/shared/ParameterExternalSourceExecutionNode.java
@@ -1,0 +1,29 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.external.shared;
+
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNode;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNodeVisitor;
+
+public class ParameterExternalSourceExecutionNode extends ExecutionNode
+{
+    public String name;
+
+    @Override
+    public <T> T accept(ExecutionNodeVisitor<T> executionNodeVisitor)
+    {
+        return executionNodeVisitor.visit(this);
+    }
+}

--- a/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/protocol/pure/v1/packageableElement/external/shared/ParameterExternalSource.java
+++ b/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/protocol/pure/v1/packageableElement/external/shared/ParameterExternalSource.java
@@ -1,0 +1,20 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared;
+
+public class ParameterExternalSource extends ExternalSource
+{
+    public String name;
+}

--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestGenerationHelper.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestGenerationHelper.java
@@ -57,6 +57,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.r
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.TestDatabaseAuthenticationStrategy;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.LocalH2DatasourceSpecification;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalFormatConnection;
+import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ParameterExternalSource;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.UrlStreamExternalSource;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.url.DataProtocolHandler;
@@ -272,6 +273,13 @@ public class ServiceTestGenerationHelper
             ExternalFormatConnection conn = (ExternalFormatConnection) connection;
             ExternalFormatConnection testConn = new ExternalFormatConnection();
             testConn.element = conn.element;
+            if (conn.externalSource instanceof ParameterExternalSource)
+            {
+                ParameterExternalSource parameterExternalSource = new ParameterExternalSource();
+                parameterExternalSource.name = ((ParameterExternalSource) conn.externalSource).name;
+                testConn.externalSource = parameterExternalSource;
+                return Optional.of(testConn);
+            }
             UrlStreamExternalSource source = new UrlStreamExternalSource();
             source.url = DataProtocolHandler.DATA_PROTOCOL_NAME + ":" + MediaType.APPLICATION_XML + ";base64," + Base64.getEncoder().encodeToString(idTestDataAccessorResult.getBytes(StandardCharsets.UTF_8));
             testConn.externalSource = source;


### PR DESCRIPTION
This PR adds support for having function/service parameters as sources of external format connections.

Depends on finos/legend-pure#422. Build will fail till legend-pure version uptick happens with this change.