### PR TITLE
Add new APIs to ServiceRunner to allow better programmatic executions

### DIFF
--- a/legend-engine-executionPlan-execution-external-store-service/src/test/java/org/finos/legend/engine/plan/execution/stores/service/utils/ServiceStoreTestUtils.java
+++ b/legend-engine-executionPlan-execution-external-store-service/src/test/java/org/finos/legend/engine/plan/execution/stores/service/utils/ServiceStoreTestUtils.java
@@ -105,7 +105,7 @@ public class ServiceStoreTestUtils
         Map<String, Result> vars = org.eclipse.collections.impl.factory.Maps.mutable.ofInitialCapacity(params.size());
         params.forEach((key, value) -> vars.put(key, new ConstantResult(value)));
 
-        JsonStreamingResult result = (JsonStreamingResult) planExecutor.execute(singleExecutionPlan, vars, null, Lists.mutable.with(new KerberosProfile(LocalCredentials.INSTANCE)), null);
+        JsonStreamingResult result = (JsonStreamingResult) planExecutor.execute(singleExecutionPlan, vars, (String) null, Lists.mutable.with(new KerberosProfile(LocalCredentials.INSTANCE)), null);
         return result.flush(new JsonStreamToJsonDefaultSerializer(result));
     }
 }

--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/PlanExecutor.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/PlanExecutor.java
@@ -150,6 +150,11 @@ public class PlanExecutor
     // TODO: Build a user friendly API
     public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider, PlanExecutionContext planExecutionContext)
     {
+        return execute(executionPlan, params, inputStreamProvider, null, planExecutionContext);
+    }
+
+    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider, MutableList<CommonProfile> profiles, PlanExecutionContext planExecutionContext)
+    {
         SingleExecutionPlan singleExecutionPlan = executionPlan.getSingleExecutionPlan(params);
         try
         {
@@ -159,7 +164,7 @@ public class PlanExecutor
             }
             Map<String, Result> vars = Maps.mutable.ofInitialCapacity(params.size());
             params.forEach((key, value) -> vars.put(key, new ConstantResult(value)));
-            return execute(singleExecutionPlan, vars, null, null, planExecutionContext);
+            return execute(singleExecutionPlan, vars, (String) null, profiles, planExecutionContext);
         }
         finally
         {

--- a/legend-engine-language-pure-dsl-service-execution/pom.xml
+++ b/legend-engine-language-pure-dsl-service-execution/pom.xml
@@ -78,6 +78,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
@@ -32,14 +32,10 @@ import org.finos.legend.engine.plan.execution.result.json.JsonStreamingResult;
 import org.finos.legend.engine.plan.execution.result.object.StreamingObjectResult;
 import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
 import org.finos.legend.engine.plan.execution.stores.StoreExecutor;
-import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.CompositeExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
-import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
-import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.result.ResultType;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.identity.credential.LegendKerberosCredential;
-import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 import org.finos.legend.server.pac4j.kerberos.KerberosProfile;
 import org.pac4j.core.profile.CommonProfile;
@@ -150,20 +146,20 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
 
     protected ExecutionBuilder executionBuilder(ServiceRunnerInput serviceRunnerInput, StreamProvider streamProvider)
     {
-        List<ServiceParameter> parameters = this.getParameters();
+        List<ServiceVariable> variables = this.getServiceVariables();
 
         List<Object> args = serviceRunnerInput.getArgs();
 
-        if (args.size() != parameters.size())
+        if (args.size() != variables.size())
         {
-            throw new IllegalArgumentException("Unexpected number of parameters. Expected parameter size: " + parameters.size() +  ", Passed parameter size: " + args.size());
+            throw new IllegalArgumentException("Unexpected number of parameters. Expected parameter size: " + variables.size() +  ", Passed parameter size: " + args.size());
         }
 
-        ExecutionBuilder executionBuilder = newExecutionBuilder(parameters.size()).withServiceRunnerInput(serviceRunnerInput).withStreamProvider(streamProvider);
+        ExecutionBuilder executionBuilder = newExecutionBuilder(variables.size()).withServiceRunnerInput(serviceRunnerInput).withStreamProvider(streamProvider);
 
-        for (int i = 0; i < parameters.size(); i++)
+        for (int i = 0; i < variables.size(); i++)
         {
-            ServiceParameter executionParameter = parameters.get(i);
+            ServiceVariable executionParameter = variables.get(i);
             Object arg = args.get(i);
             if (arg != null)
             {

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
@@ -144,7 +144,7 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
         return this.executor.getPlanExecutorInfo();
     }
 
-    protected ExecutionBuilder executionBuilder(ServiceRunnerInput serviceRunnerInput, StreamProvider streamProvider)
+    private ExecutionBuilder newExecutionBuilder(ServiceRunnerInput serviceRunnerInput, StreamProvider streamProvider)
     {
         List<ServiceVariable> variables = this.getServiceVariables();
 
@@ -178,12 +178,12 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
 
     public void run(ServiceRunnerInput serviceRunnerInput, StreamProvider streamProvider, OutputStream outputStream)
     {
-        this.executionBuilder(serviceRunnerInput, streamProvider).executeToStream(outputStream);
+        this.newExecutionBuilder(serviceRunnerInput, streamProvider).executeToStream(outputStream);
     }
 
     public Result execute(ServiceRunnerInput serviceRunnerInput, StreamProvider streamProvider)
     {
-        return this.executionBuilder(serviceRunnerInput, streamProvider).execute();
+        return this.newExecutionBuilder(serviceRunnerInput, streamProvider).execute();
     }
 
     @Override

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
@@ -33,9 +33,11 @@ import org.finos.legend.engine.plan.execution.result.object.StreamingObjectResul
 import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
 import org.finos.legend.engine.plan.execution.stores.StoreExecutor;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.identity.credential.LegendKerberosCredential;
+import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 import org.finos.legend.server.pac4j.kerberos.KerberosProfile;
 import org.pac4j.core.profile.CommonProfile;
@@ -221,6 +223,12 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
                 return new MultiParameterExecutionBuilder(parameterCount);
             }
         }
+    }
+
+    protected ServiceVariable newServiceVariable(String name, Class<?> type, int multiplicityLoweBound, Integer multiplicityUpperBound)
+    {
+        Assert.assertFalse(type.isPrimitive(), () -> "type should not be the primitive class");
+        return new ServiceVariable(name, type, new Multiplicity(multiplicityLoweBound, multiplicityUpperBound));
     }
 
     protected ExecutionBuilder newNoParameterExecutionBuilder()
@@ -410,11 +418,10 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
         @Override
         protected void addParameter(String name, Object value)
         {
-            if (!this.parameters.isEmpty())
+            if(value != null)
             {
-                throw new IllegalStateException("Single parameter already exists");
+                this.parameters = Collections.singletonMap(name, value);
             }
-            this.parameters = Collections.singletonMap(name, value);
         }
 
         @Override
@@ -441,7 +448,10 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
         @Override
         protected void addParameter(String name, Object value)
         {
-            this.parameters.put(name, value);
+            if (value != null)
+            {
+                this.parameters.put(name, value);
+            }
         }
 
         @Override

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
@@ -148,30 +148,6 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
         return this.executor.getPlanExecutorInfo();
     }
 
-    @Override
-    public ResultType getResultType()
-    {
-        if (this.plan instanceof SingleExecutionPlan)
-        {
-            return ((SingleExecutionPlan) this.plan).rootExecutionNode.resultType;
-        }
-        else if(this.plan instanceof CompositeExecutionPlan)
-        {
-            List<ResultType> resultTypes = ((CompositeExecutionPlan) this.plan).executionPlans.values()
-                    .stream()
-                    .map(x -> x.rootExecutionNode.resultType)
-                    .collect(Collectors.toList());
-
-            Assert.assertFalse(resultTypes.isEmpty(), () -> "Composite plan without any actual plan?");
-            Assert.assertTrue(resultTypes.stream().allMatch(x -> x.getClass().equals(resultTypes.get(0).getClass())), () -> "Composite with different result types among plans?");
-            return resultTypes.get(0);
-        }
-        else
-        {
-            throw new UnsupportedOperationException("Not supported: " + this.plan.getClass());
-        }
-    }
-
     protected ExecutionBuilder executionBuilder(ServiceRunnerInput serviceRunnerInput, StreamProvider streamProvider)
     {
         List<ServiceParameter> parameters = this.getParameters();

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceParameter.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceParameter.java
@@ -1,0 +1,53 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.dsl.service.execution;
+
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
+import org.finos.legend.engine.shared.core.operational.Assert;
+
+public class ServiceParameter
+{
+    private final String name;
+    private final Class<?> type;
+    private final Multiplicity multiplicity;
+
+    public ServiceParameter(String name, Class<?> type, Multiplicity multiplicity)
+    {
+        Assert.assertFalse(type.isPrimitive(), () -> "type should not be the primitive class");
+        this.name = name;
+        this.type = type;
+        this.multiplicity = multiplicity;
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public Class<?> getType()
+    {
+        return this.type;
+    }
+
+    public boolean isOptional()
+    {
+        return this.multiplicity.lowerBound < 1;
+    }
+
+    public boolean isToMany()
+    {
+        return this.multiplicity.isUpperBoundGreaterThan(1);
+    }
+}

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
@@ -16,6 +16,8 @@ package org.finos.legend.engine.language.pure.dsl.service.execution;
 
 import org.finos.legend.engine.plan.execution.PlanExecutorInfo;
 import org.finos.legend.engine.plan.execution.cache.graphFetch.GraphFetchCrossAssociationKeys;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.result.ResultType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -47,6 +49,21 @@ public interface ServiceRunner
      * @return plan executor information
      */
     PlanExecutorInfo getPlanExecutorInfo();
+
+    /**
+     * Get the service result output type
+     * @return service result output type
+     */
+    ResultType getResultType();
+
+    /**
+     * Get the list of parameters the service expects
+     * @return service parameters
+     */
+    default List<ServiceParameter> getParameters()
+    {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 
     /**
      * Run the service and return the serialized result

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
@@ -51,12 +51,6 @@ public interface ServiceRunner
     PlanExecutorInfo getPlanExecutorInfo();
 
     /**
-     * Get the service result output type
-     * @return service result output type
-     */
-    ResultType getResultType();
-
-    /**
      * Get the list of parameters the service expects
      * @return service parameters
      */

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceRunner.java
@@ -16,8 +16,6 @@ package org.finos.legend.engine.language.pure.dsl.service.execution;
 
 import org.finos.legend.engine.plan.execution.PlanExecutorInfo;
 import org.finos.legend.engine.plan.execution.cache.graphFetch.GraphFetchCrossAssociationKeys;
-import org.finos.legend.engine.plan.execution.result.Result;
-import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.result.ResultType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -51,10 +49,10 @@ public interface ServiceRunner
     PlanExecutorInfo getPlanExecutorInfo();
 
     /**
-     * Get the list of parameters the service expects
-     * @return service parameters
+     * Get the list of variables the service expects
+     * @return service variables
      */
-    default List<ServiceParameter> getParameters()
+    default List<ServiceVariable> getServiceVariables()
     {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceVariable.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceVariable.java
@@ -15,7 +15,6 @@
 package org.finos.legend.engine.language.pure.dsl.service.execution;
 
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
-import org.finos.legend.engine.shared.core.operational.Assert;
 
 public class ServiceVariable
 {
@@ -25,7 +24,6 @@ public class ServiceVariable
 
     public ServiceVariable(String name, Class<?> type, Multiplicity multiplicity)
     {
-        Assert.assertFalse(type.isPrimitive(), () -> "type should not be the primitive class");
         this.name = name;
         this.type = type;
         this.multiplicity = multiplicity;

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceVariable.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/ServiceVariable.java
@@ -17,13 +17,13 @@ package org.finos.legend.engine.language.pure.dsl.service.execution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 import org.finos.legend.engine.shared.core.operational.Assert;
 
-public class ServiceParameter
+public class ServiceVariable
 {
     private final String name;
     private final Class<?> type;
     private final Multiplicity multiplicity;
 
-    public ServiceParameter(String name, Class<?> type, Multiplicity multiplicity)
+    public ServiceVariable(String name, Class<?> type, Multiplicity multiplicity)
     {
         Assert.assertFalse(type.isPrimitive(), () -> "type should not be the primitive class");
         this.name = name;

--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -72,7 +72,6 @@ public class TestServiceRunner
 
         String result = simpleM2MServiceRunner.run(serviceRunnerInput);
         Assert.assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}}", result);
-        MatcherAssert.assertThat(simpleM2MServiceRunner.getResultType(), CoreMatchers.instanceOf(DataTypeResultType.class));
     }
 
     @Test

--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -34,7 +34,6 @@ import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransforme
 import org.finos.legend.engine.plan.platform.PlanPlatform;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
-import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.result.DataTypeResultType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Function;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 import org.finos.legend.engine.shared.javaCompiler.EngineJavaCompiler;
@@ -322,9 +321,9 @@ public class TestServiceRunner
         }
 
         @Override
-        public List<ServiceParameter> getParameters()
+        public List<ServiceVariable> getServiceVariables()
         {
-            return Collections.singletonList(new ServiceParameter("input", String.class, PURE_ONE));
+            return Collections.singletonList(new ServiceVariable("input", String.class, PURE_ONE));
         }
     }
 
@@ -336,11 +335,11 @@ public class TestServiceRunner
         }
 
         @Override
-        public List<ServiceParameter> getParameters()
+        public List<ServiceVariable> getServiceVariables()
         {
             return Lists.mutable.of(
-                    new ServiceParameter("input1", String.class, PURE_ONE),
-                    new ServiceParameter("input2", String.class, PURE_ONE)
+                    new ServiceVariable("input1", String.class, PURE_ONE),
+                    new ServiceVariable("input2", String.class, PURE_ONE)
             );
         }
     }
@@ -353,9 +352,9 @@ public class TestServiceRunner
         }
 
         @Override
-        public List<ServiceParameter> getParameters()
+        public List<ServiceVariable> getServiceVariables()
         {
-            return Collections.singletonList(new ServiceParameter("input", String.class, PURE_ONE));
+            return Collections.singletonList(new ServiceVariable("input", String.class, PURE_ONE));
         }
     }
 
@@ -367,9 +366,9 @@ public class TestServiceRunner
         }
 
         @Override
-        public List<ServiceParameter> getParameters()
+        public List<ServiceVariable> getServiceVariables()
         {
-            return Collections.singletonList(new ServiceParameter("ip", String.class, PURE_MANY));
+            return Collections.singletonList(new ServiceVariable("ip", String.class, PURE_MANY));
         }
     }
 
@@ -384,7 +383,7 @@ public class TestServiceRunner
         }
 
         @Override
-        public List<ServiceParameter> getParameters()
+        public List<ServiceVariable> getServiceVariables()
         {
             return Collections.emptyList();
         }


### PR DESCRIPTION
This PR adds new APIs to ServiceRunner to be able to:

- Get the service result type - useful to know how to parse the results of the execution (tds, graph, constant value, etc)
- Get the list of variables the service expects and details of these variables - useful when operating on the ServicerRunner interface rather than on the SDLC generated instance.  

With the changes, the PR also ensure all the run/execution APIs support the same features, reducing confusion among users.

This also moves execution logic from legend-sdlc, letting SDLC define the service and its arguments, and engine to define how these will be use and executed. 