### PR TITLE
Prevent jackson from closing the output stream when generating JSON

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/json/JsonSerializer.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/json/JsonSerializer.java
@@ -27,6 +27,7 @@ abstract class JsonSerializer extends Serializer
     {
         return new JsonFactory().createGenerator(stream)
                 .disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)
+                .disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
                 .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
     }
 }

--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/ExecutionResultObjectMapperFactory.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/ExecutionResultObjectMapperFactory.java
@@ -32,6 +32,7 @@ public class ExecutionResultObjectMapperFactory
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+        objectMapper.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
         SimpleModule simpleModule = new SimpleModule();
         simpleModule.addSerializer(PureDate.class, new ExecutionResultObjectMapperFactory.PureDateSerializer());
         objectMapper.registerModule(simpleModule);

--- a/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/test/serialization/TestExecutionResultObjectMapperFactory.java
+++ b/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/test/serialization/TestExecutionResultObjectMapperFactory.java
@@ -15,10 +15,12 @@
 package org.finos.legend.engine.plan.execution.result.test.serialization;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.finos.legend.engine.plan.execution.result.serialization.ExecutionResultObjectMapperFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 
@@ -34,5 +36,21 @@ public class TestExecutionResultObjectMapperFactory
         generator.close();
 
         Assert.assertEquals("Generator should not autoclose JSON array and object", "[{", writer.toString());
+    }
+
+    @Test
+    public void doesNotAutocloseOutputStream() throws IOException
+    {
+        ByteArrayOutputStream os = new ByteArrayOutputStream()
+        {
+            @Override
+            public void close()
+            {
+                Assert.fail("Close should not be call");
+            }
+        };
+
+        ObjectMapper mapper = ExecutionResultObjectMapperFactory.getNewObjectMapper();
+        mapper.writeValue(os, "hello");
     }
 }

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/ObjectMapperFactory.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/ObjectMapperFactory.java
@@ -30,7 +30,8 @@ public class ObjectMapperFactory
         objectMapper
                 .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
                 .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
-                .disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+                .disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)
+                .disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
         objectMapper.setTimeZone(TimeZone.getDefault());
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;

--- a/legend-engine-shared-core/src/test/java/org/finos/legend/engine/shared/core/test/TestObjectMapperFactory.java
+++ b/legend-engine-shared-core/src/test/java/org/finos/legend/engine/shared/core/test/TestObjectMapperFactory.java
@@ -21,6 +21,7 @@ import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
@@ -36,6 +37,22 @@ public class TestObjectMapperFactory
         generator.writeStartObject();
         generator.close();
         Assert.assertEquals("Generator should not autoclose JSON array and object", "[{", writer.toString());
+    }
+
+    @Test
+    public void doesNotAutocloseOutputStream() throws IOException
+    {
+        ByteArrayOutputStream os = new ByteArrayOutputStream()
+        {
+            @Override
+            public void close()
+            {
+                Assert.fail("Close should not be call");
+            }
+        };
+
+        ObjectMapper mapper = ObjectMapperFactory.getNewStandardObjectMapper();
+        mapper.writeValue(os, "hello");
     }
 
     @Test


### PR DESCRIPTION
This prevents exceptions on streams that are sensitive the close call.