### PR TITLE
Create in-memory H2 JDBC URL only for Local H2 connections

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/h2/H2Manager.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/h2/H2Manager.java
@@ -41,7 +41,7 @@ public class H2Manager extends DatabaseManager
             String autoServerMode =  extraUserDataSourceProperties.getProperty(EmbeddedH2DataSourceSpecification.H2_AUTO_SERVER_MODE);
             return "jdbc:h2:file:" + dataDirectoryPath + "/" + databaseName + ";AUTO_SERVER=" + autoServerMode;
         }
-        return "jdbc:h2:tcp://" + host + ":" + port + "/" + (isLocalH2DataSource(extraUserDataSourceProperties) ? "mem:" + databaseName : databaseName);
+        return "jdbc:h2:tcp://" + host + ":" + port + "/" + (isLocalH2DataSource(host, extraUserDataSourceProperties) ? "mem:" + databaseName : databaseName);
     }
 
     @Override
@@ -60,9 +60,9 @@ public class H2Manager extends DatabaseManager
         return properties.containsKey(EmbeddedH2DataSourceSpecification.H2_DATA_DIRECTORY_PATH);
     }
 
-    private boolean isLocalH2DataSource(Properties properties)
+    private boolean isLocalH2DataSource(String host, Properties properties)
     {
-        return properties.containsKey(LocalH2DataSourceSpecification.LOCAL_H2_DATA_SOURCE);
+        return properties.containsKey(LocalH2DataSourceSpecification.LOCAL_H2_DATA_SOURCE) || host.equals("127.0.0.1") || host.equalsIgnoreCase("localhost");
     }
 
     @Override

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/h2/H2Manager.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/h2/H2Manager.java
@@ -20,6 +20,7 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.drive
 import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.EmbeddedH2DataSourceSpecification;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.LocalH2DataSourceSpecification;
 
 import java.util.Properties;
 
@@ -40,7 +41,7 @@ public class H2Manager extends DatabaseManager
             String autoServerMode =  extraUserDataSourceProperties.getProperty(EmbeddedH2DataSourceSpecification.H2_AUTO_SERVER_MODE);
             return "jdbc:h2:file:" + dataDirectoryPath + "/" + databaseName + ";AUTO_SERVER=" + autoServerMode;
         }
-        return "jdbc:h2:tcp://" + host + ":" + port + "/mem:" +databaseName;
+        return "jdbc:h2:tcp://" + host + ":" + port + "/" + (isLocalH2DataSource(extraUserDataSourceProperties) ? "mem:" + databaseName : databaseName);
     }
 
     @Override
@@ -57,6 +58,11 @@ public class H2Manager extends DatabaseManager
     private boolean isEmbeddedMode(Properties properties)
     {
         return properties.containsKey(EmbeddedH2DataSourceSpecification.H2_DATA_DIRECTORY_PATH);
+    }
+
+    private boolean isLocalH2DataSource(Properties properties)
+    {
+        return properties.containsKey(LocalH2DataSourceSpecification.LOCAL_H2_DATA_SOURCE);
     }
 
     @Override

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/LocalH2DataSourceSpecification.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/LocalH2DataSourceSpecification.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications;
 
-import org.finos.legend.engine.plan.execution.stores.relational.connection.RelationalExecutorInfo;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.AuthenticationStrategy;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.DatabaseManager;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.keys.LocalH2DataSourceSpecificationKey;
@@ -31,6 +30,7 @@ import java.util.function.Supplier;
 
 public class LocalH2DataSourceSpecification extends StaticDataSourceSpecification
 {
+    public static final String LOCAL_H2_DATA_SOURCE = "h2_local_data_source";
 
     private static final int MAX_POOL_SIZE = 100;
     private static final int MIN_POOL_SIZE = 0;
@@ -38,6 +38,7 @@ public class LocalH2DataSourceSpecification extends StaticDataSourceSpecificatio
     public LocalH2DataSourceSpecification(List<String> setupSQLs, DatabaseManager databaseManager, AuthenticationStrategy authenticationStrategy)
     {
         super(new LocalH2DataSourceSpecificationKey(setupSQLs), databaseManager, authenticationStrategy, new Properties(), MAX_POOL_SIZE, MIN_POOL_SIZE);
+        this.extraDatasourceProperties.put(LOCAL_H2_DATA_SOURCE, true);
     }
 
     @Override

--- a/legend-engine-executionPlan-execution-store-relational-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/TestConnectionObjectProtocol_server.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/TestConnectionObjectProtocol_server.java
@@ -81,7 +81,7 @@ public class TestConnectionObjectProtocol_server extends org.finos.legend.engine
         String staticDBName = tempFolder.newFolder().getAbsolutePath() + "/staticTestDB";
 
         int port1 = DynamicPortGenerator.generatePort();
-        StaticDataSourceSpecification ds1 = new StaticDataSourceSpecification(new StaticDataSourceSpecificationKey("127.0.0.1", port1, staticDBName), new H2Manager(), new DefaultH2AuthenticationStrategy());
+        StaticDataSourceSpecification ds1 = new StaticDataSourceSpecification(new StaticDataSourceSpecificationKey("0", port1, staticDBName), new H2Manager(), new DefaultH2AuthenticationStrategy());
         Server server1 = AlloyH2Server.startServer(port1);
         try (Connection connection = ds1.getConnectionUsingSubject(null))
         {
@@ -98,7 +98,7 @@ public class TestConnectionObjectProtocol_server extends org.finos.legend.engine
         }
 
         int port2 = DynamicPortGenerator.generatePort();
-        StaticDataSourceSpecification ds2 = new StaticDataSourceSpecification(new StaticDataSourceSpecificationKey("127.0.0.1", port2, staticDBName), new H2Manager(), new DefaultH2AuthenticationStrategy());
+        StaticDataSourceSpecification ds2 = new StaticDataSourceSpecification(new StaticDataSourceSpecificationKey("0", port2, staticDBName), new H2Manager(), new DefaultH2AuthenticationStrategy());
         Server server2 = AlloyH2Server.startServer(port2);
         try (Connection connection = ds2.getConnectionUsingSubject(null))
         {


### PR DESCRIPTION
This PR adds support to connect to a remote H2 database using StaticDataSourceSpecification and DefaultH2AuthenticationStrategy