### PR TITLE
Fix relational executor freemarker exception handling

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational/pom.xml
+++ b/legend-engine-executionPlan-execution-store-relational/pom.xml
@@ -231,6 +231,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <scope>test</scope>

--- a/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/RelationalExecutor.java
+++ b/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/RelationalExecutor.java
@@ -274,10 +274,10 @@ public class RelationalExecutor
         }
         catch (Exception e)
         {
-            LOGGER.info("Exception while reprocessing SQL Query. Detail: " + e.getMessage() + ".");
+            throw new IllegalStateException("Reprocessing sql failed with vars " + executionState.getResults().keySet(), e);
         }
 
-        LOGGER.info(new LogInfo(profiles, LoggingEventType.EXECUTION_RELATIONAL_REPROCESS_SQL, "Reprocessing sql with vars [" + executionState.getResults().keySet() + "]: " + sqlQuery).toString());
+        LOGGER.info(new LogInfo(profiles, LoggingEventType.EXECUTION_RELATIONAL_REPROCESS_SQL, "Reprocessing sql with vars " + executionState.getResults().keySet() + ": " + sqlQuery).toString());
 
         executionState.activities.add(new RelationalExecutionActivity(sqlQuery));
     }

--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/freemarker/FreeMarkerExecutor.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/freemarker/FreeMarkerExecutor.java
@@ -73,7 +73,7 @@ public class FreeMarkerExecutor
 
     private static String process(String input, Map<String, ?> variableMap, String templateFunctions)
     {
-        String result;
+        StringWriter stringWriter = new StringWriter();
         try
         {
             Configuration cfg = new Configuration();
@@ -82,14 +82,12 @@ public class FreeMarkerExecutor
             Map<String, TemplateDateFormatFactory> customDateFormats = Maps.mutable.with("alloyDate", PlanDateParameterDateFormatFactory.INSTANCE);
             template.setCustomDateFormats(customDateFormats);
             template.setDateFormat("@alloyDate");
-            StringWriter stringWriter = new StringWriter();
             template.process(variableMap, stringWriter);
-            result = stringWriter.toString();
+            return stringWriter.toString();
         }
         catch (Exception e)
         {
-            throw new RuntimeException("Issue processing freemarker function: " + e.getMessage(), e);
+            throw new RuntimeException("Issue processing freemarker function.  Template with error: " + stringWriter.toString(), e);
         }
-        return result;
     }
 }


### PR DESCRIPTION
Freemarker exceptions were not bubbling up properly, and query template (before freemarker) were executed, leading to sql exceptions.  By bubbling the freemarker errors, it should be more clear what is the problem.