### PR TITLE
Fix bug in plan executor construction

### DIFF
--- a/legend-engine-executionPlan-execution-store-inMemory/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/FakeRelationalStoreExecutorBuilder.java
+++ b/legend-engine-executionPlan-execution-store-inMemory/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/FakeRelationalStoreExecutorBuilder.java
@@ -1,0 +1,85 @@
+package org.finos.legend.engine.plan.execution.stores.relational.plugin;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.nodes.state.ExecutionState;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.*;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNodeVisitor;
+import org.pac4j.core.profile.CommonProfile;
+
+public class FakeRelationalStoreExecutorBuilder implements StoreExecutorBuilder  {
+
+    @Override
+    public StoreType getStoreType() {
+        return StoreType.Relational;
+    }
+
+    public static class Configuration implements StoreExecutorConfiguration
+    {
+        @Override
+        public StoreType getStoreType() {
+            return StoreType.Relational;
+        }
+    }
+
+    public static class Executor implements StoreExecutor
+    {
+        private StoreExecutorConfiguration configuration;
+
+        public Executor(StoreExecutorConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public StoreExecutorConfiguration getConfiguration() {
+            return configuration;
+        }
+
+        @Override
+        public StoreExecutionState buildStoreExecutionState() {
+            return new StoreExecutionState() {
+                @Override
+                public StoreState getStoreState() {
+                    return null;
+                }
+
+                @Override
+                public ExecutionNodeVisitor<Result> getVisitor(MutableList<CommonProfile> profiles, ExecutionState executionState) {
+                    return null;
+                }
+
+                @Override
+                public StoreExecutionState copy() {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public StoreState getStoreState() {
+            return new StoreState() {
+                @Override
+                public StoreType getStoreType() {
+                    return StoreType.Relational;
+                }
+
+                @Override
+                public Object getStoreExecutionInfo() {
+                    return new Object();
+                }
+            };
+        }
+    }
+
+    @Override
+    public StoreExecutor build()
+    {
+        return new Executor(null);
+    }
+
+    @Override
+    public StoreExecutor build(StoreExecutorConfiguration storeExecutorConfiguration)
+    {
+        return new Executor(storeExecutorConfiguration);
+    }
+}

--- a/legend-engine-executionPlan-execution-store-inMemory/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/FakeServiceStoreExecutorBuilder.java
+++ b/legend-engine-executionPlan-execution-store-inMemory/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/FakeServiceStoreExecutorBuilder.java
@@ -1,0 +1,93 @@
+package org.finos.legend.engine.plan.execution.stores.relational.plugin;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.nodes.state.ExecutionState;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.*;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNodeVisitor;
+import org.pac4j.core.profile.CommonProfile;
+
+public class FakeServiceStoreExecutorBuilder implements StoreExecutorBuilder {
+
+    @Override
+    public StoreType getStoreType() {
+        return StoreType.Service;
+    }
+
+    public static class Configuration implements StoreExecutorConfiguration
+    {
+        @Override
+        public StoreType getStoreType() {
+            return StoreType.Service;
+        }
+    }
+
+    public static class Executor implements StoreExecutor
+    {
+        private final StoreExecutorConfiguration configuration;
+
+        public Executor(StoreExecutorConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        @Override
+        public StoreExecutionState buildStoreExecutionState() {
+            return new StoreExecutionState() {
+                @Override
+                public StoreState getStoreState() {
+                    return new StoreState() {
+                        @Override
+                        public StoreType getStoreType() {
+                            return StoreType.Service;
+                        }
+
+                        @Override
+                        public Object getStoreExecutionInfo() {
+                            return new Object();
+                        }
+                    };
+                }
+
+                @Override
+                public ExecutionNodeVisitor<Result> getVisitor(MutableList<CommonProfile> profiles, ExecutionState executionState) {
+                    return null;
+                }
+
+                @Override
+                public StoreExecutionState copy() {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public StoreState getStoreState() {
+            return new StoreState() {
+                @Override
+                public StoreType getStoreType() {
+                    return StoreType.Service;
+                }
+
+                @Override
+                public Object getStoreExecutionInfo() {
+                    return new Object();
+                }
+            };
+        }
+
+        public StoreExecutorConfiguration getConfiguration() {
+            return configuration;
+        }
+    }
+
+    @Override
+    public StoreExecutor build() {
+        return new Executor(null);
+    }
+
+    @Override
+    public StoreExecutor build(StoreExecutorConfiguration storeExecutorConfiguration) {
+        return new Executor(storeExecutorConfiguration);
+    }
+}

--- a/legend-engine-executionPlan-execution-store-inMemory/src/test/resources/META-INF/services/org.finos.legend.engine.plan.execution.stores.StoreExecutorBuilder
+++ b/legend-engine-executionPlan-execution-store-inMemory/src/test/resources/META-INF/services/org.finos.legend.engine.plan.execution.stores.StoreExecutorBuilder
@@ -1,0 +1,2 @@
+org.finos.legend.engine.plan.execution.stores.relational.plugin.FakeRelationalStoreExecutorBuilder
+org.finos.legend.engine.plan.execution.stores.relational.plugin.FakeServiceStoreExecutorBuilder

--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/PlanExecutor.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/PlanExecutor.java
@@ -47,14 +47,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
+import java.util.*;
 import java.util.stream.Collectors;
 
-public class PlanExecutor
-{
+public class PlanExecutor {
     public static final long DEFAULT_GRAPH_FETCH_BATCH_MEMORY_LIMIT = 52_428_800L; /* 50MB - 50 * 1024 * 1024 */
 
     private static final ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
@@ -65,8 +61,7 @@ public class PlanExecutor
     private final PlanExecutorInfo planExecutorInfo;
     private long graphFetchBatchMemoryLimit;
 
-    private PlanExecutor(boolean isJavaCompilationAllowed, ImmutableList<StoreExecutor> extraExecutors, long graphFetchBatchMemoryLimit)
-    {
+    private PlanExecutor(boolean isJavaCompilationAllowed, ImmutableList<StoreExecutor> extraExecutors, long graphFetchBatchMemoryLimit) {
         EngineUrlStreamHandlerFactory.initialize();
         this.isJavaCompilationAllowed = isJavaCompilationAllowed;
         this.extraExecutors = extraExecutors;
@@ -74,126 +69,104 @@ public class PlanExecutor
         this.graphFetchBatchMemoryLimit = graphFetchBatchMemoryLimit;
     }
 
-    public PlanExecutorInfo getPlanExecutorInfo()
-    {
+    public PlanExecutorInfo getPlanExecutorInfo() {
         return this.planExecutorInfo;
     }
 
-    public Result execute(String executionPlan)
-    {
+    public ImmutableList<StoreExecutor> getExtraExecutors() {
+        return extraExecutors;
+    }
+
+    public Result execute(String executionPlan) {
         return execute(executionPlan, (InputStream) null);
     }
 
-    public Result execute(String executionPlan, String input)
-    {
+    public Result execute(String executionPlan, String input) {
         return execute(executionPlan, input, Collections.emptyMap());
     }
 
-    public Result execute(String executionPlan, Map<String, ?> params)
-    {
+    public Result execute(String executionPlan, Map<String, ?> params) {
         return execute(executionPlan, (InputStream) null, params);
     }
 
-    public Result execute(String executionPlan, String input, Map<String, ?> params)
-    {
+    public Result execute(String executionPlan, String input, Map<String, ?> params) {
         return execute(executionPlan, (input == null) ? null : new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), params);
     }
 
-    public Result execute(String executionPlan, InputStream input)
-    {
+    public Result execute(String executionPlan, InputStream input) {
         return execute(executionPlan, input, Collections.emptyMap());
     }
 
-    public Result execute(String executionPlan, InputStream inputStream, Map<String, ?> params)
-    {
+    public Result execute(String executionPlan, InputStream inputStream, Map<String, ?> params) {
         return execute(readExecutionPlan(executionPlan), inputStream, params);
     }
 
-    public Result execute(ExecutionPlan executionPlan)
-    {
+    public Result execute(ExecutionPlan executionPlan) {
         return execute(executionPlan, (InputStream) null);
     }
 
-    public Result execute(ExecutionPlan executionPlan, String input)
-    {
+    public Result execute(ExecutionPlan executionPlan, String input) {
         return execute(executionPlan, input, Collections.emptyMap());
     }
 
-    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params)
-    {
+    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params) {
         return execute(executionPlan, (InputStream) null, params);
     }
 
-    public Result execute(ExecutionPlan executionPlan, InputStream inputStream)
-    {
+    public Result execute(ExecutionPlan executionPlan, InputStream inputStream) {
         return execute(executionPlan, inputStream, Collections.emptyMap());
     }
 
-    public Result execute(ExecutionPlan executionPlan, String input, Map<String, ?> params)
-    {
+    public Result execute(ExecutionPlan executionPlan, String input, Map<String, ?> params) {
         return execute(executionPlan, (input == null) ? null : new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), params);
     }
 
-    public Result execute(ExecutionPlan executionPlan, InputStream inputStream, Map<String, ?> params)
-    {
+    public Result execute(ExecutionPlan executionPlan, InputStream inputStream, Map<String, ?> params) {
         return execute(executionPlan, params, (inputStream == null) ? null : new InputStreamProvider(inputStream));
     }
 
-    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider)
-    {
+    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider) {
         return execute(executionPlan, params, inputStreamProvider, null);
     }
 
-    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, String user, MutableList<CommonProfile> profiles, PlanExecutionContext planExecutionContext)
-    {
+    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, String user, MutableList<CommonProfile> profiles, PlanExecutionContext planExecutionContext) {
         Map<String, Result> vars = Maps.mutable.ofInitialCapacity(params.size());
         params.forEach((key, value) -> vars.put(key, new ConstantResult(value)));
         return execute(executionPlan.getSingleExecutionPlan(params), vars, user, profiles, planExecutionContext);
     }
 
     // TODO: Build a user friendly API
-    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider, PlanExecutionContext planExecutionContext)
-    {
+    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider, PlanExecutionContext planExecutionContext) {
         return execute(executionPlan, params, inputStreamProvider, null, planExecutionContext);
     }
 
-    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider, MutableList<CommonProfile> profiles, PlanExecutionContext planExecutionContext)
-    {
+    public Result execute(ExecutionPlan executionPlan, Map<String, ?> params, StreamProvider inputStreamProvider, MutableList<CommonProfile> profiles, PlanExecutionContext planExecutionContext) {
         SingleExecutionPlan singleExecutionPlan = executionPlan.getSingleExecutionPlan(params);
-        try
-        {
-            if (inputStreamProvider != null)
-            {
+        try {
+            if (inputStreamProvider != null) {
                 StreamProviderHolder.streamProviderThreadLocal.set(inputStreamProvider);
             }
             Map<String, Result> vars = Maps.mutable.ofInitialCapacity(params.size());
             params.forEach((key, value) -> vars.put(key, new ConstantResult(value)));
             return execute(singleExecutionPlan, vars, (String) null, profiles, planExecutionContext);
-        }
-        finally
-        {
+        } finally {
             StreamProviderHolder.streamProviderThreadLocal.remove();
         }
     }
 
-    public Result execute(SingleExecutionPlan executionPlan, Map<String, Result> vars, String user, MutableList<CommonProfile> profiles)
-    {
+    public Result execute(SingleExecutionPlan executionPlan, Map<String, Result> vars, String user, MutableList<CommonProfile> profiles) {
         return execute(executionPlan, buildDefaultExecutionState(executionPlan, vars), user, profiles);
     }
 
-    public Result execute(SingleExecutionPlan executionPlan, Map<String, Result> vars, String user, MutableList<CommonProfile> profiles, PlanExecutionContext planExecutionContext)
-    {
+    public Result execute(SingleExecutionPlan executionPlan, Map<String, Result> vars, String user, MutableList<CommonProfile> profiles, PlanExecutionContext planExecutionContext) {
         return execute(executionPlan, buildDefaultExecutionState(executionPlan, vars, planExecutionContext), user, profiles);
     }
 
-    public Result execute(SingleExecutionPlan singleExecutionPlan, ExecutionState state, String user, MutableList<CommonProfile> profiles)
-    {
+    public Result execute(SingleExecutionPlan singleExecutionPlan, ExecutionState state, String user, MutableList<CommonProfile> profiles) {
         EngineJavaCompiler engineJavaCompiler = possiblyCompilePlan(singleExecutionPlan, state, profiles);
-        try (JavaHelper.ThreadContextClassLoaderScope scope = (engineJavaCompiler == null) ? null : JavaHelper.withCurrentThreadContextClassLoader(engineJavaCompiler.getClassLoader()))
-        {
+        try (JavaHelper.ThreadContextClassLoaderScope scope = (engineJavaCompiler == null) ? null : JavaHelper.withCurrentThreadContextClassLoader(engineJavaCompiler.getClassLoader())) {
             // set up the state
-            if (singleExecutionPlan.authDependent)
-            {
+            if (singleExecutionPlan.authDependent) {
                 state.setAuthUser((singleExecutionPlan.kerberos == null) ? user : singleExecutionPlan.kerberos);
             }
             singleExecutionPlan.getExecutionStateParams(org.eclipse.collections.api.factory.Maps.mutable.empty()).forEach(state::addParameterValue);
@@ -203,54 +176,41 @@ public class PlanExecutor
         }
     }
 
-    public void setGraphFetchBatchMemoryLimit(long graphFetchBatchMemoryLimit)
-    {
+    public void setGraphFetchBatchMemoryLimit(long graphFetchBatchMemoryLimit) {
         this.graphFetchBatchMemoryLimit = graphFetchBatchMemoryLimit;
     }
 
-    private EngineJavaCompiler possiblyCompilePlan(SingleExecutionPlan plan, ExecutionState state, MutableList<CommonProfile> profiles)
-    {
-        if (state.isJavaCompilationForbidden())
-        {
+    private EngineJavaCompiler possiblyCompilePlan(SingleExecutionPlan plan, ExecutionState state, MutableList<CommonProfile> profiles) {
+        if (state.isJavaCompilationForbidden()) {
             return null;
         }
-        if (state.hasJavaCompiler())
-        {
+        if (state.hasJavaCompiler()) {
             return state.getJavaCompiler();
         }
-        try
-        {
+        try {
             EngineJavaCompiler engineJavaCompiler = JavaHelper.compilePlan(plan, profiles);
-            if (engineJavaCompiler != null)
-            {
+            if (engineJavaCompiler != null) {
                 state.setJavaCompiler(engineJavaCompiler);
             }
             return engineJavaCompiler;
-        }
-        catch (JavaCompileException e)
-        {
+        } catch (JavaCompileException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public ExecutionState buildDefaultExecutionState(SingleExecutionPlan executionPlan, Map<String, Result> vars)
-    {
+    public ExecutionState buildDefaultExecutionState(SingleExecutionPlan executionPlan, Map<String, Result> vars) {
         return buildDefaultExecutionState(executionPlan, vars, null);
     }
 
-    private ExecutionState buildDefaultExecutionState(SingleExecutionPlan executionPlan, Map<String, Result> vars, PlanExecutionContext planExecutionContext)
-    {
+    private ExecutionState buildDefaultExecutionState(SingleExecutionPlan executionPlan, Map<String, Result> vars, PlanExecutionContext planExecutionContext) {
         ExecutionState executionState = new ExecutionState(vars, executionPlan.templateFunctions, this.extraExecutors.collect(StoreExecutor::buildStoreExecutionState), this.isJavaCompilationAllowed, this.graphFetchBatchMemoryLimit);
 
-        if (planExecutionContext != null)
-        {
-            if (planExecutionContext.getExternalJavaCompiler() != null)
-            {
+        if (planExecutionContext != null) {
+            if (planExecutionContext.getExternalJavaCompiler() != null) {
                 executionState.setJavaCompiler(planExecutionContext.getExternalJavaCompiler());
             }
 
-            if (planExecutionContext.getGraphFetchCaches() != null)
-            {
+            if (planExecutionContext.getGraphFetchCaches() != null) {
                 executionState.setGraphFetchCaches(planExecutionContext.getGraphFetchCaches());
             }
         }
@@ -258,119 +218,107 @@ public class PlanExecutor
         return executionState;
     }
 
-    public static ExecutionPlan readExecutionPlan(String string)
-    {
-        try
-        {
+    public static ExecutionPlan readExecutionPlan(String string) {
+        try {
             return objectMapper.readValue(string, ExecutionPlan.class);
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static ExecutionPlan readExecutionPlan(Reader reader)
-    {
-        try
-        {
+    public static ExecutionPlan readExecutionPlan(Reader reader) {
+        try {
             return objectMapper.readValue(reader, ExecutionPlan.class);
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, Iterable<? extends StoreExecutor> storeExecutors, long graphFetchBatchMemoryLimit)
-    {
+    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, Iterable<? extends StoreExecutor> storeExecutors, long graphFetchBatchMemoryLimit) {
         return new PlanExecutor(isJavaCompilationAllowed, Lists.immutable.withAll(storeExecutors), graphFetchBatchMemoryLimit);
     }
 
-    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, Iterable<? extends StoreExecutor> storeExecutors)
-    {
+    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, Iterable<? extends StoreExecutor> storeExecutors) {
         return PlanExecutor.newPlanExecutor(isJavaCompilationAllowed, storeExecutors, DEFAULT_GRAPH_FETCH_BATCH_MEMORY_LIMIT);
     }
 
-    public static PlanExecutor newPlanExecutor(Iterable<? extends StoreExecutor> storeExecutors)
-    {
+    public static PlanExecutor newPlanExecutor(Iterable<? extends StoreExecutor> storeExecutors) {
         return newPlanExecutor(DEFAULT_IS_JAVA_COMPILATION_ALLOWED, storeExecutors);
     }
 
-    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, StoreExecutor... storeExecutors)
-    {
+    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, StoreExecutor... storeExecutors) {
         return new PlanExecutor(isJavaCompilationAllowed, Lists.immutable.with(storeExecutors), DEFAULT_GRAPH_FETCH_BATCH_MEMORY_LIMIT);
     }
 
-    public static PlanExecutor newPlanExecutor(StoreExecutor... storeExecutors)
-    {
+    public static PlanExecutor newPlanExecutor(StoreExecutor... storeExecutors) {
         return newPlanExecutor(DEFAULT_IS_JAVA_COMPILATION_ALLOWED, storeExecutors);
     }
 
-    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, StoreExecutor storeExecutor)
-    {
+    public static PlanExecutor newPlanExecutor(boolean isJavaCompilationAllowed, StoreExecutor storeExecutor) {
         return new PlanExecutor(isJavaCompilationAllowed, Lists.immutable.with(storeExecutor), DEFAULT_GRAPH_FETCH_BATCH_MEMORY_LIMIT);
     }
 
-    public static PlanExecutor newPlanExecutor(StoreExecutor storeExecutor)
-    {
+    public static PlanExecutor newPlanExecutor(StoreExecutor storeExecutor) {
         return newPlanExecutor(DEFAULT_IS_JAVA_COMPILATION_ALLOWED, Lists.immutable.with(storeExecutor));
     }
 
-    public static PlanExecutor newPlanExecutorWithAvailableStoreExecutors(boolean isJavaCompilationAllowed, long graphFetchBatchMemoryLimit)
-    {
+    public static PlanExecutor newPlanExecutorWithAvailableStoreExecutors(boolean isJavaCompilationAllowed, long graphFetchBatchMemoryLimit) {
         return newPlanExecutor(isJavaCompilationAllowed, IterableIterate.collect(ServiceLoader.load(StoreExecutorBuilder.class), StoreExecutorBuilder::build, Lists.mutable.empty()), graphFetchBatchMemoryLimit);
     }
 
-    public static PlanExecutor newPlanExecutorWithAvailableStoreExecutors(boolean isJavaCompilationAllowed)
-    {
+    public static PlanExecutor newPlanExecutorWithAvailableStoreExecutors(boolean isJavaCompilationAllowed) {
         return newPlanExecutorWithAvailableStoreExecutors(isJavaCompilationAllowed, PlanExecutor.DEFAULT_GRAPH_FETCH_BATCH_MEMORY_LIMIT);
     }
 
-    public static PlanExecutor newPlanExecutorWithAvailableStoreExecutors()
-    {
+    public static PlanExecutor newPlanExecutorWithAvailableStoreExecutors() {
         return newPlanExecutorWithAvailableStoreExecutors(DEFAULT_IS_JAVA_COMPILATION_ALLOWED);
     }
 
-    public static List<StoreExecutorBuilder> loadStoreExecutorBuilders()
-    {
+    public static List<StoreExecutorBuilder> loadStoreExecutorBuilders() {
         return Iterate.addAllTo(ServiceLoader.load(StoreExecutorBuilder.class), Lists.mutable.empty());
     }
 
-    public static PlanExecutor newPlanExecutorWithConfigurations(StoreExecutorConfiguration...storeExecutorConfigurations)
-    {
+    public static PlanExecutor newPlanExecutorWithConfigurations(StoreExecutorConfiguration... storeExecutorConfigurations) {
+
         MutableList<StoreExecutorBuilder> storeExecutorBuilders = Iterate.addAllTo(ServiceLoader.load(StoreExecutorBuilder.class), org.eclipse.collections.impl.factory.Lists.mutable.empty());
         ImmutableListMultimap<StoreType, StoreExecutorConfiguration> configurationsByType = Lists.immutable.with(storeExecutorConfigurations).groupBy(storeExecutorConfiguration -> storeExecutorConfiguration.getStoreType());
+        ImmutableListMultimap<StoreType, StoreExecutorBuilder> buildersByType = Lists.immutable.withAll(storeExecutorBuilders).groupBy(storeExecutorBuilder -> storeExecutorBuilder.getStoreType());
 
-        MutableList<StoreExecutor> storeExecutors = Lists.mutable.empty();
-        configurationsByType.forEachKey(storeType -> {
-            ImmutableList<StoreExecutorConfiguration> matchingConfigurations = configurationsByType.get(storeType);
-            StoreExecutor storeExecutor = buildStoreExecutor(storeType, matchingConfigurations, storeExecutorBuilders);
-            storeExecutors.add(storeExecutor);
-        });
+        List<StoreExecutor> storeExecutors = Lists.immutable.with(StoreType.values())
+                .stream()
+                .map(storeType -> {
+                            ImmutableList<StoreExecutorConfiguration> configurationsForType = configurationsByType.get(storeType);
+                            ImmutableList<StoreExecutorBuilder> buildersForType = buildersByType.get(storeType);
+                            return buildStoreExecutor(storeType, configurationsForType, buildersForType);
+                        }
+                )
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
         return PlanExecutor.newPlanExecutor(storeExecutors);
     }
 
-    private static StoreExecutor buildStoreExecutor(StoreType storeType, ImmutableList<StoreExecutorConfiguration> matchingConfigurations, MutableList<StoreExecutorBuilder> storeExecutorBuilders)
-    {
-        if (matchingConfigurations.size() > 1)
-        {
-            List<String> configurationClasses = matchingConfigurations.stream().map(config -> config.getClass().getCanonicalName()).collect(Collectors.toList());
-            String message = String.format("Found more than one configuration for store type %s. Configuration object types=%s", storeType, configurationClasses.size());
-            throw new RuntimeException(message);
+    private static Optional<StoreExecutor> buildStoreExecutor(StoreType storeType, ImmutableList<StoreExecutorConfiguration> configurations, ImmutableList<StoreExecutorBuilder> builders) {
+        if (builders.size() == 0) {
+            return Optional.empty();
         }
 
-        MutableList<StoreExecutorBuilder> matchingBuilders = storeExecutorBuilders.select(builder -> builder.getStoreType() == storeType);
-        if (matchingBuilders.size() != 1)
-        {
-            List<String> builderClasses = matchingBuilders.stream().map(builder -> builder.getClass().getCanonicalName()).collect(Collectors.toList());
+        if (builders.size() > 1) {
+            List<String> builderClasses = builders.stream().map(builder -> builder.getClass().getCanonicalName()).collect(Collectors.toList());
             String message = String.format("Found more than one builder for store type %s. Builders=%s", storeType, builderClasses);
             throw new RuntimeException(message);
         }
 
-        StoreExecutorBuilder builder = matchingBuilders.get(0);
-        StoreExecutorConfiguration configuration = matchingConfigurations.size() == 1 ? matchingConfigurations.get(0) : null;
+        if (configurations.size() > 1) {
+            List<String> configurationClasses = configurations.stream().map(config -> config.getClass().getCanonicalName()).collect(Collectors.toList());
+            String message = String.format("Found more than one configuration for store type %s. Configuration object types=%s", storeType, configurationClasses.size());
+            throw new RuntimeException(message);
+        }
+
+        StoreExecutorBuilder builder = builders.get(0);
+        StoreExecutorConfiguration configuration = configurations.size() == 1 ? configurations.get(0) : null;
         StoreExecutor storeExecutor = configuration == null ? builder.build() : builder.build(configuration);
-        return storeExecutor;
+        return Optional.of(storeExecutor);
     }
 }


### PR DESCRIPTION
This PR fixes a bug in the factory method that accepts store executor configurations as input.

The bug is that the factory creates an executor of type T if and only if a configuration for type T is also provided as input.

The desired behavior is that the factory creates executors for all types T.
If a configuration for type T is provided as input, the corresponding builder is invoked with this configuration. Otherwise the no-arg build method is invoked.