### PR TITLE
Rollback ServiceRunner result processing to ensure proper RelationalResult processing

### DIFF
--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/SimpleRelationalServiceRunnerTDS.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/SimpleRelationalServiceRunnerTDS.java
@@ -1,0 +1,25 @@
+package org.finos.legend.engine.language.pure.dsl.service.execution;
+
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
+
+import java.io.OutputStream;
+
+public class SimpleRelationalServiceRunnerTDS extends AbstractServicePlanExecutor
+{
+    public SimpleRelationalServiceRunnerTDS()
+    {
+        this(new StoreExecutorConfiguration[0]);
+    }
+
+    public SimpleRelationalServiceRunnerTDS(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::RelationalService", "plans/org/finos/service/SimpleRelationalServiceRunnerTDS.json", storeExecutorConfigurations);
+    }
+
+    @Override
+    public void run(ServiceRunnerInput serviceRunnerInput, OutputStream outputStream) {
+        newExecutionBuilder()
+                .withServiceRunnerInput(serviceRunnerInput)
+                .executeToStream(outputStream);
+    }
+}

--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -156,6 +156,27 @@ public class TestServiceRunner
     }
 
     @Test
+    public void testSimpleRelationalServiceExecutionWithTDSResult()
+    {
+        RelationalExecutionConfiguration relationalExecutionConfiguration = RelationalExecutionConfiguration.newInstance()
+                .withDatabaseAuthenticationFlowProvider(LegendDefaultDatabaseAuthenticationFlowProvider.class, new LegendDefaultDatabaseAuthenticationFlowProviderConfiguration())
+                .build();
+
+        SimpleRelationalServiceRunnerTDS simpleRelationalServiceRunner = (SimpleRelationalServiceRunnerTDS)ServiceRunnerBuilder.newInstance()
+                .withServiceRunnerClass(SimpleRelationalServiceRunnerTDS.class.getCanonicalName())
+                .withAllowJavaCompilation(false)
+                .withStoreExecutorConfigurations(relationalExecutionConfiguration)
+                .build();
+
+        ServiceRunnerInput serviceRunnerInput1 = ServiceRunnerInput
+                .newInstance()
+                .withArgs(Collections.singletonList(Collections.singletonList("John")))
+                .withSerializationFormat(SerializationFormat.PURE);
+        String result1 = simpleRelationalServiceRunner.run(serviceRunnerInput1);
+        Assert.assertEquals("{\"columns\":[{\"name\":\"Age\",\"type\":\"Integer\"},{\"name\":\"First Name\",\"type\":\"String\"},{\"name\":\"Last Name\",\"type\":\"String\"}],\"rows\":[{\"values\":[1,\"f1\",\"l1\"]}]}", result1);
+    }
+
+    @Test
     public void testXStoreServiceExecutionWithNoCrossPropertyAccess() throws JavaCompileException
     {
         XStoreServiceRunnerWithNoCrossPropertyAccess xStoreServiceRunner = new XStoreServiceRunnerWithNoCrossPropertyAccess();

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/plans/org/finos/service/SimpleRelationalService.json
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/plans/org/finos/service/SimpleRelationalService.json
@@ -13,6 +13,7 @@
         "datasourceSpecification" : {
           "_type" : "h2Local",
           "testDataSetupSqls": [
+            "drop schema if exists MAIN_SCHEMA cascade;",
             "create schema MAIN_SCHEMA;",
             "create table MAIN_SCHEMA.PERSON_TABLE(AGE INT, FIRST_NAME VARCHAR(100), LAST_NAME VARCHAR(100));",
             "insert into MAIN_SCHEMA.PERSON_TABLE(AGE, FIRST_NAME, LAST_NAME) values(1, 'f1', 'l1');"

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/plans/org/finos/service/SimpleRelationalServiceRunnerTDS.json
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/plans/org/finos/service/SimpleRelationalServiceRunnerTDS.json
@@ -13,6 +13,7 @@
         "datasourceSpecification" : {
           "_type" : "h2Local",
           "testDataSetupSqls": [
+            "drop schema if exists MAIN_SCHEMA cascade;",
             "create schema MAIN_SCHEMA;",
             "create table MAIN_SCHEMA.PERSON_TABLE(AGE INT, FIRST_NAME VARCHAR(100), LAST_NAME VARCHAR(100));",
             "insert into MAIN_SCHEMA.PERSON_TABLE(AGE, FIRST_NAME, LAST_NAME) values(1, 'f1', 'l1');"

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/plans/org/finos/service/SimpleRelationalServiceRunnerTDS.json
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/plans/org/finos/service/SimpleRelationalServiceRunnerTDS.json
@@ -1,0 +1,68 @@
+{
+  "_type" : "simple",
+  "authDependent" : false,
+  "rootExecutionNode" : {
+    "_type" : "relationalTdsInstantiation",
+    "executionNodes" : [ {
+      "_type" : "sql",
+      "connection" : {
+        "_type" : "RelationalDatabaseConnection",
+        "authenticationStrategy" : {
+          "_type" : "test"
+        },
+        "datasourceSpecification" : {
+          "_type" : "h2Local",
+          "testDataSetupSqls": [
+            "create schema MAIN_SCHEMA;",
+            "create table MAIN_SCHEMA.PERSON_TABLE(AGE INT, FIRST_NAME VARCHAR(100), LAST_NAME VARCHAR(100));",
+            "insert into MAIN_SCHEMA.PERSON_TABLE(AGE, FIRST_NAME, LAST_NAME) values(1, 'f1', 'l1');"
+          ]
+        },
+        "element" : "store::MyDatabase",
+        "postProcessorWithParameter" : [ ],
+        "postProcessors" : [ ],
+        "type" : "H2"
+      },
+      "executionNodes" : [ ],
+      "resultColumns" : [ {
+        "dataType" : "NUMERIC(38,0)",
+        "label" : "\"Age\""
+      }, {
+        "dataType" : "VARCHAR(16777216)",
+        "label" : "\"First Name\""
+      }, {
+        "dataType" : "VARCHAR(16777216)",
+        "label" : "\"Last Name\""
+      } ],
+      "resultType" : {
+        "_type" : "dataType",
+        "dataType" : "meta::pure::metamodel::type::Any"
+      },
+      "sqlQuery" : "select \"root\".AGE as \"Age\", \"root\".FIRST_NAME as \"First Name\", \"root\".LAST_NAME as \"Last Name\" from MAIN_SCHEMA.PERSON_TABLE as \"root\""
+    } ],
+    "resultType" : {
+      "_type" : "tds",
+      "tdsColumns" : [ {
+        "enumMapping" : { },
+        "name" : "Age",
+        "relationalType" : "NUMERIC(38,0)",
+        "type" : "Integer"
+      }, {
+        "enumMapping" : { },
+        "name" : "First Name",
+        "relationalType" : "VARCHAR(16777216)",
+        "type" : "String"
+      }, {
+        "enumMapping" : { },
+        "name" : "Last Name",
+        "relationalType" : "VARCHAR(16777216)",
+        "type" : "String"
+      } ]
+    }
+  },
+  "serializer" : {
+    "name" : "pure",
+    "version" : "vX_X_X"
+  },
+  "templateFunctions" : [ "<#function renderCollection collection separator prefix suffix defaultValue><#if collection?size == 0><#return defaultValue></#if><#return prefix + collection?join(suffix + separator + prefix) + suffix></#function>", "<#function collectionSize collection> <#return collection?size?c> </#function>" ]
+}


### PR DESCRIPTION
This rollbacks this changes: https://github.com/finos/legend-engine/pull/518/files#diff-d7d199bf41928d214e88941922d2af5b7581f9871f35e9d9ed90931cce5dc0d4R289