### PR TITLE
Clean up pom duplicated dependencies to avoid maven malformed pom warnings

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational/pom.xml
+++ b/legend-engine-executionPlan-execution-store-relational/pom.xml
@@ -280,11 +280,6 @@
             <artifactId>json-unit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-protocol-relational/pom.xml
+++ b/legend-engine-protocol-relational/pom.xml
@@ -74,18 +74,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-protocol</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-protocol</artifactId>
         </dependency>
         <!-- TEST -->
     </dependencies>


### PR DESCRIPTION
This PR clears the following maven warnings:

```text
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.finos.legend.engine:legend-engine-executionPlan-execution-store-relational:jar:2.57.1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.hamcrest:hamcrest-core:jar -> duplicate declaration of version (?) @ line 283, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.finos.legend.engine:legend-engine-protocol-relational:jar:2.57.1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.finos.legend.engine:legend-engine-protocol:jar -> duplicate declaration of version (?) @ line 76, column 21
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.finos.legend.engine:legend-engine-protocol:jar -> duplicate declaration of version (?) @ line 86, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```