### PR TITLE
Add ability to build service runner using pure element path

### DIFF
--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -149,7 +149,7 @@ public class TestServiceRunner
                 .build();
 
         SimpleRelationalServiceRunner simpleRelationalServiceRunner = (SimpleRelationalServiceRunner)ServiceRunnerBuilder.newInstance()
-                .withServiceRunnerClass(SimpleRelationalServiceRunner.class.getCanonicalName())
+                .withServicePath("org.finos.legend.engine", "language.pure.dsl", "service::execution::SimpleRelationalServiceRunner")
                 .withAllowJavaCompilation(false)
                 .withStoreExecutorConfigurations(relationalExecutionConfiguration)
                 .build();

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/plan/platform/java/JavaSourceHelper.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/plan/platform/java/JavaSourceHelper.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class JavaSourceHelper
@@ -276,5 +277,21 @@ public class JavaSourceHelper
     private static boolean fileHasContent(Path path, byte[] content) throws IOException
     {
         return (Files.size(path) == content.length) && Arrays.equals(content, Files.readAllBytes(path));
+    }
+
+    public static String serviceElementPathToJavaPath(String packagePrefix, String servicePath)
+    {
+        Stream<String> packagePrefixStream = Stream.empty();
+        if (packagePrefix != null)
+        {
+            packagePrefixStream = Stream.of(packagePrefix);
+            if (!SourceVersion.isName(packagePrefix))
+            {
+                throw new RuntimeException("Invalid package prefix: \"" + packagePrefix + "\"");
+            }
+        }
+
+        Stream<String> servicePathAsJavaIdentifiers = Arrays.stream(servicePath.split("::")).map(JavaSourceHelper::toValidJavaIdentifier);
+        return Stream.concat(packagePrefixStream, servicePathAsJavaIdentifiers).collect(Collectors.joining("."));
     }
 }


### PR DESCRIPTION
Add the ability to use pure element path in conjunction with studio project coordinates to find and load the ServiceRunner class.  This allow users to focus on first class concepts Studio present rather than expecting the generated class name.