### PR TITLE
Refactor Kerberos auth to use identity/flow

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceWithStatistics.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceWithStatistics.java
@@ -25,6 +25,7 @@ import org.finos.legend.engine.shared.core.identity.Identity;
 
 import javax.sql.DataSource;
 import java.util.Optional;
+import java.util.Properties;
 
 public class DataSourceWithStatistics
 {
@@ -141,6 +142,11 @@ public class DataSourceWithStatistics
 
     public boolean hasActiveConnections() {
         return this.dataSource!=null && ((HikariDataSource)dataSource).getHikariPoolMXBean().getActiveConnections()>0;
+    }
+
+    public Properties getProperties()
+    {
+        return ((HikariDataSource)this.dataSource).getDataSourceProperties();
     }
 }
 


### PR DESCRIPTION
This PR refactors the delegated auth strategy to use the Identity API.