### PR TITLE
Add support for header parameters in service store

### DIFF
--- a/legend-engine-executionPlan-execution-external-store-service/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
+++ b/legend-engine-executionPlan-execution-external-store-service/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
@@ -626,4 +626,61 @@ public class ServiceStoreJsonShowcaseTest extends ServiceStoreTestSuite
 
         Assert.assertEquals(expectedResWithEmptyList, executePlan(plan));
     }
+
+    @Test
+    public void serviceStoreHeaderParam()
+    {
+        String query = "###Pure\n" +
+                "function showcase::query(): Any[1]\n" +
+                "{\n" +
+                "   {|meta::external::store::service::showcase::domain::Firm.all()" +
+                "       ->filter(f | $f.name == 'FirmA')\n" +
+                "       ->graphFetch(#{\n" +
+                "           meta::external::store::service::showcase::domain::Firm {\n" +
+                "               name,\n" +
+                "               employeesCount\n" +
+                "           }\n" +
+                "         }#)" +
+                "       ->serialize(#{\n" +
+                "           meta::external::store::service::showcase::domain::Firm {\n" +
+                "               name,\n" +
+                "               employeesCount\n" +
+                "           }\n" +
+                "        }#)};\n" +
+                "}";
+
+        SingleExecutionPlan plan = buildPlanForQuery(pureGrammar + "\n\n" + query);
+
+        String expectedResWithEmptyList = "{\"builder\":{\"_type\":\"json\"},\"values\":{\"name\":\"FirmA\",\"employeesCount\":500}}";
+
+        Assert.assertEquals(expectedResWithEmptyList, executePlan(plan));
+    }
+
+    @Test
+    public void serviceStoreHeaderParamWithList()
+    {
+        String query = "###Pure\n" +
+                "function showcase::query(): Any[1]\n" +
+                "{\n" +
+                "   {|meta::external::store::service::showcase::domain::Firm.all()" +
+                "       ->graphFetch(#{\n" +
+                "           meta::external::store::service::showcase::domain::Firm {\n" +
+                "               name,\n" +
+                "               employeesCount\n" +
+                "           }\n" +
+                "         }#)" +
+                "       ->serialize(#{\n" +
+                "           meta::external::store::service::showcase::domain::Firm {\n" +
+                "               name,\n" +
+                "               employeesCount\n" +
+                "           }\n" +
+                "        }#)};\n" +
+                "}";
+
+        SingleExecutionPlan plan = buildPlanForQuery(pureGrammar + "\n\n" + query);
+
+        String expectedResWithEmptyList = "{\"builder\":{\"_type\":\"json\"},\"values\":[{\"name\":\"FirmA\",\"employeesCount\":500},{\"name\":\"FirmB\",\"employeesCount\":50},{\"name\":\"FirmC\",\"employeesCount\":5000}]}";
+
+        Assert.assertEquals(expectedResWithEmptyList, executePlan(plan));
+    }
 }

--- a/legend-engine-executionPlan-execution-external-store-service/src/test/resources/showcase/json/mappings/stub.json
+++ b/legend-engine-executionPlan-execution-external-store-service/src/test/resources/showcase/json/mappings/stub.json
@@ -176,6 +176,54 @@
           ]
         }
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "/firms/getFirmByName",
+        "headers": {
+          "name": {
+            "equalTo": "FirmA"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "name": "FirmA",
+            "employeesCount": 500
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "/firms/getFirmsByNames",
+        "headers": {
+          "name": {
+            "equalTo": "FirmA,FirmB,FirmC"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "name": "FirmA",
+            "employeesCount": 500
+          },
+          {
+            "name": "FirmB",
+            "employeesCount": 50
+          },
+          {
+            "name": "FirmC",
+            "employeesCount": 5000
+          }
+        ]
+      }
     }
   ]
 }

--- a/legend-engine-executionPlan-execution-external-store-service/src/test/resources/showcase/json/testGrammar.pure
+++ b/legend-engine-executionPlan-execution-external-store-service/src/test/resources/showcase/json/testGrammar.pure
@@ -93,6 +93,12 @@ Association meta::external::store::service::showcase::domain::S_Trade_S_Product
   s_trades  : meta::external::store::service::showcase::domain::S_Trade[*];
 }
 
+Class meta::external::store::service::showcase::domain::Firm
+{
+  name           : String[1];
+  employeesCount : Integer[1];
+}
+
 ###Mapping
 Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping
 (
@@ -163,6 +169,25 @@ Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping
             name : 'product 30'
          )
          s_description : $service.parameters.description
+     )
+  }
+
+  *meta::external::store::service::showcase::domain::Firm[firm_set]: ServiceStore
+  {
+     ~service [meta::external::store::service::showcase::store::TradeProductServiceStore] FirmServices.FirmByName
+     (
+         ~paramMapping
+         (
+            name : $this.name
+         )
+     )
+
+     ~service [meta::external::store::service::showcase::store::TradeProductServiceStore] FirmServices.FirmsByNames
+     (
+         ~paramMapping
+         (
+            name : ['FirmA', 'FirmB', 'FirmC']
+         )
      )
   }
 
@@ -315,6 +340,35 @@ ServiceStore meta::external::store::service::showcase::store::TradeProductServic
          response : [meta::external::store::service::showcase::domain::S_Product <- meta::external::store::service::showcase::store::prodServiceStoreSchemaBinding];
       )
    )
+
+   ServiceGroup FirmServices
+   (
+      path : '/firms';
+
+      Service FirmByName
+      (
+         path : '/getFirmByName';
+         method : GET;
+         parameters :
+         (
+            name : String (location = header)
+         );
+         security : [];
+         response : [meta::external::store::service::showcase::domain::Firm <- meta::external::store::service::showcase::store::firmServiceStoreSchemaBinding];
+      )
+
+      Service FirmsByNames
+      (
+         path : '/getFirmsByNames';
+         method : GET;
+         parameters :
+         (
+            name : [String] (location = header, style = simple, explode = true)
+         );
+         security : [];
+         response : [meta::external::store::service::showcase::domain::Firm <- meta::external::store::service::showcase::store::firmServiceStoreSchemaBinding];
+      )
+   )
 )
 
 ###ExternalFormat
@@ -328,6 +382,12 @@ Binding meta::external::store::service::showcase::store::prodServiceStoreSchemaB
 {
   contentType   : 'application/json';
   modelIncludes : [ meta::external::store::service::showcase::domain::S_Product, meta::external::store::service::showcase::domain::S_Synonym ];
+}
+
+Binding meta::external::store::service::showcase::store::firmServiceStoreSchemaBinding
+{
+  contentType   : 'application/json';
+  modelIncludes : [ meta::external::store::service::showcase::domain::Firm ];
 }
 
 ###Runtime

--- a/legend-engine-language-external-store-service/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreBuilder.java
+++ b/legend-engine-language-external-store-service/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreBuilder.java
@@ -195,6 +195,8 @@ public class HelperServiceStoreBuilder
 
     private static Root_meta_external_store_service_metamodel_ServiceParameter compileServiceParameter(ServiceParameter serviceParameter, CompileContext context)
     {
+        validateServiceParameter(serviceParameter);
+
         Root_meta_external_store_service_metamodel_ServiceParameter pureServiceParameter = new Root_meta_external_store_service_metamodel_ServiceParameter_Impl(serviceParameter.name);
 
         pureServiceParameter._name(serviceParameter.name);
@@ -235,6 +237,15 @@ public class HelperServiceStoreBuilder
         }
 
         return pureServiceParameter;
+    }
+
+    private static void validateServiceParameter(ServiceParameter serviceParameter)
+    {
+        List<String> bannedHeaderParamNames = FastList.newListWith("Accept", "Content-Type", "Authorization");
+        if(serviceParameter.location == Location.HEADER && bannedHeaderParamNames.contains(serviceParameter.name))
+        {
+            throw new EngineException("Header parameters cannot have following names : [" + String.join(",", bannedHeaderParamNames) + "]", serviceParameter.sourceInformation, EngineErrorType.COMPILATION);
+        }
     }
 
     private static Root_meta_external_store_service_metamodel_TypeReference compileTypeReference(TypeReference typeReference, CompileContext context)

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreCompilationFromGrammar.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreCompilationFromGrammar.java
@@ -75,6 +75,22 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    method : GET;\n" +
                 "    parameters :\n" +
                 "    (\n" +
+                "      serializationFormat : String ( location = header )\n" +
+                "    );\n" +
+                "    response : [ test::Person <- test::TestBinding ];\n" +
+                "    security : [];\n" +
+                "  )\n" +
+                ")\n");
+
+        test(TEST_BINDING + "###ServiceStore\n" +
+                "ServiceStore test::testServiceStoreCompilationWithSingleService\n" +
+                "(\n" +
+                "  Service TestService\n" +
+                "  (\n" +
+                "    path : '/testService';\n" +
+                "    method : GET;\n" +
+                "    parameters :\n" +
+                "    (\n" +
                 "      \"abc.xyz\" : String ( location = query )\n" +
                 "    );\n" +
                 "    response : [ test::Person <- test::TestBinding ];\n" +
@@ -390,5 +406,54 @@ public class TestServiceStoreCompilationFromGrammar extends TestCompilationFromG
                 "    security : [];\n" +
                 "  )\n" +
                 ")\n", "COMPILATION error at [34:1-47:1]: Error in 'test::testServiceStoreCompilationWithSingleService': Can't find class 'test::Trade'");
+
+        // Header params can't have reserved names - Accept, Content-Type and Authorization
+        test(TEST_BINDING + "###ServiceStore\n" +
+                "ServiceStore test::testServiceStoreCompilationWithSingleService\n" +
+                "(\n" +
+                "  Service TestService\n" +
+                "  (\n" +
+                "    path : '/testService';\n" +
+                "    method : GET;\n" +
+                "    parameters :\n" +
+                "    (\n" +
+                "      Accept : String ( location = header )\n" +
+                "    );\n" +
+                "    response : [ test::Person <- test::TestBinding ];\n" +
+                "    security : [];\n" +
+                "  )\n" +
+                ")\n", "COMPILATION error at [42:7-43]: Header parameters cannot have following names : [Accept,Content-Type,Authorization]");
+
+        test(TEST_BINDING + "###ServiceStore\n" +
+                "ServiceStore test::testServiceStoreCompilationWithSingleService\n" +
+                "(\n" +
+                "  Service TestService\n" +
+                "  (\n" +
+                "    path : '/testService';\n" +
+                "    method : GET;\n" +
+                "    parameters :\n" +
+                "    (\n" +
+                "      \"Content-Type\" : String ( location = header )\n" +
+                "    );\n" +
+                "    response : [ test::Person <- test::TestBinding ];\n" +
+                "    security : [];\n" +
+                "  )\n" +
+                ")\n", "COMPILATION error at [42:7-51]: Header parameters cannot have following names : [Accept,Content-Type,Authorization]");
+
+        test(TEST_BINDING + "###ServiceStore\n" +
+                "ServiceStore test::testServiceStoreCompilationWithSingleService\n" +
+                "(\n" +
+                "  Service TestService\n" +
+                "  (\n" +
+                "    path : '/testService';\n" +
+                "    method : GET;\n" +
+                "    parameters :\n" +
+                "    (\n" +
+                "      Authorization : String ( location = header )\n" +
+                "    );\n" +
+                "    response : [ test::Person <- test::TestBinding ];\n" +
+                "    security : [];\n" +
+                "  )\n" +
+                ")\n", "COMPILATION error at [42:7-50]: Header parameters cannot have following names : [Accept,Content-Type,Authorization]");
     }
 }

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarParser.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarParser.java
@@ -270,7 +270,7 @@ public class TestServiceStoreGrammarParser extends TestGrammarParser.TestGrammar
                 "    response : ExampleClass <- tests::store::exampleBinding;\n" +
                 "    security : [];\n" +
                 "  )\n"+
-                ")\n", "PARSER error at [10:7-61]: Unsupported Parameter Location - requestBody. Supported Locations are - path,query");
+                ")\n", "PARSER error at [10:7-61]: Unsupported Parameter Location - requestBody. Supported Locations are - header,path,query");
 
         // Path parameters can't be optional
         test("###ServiceStore\n" +

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarRoundtrip.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreGrammarRoundtrip.java
@@ -163,6 +163,54 @@ public class TestServiceStoreGrammarRoundtrip extends TestGrammarRoundtrip.TestG
                 "(\n" +
                 "  Service TestService\n" +
                 "  (\n" +
+                "    path : '/testService';\n" +
+                "    method : GET;\n" +
+                "    parameters :\n" +
+                "    (\n" +
+                "      serializationFormat : String ( location = header )\n" +
+                "    );\n" +
+                "    response : ExampleClass <- tests::store::exampleBinding;\n" +
+                "    security : [];\n" +
+                "  )\n"+
+                ")\n");
+
+        test("###ServiceStore\n" +
+                "ServiceStore test::testServiceStoreGrammarWithSingleService\n" +
+                "(\n" +
+                "  Service TestService\n" +
+                "  (\n" +
+                "    path : '/testService';\n" +
+                "    method : GET;\n" +
+                "    parameters :\n" +
+                "    (\n" +
+                "      serializationFormat : String ( location = header, required = true )\n" +
+                "    );\n" +
+                "    response : ExampleClass <- tests::store::exampleBinding;\n" +
+                "    security : [];\n" +
+                "  )\n"+
+                ")\n");
+
+        test("###ServiceStore\n" +
+                "ServiceStore test::testServiceStoreGrammarWithSingleService\n" +
+                "(\n" +
+                "  Service TestService\n" +
+                "  (\n" +
+                "    path : '/testService';\n" +
+                "    method : GET;\n" +
+                "    parameters :\n" +
+                "    (\n" +
+                "      serializationFormat : [String] ( location = header, style = simple, explode = true, required = true )\n" +
+                "    );\n" +
+                "    response : ExampleClass <- tests::store::exampleBinding;\n" +
+                "    security : [];\n" +
+                "  )\n"+
+                ")\n");
+
+        test("###ServiceStore\n" +
+                "ServiceStore test::testServiceStoreGrammarWithSingleService\n" +
+                "(\n" +
+                "  Service TestService\n" +
+                "  (\n" +
                 "    path : '/testService/{serializationFormat}';\n" +
                 "    method : GET;\n" +
                 "    parameters :\n" +

--- a/legend-engine-protocol-external-store-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/service/model/Location.java
+++ b/legend-engine-protocol-external-store-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/service/model/Location.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.
 
 public enum Location
 {
+    HEADER,
     PATH,
     QUERY
 }


### PR DESCRIPTION
Add support for header parameters in service store
ref - https://swagger.io/docs/specification/describing-parameters/
Depends on - https://github.com/finos/legend-pure/pull/486 