### PR TITLE
Add Relational extension metadata API

### DIFF
--- a/legend-engine-executionPlan-execution-store-authentication/pom.xml
+++ b/legend-engine-executionPlan-execution-store-authentication/pom.xml
@@ -36,12 +36,26 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-relational</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- JACKSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <!-- JACKSON -->
 

--- a/legend-engine-executionPlan-execution-store-authentication/src/main/java/org/finos/legend/engine/authentication/DatabaseAuthenticationFlowMetadata.java
+++ b/legend-engine-executionPlan-execution-store-authentication/src/main/java/org/finos/legend/engine/authentication/DatabaseAuthenticationFlowMetadata.java
@@ -1,0 +1,52 @@
+package org.finos.legend.engine.authentication;
+
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
+
+public class DatabaseAuthenticationFlowMetadata implements Comparable<DatabaseAuthenticationFlowMetadata>
+{
+    private DatabaseType databaseType;
+
+    //TODO : Should these be strings ??
+    private String datasourceType;
+    private String authenticationType;
+
+    public DatabaseAuthenticationFlowMetadata()
+    {
+        // Jackson
+    }
+
+    public DatabaseAuthenticationFlowMetadata(DatabaseType databaseType, String datasourceType, String authenticationType)
+    {
+        this.databaseType = databaseType;
+        this.datasourceType = datasourceType;
+        this.authenticationType = authenticationType;
+    }
+
+    public DatabaseType getDatabaseType() {
+        return databaseType;
+    }
+
+    public String getDatasourceType() {
+        return datasourceType;
+    }
+
+    public String getAuthenticationType() {
+        return authenticationType;
+    }
+
+    @Override
+    public int compareTo(DatabaseAuthenticationFlowMetadata other)
+    {
+        int comparison = this.databaseType.compareTo(other.databaseType);
+        if (comparison != 0 )
+        {
+            return comparison;
+        }
+        comparison = this.datasourceType.compareTo(other.datasourceType);
+        if (comparison != 0 )
+        {
+            return comparison;
+        }
+        return this.authenticationType.compareTo(other.authenticationType);
+    }
+}

--- a/legend-engine-executionPlan-execution-store-authentication/src/main/java/org/finos/legend/engine/authentication/provider/DatabaseAuthenticationFlowProvider.java
+++ b/legend-engine-executionPlan-execution-store-authentication/src/main/java/org/finos/legend/engine/authentication/provider/DatabaseAuthenticationFlowProvider.java
@@ -16,7 +16,10 @@ package org.finos.legend.engine.authentication.provider;
 
 import java.util.Optional;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.finos.legend.engine.authentication.DatabaseAuthenticationFlow;
+import org.finos.legend.engine.authentication.DatabaseAuthenticationFlowMetadata;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
 
 public interface DatabaseAuthenticationFlowProvider
@@ -41,4 +44,9 @@ public interface DatabaseAuthenticationFlowProvider
     void configure(DatabaseAuthenticationFlowProviderConfiguration configuration);
 
     int count();
+
+    default ImmutableList<DatabaseAuthenticationFlowMetadata> getSupportedFlowsMetadata()
+    {
+        return Lists.immutable.empty();
+    }
 }

--- a/legend-engine-executionPlan-execution-store-authentication/src/test/java/org/finos/legend/engine/authentication/TestDefaultSupportedFlowsMetadata.java
+++ b/legend-engine-executionPlan-execution-store-authentication/src/test/java/org/finos/legend/engine/authentication/TestDefaultSupportedFlowsMetadata.java
@@ -1,0 +1,58 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.authentication;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class TestDefaultSupportedFlowsMetadata
+{
+    private static LegendDefaultDatabaseAuthenticationFlowProvider DEFAULT_PROVIDER = new LegendDefaultDatabaseAuthenticationFlowProvider();
+
+    @Test
+    public void testMetadata() throws JsonProcessingException {
+        ImmutableList<DatabaseAuthenticationFlowMetadata> supportedFlowsMetadata = DEFAULT_PROVIDER.getSupportedFlowsMetadata();
+        MutableList<DatabaseAuthenticationFlowMetadata> sortedMetadata = supportedFlowsMetadata.toSortedList();
+        String metadataString = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(sortedMetadata);
+        String expected = "[ {\n" +
+                "  \"databaseType\" : \"H2\",\n" +
+                "  \"datasourceType\" : \"static\",\n" +
+                "  \"authenticationType\" : \"test\"\n" +
+                "}, {\n" +
+                "  \"databaseType\" : \"SqlServer\",\n" +
+                "  \"datasourceType\" : \"static\",\n" +
+                "  \"authenticationType\" : \"userNamePassword\"\n" +
+                "}, {\n" +
+                "  \"databaseType\" : \"Snowflake\",\n" +
+                "  \"datasourceType\" : \"snowflake\",\n" +
+                "  \"authenticationType\" : \"snowflakePublic\"\n" +
+                "}, {\n" +
+                "  \"databaseType\" : \"BigQuery\",\n" +
+                "  \"datasourceType\" : \"bigQuery\",\n" +
+                "  \"authenticationType\" : \"gcpApplicationDefaultCredentials\"\n" +
+                "}, {\n" +
+                "  \"databaseType\" : \"Databricks\",\n" +
+                "  \"datasourceType\" : \"databricks\",\n" +
+                "  \"authenticationType\" : \"apiToken\"\n" +
+                "} ]";
+        assertEquals(expected, metadataString.replaceAll("\\r", ""));
+    }
+}

--- a/legend-engine-executionPlan-execution-store-relational-connection-api/pom.xml
+++ b/legend-engine-executionPlan-execution-store-relational-connection-api/pom.xml
@@ -94,6 +94,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-execution-store-relational</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution-store-authentication</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- TEST -->

--- a/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/extensions/relational/RelationalExtensionsMetadataApi.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/extensions/relational/RelationalExtensionsMetadataApi.java
@@ -1,0 +1,87 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.connection.api.extensions.relational;
+
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.finos.legend.engine.authentication.DatabaseAuthenticationFlowMetadata;
+import org.finos.legend.engine.authentication.provider.DatabaseAuthenticationFlowProvider;
+import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionTool;
+import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+// TODO : epsstan - Refactor path
+@Api(tags = "Connectors - Metadata")
+@Path("pure/v1/protocols/relational")
+@Produces(MediaType.APPLICATION_JSON)
+
+public class RelationalExtensionsMetadataApi {
+    private Optional<DatabaseAuthenticationFlowProvider> flowProviderHolder;
+
+    public RelationalExtensionsMetadataApi(Optional<DatabaseAuthenticationFlowProvider> databaseAuthenticationFlowProvider)
+    {
+        this.flowProviderHolder = databaseAuthenticationFlowProvider;
+    }
+
+    @Path("flow/metadata")
+    @ApiOperation(value = "Get metadata about available database authentication flows")
+    @GET
+    public Response getFlows() {
+        try {
+            if (!this.flowProviderHolder.isPresent())
+            {
+                return Response.ok(Lists.immutable.empty(), MediaType.APPLICATION_JSON_TYPE).build();
+            }
+            else
+            {
+                ImmutableList<DatabaseAuthenticationFlowMetadata> supportedFlowsMetadata = this.flowProviderHolder.get().getSupportedFlowsMetadata();
+                return Response.ok(supportedFlowsMetadata, MediaType.APPLICATION_JSON_TYPE).build();
+            }
+        } catch (Exception e) {
+            return ExceptionTool.exceptionManager(e, LoggingEventType.CATCH_ALL, null);
+        }
+    }
+
+    @Path("datasource/metadata")
+    @ApiOperation(value = "Get metadata about available data sources")
+    @GET
+    public Response getDatasources() {
+        try {
+            return Response.ok().build();
+        } catch (Exception e) {
+            return ExceptionTool.exceptionManager(e, LoggingEventType.CATCH_ALL, null);
+        }
+    }
+
+    @Path("authenticationStrategy/metadata")
+    @ApiOperation(value = "Get metadata about available authentication schemes")
+    @GET
+    public Response getAuthenticationStrategies() {
+        try {
+            return Response.ok().build();
+        } catch (Exception e) {
+            return ExceptionTool.exceptionManager(e, LoggingEventType.CATCH_ALL, null);
+        }
+    }
+}

--- a/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/extensions/relational/RelationalExtensionsMetadataApi.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/extensions/relational/RelationalExtensionsMetadataApi.java
@@ -29,11 +29,18 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 // TODO : epsstan - Refactor path
-@Api(tags = "Connectors - Metadata")
-@Path("pure/v1/protocols/relational")
+@Api(tags = "Relational Extensions - Metadata")
+@Path("pure/v1/protocols/vX_X_X/extension/relational")
 @Produces(MediaType.APPLICATION_JSON)
 
 public class RelationalExtensionsMetadataApi {
@@ -68,10 +75,19 @@ public class RelationalExtensionsMetadataApi {
     @GET
     public Response getDatasources() {
         try {
-            return Response.ok().build();
+            String rawJson = this.buildDatasourcesMetadata();
+            return Response.ok()
+                    .entity(rawJson)
+                    .build();
         } catch (Exception e) {
             return ExceptionTool.exceptionManager(e, LoggingEventType.CATCH_ALL, null);
         }
+    }
+
+    protected String buildDatasourcesMetadata() throws URISyntaxException, IOException {
+        URL resource = RelationalExtensionsMetadataApi.class.getResource("/legend-datasources.json");
+        URL url = resource.toURI().toURL();
+        return Files.readAllLines(Paths.get(url.toURI()), Charset.defaultCharset()).stream().collect(Collectors.joining());
     }
 
     @Path("authenticationStrategy/metadata")
@@ -79,9 +95,18 @@ public class RelationalExtensionsMetadataApi {
     @GET
     public Response getAuthenticationStrategies() {
         try {
-            return Response.ok().build();
+            String rawJson = this.buildAuthenticationStrategiesMetadata();
+            return Response.ok()
+                    .entity(rawJson)
+                    .build();
         } catch (Exception e) {
             return ExceptionTool.exceptionManager(e, LoggingEventType.CATCH_ALL, null);
         }
+    }
+
+    protected String buildAuthenticationStrategiesMetadata() throws URISyntaxException, IOException {
+        URL resource = RelationalExtensionsMetadataApi.class.getResource("/legend-authenticationtrategies.json");
+        URL url = resource.toURI().toURL();
+        return Files.readAllLines(Paths.get(url.toURI()), Charset.defaultCharset()).stream().collect(Collectors.joining());
     }
 }

--- a/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/resources/legend-authenticationtrategies.json
+++ b/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/resources/legend-authenticationtrategies.json
@@ -1,0 +1,86 @@
+[
+  {
+    "name": "DelegatedKerberosAuthenticationStrategy",
+    "_type" : "delegatedKerberos",
+    "properties": [
+      {
+        "name": "serverPrincipal",
+        "description": "",
+        "type": "String",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "UserNamePasswordAuthenticationStrategy",
+    "_type":"userNamePassword",
+    "properties": [
+      {
+        "name": "baseVaultReference",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "userNameVaultReference",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "passwordVaultReference",
+        "description": "",
+        "type": "String",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "DefaultH2AuthenticationStrategy",
+    "_type": "h2Default",
+    "properties": [
+    ]
+  },
+  {
+    "name": "ApiTokenAuthenticationStrategy",
+    "_type": "apiToken",
+    "properties": [
+      {
+        "name": "apiToken",
+        "description": "",
+        "type": "String",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "SnowflakePublicAuthenticationStrategy",
+    "_type": "snowflakePublic",
+    "properties": [
+      {
+        "name": "privateKeyVaultReference",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "passPhraseVaultReference",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "publicUserName",
+        "description": "",
+        "type": "String",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "GCPApplicationDefaultCredentialsAuthenticationStrategy",
+    "_type": "gcpApplicationDefaultCredentials",
+    "properties": [
+    ]
+  }
+]

--- a/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/resources/legend-datasources.json
+++ b/legend-engine-executionPlan-execution-store-relational-connection-api/src/main/resources/legend-datasources.json
@@ -1,0 +1,170 @@
+[
+  {
+    "name": "LocalH2DatasourceSpecification",
+    "_type" : "localH2",
+    "properties": [
+      {
+        "name": "testDataSetupCsv",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "testDataSetupSqls",
+        "description": "",
+        "type": "Array",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "StaticDatasourceSpecification",
+    "_type" : "static",
+    "properties": [
+      {
+        "name": "host",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "port",
+        "description": "",
+        "type": "Integer",
+        "required": true
+      },
+      {
+        "name": "databaseName",
+        "description": "",
+        "type": "String",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "DatabricksDatasourceSpecification",
+    "_type" : "databricks",
+    "properties": [
+      {
+        "name": "hostname",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "port",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "protocol",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "httpPath",
+        "description": "",
+        "type": "String",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "SnowflakeDatasourceSpecification",
+    "_type" : "snowflake",
+    "properties": [
+      {
+        "name": "accountName",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "region",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "warehouseName",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "databaseName",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "cloudType",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "accountType",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "organization",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "quotedIdentifiersIgnoreCase",
+        "description": "",
+        "type": "Boolean",
+        "required": false
+      },
+      {
+        "name": "proxyHost",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "proxyPort",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "nonProxyHosts",
+        "description": "",
+        "type": "String",
+        "required": false
+      },
+      {
+        "name": "role",
+        "description": "",
+        "type": "String",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "BigQueryDatasourceSpecification",
+    "_type" : "bigQuery",
+    "properties": [
+      {
+        "name": "projectId",
+        "description": "",
+        "type": "String",
+        "required": true
+      },
+      {
+        "name": "defaultDataset",
+        "description": "",
+        "type": "String",
+        "required": true
+      }
+    ]
+  }
+]

--- a/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/RelationalExecutor.java
+++ b/legend-engine-executionPlan-execution-store-relational/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/RelationalExecutor.java
@@ -112,6 +112,11 @@ public class RelationalExecutor
         this.resultInterpreterExtensions = Iterate.addAllTo(ServiceLoader.load(ResultInterpreterExtension.class), Lists.mutable.empty()).collect(ResultInterpreterExtension::additionalResultBuilder);
     }
 
+    public Optional<DatabaseAuthenticationFlowProvider> getFlowProviderHolder()
+    {
+        return flowProviderHolder;
+    }
+
     public RelationalExecutionConfiguration getRelationalExecutionConfiguration()
     {
         return this.relationalExecutionConfiguration;

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -172,6 +172,10 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-relational</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-modelManager-sdlc</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.finos.legend.engine.application.query.api.ApplicationQuery;
 import org.finos.legend.engine.application.query.configuration.ApplicationQueryConfiguration;
 import org.finos.legend.engine.authentication.LegendDefaultDatabaseAuthenticationFlowProviderConfiguration;
+import org.finos.legend.engine.authentication.provider.DatabaseAuthenticationFlowProvider;
 import org.finos.legend.engine.external.shared.format.extension.GenerationExtension;
 import org.finos.legend.engine.external.shared.format.extension.GenerationMode;
 import org.finos.legend.engine.external.shared.format.generations.loaders.CodeGenerators;
@@ -59,12 +60,12 @@ import org.finos.legend.engine.plan.execution.api.ExecutePlanStrategic;
 import org.finos.legend.engine.plan.execution.service.api.ServiceModelingApi;
 import org.finos.legend.engine.plan.execution.stores.inMemory.plugin.InMemory;
 import org.finos.legend.engine.plan.execution.stores.relational.api.RelationalExecutorInformation;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.api.extensions.relational.RelationalExtensionsMetadataApi;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.api.schema.SchemaExplorationApi;
 import org.finos.legend.engine.plan.execution.stores.relational.plugin.Relational;
 import org.finos.legend.engine.plan.execution.stores.relational.plugin.RelationalStoreExecutor;
 import org.finos.legend.engine.plan.execution.stores.service.plugin.ServiceStore;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
-import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransformers;
 import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
 import org.finos.legend.engine.query.graphQL.api.debug.GraphQLDebug;
 import org.finos.legend.engine.query.graphQL.api.execute.GraphQLExecute;
@@ -95,10 +96,7 @@ import org.slf4j.Logger;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import javax.ws.rs.container.DynamicFeature;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.ServiceLoader;
+import java.util.*;
 
 public class Server extends Application<ServerConfiguration>
 {
@@ -180,6 +178,8 @@ public class Server extends Application<ServerConfiguration>
 
         // Relational
         environment.jersey().register(new SchemaExplorationApi(modelManager, relationalStoreExecutor));
+        Optional<DatabaseAuthenticationFlowProvider> flowProviderHolder = relationalStoreExecutor.getStoreState().getRelationalExecutor().getFlowProviderHolder();
+        environment.jersey().register(new RelationalExtensionsMetadataApi(flowProviderHolder));
 
         // Compilation
         environment.jersey().register((DynamicFeature) (resourceInfo, context) -> context.register(new InflateInterceptor()));


### PR DESCRIPTION
This PR introduces the a metadata API for the relational extension.  The API provides the following metadata 
* Metadata about supported data source specifications
* Metadata about supported authentication strategies
* Metadata about supported database type, data source specification and authentication strategy combinations