### PR TITLE
throw error when non-batch `grammarToJson` endpoints fail

### DIFF
--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarGraphFetchApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarGraphFetchApi.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
 import org.finos.legend.engine.language.pure.grammar.api.jsonToGrammar.JsonToGrammar;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.graph.RootGraphFetchTree;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
@@ -42,7 +43,7 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
                         "      }\n" +
                         "    }\n" +
                         "  }\n" +
-                        "}#", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":9,\"endLine\":3,\"sourceId\":\"\",\"startColumn\":5,\"startLine\":3}}");
+                        "}#", "Unexpected token", new SourceInformation("", 3, 5, 3, 9));
     }
 
     @Test

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarLambdaApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarLambdaApi.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
 import org.finos.legend.engine.language.pure.grammar.api.jsonToGrammar.JsonToGrammar;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
@@ -45,7 +46,7 @@ public class TestGrammarLambdaApi extends TestGrammar<Lambda>
     @Test
     public void testSimpleParsingError()
     {
-        testError("|1->toString(),", "{\"message\":\"no viable alternative at input '->toString(),'\",\"sourceInformation\":{\"endColumn\":15,\"endLine\":1,\"sourceId\":\"\",\"startColumn\":15,\"startLine\":1}}");
+        testError("|1->toString(),", "no viable alternative at input '->toString(),'", new SourceInformation("", 1, 15, 1, 15));
     }
 
     @Test

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
@@ -3,6 +3,7 @@ package org.finos.legend.engine.language.pure.grammar.api.test;
 import org.eclipse.collections.api.block.function.Function2;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
 import org.finos.legend.engine.language.pure.grammar.api.jsonToGrammar.JsonToGrammar;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
@@ -35,7 +36,7 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     @Test
     public void testSimpleError()
     {
-        testError("Class A\n{", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":1,\"endLine\":2,\"sourceId\":\"\",\"startColumn\":1,\"startLine\":2}}");
+        testError("Class A\n{", "Unexpected token", new SourceInformation("", 2, 1, 2, 1));
     }
 
     private static final GrammarToJson grammarToJson = new GrammarToJson();

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarValueSpecificationApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarValueSpecificationApi.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
 import org.finos.legend.engine.language.pure.grammar.api.jsonToGrammar.JsonToGrammar;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
@@ -28,11 +29,10 @@ public class TestGrammarValueSpecificationApi extends TestGrammar<ValueSpecifica
     @Test
     public void testSimpleError()
     {
-        testError("1", "{\"_type\":\"integer\",\"multiplicity\":{\"lowerBound\":1,\"upperBound\":1},\"sourceInformation\":{\"endColumn\":1,\"endLine\":1,\"sourceId\":\"\",\"startColumn\":1,\"startLine\":1},\"values\":[1]}");
         testError("true->func(\n" +
                 "  2\n" +
                 "  'www'\n" +
-                ")", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":7,\"endLine\":3,\"sourceId\":\"\",\"startColumn\":3,\"startLine\":3}}");
+                ")", "Unexpected token", new SourceInformation("", 3, 3, 3, 7));
     }
 
     @Test

--- a/legend-engine-language-pure-store-relational-grammar-api/pom.xml
+++ b/legend-engine-language-pure-store-relational-grammar-api/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-language-pure-store-relational-grammar-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
+++ b/legend-engine-language-pure-store-relational-grammar-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.RelationalOperationElementGrammarToJson;
 import org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.RelationalOperationElementJsonToGrammar;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
@@ -24,7 +25,7 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     @Test
     public void testSimpleError()
     {
-        testError("add(1,", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":11,\"endLine\":1,\"sourceId\":\"\",\"startColumn\":7,\"startLine\":1}}");
+        testError("add(1,", "Unexpected token", new SourceInformation("", 1, 7, 1, 11));
     }
 
     @Test

--- a/legend-engine-query-graphQL/src/test/java/org/finos/legend/engine/query/graphQL/api/grammar/test/TestGrammarApi.java
+++ b/legend-engine-query-graphQL/src/test/java/org/finos/legend/engine/query/graphQL/api/grammar/test/TestGrammarApi.java
@@ -3,6 +3,7 @@ package org.finos.legend.engine.query.graphQL.api.grammar.test;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.graphQL.metamodel.ExecutableDocument;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.query.graphQL.api.grammar.GraphQLGrammar;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
@@ -33,7 +34,7 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
                 "  name String!\n" +
                 "  values: [String]\n" +
                 "  length(unit: LengthUnit = METER): Float\n" +
-                "}", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":13,\"endLine\":3,\"sourceId\":\"\",\"startColumn\":8,\"startLine\":3}}");
+                "}", "Unexpected token", new SourceInformation("", 3, 8, 3, 13));
     }
 
     @Test

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/ExceptionTool.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/ExceptionTool.java
@@ -33,15 +33,25 @@ public class ExceptionTool
 
     public static Response exceptionManager(Exception exception, LoggingEventType eventType, Iterable<? extends CommonProfile> pm)
     {
-        return manage(eventType, pm, new ExceptionError(-1, exception));
+        return manage(eventType, pm, new ExceptionError(-1, exception), Response.Status.INTERNAL_SERVER_ERROR);
     }
 
     public static Response exceptionManager(String message, LoggingEventType eventType, Iterable<? extends CommonProfile> pm)
     {
-        return manage(eventType, pm, new ExceptionError(-1, message));
+        return manage(eventType, pm, new ExceptionError(-1, message), Response.Status.INTERNAL_SERVER_ERROR);
     }
 
-    private static Response manage(LoggingEventType eventType, Iterable<? extends CommonProfile> pm, ExceptionError error)
+    public static Response exceptionManager(Exception exception, LoggingEventType eventType, Response.Status status, Iterable<? extends CommonProfile> pm)
+    {
+        return manage(eventType, pm, new ExceptionError(-1, exception), status);
+    }
+
+    public static Response exceptionManager(String message, LoggingEventType eventType, Response.Status status, Iterable<? extends CommonProfile> pm)
+    {
+        return manage(eventType, pm, new ExceptionError(-1, message), status);
+    }
+
+    private static Response manage(LoggingEventType eventType, Iterable<? extends CommonProfile> pm, ExceptionError error, Response.Status status)
     {
         LOGGER.error(new LogInfo(pm, eventType, error).toString());
         String text;
@@ -57,6 +67,6 @@ public class ExceptionTool
         {
             GlobalTracer.get().activeSpan().setTag("error", text);
         }
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
+        return Response.status(status).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
     }
 }

--- a/legend-engine-shared-core/src/test/java/org/finos/legend/engine/shared/core/api/TestGrammar.java
+++ b/legend-engine-shared-core/src/test/java/org/finos/legend/engine/shared/core/api/TestGrammar.java
@@ -6,15 +6,18 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.MapIterate;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
+import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionError;
 
 import javax.ws.rs.core.Response;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public abstract class TestGrammar<Z>
 {
@@ -43,13 +46,20 @@ public abstract class TestGrammar<Z>
         }
     }
 
-    protected void testError(String str, String expected)
+    protected void testError(String str, String expectedErrorMessage, SourceInformation expectedErrorSourceInformation)
     {
         try
         {
             Response result = grammarToJson().apply(str, true);
-            String actual = result.getEntity().toString();
-            assertEquals(expected, actual);
+            Object errorObject = result.getEntity();
+            assertTrue(errorObject instanceof ExceptionError);
+            ExceptionError error = (ExceptionError) errorObject;
+            assertEquals(expectedErrorMessage, error.getMessage());
+            assertEquals(expectedErrorSourceInformation.sourceId, error.getSourceInformation().sourceId);
+            assertEquals(expectedErrorSourceInformation.startLine, error.getSourceInformation().startLine);
+            assertEquals(expectedErrorSourceInformation.startColumn, error.getSourceInformation().startColumn);
+            assertEquals(expectedErrorSourceInformation.endLine, error.getSourceInformation().endLine);
+            assertEquals(expectedErrorSourceInformation.endColumn, error.getSourceInformation().endColumn);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
This applies to non-batch `grammarToJson` endpoints:

- `/grammarToJson/model`
- `/grammarToJson/valueSpecification`
- `/grammarToJson/lambda`
- `/grammarToJson/graphFetch`
- `/grammarToJson/relationalOperationElement`

When there's a parsing error, these endpoint return `200` with the return body as the error. We should throw this error instead and I opt for using error code `400: Bad Request`