### PR TITLE
Add missing steps in relational parsing and compiling

### DIFF
--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -926,6 +926,12 @@ public class HelperRelationalBuilder
 
         rpm.setSourceInformation(SourceInformationHelper.toM3SourceInformation(propertyMapping.sourceInformation));
 
+        if (propertyMapping.localMappingProperty != null)
+        {
+            res._localMappingPropertyType(context.resolveType(propertyMapping.localMappingProperty.type, propertyMapping.localMappingProperty.sourceInformation));
+            res._localMappingPropertyMultiplicity(context.pureModel.getMultiplicity(propertyMapping.localMappingProperty.multiplicity));
+        }
+
         if (propertyMapping.enumMappingId != null)
         {
             EnumerationMapping<Object> eMap = allEnumerationMappings.select(e -> e._name().equals(propertyMapping.enumMappingId)).getFirst();
@@ -1271,6 +1277,7 @@ public class HelperRelationalBuilder
     {
         org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.FilterMapping filterMapping = new Root_meta_relational_mapping_FilterMapping_Impl("");
         filterMapping._filter(getFilter(ownerDb, srcFilterMapping.filter.name, srcFilterMapping.sourceInformation));
+        filterMapping._filterName(srcFilterMapping.filter.name);
         if (!srcFilterMapping.joins.isEmpty())
         {
             filterMapping._joinTreeNode(buildElementWithJoinsJoinTreeNode(srcFilterMapping.joins, context));

--- a/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
+++ b/legend-engine-language-pure-store-relational/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
@@ -53,10 +53,13 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.r
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.postprocessor.PostProcessor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.RelationalAssociationMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.RelationalPropertyMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.RootRelationalClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.mappingTest.RelationalInputData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.mappingTest.RelationalInputType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.milestoning.Milestoning;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.ElementWithJoins;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.JoinPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 
@@ -111,9 +114,9 @@ public class RelationalGrammarParserExtension implements IRelationalGrammarParse
                     RelationalAssociationMapping associationMapping = new RelationalAssociationMapping();
                     associationMapping.association = PureGrammarParserUtility.fromQualifiedName(ctx.qualifiedName().packagePath() == null ? Collections.emptyList() : ctx.qualifiedName().packagePath().identifier(), ctx.qualifiedName().identifier());
                     associationMapping.id = ctx.mappingElementId() != null ? ctx.mappingElementId().getText() : null;
-                    // TODO? stores
                     associationMapping.sourceInformation = parserInfo.sourceInformation;
                     walker.visitRelationalAssociationMapping((RelationalParserGrammar.AssociationMappingContext) parserInfo.rootContext, associationMapping);
+                    propagateStorePath(associationMapping);
                     return associationMapping;
                 }
                 throw new EngineException("Unknown relational mapping element type: " + parserInfo.rootContext.getClass().getName(), parserInfo.sourceInformation, EngineErrorType.PARSER);
@@ -350,5 +353,23 @@ public class RelationalGrammarParserExtension implements IRelationalGrammarParse
         parser.addErrorListener(errorListener);
         RelationalParseTreeWalker walker = new RelationalParseTreeWalker(parseTreeWalkerSourceInformation);
         return walker.visitOperation(parser.operation(), null);
+    }
+
+    public static void propagateStorePath(RelationalAssociationMapping mapping)
+    {
+        RelationalPropertyMapping propertyMapping = (RelationalPropertyMapping) mapping.propertyMappings.stream()
+                .filter(prop -> prop instanceof RelationalPropertyMapping && ((RelationalPropertyMapping) prop).relationalOperation!= null)
+                .findFirst().orElse(null);
+
+        if (propertyMapping != null && propertyMapping.relationalOperation instanceof ElementWithJoins)
+        {
+            JoinPointer pointer = ((ElementWithJoins) propertyMapping.relationalOperation).joins.stream()
+                    .filter(join -> join.db != null).findFirst().orElse(null);
+
+            if(pointer != null)
+            {
+                mapping.stores = Lists.mutable.with(pointer.db);
+            }
+        }
     }
 }


### PR DESCRIPTION
- Add proper handling localPropertyMappings (information added: type and multiplicity)
- Add proper handling for relational filters (filterName field should not be empty as it is used in protocol transofmartions)
- Propagate stores information in relational association mappings parsing (otherwise protocol transformation may fail)