### PR TITLE
Support list parameters for service tests

### DIFF
--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
@@ -30,3 +30,4 @@ SERVICE_TEST:                       'test';
 SERVICE_TEST_TESTS:                 'tests';
 SERVICE_DATA:                       'data';
 SERVICE_ASSERTS:                    'asserts';
+PARAM_GROUP:                        'list';

--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
@@ -152,5 +152,18 @@ testAssert:                             BRACE_OPEN
                                             testParameters COMMA combinedExpression
                                         BRACE_CLOSE
 ;
-testParameters:                         BRACKET_OPEN (primitiveValue (COMMA primitiveValue)*)? BRACKET_CLOSE
+testParameters:                         BRACKET_OPEN (testParam (COMMA testParam)*)? BRACKET_CLOSE
+;
+
+testListValueParam:                          PARAM_GROUP PAREN_OPEN
+                                                        BRACKET_OPEN
+                                                            (primitiveValue (COMMA primitiveValue)*)?
+                                                        BRACKET_CLOSE
+                                                  PAREN_CLOSE
+;
+
+testSingleValueParam:                        primitiveValue
+;
+
+testParam:                              testListValueParam | testSingleValueParam
 ;

--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
@@ -17,7 +17,7 @@ identifier:                             VALID_STRING | STRING
                                         | SERVICE_SINGLE | SERVICE_MULTI
                                         | SERVICE_PATTERN | SERVICE_OWNERS | SERVICE_DOCUMENTATION | SERVICE_AUTO_ACTIVATE_UPDATES
                                         | SERVICE_EXECUTION | SERVICE_FUNCTION | SERVICE_EXECUTION_KEY | SERVICE_EXECUTION_EXECUTIONS | SERVICE_RUNTIME | SERVICE_MAPPING
-                                        | SERVICE_TEST | SERVICE_TEST_TESTS | SERVICE_DATA | SERVICE_ASSERTS
+                                        | SERVICE_TEST | SERVICE_TEST_TESTS | SERVICE_DATA | SERVICE_ASSERTS | PARAM_GROUP
 ;
 
 

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
@@ -44,6 +44,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.TestContainer;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.PureList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -257,8 +258,28 @@ public class ServiceParseTreeWalker
 
     private List<ValueSpecification> visitTestParameters(ServiceParserGrammar.TestParametersContext ctx)
     {
-        List<ValueSpecification> testParameters = ctx != null && ctx.primitiveValue() != null ? ListIterate.collect(ctx.primitiveValue(), this::visitTestParameter): null;
+        List<ValueSpecification> testParameters = ctx != null && ctx.testParam() != null ? ListIterate.collect(ctx.testParam(), this::visitParam): null;
         return testParameters;
+    }
+
+    private ValueSpecification visitParam(ServiceParserGrammar.TestParamContext ctx)
+    {
+        if(ctx != null)
+        {
+            if(ctx.testListValueParam() != null)
+            {
+                List<ValueSpecification> paramValues = ListIterate.collect(ctx.testListValueParam().primitiveValue(), this::visitTestParameter);
+                PureList param =  new PureList();
+                param.values = paramValues;
+                param.sourceInformation = walkerSourceInformation.getSourceInformation(ctx.testListValueParam());
+                return param;
+            }
+            else if(ctx.testSingleValueParam() != null)
+            {
+                return visitTestParameter(ctx.testSingleValueParam().primitiveValue());
+            }
+        }
+        throw new UnsupportedOperationException();
     }
 
     private ValueSpecification visitTestParameter(ServiceParserGrammar.PrimitiveValueContext ctx) {

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
@@ -940,5 +940,78 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "    ];\n" +
                 "  }\n" +
                 "}\n");
+
+        //test  list param
+        test(resource + "###Service\n" +
+                "Service test::Service\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  owners: ['ownerName'];\n" +
+                "  documentation: 'test';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Single\n" +
+                "  {\n" +
+                "    query: src:    test::class[1]|$src.prop1;\n" +
+                "      mapping: test::mapping;\n" +
+                "      runtime: test::runtime;\n" +
+                "  }\n" +
+                "  test: Single\n" +
+                "  {\n" +
+                "    data: 'test';\n" +
+                "    asserts:\n" +
+                "    [\n" +
+                "      {[list(['param'])],'testexpression'}\n" +
+                "    ];\n" +
+                "  }\n" +
+                "}\n");
+
+
+        //test single and list param
+        test(resource + "###Service\n" +
+                "Service test::Service\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  owners: ['ownerName'];\n" +
+                "  documentation: 'test';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Single\n" +
+                "  {\n" +
+                "    query: src:    test::class[1]|$src.prop1;\n" +
+                "      mapping: test::mapping;\n" +
+                "      runtime: test::runtime;\n" +
+                "  }\n" +
+                "  test: Single\n" +
+                "  {\n" +
+                "    data: 'test';\n" +
+                "    asserts:\n" +
+                "    [\n" +
+                "      {[list(['param']),'testparameter'],'testexpression'}\n" +
+                "    ];\n" +
+                "  }\n" +
+                "}\n");
+
+        //test many list param
+        test(resource + "###Service\n" +
+                "Service test::Service\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  owners: ['ownerName'];\n" +
+                "  documentation: 'test';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Single\n" +
+                "  {\n" +
+                "    query: src:    test::class[1]|$src.prop1;\n" +
+                "      mapping: test::mapping;\n" +
+                "      runtime: test::runtime;\n" +
+                "  }\n" +
+                "  test: Single\n" +
+                "  {\n" +
+                "    data: 'test';\n" +
+                "    asserts:\n" +
+                "    [\n" +
+                "      {[list(['param']), 'singleparam', list([1,2,3]), list([%2019-05-24, %2019-05-25])],'testexpression'}\n" +
+                "    ];\n" +
+                "  }\n" +
+                "}\n");
     }
 }


### PR DESCRIPTION
This will enable users add tests for services that have parameters with multiplicity [*]