### PR TITLE
Update Databricks integration test to use a long running cluster

### DIFF
--- a/.github/workflows/database-databricks-integration-test.yml
+++ b/.github/workflows/database-databricks-integration-test.yml
@@ -41,9 +41,6 @@ jobs:
           ${DATABRICKS_API_TOKEN}
           EOF
         shell: bash
-      - name: Start databricks endpoint
-        run: databricks clusters start --cluster-id ${DATABRICKS_CLUSTERID}
-        shell: bash
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Set up JDK
@@ -67,6 +64,3 @@ jobs:
         run: |
           mvn clean install -DskipTests=true
           mvn -P run-databricks-integration -pl legend-engine-executionPlan-execution-store-relational-connection-tests  -Dtest="ExternalIntegration*Databricks*" test
-      - name: Stop databricks endpoint
-        run: databricks clusters delete --cluster-id ${DATABRICKS_CLUSTERID}
-        shell: bash


### PR DESCRIPTION
This PR removes the cluster start/stop workflow steps.

When multiple PRs are pushed to master, each PR triggers a workflow which executes cluster start/stop.
The cluster start/stop actions are not idempotent and throw errors (e.g when the action tries to start the cluster but the cluster is already running).

For now, we are switching the cluster to a long running cluster and removing the start/stop.
We will switch to using serverless Databricks when it becomes available.

@aamend 