### PR TITLE
Fix service store mapping builder

### DIFF
--- a/legend-engine-language-external-store-service/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreClassMappingBuilder.java
+++ b/legend-engine-language-external-store-service/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreClassMappingBuilder.java
@@ -70,10 +70,9 @@ public class HelperServiceStoreClassMappingBuilder
 
         validateRootServiceStoreClassMapping(res, serviceStoreClassMapping);
 
-        List<PropertyMapping> generatePropertyMappings = generatePropertyMappingsForClassMapping(res, serviceStoreClassMapping, context);
+        MutableList<EmbeddedSetImplementation> embeddedSetImplementations = Lists.mutable.empty();
+        List<PropertyMapping> generatePropertyMappings = generatePropertyMappingsForClassMapping(res, embeddedSetImplementations, serviceStoreClassMapping, context);
         res._propertyMappings(FastList.newList(generatePropertyMappings).toImmutable());
-
-        MutableList<EmbeddedSetImplementation> embeddedSetImplementations = ListIterate.selectInstancesOf(generatePropertyMappings, EmbeddedSetImplementation.class);
 
         return Tuples.pair(res, embeddedSetImplementations);
     }
@@ -212,7 +211,7 @@ public class HelperServiceStoreClassMappingBuilder
                 ._expressionSequence(valueSpecifications);
     }
 
-    private static List<PropertyMapping> generatePropertyMappingsForClassMapping(Root_meta_external_store_service_metamodel_mapping_RootServiceInstanceSetImplementation rootClassMapping, RootServiceStoreClassMapping serviceStoreClassMapping, CompileContext context)
+    private static List<PropertyMapping> generatePropertyMappingsForClassMapping(Root_meta_external_store_service_metamodel_mapping_RootServiceInstanceSetImplementation rootClassMapping, List<EmbeddedSetImplementation> embeddedSetImplementations, RootServiceStoreClassMapping serviceStoreClassMapping, CompileContext context)
     {
         Root_meta_external_shared_format_binding_Binding binding = rootClassMapping._servicesMapping().getAny()._service()._response()._binding();
 
@@ -221,7 +220,7 @@ public class HelperServiceStoreClassMappingBuilder
 
         if (bindingDetail instanceof Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail)
         {
-            return generatePropertyMappings((Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail) bindingDetail, rootClassMapping._class(), rootClassMapping._id(), rootClassMapping, context);
+            return generatePropertyMappings((Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail) bindingDetail, rootClassMapping._class(), rootClassMapping._id(), embeddedSetImplementations, rootClassMapping, context);
         }
         else
         {
@@ -229,7 +228,7 @@ public class HelperServiceStoreClassMappingBuilder
         }
     }
 
-    private static List<PropertyMapping> generatePropertyMappings(Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail bindingDetail, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass, String sourceSetId, PropertyMappingsImplementation owner, CompileContext context)
+    private static List<PropertyMapping> generatePropertyMappings(Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail bindingDetail, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass, String sourceSetId, List<EmbeddedSetImplementation> embeddedSetImplementations, PropertyMappingsImplementation owner, CompileContext context)
     {
         RichIterable<Property> properties = bindingDetail.mappedPropertiesForClass(pureClass, context.getExecutionSupport());
 
@@ -237,7 +236,7 @@ public class HelperServiceStoreClassMappingBuilder
         RichIterable<Property> nonPrimitiveProperties = properties.select(prop -> !core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_isPrimitiveValueProperty_AbstractProperty_1__Boolean_1_(prop, context.getExecutionSupport()));
 
         List<PropertyMapping> primitivePropertyMappings = primitiveProperties.collect(prop -> buildPrimitivePropertyMapping(prop, sourceSetId)).toList();
-        List<PropertyMapping> nonPrimitivePropertyMappings = nonPrimitiveProperties.collect(prop -> buildNonPrimitivePropertyMapping(prop, sourceSetId, bindingDetail, owner._parent(), owner, context)).toList();
+        List<PropertyMapping> nonPrimitivePropertyMappings = nonPrimitiveProperties.collect(prop -> buildNonPrimitivePropertyMapping(prop, sourceSetId, bindingDetail, owner._parent(), embeddedSetImplementations, owner, context)).toList();
 
         List<PropertyMapping> allPropertyMapping = Lists.mutable.empty();
         allPropertyMapping.addAll(primitivePropertyMappings);
@@ -257,7 +256,7 @@ public class HelperServiceStoreClassMappingBuilder
         return propertyMapping;
     }
 
-    private static PropertyMapping buildNonPrimitivePropertyMapping(Property property, String sourceSetId, Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail bindingDetail, org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping parent, PropertyMappingsImplementation owner, CompileContext context)
+    private static PropertyMapping buildNonPrimitivePropertyMapping(Property property, String sourceSetId, Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail bindingDetail, org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping parent, List<EmbeddedSetImplementation> embeddedSetImplementations, PropertyMappingsImplementation owner, CompileContext context)
     {
         Root_meta_external_store_service_metamodel_mapping_EmbeddedServiceStoreSetImplementation propertyMapping = new Root_meta_external_store_service_metamodel_mapping_EmbeddedServiceStoreSetImplementation_Impl("");
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class) property._genericType()._rawType();
@@ -272,7 +271,9 @@ public class HelperServiceStoreClassMappingBuilder
         propertyMapping._sourceSetImplementationId(sourceSetId);
         propertyMapping._targetSetImplementationId(id);
 
-        propertyMapping._propertyMappings(FastList.newList(generatePropertyMappings(bindingDetail, pureClass, id, propertyMapping, context)).toImmutable());
+        propertyMapping._propertyMappings(FastList.newList(generatePropertyMappings(bindingDetail, pureClass, id, embeddedSetImplementations, propertyMapping, context)).toImmutable());
+
+        embeddedSetImplementations.add(propertyMapping);
         return propertyMapping;
     }
 

--- a/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreMappingCompilationFromGrammar.java
+++ b/legend-engine-language-external-store-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceStoreMappingCompilationFromGrammar.java
@@ -14,6 +14,10 @@
 
 package org.finos.legend.engine.language.pure.compiler.test;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.finos.legend.engine.language.pure.compiler.test.TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test;
@@ -1817,5 +1821,22 @@ public class TestServiceStoreMappingCompilationFromGrammar
                 "    )\n" +
                 "  }\n" +
                 ")\n");
+    }
+
+    @Test
+    public void testMultiLevelNesting()
+    {
+        Pair<PureModelContextData, PureModel> result =
+                test(JSON_BINDING +
+                        "###Mapping\n" +
+                        "Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping\n" +
+                        "(\n" +
+                        "    *meta::external::store::service::showcase::domain::ApiResponse[response_set]: ServiceStore\n" +
+                        "    {\n" +
+                        "        ~service [meta::external::store::service::showcase::store::EmployeesServiceStore] EmployeesService\n" +
+                        "    }\n" +
+                        ")\n\n");
+
+        Assert.assertEquals(5, result.getTwo().getMapping("meta::external::store::service::showcase::mapping::ServiceStoreMapping")._classMappings().size());
     }
 }


### PR DESCRIPTION
Currently we are not correctly updating generated embedded set implementations for multi-level nesting while compiling service store mapping. 
Changes in this PR fix this flow