### PR TITLE
add support to run db tests from engine

### DIFF
--- a/legend-engine-executionPlan-execution-store-relational-connection-tests-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/H2AlloyServer.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection-tests-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/H2AlloyServer.java
@@ -36,7 +36,7 @@ public class H2AlloyServer implements DynamicTestConnection
     public void setup()
     {
         long start = System.currentTimeMillis();
-        System.out.println("Starting setup of connection for database: H2 ");
+        System.out.println("Starting setup of dynamic connection for database: H2 ");
 
         int relationalDBPort = DynamicPortGenerator.generatePort();
         try
@@ -49,7 +49,7 @@ public class H2AlloyServer implements DynamicTestConnection
         }
         long end = System.currentTimeMillis();
 
-        System.out.println("Completed setup of connection for database: H2 on port:" + relationalDBPort + " , time taken(ms):"+ (end-start));
+        System.out.println("Completed setup of dynamic connection for database: H2 on port:" + relationalDBPort + " , time taken(ms):"+ (end-start));
     }
 
     @Override

--- a/legend-engine-executionPlan-execution-store-relational-connection-tests-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/SqlServerTestContainers.java
+++ b/legend-engine-executionPlan-execution-store-relational-connection-tests-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/SqlServerTestContainers.java
@@ -48,7 +48,7 @@ public class SqlServerTestContainers implements DynamicTestConnection
 
     private void startMSSQLServerContainer()
     {
-        System.out.println("Starting setup of connection for database: SqlServer ");
+        System.out.println("Starting setup of dynamic connection for database: SqlServer ");
 
         long start = System.currentTimeMillis();
         this.mssqlserver.start();
@@ -56,7 +56,7 @@ public class SqlServerTestContainers implements DynamicTestConnection
         int containerPort = this.mssqlserver.getMappedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT);
         long end = System.currentTimeMillis();
 
-        System.out.println("Completed setup of connection for database: SqlServer on host:" + containerHost + " and port:" + containerPort + " , time taken(ms):"+ (end-start));
+        System.out.println("Completed setup of dynamic connection for database: SqlServer on host:" + containerHost + " and port:" + containerPort + " , time taken(ms):"+ (end-start));
     }
 
     public void registerVault()

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -70,6 +70,8 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <excludes>
                         <exclude>**/Test_Relational_DbSpecific_SqlServer_UsingPureClientTestSuite.java</exclude>
+                        <exclude>**/Test_Relational_DbSpecific_Redshift_UsingPureClientTestSuite.java</exclude>
+                        <exclude>**/Test_Relational_DbSpecific_Snowflake_UsingPureClientTestSuite.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_H2_UsingPureClientTestSuite.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_H2_UsingPureClientTestSuite.java
@@ -18,9 +18,9 @@ import junit.framework.Test;
 
 public class Test_Relational_DbSpecific_H2_UsingPureClientTestSuite extends Test_Relational_DbSpecific_UsingPureClientTestSuite
 {
-    public static Test suite()
+    public static Test suite() throws Exception
     {
-        return createSuite("meta::relational::tests::dbSpecificTests::H2","org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json");
+        return createSuite("H2", "meta::relational::tests::dbSpecificTests::sqlQueryTests","org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json");
     }
 }
 

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_Redshift_UsingPureClientTestSuite.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_Redshift_UsingPureClientTestSuite.java
@@ -1,0 +1,27 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.server.test.pureClient.stores.dbSpecific;
+
+import junit.framework.Test;
+
+public class Test_Relational_DbSpecific_Redshift_UsingPureClientTestSuite
+        extends Test_Relational_DbSpecific_UsingPureClientTestSuite
+{
+    public static Test suite() throws Exception
+    {
+        return createSuite("Redshift","meta::relational::tests::dbSpecificTests::sqlQueryTests","org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json");
+    }
+}
+

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_Snowflake_UsingPureClientTestSuite.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_Snowflake_UsingPureClientTestSuite.java
@@ -1,0 +1,27 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.server.test.pureClient.stores.dbSpecific;
+
+import junit.framework.Test;
+
+public class Test_Relational_DbSpecific_Snowflake_UsingPureClientTestSuite
+        extends Test_Relational_DbSpecific_UsingPureClientTestSuite
+{
+    public static Test suite() throws Exception
+    {
+        return createSuite("Snowflake","meta::relational::tests::dbSpecificTests::sqlQueryTests","org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json");
+    }
+}
+

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_SqlServer_UsingPureClientTestSuite.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_SqlServer_UsingPureClientTestSuite.java
@@ -19,9 +19,9 @@ import junit.framework.Test;
 public class Test_Relational_DbSpecific_SqlServer_UsingPureClientTestSuite
         extends Test_Relational_DbSpecific_UsingPureClientTestSuite
 {
-    public static Test suite()
+    public static Test suite() throws Exception
     {
-        return createSuite("meta::relational::tests::dbSpecificTests::SqlServer","org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json");
+        return createSuite("SqlServer","meta::relational::tests::dbSpecificTests::sqlQueryTests","org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json");
     }
 }
 

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_UsingPureClientTestSuite.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_UsingPureClientTestSuite.java
@@ -34,16 +34,9 @@ public abstract class Test_Relational_DbSpecific_UsingPureClientTestSuite extend
     {
         CompiledExecutionSupport executionSupport = getClassLoaderExecutionSupport();
 
-        try
-        {
-            //Run test engine server - needs to be setup before as we need testParam(connection details) to create test suite
-            PureTestHelper.initClientVersionIfNotAlreadySet( "vX_X_X" );
-            state.set( PureTestHelper.initEnvironment( false, testServerConfigFilePath ) );
-        }
-        catch ( Exception e )
-        {
-            throw e;
-        }
+        //Run test engine server - needs to be setup before as we need testParam(connection details) to create test suite
+        PureTestHelper.initClientVersionIfNotAlreadySet( "vX_X_X" );
+        state.set( PureTestHelper.initEnvironment( false, testServerConfigFilePath ) );
 
         Root_meta_relational_dbTestRunner_DbTestConfig dbTestConfig =
                 core_relational_relational_dbTestRunner_shared.Root_meta_relational_dbTestRunner_createDbConfig_String_1__DbTestConfig_1_(

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/TestServer.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/TestServer.java
@@ -26,6 +26,8 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.r
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
 import org.finos.legend.engine.server.Server;
 import org.finos.legend.engine.shared.core.url.EngineUrlStreamHandlerFactory;
+import org.finos.legend.engine.shared.core.vault.EnvironmentVaultImplementation;
+import org.finos.legend.engine.shared.core.vault.Vault;
 
 public class TestServer extends Server<TestServerConfiguration>
 {
@@ -41,6 +43,7 @@ public class TestServer extends Server<TestServerConfiguration>
     public void run(TestServerConfiguration serverConfiguration, Environment environment)
     {
         super.run(serverConfiguration, environment);
+        Vault.INSTANCE.registerImplementation(new EnvironmentVaultImplementation());
         environment.jersey().register(new TestConnectionProviderApi(getTestConnections(serverConfiguration)));
     }
 
@@ -54,6 +57,7 @@ public class TestServer extends Server<TestServerConfiguration>
             if (serverConfiguration.testConnectionsToEnable.contains(dbType))
             {
                 testConnections.putIfAbsent(dbType, serverConfiguration.staticTestConnections.get(dbType));
+                System.out.println("Configured to reach static connection for database : " + dbType);
             }
         }
 

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
@@ -1,0 +1,104 @@
+{
+  "deployment": {
+    "mode": "TEST_IGNORE_FUNCTION_MATCH"
+  },
+  "logging": {
+    "level": "error",
+    "appenders": [
+      {
+        "type": "console",
+        "logFormat": "%msg\r\n"
+      }
+    ]
+  },
+  "pac4j": {
+    "bypassPaths": [
+      "/api/server/v1/info"
+    ],
+    "clients": [
+      {
+        "org.pac4j.core.client.direct.AnonymousClient": {
+        }
+      }
+    ],
+    "mongoSession": {
+      "enabled": false
+    }
+  },
+  "opentracing": {
+    "elastic": "",
+    "zipkin": "",
+    "uri": "",
+    "authenticator": {
+      "principal": "",
+      "keytab": ""
+    }
+  },
+  "swagger": {
+    "title": "Legend Engine",
+    "resourcePackage": "org.finos.legend",
+    "uriPrefix": "/api"
+  },
+  "server": {
+    "type": "simple",
+    "applicationContextPath": "/",
+    "adminContextPath": "/admin",
+    "connector": {
+      "maxRequestHeaderSize": "32KiB",
+      "type": "http",
+      "port": 6060
+    },
+    "requestLog": {
+      "appenders": [
+      ]
+    }
+  },
+  "metadataserver": {
+    "pure": {
+      "host": "127.0.0.1",
+      "port": 8080
+    },
+    "alloy": {
+      "host": "127.0.0.1",
+      "port": 8075
+    }
+  },
+  "temporarytestdb": {
+    "port": 9099
+  },
+  "relationalexecution": {
+    "tempPath": "/tmp/",
+    "temporarytestdb": {
+      "port": 9099
+    },
+    "flowProviderClass": "org.finos.legend.engine.authentication.LegendDefaultDatabaseAuthenticationFlowProvider",
+    "flowProviderConfiguration": {
+      "_type": "legendDefault"
+    }
+  },
+  "testConnectionsToEnable" : ["Redshift"],
+  "staticTestConnections" : {
+    "Redshift" : {
+      "_type": "RelationalDatabaseConnection",
+      "datasourceSpecification": {
+        "_type": "redshift",
+        "host": "redshift-load-balancer-cb907ffe8879f6c2.elb.us-east-1.amazonaws.com",
+        "port": 5439,
+        "databaseName": "dev",
+        "clusterID": "",
+        "region": "us-east-1"
+      },
+      "authenticationStrategy": {
+        "_type": "userNamePassword",
+        "baseVaultReference": "",
+        "userNameVaultReference": "REDSHIFT_LEGEND_INTEG_USERNAME",
+        "passwordVaultReference": "REDSHIFT_LEGEND_INTEG_PASSWORD"
+      },
+      "type": "Redshift",
+      "element" : "",
+      "databaseType": "Redshift",
+      "postProcessors": [],
+      "postProcessorWithParameter": []
+    }
+  }
+}

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
@@ -1,0 +1,105 @@
+{
+  "deployment": {
+    "mode": "TEST_IGNORE_FUNCTION_MATCH"
+  },
+  "logging": {
+    "level": "error",
+    "appenders": [
+      {
+        "type": "console",
+        "logFormat": "%msg\r\n"
+      }
+    ]
+  },
+  "pac4j": {
+    "bypassPaths": [
+      "/api/server/v1/info"
+    ],
+    "clients": [
+      {
+        "org.pac4j.core.client.direct.AnonymousClient": {
+        }
+      }
+    ],
+    "mongoSession": {
+      "enabled": false
+    }
+  },
+  "opentracing": {
+    "elastic": "",
+    "zipkin": "",
+    "uri": "",
+    "authenticator": {
+      "principal": "",
+      "keytab": ""
+    }
+  },
+  "swagger": {
+    "title": "Legend Engine",
+    "resourcePackage": "org.finos.legend",
+    "uriPrefix": "/api"
+  },
+  "server": {
+    "type": "simple",
+    "applicationContextPath": "/",
+    "adminContextPath": "/admin",
+    "connector": {
+      "maxRequestHeaderSize": "32KiB",
+      "type": "http",
+      "port": 6060
+    },
+    "requestLog": {
+      "appenders": [
+      ]
+    }
+  },
+  "metadataserver": {
+    "pure": {
+      "host": "127.0.0.1",
+      "port": 8080
+    },
+    "alloy": {
+      "host": "127.0.0.1",
+      "port": 8075
+    }
+  },
+  "temporarytestdb": {
+    "port": 9099
+  },
+  "relationalexecution": {
+    "tempPath": "/tmp/",
+    "temporarytestdb": {
+      "port": 9099
+    },
+    "flowProviderClass": "org.finos.legend.engine.authentication.LegendDefaultDatabaseAuthenticationFlowProvider",
+    "flowProviderConfiguration": {
+      "_type": "legendDefault"
+    }
+  },
+  "testConnectionsToEnable" : ["Snowflake"],
+  "staticTestConnections" : {
+    "Snowflake" : {
+      "_type": "RelationalDatabaseConnection",
+      "datasourceSpecification": {
+        "_type": "snowflake",
+        "accountName": "ki79827",
+        "region": "us-east-2",
+        "warehouseName": "LEGEND_INTEGRATION_WH1",
+        "databaseName": "LEGEND_INTEGRATION_DB1",
+        "cloudType": "aws",
+        "role": "LEGEND_INTEGRATION_ROLE1"
+      },
+      "authenticationStrategy": {
+        "_type": "snowflakePublic",
+        "privateKeyVaultReference": "SNOWFLAKE_LEGEND_INTEG_RO1_PRIVATEKEY",
+        "passPhraseVaultReference": "SNOWFLAKE_LEGEND_INTEG_RO1_PASSWORD",
+        "publicUserName": "LEGEND_INTEG_RO1"
+      },
+      "type": "Snowflake",
+      "element" : "",
+      "databaseType": "Snowflake",
+      "postProcessors": [],
+      "postProcessorWithParameter": []
+    }
+  }
+}


### PR DESCRIPTION
depends on legend-pure changes - [pull request](https://github.com/finos/legend-pure/pull/538)