### PR TITLE
IDE Light: Make Legend-Pure core files location configurable

### DIFF
--- a/legend-engine-pure-ide-light/README.md
+++ b/legend-engine-pure-ide-light/README.md
@@ -1,0 +1,28 @@
+#Pure IDE Light
+
+Pure IDE Light is a development environment for Pure, the language underlying the Legend platform.
+
+
+##Running Pure IDE Light
+
+From the root of legend-engine, run the following to launch the Pure IDE Light server.
+
+```
+mvn -pl legend-engine-pure-ide-light exec:java -Dexec.mainClass="org.finos.legend.engine.ide.PureIDELight" -Dexec.args="server ./legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json"
+```
+
+Then navigate to http://127.0.0.1/ide
+
+## Changing the location of core files from legend-pure
+Some core code lives in [legend-pure](https://github.com/finos/legend-pure).
+By default, Pure IDE Light assumes that legend-pure is checked out as a sibling to legend-engine project in the filesystem.
+This can be overriden by editing the ideLightConfig.json file and adding the following to the end of the configuration file
+
+```
+ "sourceLocationConfiguration" : {
+    "coreFilesLocation" : <location of legend-pure directory>
+  }
+```
+
+The core files under legend-pure will now be sourced from the location specified.
+

--- a/legend-engine-pure-ide-light/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
+++ b/legend-engine-pure-ide-light/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
@@ -29,6 +29,10 @@ public class PureIDELight extends PureIDEServer
                     .flatMap(s -> Optional.ofNullable(s.ideFilesLocation))
                     .orElse("legend-engine-pure-ide-light/src/main/resources/pure_ide");
 
+            String coreFilesLocation = Optional.ofNullable(sourceLocationConfiguration)
+                    .flatMap(s -> Optional.ofNullable(s.coreFilesLocation))
+                    .orElse("../legend-pure");
+
             return Lists.mutable
                     .<RepositoryCodeStorage>with(new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository()))
                     .with(this.buildCore("legend-engine-xt-persistence-pure", "persistence"))
@@ -39,8 +43,8 @@ public class PureIDELight extends PureIDEServer
                     .with(this.buildCore("legend-engine-xt-xml-pure", "external-format-xml"))
                     .with(this.buildCore("legend-engine-xt-graphQL-pure", "external-query-graphql"))
                     .with(this.buildCore("legend-engine-pure-ide-light-metadata-pure", "ide_metadata"))
-                    .with(this.buildCore("../legend-pure/legend-pure-code-compiled-core", ""))
-                    .with(this.buildCore("../legend-pure/legend-pure-code-compiled-core-external-shared", "external-shared"))
+                    .with(this.buildCore(coreFilesLocation + "/legend-pure-code-compiled-core", ""))
+                    .with(this.buildCore(coreFilesLocation + "/legend-pure-code-compiled-core-external-shared", "external-shared"))
                     .with(new MutableFSCodeStorage(new PureIDECodeRepository(), Paths.get(ideFilesLocation)));
         }
         catch (IOException e)


### PR DESCRIPTION
Make location of legend-pure repository configurable in Pure IDE Light when building repositories