### PR TITLE
organize relational commands into db specific extensions

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
@@ -24,6 +24,7 @@ import meta::relational::metamodel::relation::*;
 import meta::relational::metamodel::*;
 import meta::relational::mapping::*;
 import meta::relational::functions::toDDL::*;
+import meta::relational::functions::sqlQueryToString::*;
 
 function meta::relational::mapping::sql(result:Result<Any|*>[1]):String[1]
 {
@@ -148,8 +149,14 @@ function <<access.private>> meta::alloy::service::execution::schemaAndTableSetup
    $schemaSetup->concatenate($tableSetup);
 }
 
-function meta::alloy::service::execution::setUpDataSQLs(data:String[1], db:Database[1]) : String[*]
+function <<doc.deprecated>> meta::alloy::service::execution::setUpDataSQLs(data:String[1], db:Database[1]) : String[*]
 {
+  meta::alloy::service::execution::setUpDataSQLs($data, $db, createDbConfig(DatabaseType.H2));
+}
+
+function meta::alloy::service::execution::setUpDataSQLs(data:String[1], db:Database[1], dbConfig:DbConfig[1]) : String[*]
+{
+
    let schemaAndTableSetup = $db->meta::alloy::service::execution::schemaAndTableSetup();
 
    let formattedData = $data->split('\n')
@@ -159,7 +166,12 @@ function meta::alloy::service::execution::setUpDataSQLs(data:String[1], db:Datab
    $schemaAndTableSetup->concatenate(loadCsvDataToDbTable($formattedData, $db, t:Table[1]|$t));
 }
 
-function meta::alloy::service::execution::setUpDataSQLs(records:List<String>[*], db:Database[1]) : String[*]
+function <<doc.deprecated>> meta::alloy::service::execution::setUpDataSQLs(records:List<String>[*], db:Database[1]) : String[*]
+{
+  meta::alloy::service::execution::setUpDataSQLs($records, $db, createDbConfig(DatabaseType.H2));
+}
+
+function meta::alloy::service::execution::setUpDataSQLs(records:List<String>[*], db:Database[1], dbConfig:DbConfig[1]) : String[*]
 {
    let schemaAndTableSetup = $db->meta::alloy::service::execution::schemaAndTableSetup();
    $schemaAndTableSetup->concatenate(loadCsvDataToDbTable($records, $db, t:Table[1]|$t));

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/tests/testSetupSqlGeneration.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/tests/testSetupSqlGeneration.pure
@@ -1,0 +1,111 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::tests::ddl::*;
+
+import meta::pure::profiles::*;
+
+import meta::relational::metamodel::*;
+import meta::relational::metamodel::relation::*;
+import meta::relational::metamodel::join::*;
+import meta::relational::metamodel::execute::*;
+import meta::relational::functions::toDDL::*;
+import meta::relational::mapping::*;
+import meta::relational::runtime::*;
+
+function <<test.Test>>  meta::relational::tests::ddl::testSetupDataSqlGeneration():Boolean[1]
+{
+  let parsedRecords =[ 
+                        list(['default']),
+                        list(['personTable']),
+                        list(['id', 'firstName', 'lastName', 'age', 'addressId', 'firmId', 'managerId']),
+                        list(['1', 'Peter', 'Smith', '23', '1' ,'1', '2']),
+                        list([''])
+                      ];
+                      // this parsed data format should be documented and standardised 
+    
+  let sqls = meta::alloy::service::execution::setUpDataSQLs($parsedRecords, meta::relational::tests::dbInc, meta::relational::functions::sqlQueryToString::createDbConfig(DatabaseType.H2));
+
+  let expectedSqls= [
+   'Drop schema if exists default cascade;',
+   'Create Schema default;',
+   'Drop schema if exists productSchema cascade;',
+   'Create Schema productSchema;',
+   'Drop table if exists personTable;',
+   'Create Table personTable(ID INT NOT NULL,FIRSTNAME VARCHAR(200) NULL,LASTNAME VARCHAR(200) NULL,AGE INT NULL,ADDRESSID INT NULL,FIRMID INT NULL,MANAGERID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists PersonTableExtension;',
+   'Create Table PersonTableExtension(ID INT NOT NULL,FIRSTNAME VARCHAR(200) NULL,LASTNAME VARCHAR(200) NULL,AGE INT NULL,ADDRESSID INT NULL,FIRMID INT NULL,MANAGERID INT NULL,birthDate DATE NULL, PRIMARY KEY(ID));',
+   'Drop table if exists differentPersonTable;',
+   'Create Table differentPersonTable(ID INT NOT NULL,FIRSTNAME VARCHAR(200) NULL,LASTNAME VARCHAR(200) NULL,AGE INT NULL,ADDRESSID INT NULL,FIRMID INT NULL,MANAGERID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists firmTable;',
+   'Create Table firmTable(ID INT NOT NULL,LEGALNAME VARCHAR(200) NULL,ADDRESSID INT NULL,CEOID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists firmExtensionTable;',
+   'Create Table firmExtensionTable(firmId INT NOT NULL,legalName VARCHAR(200) NULL,establishedDate DATE NULL, PRIMARY KEY(firmId));',
+   'Drop table if exists otherFirmTable;',
+   'Create Table otherFirmTable(ID INT NOT NULL,LEGALNAME VARCHAR(200) NULL,ADDRESSID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists addressTable;',
+   'Create Table addressTable(ID INT NOT NULL,TYPE INT NULL,NAME VARCHAR(200) NULL,STREET VARCHAR(100) NULL,COMMENTS VARCHAR(100) NULL, PRIMARY KEY(ID));',
+   'Drop table if exists locationTable;',
+   'Create Table locationTable(ID INT NOT NULL,PERSONID INT NULL,PLACE VARCHAR(200) NULL,date DATE NULL, PRIMARY KEY(ID));',
+   'Drop table if exists placeOfInterestTable;',
+   'Create Table placeOfInterestTable(ID INT NOT NULL,locationID INT NOT NULL,NAME VARCHAR(200) NULL, PRIMARY KEY(ID,locationID));',
+   'Drop table if exists productSchema.productTable;',
+   'Create Table productSchema.productTable(ID INT NOT NULL,NAME VARCHAR(200) NULL, PRIMARY KEY(ID));',
+   'insert into personTable (ID,FIRSTNAME,LASTNAME,AGE,ADDRESSID,FIRMID,MANAGERID) values (1,\'Peter\',\'Smith\',23,1,1,2);'
+   ];
+  assertEquals($sqls,$expectedSqls);
+}  
+
+
+
+//pure based parsing is higly unstable
+function <<test.Test>>  meta::relational::tests::ddl::testSetupDataSqlGenerationWithDataAsString():Boolean[1]
+{
+
+  let records ='default\n'+
+                'personTable\n'+
+                'id, firstName, lastName, age, addressId, firmId, managerId\n'+
+                '1,Peter,Smith,23,1,1,2';
+
+  let sqls = meta::alloy::service::execution::setUpDataSQLs($records, meta::relational::tests::dbInc, meta::relational::functions::sqlQueryToString::createDbConfig(DatabaseType.H2));
+  
+  let expectedSqls= [
+   'Drop schema if exists default cascade;',
+   'Create Schema default;',
+   'Drop schema if exists productSchema cascade;',
+   'Create Schema productSchema;',
+   'Drop table if exists personTable;',
+   'Create Table personTable(ID INT NOT NULL,FIRSTNAME VARCHAR(200) NULL,LASTNAME VARCHAR(200) NULL,AGE INT NULL,ADDRESSID INT NULL,FIRMID INT NULL,MANAGERID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists PersonTableExtension;',
+   'Create Table PersonTableExtension(ID INT NOT NULL,FIRSTNAME VARCHAR(200) NULL,LASTNAME VARCHAR(200) NULL,AGE INT NULL,ADDRESSID INT NULL,FIRMID INT NULL,MANAGERID INT NULL,birthDate DATE NULL, PRIMARY KEY(ID));',
+   'Drop table if exists differentPersonTable;',
+   'Create Table differentPersonTable(ID INT NOT NULL,FIRSTNAME VARCHAR(200) NULL,LASTNAME VARCHAR(200) NULL,AGE INT NULL,ADDRESSID INT NULL,FIRMID INT NULL,MANAGERID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists firmTable;',
+   'Create Table firmTable(ID INT NOT NULL,LEGALNAME VARCHAR(200) NULL,ADDRESSID INT NULL,CEOID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists firmExtensionTable;',
+   'Create Table firmExtensionTable(firmId INT NOT NULL,legalName VARCHAR(200) NULL,establishedDate DATE NULL, PRIMARY KEY(firmId));',
+   'Drop table if exists otherFirmTable;',
+   'Create Table otherFirmTable(ID INT NOT NULL,LEGALNAME VARCHAR(200) NULL,ADDRESSID INT NULL, PRIMARY KEY(ID));',
+   'Drop table if exists addressTable;',
+   'Create Table addressTable(ID INT NOT NULL,TYPE INT NULL,NAME VARCHAR(200) NULL,STREET VARCHAR(100) NULL,COMMENTS VARCHAR(100) NULL, PRIMARY KEY(ID));',
+   'Drop table if exists locationTable;',
+   'Create Table locationTable(ID INT NOT NULL,PERSONID INT NULL,PLACE VARCHAR(200) NULL,date DATE NULL, PRIMARY KEY(ID));',
+   'Drop table if exists placeOfInterestTable;',
+   'Create Table placeOfInterestTable(ID INT NOT NULL,locationID INT NOT NULL,NAME VARCHAR(200) NULL, PRIMARY KEY(ID,locationID));',
+   'Drop table if exists productSchema.productTable;',
+   'Create Table productSchema.productTable(ID INT NOT NULL,NAME VARCHAR(200) NULL, PRIMARY KEY(ID));',
+   'insert into personTable (ID,FIRSTNAME,LASTNAME,AGE,ADDRESSID,FIRMID,MANAGERID) values (1,\'Peter\',\'Smith\',23,1,1,2);'
+   ];
+  assertEquals($sqls,$expectedSqls);
+}  

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/toDDL.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/toDDL.pure
@@ -73,64 +73,115 @@ function meta::relational::functions::toDDL::dropAndCreateSchemaInDb(schema: Str
    true;
 }
 
-function meta::relational::functions::toDDL::createSchemaStatement(schema:String[1]) : String[1]
+//use corresponding functions parameterized with dbType instead
+function <<doc.deprecated>> meta::relational::functions::toDDL::createSchemaStatement(schema:String[1]) : String[1]
 {
-   'Create Schema ' + $schema + ';';
+   meta::relational::functions::toDDL::createSchemaStatement($schema, createDbConfig(DatabaseType.H2));
 }
 
-function meta::relational::functions::toDDL::dropSchemaStatement(schema:String[1]) : String[1]
+function meta::relational::functions::toDDL::createSchemaStatement(schema:String[1], dbConfig:DbConfig[1]) : String[1]
 {
-   'Drop schema if exists ' + $schema + ' cascade;';
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->size()==1, ' No relational commands provider found for given db type : '+ $dbConfig.dbType->toString());
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().createSchema->size()==1, ' No create schema command provider found for given db type : '+ $dbConfig.dbType->toString());
+  $dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().createSchema->toOne()->eval($schema);
 }
 
-function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], tableName: String[1]) : String[1]
+function <<doc.deprecated>> meta::relational::functions::toDDL::dropSchemaStatement(schema:String[1]) : String[1]
 {
-    dropTableStatement($database, 'default', $tableName);
+   dropSchemaStatement($schema, createDbConfig(DatabaseType.H2));
 }
 
-function meta::relational::functions::toDDL::createTableStatement(database:Database[1], tableName: String[1]) : String[1]
+function meta::relational::functions::toDDL::dropSchemaStatement(schema:String[1], dbConfig:DbConfig[1]) : String[1]
 {
-    createTableStatement($database, 'default', $tableName);
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->size()==1, ' No relational commands provider found for given db type : '+ $dbConfig.dbType->toString());
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().dropSchema->size()==1, ' No drop Schema command provider found for given db type : '+ $dbConfig.dbType->toString());
+  $dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().dropSchema->toOne()->eval($schema);
 }
 
-function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1]) : String[1]
+function <<doc.deprecated>> meta::relational::functions::toDDL::dropTableStatement(database:Database[1], tableName: String[1]) : String[1]
 {
-   dropTableStatement($database, $schema, $tableName, getTableToTableIdentityFunction());
+    dropTableStatement($database, $tableName, createDbConfig(DatabaseType.H2));
 }
 
-function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1]) : String[1]
+function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+{
+    dropTableStatement($database, 'default', $tableName, $dbConfig);
+}
+
+function <<doc.deprecated>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], tableName: String[1]) : String[1]
+{
+    createTableStatement($database, $tableName, createDbConfig(DatabaseType.H2));
+}
+
+function meta::relational::functions::toDDL::createTableStatement(database:Database[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+{
+    createTableStatement($database, 'default', $tableName, $dbConfig);
+}
+
+function <<doc.deprecated>> meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1]) : String[1]
+{
+   dropTableStatement($database, $schema, $tableName , createDbConfig(DatabaseType.H2));
+}
+
+function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+{
+   dropTableStatement($database, $schema, $tableName, getTableToTableIdentityFunction(), $dbConfig);
+}
+
+function <<doc.deprecated>> meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1]) : String[1]
+{
+    dropTableStatement($database, $schema, $tableName, $tablePostProcess, createDbConfig(DatabaseType.H2));
+}
+
+function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], dbConfig:DbConfig[1]) : String[1]
 {
    let t = $tablePostProcess->eval(getTable($database, $schema, $tableName));
-
-   'Drop table if exists '+if($t.schema.name == 'default',|'',|$t.schema.name+'.')+$t.name+';';
+   dropTableStatement($t, $dbConfig);
 }
 
-function meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1]) : String[1]
+function  meta::relational::functions::toDDL::dropTableStatement(t:Table[1], dbConfig:DbConfig[1]) : String[1]
 {
-   createTableStatement($database, $schema, $tableName, getTableToTableIdentityFunction(), true);
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->size()==1, ' No relational commands provider found for given db type : '+ $dbConfig.dbType->toString());
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().dropTable->size()==1, ' No drop table command provider found for given db type : '+ $dbConfig.dbType->toString());
+  $dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().dropTable->toOne()->eval($t);
 }
 
+function <<doc.deprecated>>  meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1]) : String[1]
+{
+   createTableStatement($database, $schema, $tableName, createDbConfig(DatabaseType.H2));
+}
+
+function meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+{
+   createTableStatement($database, $schema, $tableName, getTableToTableIdentityFunction(), true, $dbConfig);
+}
+
+//deprecated
 function <<access.private>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], applyConstraints:Boolean[1]) : String[1]
 {
-   // if no db type provided, then assume we are doing this for H2
-   let dbConfig = createDbConfig(DatabaseType.H2);
-   createTableStatement($database, DatabaseType.H2, $schema, $tableName, $tablePostProcess, $applyConstraints);
+   createTableStatement($database, $schema, $tableName, $tablePostProcess, $applyConstraints, createDbConfig(DatabaseType.H2));
 }
 
+//deprecated
 function <<access.private>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], dbType:DatabaseType[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], applyConstraints:Boolean[1]) : String[1]
 {
-   let dbConfig = createDbConfig($dbType);
-   let t = $tablePostProcess->eval(getTable($database, $schema, $tableName));
-
-   'Create Table '+if($t.schema.name == 'default',|'',|$t.schema.name+'.')+$t.name+
-      + '('
-      + $t.columns->cast(@meta::relational::metamodel::Column)
-         ->map(c | $c.name->meta::relational::functions::sqlQueryToString::processColumnName($dbConfig) + ' ' + meta::relational::functions::toDDL::getColumnTypeSqlText($c.type, $dbConfig.dbType) + if($c.nullable->isEmpty() || $applyConstraints == false, | '', | if($c.nullable == true , | ' NULL', | ' NOT NULL' )))
-        ->joinStrings(',')
-      + if ($t.primaryKey->isEmpty() || $applyConstraints == false, | '', | ', PRIMARY KEY(' + $t.primaryKey->map(c | $c.name)->joinStrings(',') + ')')
-      +');';
+   createTableStatement($database, $schema, $tableName, $tablePostProcess, $applyConstraints, createDbConfig($dbType));
 }
 
+function <<access.private>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], applyConstraints:Boolean[1], dbConfig:DbConfig[1]) : String[1]
+{
+   let t = $tablePostProcess->eval(getTable($database, $schema, $tableName));
+   $t->createTableStatement($applyConstraints, $dbConfig);
+}
+
+function  meta::relational::functions::toDDL::createTableStatement(t:Table[1], applyConstraints:Boolean[1], dbConfig:DbConfig[1]) : String[1]
+{
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->size()==1, ' No relational commands provider found for given db type : '+ $dbConfig.dbType->toString());
+  assert($dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().createTable->size()==1, ' No create table command provider found for given db type : '+ $dbConfig.dbType->toString());
+  $dbConfig.dbExtension.relationalDatabaseCommandsProvider->toOne().createTable->toOne()->eval($t,  $applyConstraints , $dbConfig);
+}
+
+//deprecated
 function <<access.private>> meta::relational::functions::toDDL::getColumnTypeSqlText(columnType:meta::relational::metamodel::datatype::DataType[1], dbType:DatabaseType[1]):String[1] 
 {
    $columnType->match([
@@ -139,6 +190,7 @@ function <<access.private>> meta::relational::functions::toDDL::getColumnTypeSql
    ])
 }
 
+//deprecated
 function <<access.private>> meta::relational::functions::toDDL::getSemiStructuredColumnTypeSqlText(columnType:meta::relational::metamodel::datatype::SemiStructured[1], dbType:DatabaseType[1]):String[1] 
 {
    if ($dbType == DatabaseType.H2,
@@ -161,16 +213,6 @@ function meta::relational::functions::toDDL::insertSQLQueryResultIntoTable(table
    executeInDb($stmt, $connection);
 }
 
-function meta::relational::functions::toDDL::createTempTableStatement() : meta::pure::metamodel::function::Function<{String[1], Column[*], DatabaseType[1]->String[1]}>[1]
-{
-  {ttName:String[1], cols: Column[*], dbType: DatabaseType[1]|
-        let colsAsString = '('+$cols->map(c|$c.name + ' ' + meta::relational::metamodel::datatype::dataTypeToSqlText($c.type))->joinStrings(',')+')';
-
-        if($dbType == DatabaseType.H2,| 'Create LOCAL TEMPORARY TABLE '+$ttName+$colsAsString+';';
-                                     ,| if([DatabaseType.Sybase, DatabaseType.SybaseIQ]->contains($dbType),| 'Declare LOCAL TEMPORARY TABLE '+$ttName+$colsAsString+' on commit preserve rows;'
-                                                                                                          ,| assert(false, | 'Temporay table creation for db type: '+$dbType->toString()+' is not supported');'';));
-  }
-}
 
 function meta::relational::functions::toDDL::getTableToTableIdentityFunction():Function<{Table[1]->Table[1]}>[1]
 {
@@ -186,4 +228,15 @@ function <<access.private>> meta::relational::functions::toDDL::getTable(databas
    let t = $schema->toOne().table($tableName);
 
    if ($t->isEmpty(), | fail('No table found with name ' + $tableName + ' in schema ' + $schemaName + ' in ' + $database.name->toOne()); $t->toOne();, | $t->toOne());
+}
+
+function meta::relational::functions::toDDL::createTempTableStatement() : meta::pure::metamodel::function::Function<{String[1], Column[*], DatabaseType[1]->String[1]}>[1]
+{
+  {ttName:String[1], cols: Column[*], dbType: DatabaseType[1]|
+        let colsAsString = '('+$cols->map(c|$c.name + ' ' + meta::relational::metamodel::datatype::dataTypeToSqlText($c.type))->joinStrings(',')+')';
+
+        if($dbType == DatabaseType.H2,| 'Create LOCAL TEMPORARY TABLE '+$ttName+$colsAsString+';';
+                                     ,| if([DatabaseType.Sybase, DatabaseType.SybaseIQ]->contains($dbType),| 'Declare LOCAL TEMPORARY TABLE '+$ttName+$colsAsString+' on commit preserve rows;'
+                                                                                                          ,| assert(false, | 'Temporay table creation for db type: '+$dbType->toString()+' is not supported');'';));
+  }
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
@@ -23,6 +23,7 @@ import meta::relational::functions::sqlQueryToString::*;
 import meta::relational::runtime::*;
 import meta::relational::functions::sqlQueryToString::functions::*;
 import meta::pure::profiles::*;
+import meta::relational::metamodel::*;
 
 Enum meta::relational::functions::sqlQueryToString::GenerationSide
 {
@@ -82,6 +83,7 @@ Class meta::relational::functions::sqlQueryToString::DbConfig
 
 Class meta::relational::functions::sqlQueryToString::DbExtension
 {
+   relationalDatabaseCommandsProvider : meta::relational::functions::sqlQueryToString::RelationalDatabaseCommandsProvider[0..1];
    dynaFuncDispatch: meta::pure::metamodel::function::Function<{DynaFunction[1], GenerationState[1] -> DynaFunctionToSql[1]}>[1];
    isDbReservedIdentifier: meta::pure::metamodel::function::Function<{String[1] -> Boolean[1]}>[1];
    literalProcessor: meta::pure::metamodel::function::Function<{Type[1] -> LiteralProcessor[1]}>[1];
@@ -132,6 +134,7 @@ function meta::relational::functions::sqlQueryToString::createDbExtension(dbType
    let reservedWords = dbReservedWords($dbType);
    let literalProcessors = getLiteralProcessors($dbType, $dbTimeZone);
    ^DbExtension(
+      relationalDatabaseCommandsProvider = meta::relational::functions::sqlQueryToString::getRelationalDatabaseCommandsProvider($dbType),
       dynaFuncDispatch = getDynaFunctionMappings($dbType),
       isDbReservedIdentifier = {str:String[1]| $str->in($reservedWords)},
       literalProcessor = {type:Type[1]| $literalProcessors->get(if($type->instanceOf(Enumeration), | Enum, | $type))->toOne()}
@@ -2589,4 +2592,76 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::trans
    let order = if($ascending == $trueVal, | 'asc', | 'desc');
 
    $func + '(' + $percentile + ') within group (order by ' + $column + ' ' + $order + ')';
+}
+
+Class meta::relational::functions::sqlQueryToString::RelationalDatabaseCommandsProvider
+{
+  createSchema: meta::pure::metamodel::function::Function<{String[1]->String[1]}>[0..1];
+  dropSchema : meta::pure::metamodel::function::Function<{String[1]->String[1]}>[0..1];
+
+  dropTable : meta::pure::metamodel::function::Function<{Table[1] -> String[1]}>[0..1];
+  createTable : meta::pure::metamodel::function::Function<{Table[1], Boolean[1], DbConfig[1]-> String[1]}>[0..1];
+
+  loadValuesToDbTable: meta::pure::metamodel::function::Function<{ List<List<String>>[1], Table[1], Column[*], DbConfig[1] ->  String[*]}>[0..1];
+}
+
+function meta::relational::functions::sqlQueryToString::getRelationalDatabaseCommandsProvider(dbType:DatabaseType[1]): RelationalDatabaseCommandsProvider[0..1]
+{
+  let h2RelationalDatabaseCommandsProvider = ^RelationalDatabaseCommandsProvider(
+        createSchema =  meta::relational::functions::sqlQueryToString::createSchemaStatementH2_String_1__String_1_,
+        dropSchema =  meta::relational::functions::sqlQueryToString::dropSchemaStatementH2_String_1__String_1_,
+        createTable =  meta::relational::functions::sqlQueryToString::createTableStatementH2_Table_1__Boolean_1__DbConfig_1__String_1_,
+        dropTable =  meta::relational::functions::sqlQueryToString::dropTableStatementH2_Table_1__String_1_,
+        loadValuesToDbTable =  meta::relational::functions::sqlQueryToString::loadValuesToDbTableH2_List_1__Table_1__Column_MANY__DbConfig_1__String_MANY_
+      );
+
+  if($dbType== DatabaseType.H2 || $dbType== DatabaseType.Postgres ||$dbType== DatabaseType.SybaseIQ ,
+   | $h2RelationalDatabaseCommandsProvider,
+   | []
+  );  
+}
+
+function <<access.private>>  meta::relational::functions::sqlQueryToString::createSchemaStatementH2(schema:String[1]) : String[1]
+{
+   'Create Schema ' + $schema + ';';
+}
+
+function <<access.private>>  meta::relational::functions::sqlQueryToString::dropSchemaStatementH2(schema:String[1]) : String[1]
+{
+   'Drop schema if exists ' + $schema + ' cascade;';
+}
+
+function <<access.private>>  meta::relational::functions::sqlQueryToString::dropTableStatementH2(t:Table[1]) : String[1]
+{
+  'Drop table if exists '+if($t.schema.name == 'default',|'',|$t.schema.name+'.')+$t.name+';';
+}
+
+function <<access.private>>  meta::relational::functions::sqlQueryToString::createTableStatementH2(t:Table[1], applyConstraints:Boolean[1], dbConfig:DbConfig[1]) : String[1]
+{
+  'Create Table '+if($t.schema.name == 'default',|'',|$t.schema.name+'.')+$t.name+
+      + '('
+      + $t.columns->cast(@meta::relational::metamodel::Column)
+         ->map(c | $c.name->meta::relational::functions::sqlQueryToString::processColumnName($dbConfig) + ' ' +  meta::relational::functions::sqlQueryToString::getColumnTypeSqlTextH2($c.type) + if($c.nullable->isEmpty() || $applyConstraints == false, | '', | if($c.nullable == true , | ' NULL', | ' NOT NULL' )))
+        ->joinStrings(',')
+      + if ($t.primaryKey->isEmpty() || $applyConstraints == false, | '', | ', PRIMARY KEY(' + $t.primaryKey->map(c | $c.name)->joinStrings(',') + ')')
+      +');';
+}
+
+function <<access.private>>  meta::relational::functions::sqlQueryToString::getColumnTypeSqlTextH2(columnType:meta::relational::metamodel::datatype::DataType[1]):String[1] 
+{
+   $columnType->match([
+      s : meta::relational::metamodel::datatype::SemiStructured[1] | 'VARCHAR(4000)',
+      a : Any[*] | meta::relational::metamodel::datatype::dataTypeToSqlText($columnType)
+   ])
+}
+
+function <<access.private>>  meta::relational::functions::sqlQueryToString::loadValuesToDbTableH2(data :List<List<String>>[1], table:Table[1],columns : Column[*], dbConfig: DbConfig[1]) : String[*]
+{
+    $data.values->map(row |  let sql = 'insert into ' + if($table.schema.name=='default', |'' ,|$table.schema.name + '.') + $table.name + ' ('
+            + $columns.name->map(colName | $colName->meta::relational::functions::sqlQueryToString::processColumnName($dbConfig))->joinStrings(',')
+            +') '
+            + 'values ('
+            + $row.values->meta::relational::functions::database::testDataSQLgeneration::convertValuesToCsv($columns.type)
+            + ');';
+   );
 }


### PR DESCRIPTION
Currently there are some helper functions that generate setup sqls given input data and store definition. These are only defined for H2 . Different DBs can have different sql syntax for DDL and insert . This PR adds support for db specific ddl sql commands generation.