### PR TITLE
support setting offset `Source Information` for grammar parser APIs

### DIFF
--- a/.github/workflows/database-bigquery-integration-test.yml
+++ b/.github/workflows/database-bigquery-integration-test.yml
@@ -28,6 +28,9 @@ on:
       - master
 jobs:
   build:
+    # NOTE: we cannot run this action in fork because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.repository == 'finos/legend-engine'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/database-databricks-integration-test.yml
+++ b/.github/workflows/database-databricks-integration-test.yml
@@ -31,6 +31,9 @@ on:
       - master
 jobs:
   build:
+    # NOTE: we cannot run this action in fork because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.repository == 'finos/legend-engine'
     runs-on: ubuntu-latest
     steps:
       - name: Configure databricks CLI

--- a/.github/workflows/database-mssqlserver-integration-test.yml
+++ b/.github/workflows/database-mssqlserver-integration-test.yml
@@ -28,6 +28,9 @@ on:
       - master
 jobs:
   build:
+    # NOTE: we cannot run this action in fork because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.repository == 'finos/legend-engine'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/database-redshift-integration-test.yml
+++ b/.github/workflows/database-redshift-integration-test.yml
@@ -29,6 +29,9 @@ on:
 jobs:
   build:
     name: Build
+    # NOTE: we cannot run this action in fork because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.repository == 'finos/legend-engine'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/database-redshift-sql-generation-integration-test.yml
+++ b/.github/workflows/database-redshift-sql-generation-integration-test.yml
@@ -29,6 +29,9 @@ on:
 jobs:
   build:
     name: Build
+    # NOTE: we cannot run this action in fork because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.repository == 'finos/legend-engine'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/database-snowflake-integration-test.yml
+++ b/.github/workflows/database-snowflake-integration-test.yml
@@ -29,6 +29,9 @@ on:
       - refactor-integration-tests
 jobs:
   build:
+    # NOTE: we cannot run this action in fork because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.repository == 'finos/legend-engine'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/database-snowflake-sql-generation-integration-test.yml
+++ b/.github/workflows/database-snowflake-sql-generation-integration-test.yml
@@ -28,6 +28,9 @@ on:
       - refactor-integration-tests
 jobs:
   build:
+    # NOTE: we cannot run this action in fork because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.repository == 'finos/legend-engine'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/legend-engine-external-shared-format-runtime/src/test/java/org/finos/legend/engine/external/shared/runtime/test/TestExternalFormatQueries.java
+++ b/legend-engine-external-shared-format-runtime/src/test/java/org/finos/legend/engine/external/shared/runtime/test/TestExternalFormatQueries.java
@@ -93,7 +93,7 @@ public abstract class TestExternalFormatQueries
             PureModel model = Compiler.compile(modelData, DeploymentMode.TEST, null);
 
             PureGrammarParser parser = PureGrammarParser.newInstance();
-            Lambda lambdaProtocol = parser.parseLambda(query, "query", true);
+            Lambda lambdaProtocol = parser.parseLambda(query);
             LambdaFunction<?> lambda = HelperValueSpecificationBuilder.buildLambda(lambdaProtocol.body, Lists.fixedSize.<Variable>empty(), model.getContext());
 
             ExecutionContext context = new Root_meta_pure_runtime_ExecutionContext_Impl(" ")._enableConstraints(true);

--- a/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
+++ b/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
@@ -14,7 +14,10 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -27,23 +30,24 @@ public class GrammarToJson extends GrammarAPI
     @POST
     @Path("model")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response model(String input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response model(ParserInput input,
+                          @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b) -> PureGrammarParser.newInstance().parseModel(a, b), pm, returnSourceInfo, "Grammar to Json : Model");
+        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseModel(a, c), pm, "Grammar to Json : Model");
     }
 
     @POST
     @Path("lambda")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response lambda(String input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue ("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response lambda(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b) -> PureGrammarParser.newInstance().parseLambda(a, "", b), pm, returnSourceInfo, "Grammar to Json : Lambda");
+        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseLambda(a, b, c), pm, "Grammar to Json : Lambda");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -58,21 +62,21 @@ public class GrammarToJson extends GrammarAPI
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response lambdaBatch(Map<String, String> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue ("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response lambdaBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b)-> PureGrammarParser.newInstance().parseLambda(a, "", b), new TypedMap(), pm, returnSourceInfo, "Grammar to Json : Lambda Batch");
+        return grammarToJsonBatch(input, (a, b, c)-> PureGrammarParser.newInstance().parseLambda(a, b, c), new TypedMap(), pm, "Grammar to Json : Lambda Batch");
     }
 
     @POST
     @Path("graphFetch")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response graphFetch(String input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue ("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response graphFetch(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b) -> PureGrammarParser.newInstance().parseGraphFetch(a, "", b), pm, returnSourceInfo, "Grammar to Json : GraphFetch");
+        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseGraphFetch(a, b, c), pm, "Grammar to Json : GraphFetch");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -87,22 +91,22 @@ public class GrammarToJson extends GrammarAPI
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response graphFetchBatch(Map<String, String> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue ("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response graphFetchBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b)-> PureGrammarParser.newInstance().parseGraphFetch(a, "", b), new TypedMapGraph(), pm, returnSourceInfo, "Grammar to Json : GraphFetch Batch");
+        return grammarToJsonBatch(input, (a, b, c)-> PureGrammarParser.newInstance().parseGraphFetch(a, b, c), new TypedMapGraph(), pm, "Grammar to Json : GraphFetch Batch");
     }
 
 
     @POST
     @Path("valueSpecification")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response valueSpecification(String input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue ("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response valueSpecification(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b) -> PureGrammarParser.newInstance().parseValueSpecification(a, "", b), pm, returnSourceInfo, "Grammar to Json : Value Specification");
+        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseValueSpecification(a, b, c), pm, "Grammar to Json : Value Specification");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -117,9 +121,9 @@ public class GrammarToJson extends GrammarAPI
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response valueSpecificationBatch(Map<String, String> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue ("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response valueSpecificationBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b)-> PureGrammarParser.newInstance().parseValueSpecification(a, "", b), new TypedMapVS(), pm, returnSourceInfo, "Grammar to Json : Value Specification Batch");
+        return grammarToJsonBatch(input, (a, b, c)-> PureGrammarParser.newInstance().parseValueSpecification(a, b, c), new TypedMapVS(), pm, "Grammar to Json : Value Specification Batch");
     }
 }

--- a/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
+++ b/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
@@ -36,7 +36,7 @@ public class GrammarToJson extends GrammarAPI
                           @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseModel(a, c), pm, "Grammar to Json : Model");
+        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseModel(a, b, c, d, e), pm, "Grammar to Json : Model");
     }
 
     @POST
@@ -47,7 +47,7 @@ public class GrammarToJson extends GrammarAPI
     public Response lambda(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseLambda(a, b, c), pm, "Grammar to Json : Lambda");
+        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseLambda(a, b, c, d, e), pm, "Grammar to Json : Lambda");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -65,7 +65,7 @@ public class GrammarToJson extends GrammarAPI
     public Response lambdaBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b, c)-> PureGrammarParser.newInstance().parseLambda(a, b, c), new TypedMap(), pm, "Grammar to Json : Lambda Batch");
+        return grammarToJsonBatch(input, (a, b, c, d, e)-> PureGrammarParser.newInstance().parseLambda(a, b, c, d, e), new TypedMap(), pm, "Grammar to Json : Lambda Batch");
     }
 
     @POST
@@ -76,7 +76,7 @@ public class GrammarToJson extends GrammarAPI
     public Response graphFetch(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseGraphFetch(a, b, c), pm, "Grammar to Json : GraphFetch");
+        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseGraphFetch(a, b, c, d, e), pm, "Grammar to Json : GraphFetch");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -94,7 +94,7 @@ public class GrammarToJson extends GrammarAPI
     public Response graphFetchBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b, c)-> PureGrammarParser.newInstance().parseGraphFetch(a, b, c), new TypedMapGraph(), pm, "Grammar to Json : GraphFetch Batch");
+        return grammarToJsonBatch(input, (a, b, c, d, e)-> PureGrammarParser.newInstance().parseGraphFetch(a, b, c, d, e), new TypedMapGraph(), pm, "Grammar to Json : GraphFetch Batch");
     }
 
 
@@ -106,7 +106,7 @@ public class GrammarToJson extends GrammarAPI
     public Response valueSpecification(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c) -> PureGrammarParser.newInstance().parseValueSpecification(a, b, c), pm, "Grammar to Json : Value Specification");
+        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseValueSpecification(a, b, c, d ,e), pm, "Grammar to Json : Value Specification");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -124,6 +124,6 @@ public class GrammarToJson extends GrammarAPI
     public Response valueSpecificationBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b, c)-> PureGrammarParser.newInstance().parseValueSpecification(a, b, c), new TypedMapVS(), pm, "Grammar to Json : Value Specification Batch");
+        return grammarToJsonBatch(input, (a, b, c, d, e)-> PureGrammarParser.newInstance().parseValueSpecification(a, b, c, d, e), new TypedMapVS(), pm, "Grammar to Json : Value Specification Batch");
     }
 }

--- a/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
+++ b/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
@@ -15,9 +15,11 @@ import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -30,24 +32,33 @@ public class GrammarToJson extends GrammarAPI
     @POST
     @Path("model")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response model(ParserInput input,
+    public Response model(String text,
+                          @DefaultValue("") @ApiParam("The source ID to be used by the parser") @QueryParam("sourceId") String sourceId,
+                          @DefaultValue("0") @ApiParam("The line number the parser will offset by") @QueryParam("lineOffset") int lineOffset,
+                          @DefaultValue("0") @ApiParam("The column number the parser will offset by") @QueryParam("columnOffset") int columnOffset,
+                          @DefaultValue("true") @QueryParam("returnSourceInformation") boolean returnSourceInformation,
                           @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseModel(a, b, c, d, e), pm, "Grammar to Json : Model");
+        return grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseModel(a, sourceId, lineOffset, columnOffset, returnSourceInformation), pm, "Grammar to Json : Model");
     }
 
     @POST
     @Path("lambda")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response lambda(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response lambda(String text,
+                           @DefaultValue("") @ApiParam("The source ID to be used by the parser") @QueryParam("sourceId") String sourceId,
+                           @DefaultValue("0") @ApiParam("The line number the parser will offset by") @QueryParam("lineOffset") int lineOffset,
+                           @DefaultValue("0") @ApiParam("The column number the parser will offset by") @QueryParam("columnOffset") int columnOffset,
+                           @DefaultValue("true") @QueryParam("returnSourceInformation") boolean returnSourceInformation,
+                           @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseLambda(a, b, c, d, e), pm, "Grammar to Json : Lambda");
+        return grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseLambda(a, sourceId, lineOffset, columnOffset, returnSourceInformation), pm, "Grammar to Json : Lambda");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -71,12 +82,17 @@ public class GrammarToJson extends GrammarAPI
     @POST
     @Path("graphFetch")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response graphFetch(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response graphFetch(String text,
+                               @DefaultValue("") @ApiParam("The source ID to be used by the parser") @QueryParam("sourceId") String sourceId,
+                               @DefaultValue("0") @ApiParam("The line number the parser will offset by") @QueryParam("lineOffset") int lineOffset,
+                               @DefaultValue("0") @ApiParam("The column number the parser will offset by") @QueryParam("columnOffset") int columnOffset,
+                               @DefaultValue("true") @QueryParam("returnSourceInformation") boolean returnSourceInformation,
+                               @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseGraphFetch(a, b, c, d, e), pm, "Grammar to Json : GraphFetch");
+        return grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseGraphFetch(a, sourceId, lineOffset, columnOffset, returnSourceInformation), pm, "Grammar to Json : GraphFetch");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -101,12 +117,17 @@ public class GrammarToJson extends GrammarAPI
     @POST
     @Path("valueSpecification")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response valueSpecification(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response valueSpecification(String text,
+                                       @DefaultValue("") @ApiParam("The source ID to be used by the parser") @QueryParam("sourceId") String sourceId,
+                                       @DefaultValue("0") @ApiParam("The line number the parser will offset by") @QueryParam("lineOffset") int lineOffset,
+                                       @DefaultValue("0") @ApiParam("The column number the parser will offset by") @QueryParam("columnOffset") int columnOffset,
+                                       @DefaultValue("true") @QueryParam("returnSourceInformation") boolean returnSourceInformation,
+                                       @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c, d, e) -> PureGrammarParser.newInstance().parseValueSpecification(a, b, c, d ,e), pm, "Grammar to Json : Value Specification");
+        return grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseValueSpecification(a, sourceId, lineOffset, columnOffset, returnSourceInformation), pm, "Grammar to Json : Value Specification");
     }
 
     // Required so that Jackson properly includes _type for the top level element

--- a/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
+++ b/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
@@ -37,12 +37,11 @@ public class GrammarToJson extends GrammarAPI
     public Response model(String text,
                           @DefaultValue("") @ApiParam("The source ID to be used by the parser") @QueryParam("sourceId") String sourceId,
                           @DefaultValue("0") @ApiParam("The line number the parser will offset by") @QueryParam("lineOffset") int lineOffset,
-                          @DefaultValue("0") @ApiParam("The column number the parser will offset by") @QueryParam("columnOffset") int columnOffset,
                           @DefaultValue("true") @QueryParam("returnSourceInformation") boolean returnSourceInformation,
                           @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseModel(a, sourceId, lineOffset, columnOffset, returnSourceInformation), pm, "Grammar to Json : Model");
+        return grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseModel(a, sourceId, lineOffset, 0, returnSourceInformation), pm, "Grammar to Json : Model");
     }
 
     @POST

--- a/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/TransformGrammarToJson.java
+++ b/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/TransformGrammarToJson.java
@@ -72,7 +72,7 @@ public class TransformGrammarToJson
             {
                 try
                 {
-                    Lambda lambda = parser.parseLambda(value, key, returnSourceInfo);
+                    Lambda lambda = parser.parseLambda(value, key, 0, 0, returnSourceInfo);
                     lambdas.put(key, lambda);
                 }
                 catch (Exception e)
@@ -98,7 +98,7 @@ public class TransformGrammarToJson
             {
                 try
                 {
-                    symmetricResult.modelDataContext = parser.parseModel(grammarInput.code, returnSourceInfo);
+                    symmetricResult.modelDataContext = parser.parseModel(grammarInput.code, "", 0, 0, returnSourceInfo);
                 }
                 catch (Exception e)
                 {

--- a/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/jsonToGrammar/JsonToGrammar.java
+++ b/legend-engine-language-pure-grammar-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/jsonToGrammar/JsonToGrammar.java
@@ -17,7 +17,12 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -28,81 +33,95 @@ import static org.finos.legend.engine.shared.core.operational.http.InflateInterc
 @Path("pure/v1/grammar/jsonToGrammar")
 public class JsonToGrammar extends GrammarAPI
 {
+
     @POST
-    @Path("graphFetch/{renderStyle}")
+    @Path("model")
+    @ApiOperation(value = "Generates Pure language text from Pure protocol Pure Model Context Data")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response model(PureModelContextData pureModelContext,
+                          @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                          @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    {
+        PureGrammarComposerExtensionLoader.logExtensionList();
+        return jsonToGrammar(pureModelContext, renderStyle, (value, renderStyle1) -> PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(renderStyle1).build()).renderPureModelContextData(value), pm, "Json to Grammar : Model");
+    }
+
+    @POST
+    @Path("graphFetch")
     @ApiOperation(value = "Generates Pure language text from Pure protocol GraphFetch fragment")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.TEXT_PLAIN)
-    public Response graphFetch(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, RootGraphFetchTree graphFetchTree, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response graphFetch(RootGraphFetchTree graphFetchTree,
+                               @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                               @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarComposerExtensionLoader.logExtensionList();
         return jsonToGrammar(graphFetchTree, renderStyle, (vs, renderStyle1) -> vs.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle1).build()), pm, "Json to Grammar : Graph Fetch");
     }
 
     @POST
-    @Path("graphFetch/{renderStyle}/batch")
+    @Path("graphFetch/batch")
     @ApiOperation(value = "Generates Pure language text from Pure protocol GraphFetch fragment")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response graphFetchBatch(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, Map<String, RootGraphFetchTree> graphFetchTrees, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response graphFetchBatch(Map<String, RootGraphFetchTree> graphFetchTrees,
+                                    @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                    @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarComposerExtensionLoader.logExtensionList();
         return jsonToGrammarBatch(renderStyle, graphFetchTrees, (vs, renderStyle1) -> vs.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle1).build()), pm, "Json to Grammar : Graph Fetch Batch");
     }
 
     @POST
-    @Path("valueSpecification/{renderStyle}")
+    @Path("valueSpecification")
     @ApiOperation(value = "Generates Pure language text from Pure protocol Value Specification fragment")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.TEXT_PLAIN)
-    public Response valueSpecification(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, ValueSpecification valueSpecification, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response valueSpecification(ValueSpecification valueSpecification,
+                                       @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                       @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarComposerExtensionLoader.logExtensionList();
         return jsonToGrammar(valueSpecification, renderStyle, (vs, renderStyle1) -> vs.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle1).build()), pm, "Json to Grammar : Value Specification");
     }
 
     @POST
-    @Path("valueSpecification/{renderStyle}/batch")
+    @Path("valueSpecification/batch")
     @ApiOperation(value = "Generates Pure language text from Pure protocol Value Specification fragment")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response valueSpecificationBatch(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, Map<String, ValueSpecification> valueSpecifications, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response valueSpecificationBatch(Map<String, ValueSpecification> valueSpecifications,
+                                            @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                            @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarComposerExtensionLoader.logExtensionList();
         return jsonToGrammarBatch(renderStyle, valueSpecifications, (vs, renderStyle1) -> vs.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle1).build()), pm, "Json to Grammar : Value Specification Batch");
     }
 
     @POST
-    @Path("lambda/{renderStyle}")
+    @Path("lambda")
     @ApiOperation(value = "Generates Pure language text from Pure protocol Value Specification fragment")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.TEXT_PLAIN)
-    public Response lambda(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, Lambda lambda, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response lambda(Lambda lambda,
+                           @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                           @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarComposerExtensionLoader.logExtensionList();
         return jsonToGrammar(lambda, renderStyle, (vs, renderStyle1) -> vs.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle1).build()), pm, "Json to Grammar : Lambda");
     }
 
     @POST
-    @Path("lambda/{renderStyle}/batch")
+    @Path("lambda/batch")
     @ApiOperation(value = "Generates Pure language text from Pure protocol Value Specification fragment")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response lambdaBatch(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, Map<String, Lambda> lambdas, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response lambdaBatch(Map<String, Lambda> lambdas,
+                                @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarComposerExtensionLoader.logExtensionList();
         return jsonToGrammarBatch(renderStyle, lambdas, (vs, renderStyle1) -> vs.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle1).build()), pm, "Json to Grammar : Lambda Batch");
     }
-
-    @POST
-    @Path("model/{renderStyle}")
-    @ApiOperation(value = "Generates Pure language text from Pure protocol Pure Model Context Data")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
-    @Produces(MediaType.TEXT_PLAIN)
-    public Response model(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, PureModelContextData pureModelContext, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
-    {
-        PureGrammarComposerExtensionLoader.logExtensionList();
-        return jsonToGrammar(pureModelContext, renderStyle, (value, renderStyle1) -> PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(renderStyle1).build()).renderPureModelContextData(value), pm, "Json to Grammar : Model");
-    }
-
 }

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarGraphFetchApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarGraphFetchApi.java
@@ -11,6 +11,7 @@ import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
 import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
+import org.finos.legend.engine.shared.core.function.Function5;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -120,13 +121,13 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
     }
 
     @Override
-    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
+    public Function5<String, String, Integer, Integer, Boolean, Response> grammarToJson()
     {
-        return (a) -> grammarToJson.graphFetch(a, null);
+        return (a, b, c, d, e) -> grammarToJson.graphFetch(a, b, c, d, e, null);
     }
 
     @Override
-    public Function2<RenderStyle, RootGraphFetchTree, Response> jsonToGrammar()
+    public Function2<RootGraphFetchTree, RenderStyle, Response> jsonToGrammar()
     {
         return (a, b) -> jsonToGrammar.graphFetch(a, b, null);
     }
@@ -138,7 +139,7 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
     }
 
     @Override
-    public Function2<RenderStyle, Map<String, RootGraphFetchTree>, Response> jsonToGrammarB()
+    public Function2<Map<String, RootGraphFetchTree>, RenderStyle, Response> jsonToGrammarB()
     {
         return (a, b) -> jsonToGrammar.graphFetchBatch(a, b, null);
     }

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarGraphFetchApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarGraphFetchApi.java
@@ -1,5 +1,6 @@
 package org.finos.legend.engine.language.pure.grammar.api.test;
 
+import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
@@ -8,6 +9,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.graph.RootGraphFetchTree;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
+import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
 import org.junit.Test;
 
@@ -49,7 +51,7 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
     @Test
     public void testBatch()
     {
-        testBatch(with( Tuples.pair("1",  "#{\n" +
+        testBatch(createBatchInput( Tuples.pair("1",  "#{\n" +
                                                     "  demo::Query{\n" +
                                                     "    firms{\n" +
                                                     "      legalName,\n" +
@@ -72,7 +74,7 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
     @Test
     public void testBatchError()
     {
-        testBatchError(with(Tuples.pair("1",  "#{\n" +
+        testBatchError(createBatchInput(Tuples.pair("1",  "#{\n" +
                                                         "  demo::Query{\n" +
                                                         "    firms{\n" +
                                                         "      legalName,\n" +
@@ -85,7 +87,7 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
                 Tuples.pair("2",  "#{\n" +
                                             "  demo::Query" +
                                             "}#")),
-                with(Tuples.pair("1",  "#{\n" +
+                createExpectedBatchResult(Tuples.pair("1",  "#{\n" +
                                                 "  demo::Query{\n" +
                                                 "    firms{\n" +
                                                 "      legalName,\n" +
@@ -118,9 +120,9 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
     }
 
     @Override
-    public Function2<String, Boolean, Response> grammarToJson()
+    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
     {
-        return (a, b) -> grammarToJson.graphFetch(a, null, b);
+        return (a) -> grammarToJson.graphFetch(a, null);
     }
 
     @Override
@@ -130,9 +132,9 @@ public class TestGrammarGraphFetchApi extends TestGrammar<RootGraphFetchTree>
     }
 
     @Override
-    public Function2<Map<String, String>, Boolean, Response> grammarToJsonB()
+    public Function<Map<String, GrammarAPI.ParserInput>, Response> grammarToJsonB()
     {
-        return (a, b) -> grammarToJson.graphFetchBatch(a, null, b);
+        return (a) -> grammarToJson.graphFetchBatch(a, null);
     }
 
     @Override

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarLambdaApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarLambdaApi.java
@@ -12,6 +12,7 @@ import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
 import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
+import org.finos.legend.engine.shared.core.function.Function5;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -93,13 +94,13 @@ public class TestGrammarLambdaApi extends TestGrammar<Lambda>
     }
 
     @Override
-    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
+    public Function5<String, String, Integer, Integer, Boolean, Response> grammarToJson()
     {
-        return (a) -> grammarToJson.lambda(a, null);
+        return (a, b, c, d, e) -> grammarToJson.lambda(a, b, c, d, e, null);
     }
 
     @Override
-    public Function2<RenderStyle, Lambda, Response> jsonToGrammar()
+    public Function2<Lambda, RenderStyle, Response> jsonToGrammar()
     {
         return (a, b) -> jsonToGrammar.lambda(a, b, null);
     }
@@ -111,7 +112,7 @@ public class TestGrammarLambdaApi extends TestGrammar<Lambda>
     }
 
     @Override
-    public Function2<RenderStyle, Map<String, Lambda>, Response> jsonToGrammarB()
+    public Function2<Map<String, Lambda>, RenderStyle, Response> jsonToGrammarB()
     {
         return (a, b) -> jsonToGrammar.lambdaBatch(a, b, null);
     }

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarLambdaApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarLambdaApi.java
@@ -1,6 +1,8 @@
 package org.finos.legend.engine.language.pure.grammar.api.test;
 
+import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
 import org.finos.legend.engine.language.pure.grammar.api.jsonToGrammar.JsonToGrammar;
@@ -8,6 +10,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
+import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
 import org.junit.Test;
 
@@ -52,7 +55,7 @@ public class TestGrammarLambdaApi extends TestGrammar<Lambda>
     @Test
     public void testBatch()
     {
-        testBatch(with(Tuples.pair("1", "a: String[1]|'hello'"),
+        testBatch(createBatchInput(Tuples.pair("1", "a: String[1]|'hello'"),
                 Tuples.pair("2", "src: String[1]|$src"),
                 Tuples.pair("3", "src: Integer[2]|$src->first()->toOne()"),
                 Tuples.pair("4", "{src: Integer[1]|\n  let a = 1;\n  $a + 1;\n}"))
@@ -62,9 +65,9 @@ public class TestGrammarLambdaApi extends TestGrammar<Lambda>
     @Test
     public void testBatchError()
     {
-        testBatchError(with(Tuples.pair("1", "a: String[1]|'hello'"),
+        testBatchError(createBatchInput(Tuples.pair("1", "a: String[1]|'hello'"),
                         Tuples.pair("2", "src: String[1]|$src,")),
-                with(Tuples.pair("1", "a: String[1]|'hello'"),
+                createExpectedBatchResult(Tuples.pair("1", "a: String[1]|'hello'"),
                         Tuples.pair("2", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":20,\"endLine\":1,\"sourceId\":\"\",\"startColumn\":20,\"startLine\":1}}"))
         );
     }
@@ -90,9 +93,9 @@ public class TestGrammarLambdaApi extends TestGrammar<Lambda>
     }
 
     @Override
-    public Function2<String, Boolean, Response> grammarToJson()
+    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
     {
-        return (a, b) -> grammarToJson.lambda(a, null, b);
+        return (a) -> grammarToJson.lambda(a, null);
     }
 
     @Override
@@ -102,9 +105,9 @@ public class TestGrammarLambdaApi extends TestGrammar<Lambda>
     }
 
     @Override
-    public Function2<Map<String, String>, Boolean, Response> grammarToJsonB()
+    public Function<Map<String, GrammarAPI.ParserInput>, Response> grammarToJsonB()
     {
-        return (a, b) -> grammarToJson.lambdaBatch(a, null, b);
+        return (a) -> grammarToJson.lambdaBatch(a, null);
     }
 
     @Override

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
@@ -54,7 +54,7 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     @Override
     public Function5<String, String, Integer, Integer, Boolean, Response> grammarToJson()
     {
-        return (a, b, c, d, e) -> grammarToJson.model(a, b, c, d, e, null);
+        return (a, b, c, d, e) -> grammarToJson.model(a, b, c, e, null);
     }
 
     @Override

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
@@ -9,6 +9,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextDa
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
+import org.finos.legend.engine.shared.core.function.Function5;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -51,13 +52,13 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     }
 
     @Override
-    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
+    public Function5<String, String, Integer, Integer, Boolean, Response> grammarToJson()
     {
-        return (a) -> grammarToJson.model(a, null);
+        return (a, b, c, d, e) -> grammarToJson.model(a, b, c, d, e, null);
     }
 
     @Override
-    public Function2<RenderStyle, PureModelContextData, Response> jsonToGrammar()
+    public Function2<PureModelContextData, RenderStyle, Response> jsonToGrammar()
     {
         return (a, b) -> jsonToGrammar.model(a, b, null);
     }
@@ -69,7 +70,7 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     }
 
     @Override
-    public Function2<RenderStyle, Map<String, PureModelContextData>, Response> jsonToGrammarB()
+    public Function2<Map<String, PureModelContextData>, RenderStyle, Response> jsonToGrammarB()
     {
         throw new RuntimeException("Not supported here");
     }

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarModelApi.java
@@ -1,11 +1,13 @@
 package org.finos.legend.engine.language.pure.grammar.api.test;
 
+import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
 import org.finos.legend.engine.language.pure.grammar.api.jsonToGrammar.JsonToGrammar;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
+import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
 import org.junit.Test;
 
@@ -19,18 +21,8 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     public void testSimple()
     {
         test("Class A\n{\n}\n", true);
-        test("###Mapping\n" +
-                "Mapping meta::pure::mapping::modelToModel::test::simple::simpleModelMapping\n" +
-                "(\n" +
-                "  *meta::pure::mapping::modelToModel::test::shared::dest::Person[meta_pure_mapping_modelToModel_test_shared_dest_Person]: Pure\n" +
-                "  {\n" +
-                "    ~src meta::pure::mapping::modelToModel::test::shared::src::_S_Person\n" +
-                "    firstName: $src.fullName->substring(\n" +
-                "  0,\n" +
-                "  $src.fullName->indexOf(' ')\n" +
-                ")\n" +
-                "  }\n" +
-                ")\n", true);
+        test("###Mapping\n" + "Mapping meta::pure::mapping::modelToModel::test::simple::simpleModelMapping\n" + "(\n" + "  *meta::pure::mapping::modelToModel::test::shared::dest::Person[meta_pure_mapping_modelToModel_test_shared_dest_Person]: Pure\n" + "  {\n" + "    ~src meta::pure::mapping::modelToModel::test::shared::src::_S_Person\n" + "    firstName: $src.fullName->substring(\n" + "  0,\n" + "  $src.fullName->indexOf(' ')\n" + ")\n" + "  }\n" + ")\n",
+            true);
     }
 
     @Test
@@ -49,7 +41,8 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     }
 
     public static class MyClass extends LinkedHashMap<String, PureModelContextData>
-    {}
+    {
+    }
 
     @Override
     public Class getBatchResultSpecializedClass()
@@ -58,9 +51,9 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     }
 
     @Override
-    public Function2<String, Boolean, Response> grammarToJson()
+    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
     {
-        return (a, b) -> grammarToJson.model(a, null, b);
+        return (a) -> grammarToJson.model(a, null);
     }
 
     @Override
@@ -70,7 +63,7 @@ public class TestGrammarModelApi extends TestGrammar<PureModelContextData>
     }
 
     @Override
-    public Function2<Map<String, String>, Boolean, Response> grammarToJsonB()
+    public Function<Map<String, GrammarAPI.ParserInput>, Response> grammarToJsonB()
     {
         throw new RuntimeException("Not supported here");
     }

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarValueSpecificationApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarValueSpecificationApi.java
@@ -1,5 +1,6 @@
 package org.finos.legend.engine.language.pure.grammar.api.test;
 
+import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.grammarToJson.GrammarToJson;
@@ -8,6 +9,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
+import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
 import org.junit.Test;
 
@@ -38,7 +40,7 @@ public class TestGrammarValueSpecificationApi extends TestGrammar<ValueSpecifica
     @Test
     public void testBatch()
     {
-        testBatch(with(Tuples.pair("1", "1 + 1"),
+        testBatch(createBatchInput(Tuples.pair("1", "1 + 1"),
                   Tuples.pair("2", "true->func(\n" +
                                              "  2,\n" +
                                              "  'www'\n" +
@@ -48,12 +50,12 @@ public class TestGrammarValueSpecificationApi extends TestGrammar<ValueSpecifica
     @Test
     public void testBatchError()
     {
-        testBatchError( with(Tuples.pair("1", "1 + 1"),
+        testBatchError( createBatchInput(Tuples.pair("1", "1 + 1"),
                              Tuples.pair("2", "true->func(\n" +
                                 "  2\n" +
                                 "  'www'\n" +
                                 ")")),
-                        with(Tuples.pair("1", "1 + 1"),
+                        createExpectedBatchResult(Tuples.pair("1", "1 + 1"),
                                 Tuples.pair("2", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":7,\"endLine\":3,\"sourceId\":\"\",\"startColumn\":3,\"startLine\":3}}"))
                          );
     }
@@ -78,9 +80,9 @@ public class TestGrammarValueSpecificationApi extends TestGrammar<ValueSpecifica
     }
 
     @Override
-    public Function2<String, Boolean, Response> grammarToJson()
+    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
     {
-        return (a, b) -> grammarToJson.valueSpecification(a, null, b);
+        return (a) -> grammarToJson.valueSpecification(a, null);
     }
 
     @Override
@@ -90,9 +92,9 @@ public class TestGrammarValueSpecificationApi extends TestGrammar<ValueSpecifica
     }
 
     @Override
-    public Function2<Map<String, String>, Boolean, Response> grammarToJsonB()
+    public Function<Map<String, GrammarAPI.ParserInput>, Response> grammarToJsonB()
     {
-        return (a, b) -> grammarToJson.valueSpecificationBatch(a, null, b);
+        return (a) -> grammarToJson.valueSpecificationBatch(a, null);
     }
 
     @Override

--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarValueSpecificationApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestGrammarValueSpecificationApi.java
@@ -11,6 +11,7 @@ import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
 import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
+import org.finos.legend.engine.shared.core.function.Function5;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -80,13 +81,13 @@ public class TestGrammarValueSpecificationApi extends TestGrammar<ValueSpecifica
     }
 
     @Override
-    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
+    public Function5<String, String, Integer, Integer, Boolean, Response> grammarToJson()
     {
-        return (a) -> grammarToJson.valueSpecification(a, null);
+        return (a, b, c, d, e) -> grammarToJson.valueSpecification(a, b, c, d, e, null);
     }
 
     @Override
-    public Function2<RenderStyle, ValueSpecification, Response> jsonToGrammar()
+    public Function2<ValueSpecification, RenderStyle, Response> jsonToGrammar()
     {
         return (a, b) -> jsonToGrammar.valueSpecification(a, b, null);
     }
@@ -98,7 +99,7 @@ public class TestGrammarValueSpecificationApi extends TestGrammar<ValueSpecifica
     }
 
     @Override
-    public Function2<RenderStyle, Map<String, ValueSpecification>, Response> jsonToGrammarB()
+    public Function2<Map<String, ValueSpecification>, RenderStyle, Response> jsonToGrammarB()
     {
         return (a, b) -> jsonToGrammar.valueSpecificationBatch(a, b, null);
     }

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ParseTreeWalkerSourceInformation.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ParseTreeWalkerSourceInformation.java
@@ -57,26 +57,12 @@ public class ParseTreeWalkerSourceInformation
 
     private final boolean returnSourceInfo;
 
-    private static final ParseTreeWalkerSourceInformation defaultWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder("", 0, 0).withReturnSourceInfo(true).build();
-    
-    private static final ParseTreeWalkerSourceInformation defaultWalkerWithStubSourceInformation = new ParseTreeWalkerSourceInformation.Builder("", 0, 0).withReturnSourceInfo(false).build();
-
     private ParseTreeWalkerSourceInformation(ParseTreeWalkerSourceInformation.Builder builder)
     {
         this.sourceId = builder.sourceId;
         this.lineOffset = builder.lineOffset;
         this.columnOffset = builder.columnOffset;
         this.returnSourceInfo = builder.returnSourceInfo;
-    }
-
-    public static ParseTreeWalkerSourceInformation DEFAULT_WALKER_SOURCE_INFORMATION(boolean returnSourceInfo)
-    {
-        return  returnSourceInfo?  defaultWalkerSourceInformation: defaultWalkerWithStubSourceInformation;
-    }
-
-    public static ParseTreeWalkerSourceInformation DEFAULT_WALKER_SOURCE_INFORMATION()
-    {
-        return  DEFAULT_WALKER_SOURCE_INFORMATION(true);
     }
 
     public String getSourceId()

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
@@ -74,26 +74,31 @@ public class PureGrammarParser
         return new PureGrammarParser(PureGrammarParserExtensions.fromAvailableExtensions());
     }
 
-    public PureModelContextData parseModel(String code, boolean returnSourceInfo)
+    public PureModelContextData parseModel(String code, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-        return this.parse(code, this.parsers, returnSourceInfo);
+        return this.parse(code, this.parsers, sourceId, lineOffset, columnOffset, returnSourceInfo);
     }
 
     public PureModelContextData parseModel(String code)
     {
-        return this.parse(code, this.parsers, true);
+        return this.parse(code, this.parsers, "", 0, 0, true);
     }
 
-    public Lambda parseLambda(String code, String lambdaId, boolean returnSourceInfo)
+    public Lambda parseLambda(String code)
     {
-        return new DomainParser().parseLambda(code, lambdaId, returnSourceInfo);
+        return this.parseLambda(code, "", 0, 0, true);
     }
 
-    private PureModelContextData parse(String code, DEPRECATED_PureGrammarParserLibrary parserLibrary, boolean returnSourceInfo)
+    public Lambda parseLambda(String code, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
+    {
+        return new DomainParser().parseLambda(code, sourceId, lineOffset, columnOffset, returnSourceInfo);
+    }
+
+    private PureModelContextData parse(String code, DEPRECATED_PureGrammarParserLibrary parserLibrary, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
         String fullCode = DEFAULT_SECTION_BEGIN + code;
         PureGrammarParserContext parserContext = new PureGrammarParserContext(this.extensions);
-        ParseTreeWalkerSourceInformation walkerSourceInformation = ParseTreeWalkerSourceInformation.DEFAULT_WALKER_SOURCE_INFORMATION(returnSourceInfo);
+        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(sourceId, lineOffset, columnOffset).withReturnSourceInfo(returnSourceInfo).build();
         // init the parser
         ParserErrorListener errorListener = new ParserErrorListener(walkerSourceInformation);
         CodeLexerGrammar lexer = new CodeLexerGrammar(CharStreams.fromString(fullCode));
@@ -176,13 +181,13 @@ public class PureGrammarParser
         return section;
     }
 
-    public RootGraphFetchTree parseGraphFetch(String input, String sourceId, boolean returnSourceInfo)
+    public RootGraphFetchTree parseGraphFetch(String input, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-        return new DomainParser().parseGraphFetch(input, sourceId, returnSourceInfo);
+        return new DomainParser().parseGraphFetch(input, sourceId, lineOffset, columnOffset, returnSourceInfo);
     }
 
-    public ValueSpecification parseValueSpecification(String input, String sourceId, boolean returnSourceInfo)
+    public ValueSpecification parseValueSpecification(String input, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-        return new DomainParser().parseValueSpecification(input, sourceId, returnSourceInfo);
+        return new DomainParser().parseValueSpecification(input, sourceId, lineOffset, columnOffset, returnSourceInfo);
     }
 }

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
@@ -123,8 +123,10 @@ public class PureGrammarParser
     {
         String parserName = ctx.SECTION_START().getText().substring(4); // the prefix is `\n###` hence 4 characters
         SourceInformation parserNameSourceInformation = walkerSourceInformation.getSourceInformation(ctx.SECTION_START().getSymbol());
-        int lineOffset = ctx.SECTION_START().getSymbol().getLine() - 2; // since the CODE_BLOCK_START is `\n###` we have to subtract 1 more line than usual
-        ParseTreeWalkerSourceInformation sectionWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder("", lineOffset, 0).withReturnSourceInfo(returnSourceInfo).build();
+        // since the CODE_BLOCK_START is `\n###` we have to subtract 1 more line than usual
+        // also, we account for the line offset
+        int lineOffset = ctx.SECTION_START().getSymbol().getLine() - 2 + walkerSourceInformation.getLineOffset();
+        ParseTreeWalkerSourceInformation sectionWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation.getSourceId(), lineOffset, 0).withReturnSourceInfo(returnSourceInfo).build();
         SourceInformation sectionSourceInformation = walkerSourceInformation.getSourceInformation(ctx);
         if (ctx.sectionContent() != null)
         {

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
@@ -176,13 +176,13 @@ public class PureGrammarParser
         return section;
     }
 
-    public RootGraphFetchTree parseGraphFetch(String input, String s, boolean returnSourceInfo)
+    public RootGraphFetchTree parseGraphFetch(String input, String sourceId, boolean returnSourceInfo)
     {
-        return new DomainParser().parseGraphFetch(input, s, returnSourceInfo);
+        return new DomainParser().parseGraphFetch(input, sourceId, returnSourceInfo);
     }
 
-    public ValueSpecification parseValueSpecification(String input, String s, boolean returnSourceInfo)
+    public ValueSpecification parseValueSpecification(String input, String sourceId, boolean returnSourceInfo)
     {
-        return new DomainParser().parseValueSpecification(input, s, returnSourceInfo);
+        return new DomainParser().parseValueSpecification(input, sourceId, returnSourceInfo);
     }
 }

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/domain/DomainParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/domain/DomainParser.java
@@ -78,21 +78,21 @@ public class DomainParser implements DEPRECATED_SectionGrammarParser
         return section;
     }
 
-    public Lambda parseLambda(String code, String lambdaId, boolean returnSourceInfo)
+    public Lambda parseLambda(String code, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-        return parseLambda(code, lambdaId, new PureGrammarParserContext(PureGrammarParserExtensions.fromExtensions(Lists.immutable.empty())), returnSourceInfo);
+        return parseLambda(code, new PureGrammarParserContext(PureGrammarParserExtensions.fromExtensions(Lists.immutable.empty())), sourceId, lineOffset, columnOffset, returnSourceInfo);
     }
 
-    public Lambda parseLambda(String code, String lambdaId, PureGrammarParserContext parserContext, boolean returnSourceInfo)
+    public Lambda parseLambda(String code, PureGrammarParserContext parserContext, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-        ParseTreeWalkerSourceInformation lambdaWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(lambdaId, 0, 0).withReturnSourceInfo(returnSourceInfo).build();
+        ParseTreeWalkerSourceInformation lambdaWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(sourceId, lineOffset, columnOffset).withReturnSourceInfo(returnSourceInfo).build();
         String prefix = "function go():Any[*]{";
         String fullCode = prefix + code + "}";
         ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(lambdaWalkerSourceInformation)
                 // NOTE: as we prepend the lambda with this prefix, we need to subtract this prefix length from the column offset
                 .withColumnOffset(lambdaWalkerSourceInformation.getColumnOffset() - prefix.length()).build();
         SourceCodeParserInfo sectionParserInfo = this.getParserInfo(fullCode, null, walkerSourceInformation, true);
-        DomainParseTreeWalker walker = new DomainParseTreeWalker(walkerSourceInformation, parserContext, (ImportAwareCodeSection) null);
+        DomainParseTreeWalker walker = new DomainParseTreeWalker(walkerSourceInformation, parserContext, null);
         return (Lambda) walker.concreteFunctionDefinition(((DomainParserGrammar.DefinitionContext) sectionParserInfo.rootContext).elementDefinition(0).functionDefinition());
     }
 
@@ -122,7 +122,7 @@ public class DomainParser implements DEPRECATED_SectionGrammarParser
         return walker.primitiveValue(((DomainParserGrammar) sectionParserInfo.parser).primitiveValue(), "line", typeParametersNames, lambdaContext, "", true, false);
     }
 
-    public RootGraphFetchTree parseGraphFetch(String input, String s, boolean returnSourceInfo)
+    public RootGraphFetchTree parseGraphFetch(String input, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
 //        PureGrammarParserContext parserContext =  new PureGrammarParserContext(PureGrammarParserExtensions.fromExtensions(Lists.immutable.empty()));
 //        ParseTreeWalkerSourceInformation lambdaWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(s, 0, 0).withReturnSourceInfo(returnSourceInfo).build();
@@ -133,20 +133,21 @@ public class DomainParser implements DEPRECATED_SectionGrammarParser
 //                .withColumnOffset(lambdaWalkerSourceInformation.getColumnOffset() - prefix.length()).build();
 //        SourceCodeParserInfo sectionParserInfo = this.getParserInfo(fullCode, null, walkerSourceInformation, true);
 //        DomainParseTreeWalker walker = new DomainParseTreeWalker(walkerSourceInformation, parserContext, (ImportAwareCodeSection) null);
-        return (RootGraphFetchTree) parseValueSpecification(input,s,returnSourceInfo);//walker.combinedExpression(((DomainParserGrammar.DefinitionContext) sectionParserInfo.rootContext).elementDefinition(0).functionDefinition().codeBlock().programLine(0).letExpression().combinedExpression(), "", Lists.mutable.empty(), null, "", false, returnSourceInfo);
+        return (RootGraphFetchTree) parseValueSpecification(input, sourceId, lineOffset, columnOffset, returnSourceInfo);
+        //walker.combinedExpression(((DomainParserGrammar.DefinitionContext) sectionParserInfo.rootContext).elementDefinition(0).functionDefinition().codeBlock().programLine(0).letExpression().combinedExpression(), "", Lists.mutable.empty(), null, "", false, returnSourceInfo);
     }
 
-    public ValueSpecification parseValueSpecification(String input, String s, boolean returnSourceInfo)
+    public ValueSpecification parseValueSpecification(String input, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
         PureGrammarParserContext parserContext =  new PureGrammarParserContext(PureGrammarParserExtensions.fromExtensions(Lists.immutable.empty()));
-        ParseTreeWalkerSourceInformation lambdaWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(s, 0, 0).withReturnSourceInfo(returnSourceInfo).build();
+        ParseTreeWalkerSourceInformation lambdaWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(sourceId, lineOffset, columnOffset).withReturnSourceInfo(returnSourceInfo).build();
         String prefix = "function go():Any[*]{let x = ";
         String fullCode = prefix + input + ";}";
         ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(lambdaWalkerSourceInformation)
                 // NOTE: as we prepend the lambda with this prefix, we need to subtract this prefix length from the column offset
                 .withColumnOffset(lambdaWalkerSourceInformation.getColumnOffset() - prefix.length()).build();
         SourceCodeParserInfo sectionParserInfo = this.getParserInfo(fullCode, null, walkerSourceInformation, true);
-        DomainParseTreeWalker walker = new DomainParseTreeWalker(walkerSourceInformation, parserContext, (ImportAwareCodeSection) null);
+        DomainParseTreeWalker walker = new DomainParseTreeWalker(walkerSourceInformation, parserContext, null);
         return (ValueSpecification) walker.combinedExpression(((DomainParserGrammar.DefinitionContext) sectionParserInfo.rootContext).elementDefinition(0).functionDefinition().codeBlock().programLine(0).letExpression().combinedExpression(), "", Lists.mutable.empty(), null, "", false, returnSourceInfo);
     }
 }

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaPrettyRendering.java
@@ -246,6 +246,6 @@ public class TestLambdaPrettyRendering
 
     private static void testLambda(String text, String formattedText, RenderStyle renderStyle)
     {
-        Assert.assertEquals(formattedText, new DomainParser().parseLambda(text, "", true).accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle).build()));
+        Assert.assertEquals(formattedText, new DomainParser().parseLambda(text, "", 0, 0, true).accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(renderStyle).build()));
     }
 }

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
@@ -358,7 +358,7 @@ public class TestLambdaRoundtrip
         Lambda postJSON_lambda;
         try
         {
-            Lambda lambda = new DomainParser().parseLambda(text, "",true);
+            Lambda lambda = new DomainParser().parseLambda(text, "", 0, 0, true);
             String json = objectMapper.writeValueAsString(lambda);
             postJSON_lambda = objectMapper.readValue(json, Lambda.class);
         }

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/api/grammar/GrammarAPI.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/api/grammar/GrammarAPI.java
@@ -3,6 +3,7 @@ package org.finos.legend.engine.shared.core.api.grammar;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
+import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.factory.Maps;
@@ -26,15 +27,14 @@ public class GrammarAPI
 {
     private static final ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
 
-    protected <T> Response grammarToJson(ParserInput input, Function5<String, String, Integer, Integer, Boolean, T> func, ProfileManager<CommonProfile> pm, String spanText)
+    protected <T> Response grammarToJson(String text, Function<String, T> func, ProfileManager<CommonProfile> pm, String spanText)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         try (Scope scope = GlobalTracer.get().buildSpan(spanText).startActive(true))
         {
             try
             {
-                ParserSourceInformationOffset sourceInformationOffset = input.sourceInformationOffset != null ? input.sourceInformationOffset : new ParserSourceInformationOffset();
-                T data = func.value(input.value, sourceInformationOffset.sourceId, sourceInformationOffset.lineOffset, sourceInformationOffset.columnOffset, input.returnSourceInformation);
+                T data = func.apply(text);
                 return ManageConstantResult.manageResult(profiles, data, objectMapper);
             }
             catch (Exception e)

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/function/Function5.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/function/Function5.java
@@ -1,0 +1,24 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.shared.core.function;
+
+import java.io.Serializable;
+
+@FunctionalInterface
+public interface Function5<T1, T2, T3, T4, T5, R>
+        extends Serializable
+{
+    R value(T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument);
+}

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/grammar/GraphQLGrammar.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/grammar/GraphQLGrammar.java
@@ -49,14 +49,14 @@ public class GraphQLGrammar extends GrammarAPI
     @Produces(MediaType.APPLICATION_JSON)
     public Response grammarToJson(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return grammarToJson(input, (a, b, c) -> {
+        return grammarToJson(input, (a, b, c, d, e) -> {
             try
             {
                 return GraphQLGrammarParser.newInstance().parseDocument(a);
             }
-            catch (GraphQLParserException e)
+            catch (GraphQLParserException ex)
             {
-                throw new EngineException(e.getMessage(), e.getSourceInformation(), EngineErrorType.PARSER);
+                throw new EngineException(ex.getMessage(), ex.getSourceInformation(), EngineErrorType.PARSER);
             }
         }, pm, "Grammar to Json : GraphQL");
     }
@@ -72,14 +72,14 @@ public class GraphQLGrammar extends GrammarAPI
     @Produces(MediaType.APPLICATION_JSON)
     public Response grammarToJsonBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return grammarToJsonBatch(input, (a, b, c) -> {
+        return grammarToJsonBatch(input, (a, b, c, d, e) -> {
             try
             {
                 return GraphQLGrammarParser.newInstance().parseDocument(a);
             }
-            catch (GraphQLParserException e)
+            catch (GraphQLParserException ex)
             {
-                throw new EngineException(e.getMessage(), e.getSourceInformation(), EngineErrorType.PARSER);
+                throw new EngineException(ex.getMessage(), ex.getSourceInformation(), EngineErrorType.PARSER);
             }
         }, new TypedMap(), pm, "Grammar to Json : GraphQL Batch");
     }

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/grammar/GraphQLGrammar.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/grammar/GraphQLGrammar.java
@@ -45,20 +45,20 @@ public class GraphQLGrammar extends GrammarAPI
     @POST
     @Path("grammarToJson")
     @ApiOperation(value = "Generates GraphQL protocol JSON from GraphQL language text")
-    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response grammarToJson(String grammar, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response grammarToJson(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return grammarToJson(grammar, (a, b) -> {
+        return grammarToJson(input, (a, b, c) -> {
             try
             {
-                return GraphQLGrammarParser.newInstance().parseDocument(grammar);
+                return GraphQLGrammarParser.newInstance().parseDocument(a);
             }
             catch (GraphQLParserException e)
             {
                 throw new EngineException(e.getMessage(), e.getSourceInformation(), EngineErrorType.PARSER);
             }
-        }, pm, returnSourceInfo, "Grammar to Json : GraphQL");
+        }, pm, "Grammar to Json : GraphQL");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -70,9 +70,9 @@ public class GraphQLGrammar extends GrammarAPI
     @ApiOperation(value = "Generates GraphQL protocol JSON from GraphQL language text (for multiple elements)")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response grammarToJsonBatch(Map<String, String> grammars, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @DefaultValue("true") @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response grammarToJsonBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return grammarToJsonBatch(grammars, (a, b) -> {
+        return grammarToJsonBatch(input, (a, b, c) -> {
             try
             {
                 return GraphQLGrammarParser.newInstance().parseDocument(a);
@@ -81,7 +81,7 @@ public class GraphQLGrammar extends GrammarAPI
             {
                 throw new EngineException(e.getMessage(), e.getSourceInformation(), EngineErrorType.PARSER);
             }
-        }, new TypedMap(), pm, returnSourceInfo, "Grammar to Json : GraphQL Batch");
+        }, new TypedMap(), pm, "Grammar to Json : GraphQL Batch");
     }
 
     @POST

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/grammar/GraphQLGrammar.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/grammar/GraphQLGrammar.java
@@ -31,7 +31,12 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -45,11 +50,16 @@ public class GraphQLGrammar extends GrammarAPI
     @POST
     @Path("grammarToJson")
     @ApiOperation(value = "Generates GraphQL protocol JSON from GraphQL language text")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response grammarToJson(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response grammarToJson(String text,
+                                  @DefaultValue("") @ApiParam("The source ID to be used by the parser") @QueryParam("sourceId") String sourceId,
+                                  @DefaultValue("0") @ApiParam("The line number the parser will offset by") @QueryParam("lineOffset") int lineOffset,
+                                  @DefaultValue("0") @ApiParam("The column number the parser will offset by") @QueryParam("columnOffset") int columnOffset,
+                                  @DefaultValue("true") @QueryParam("returnSourceInformation") boolean returnSourceInformation,
+                                  @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return grammarToJson(input, (a, b, c, d, e) -> {
+        return grammarToJson(text, (a) -> {
             try
             {
                 return GraphQLGrammarParser.newInstance().parseDocument(a);
@@ -85,21 +95,25 @@ public class GraphQLGrammar extends GrammarAPI
     }
 
     @POST
-    @Path("jsonToGrammar/{renderStyle}")
+    @Path("jsonToGrammar")
     @ApiOperation(value = "Generates GraphQL language text from GraphQL protocol JSON")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.TEXT_PLAIN)
-    public Response jsonToGrammar(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, ExecutableDocument document,  @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response jsonToGrammar(ExecutableDocument document,
+                                  @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                  @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         return jsonToGrammar(document, renderStyle, (vs, renderStyle1) -> GraphQLGrammarComposer.newInstance().renderDocument(vs), pm, "Json to Grammar : GraphQL");
     }
 
     @POST
-    @Path("jsonToGrammar/{renderStyle}/batch")
+    @Path("jsonToGrammar/batch")
     @ApiOperation(value = "Generates GraphQL language text from GraphQL protocol JSON")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response jsonToGrammarBatch(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, Map<String, ExecutableDocument> documents, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response jsonToGrammarBatch(Map<String, ExecutableDocument> documents,
+                                       @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                       @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         return jsonToGrammarBatch(renderStyle, documents, (vs, renderStyle1) -> GraphQLGrammarComposer.newInstance().renderDocument(vs), pm, "Json to Grammar : GraphQL Batch");
     }

--- a/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/grammar/test/TestGrammarApi.java
+++ b/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/grammar/test/TestGrammarApi.java
@@ -10,6 +10,7 @@ import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
 import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
+import org.finos.legend.engine.shared.core.function.Function5;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -100,13 +101,13 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
     }
 
     @Override
-    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
+    public Function5<String, String, Integer, Integer, Boolean, Response> grammarToJson()
     {
-        return (a) -> graphQLGrammar.grammarToJson(a, null);
+        return (a, b, c, d, e) -> graphQLGrammar.grammarToJson(a, b, c, d, e, null);
     }
 
     @Override
-    public Function2<RenderStyle, ExecutableDocument, Response> jsonToGrammar()
+    public Function2<ExecutableDocument, RenderStyle, Response> jsonToGrammar()
     {
         return (a, b) -> graphQLGrammar.jsonToGrammar(a, b, null);
     }
@@ -118,7 +119,7 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
     }
 
     @Override
-    public Function2<RenderStyle, Map<String, ExecutableDocument>, Response> jsonToGrammarB()
+    public Function2<Map<String, ExecutableDocument>, RenderStyle, Response> jsonToGrammarB()
     {
         return (a, b) -> graphQLGrammar.jsonToGrammarBatch(a, b, null);
     }

--- a/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/grammar/test/TestGrammarApi.java
+++ b/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/grammar/test/TestGrammarApi.java
@@ -1,5 +1,6 @@
 package org.finos.legend.engine.query.graphQL.api.grammar.test;
 
+import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.graphQL.metamodel.ExecutableDocument;
@@ -7,6 +8,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.query.graphQL.api.grammar.GraphQLGrammar;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
+import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
 import org.junit.Test;
 
@@ -40,7 +42,7 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
     @Test
     public void testBatch()
     {
-        testBatch(with(Tuples.pair("1", "type Car implements Vehicle & X & Z {\n" +
+        testBatch(createBatchInput(Tuples.pair("1", "type Car implements Vehicle & X & Z {\n" +
                         "  id: ID!\n" +
                         "  name: String!\n" +
                         "  values: [String]\n" +
@@ -57,7 +59,7 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
     @Test
     public void testBatchError()
     {
-        testBatchError(with(Tuples.pair("1", "type Car implements Vehicle & X & Z {\n" +
+        testBatchError(createBatchInput(Tuples.pair("1", "type Car implements Vehicle & X & Z {\n" +
                         "  id: ID!\n" +
                         "  name: String!\n" +
                         "  values: [String]\n" +
@@ -69,7 +71,7 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
                         "  EAST\n"+
                         "  WEST\n"+
                         "}")),
-                with(Tuples.pair("1", "type Car implements Vehicle & X & Z {\n" +
+                createExpectedBatchResult(Tuples.pair("1", "type Car implements Vehicle & X & Z {\n" +
                                 "  id: ID!\n" +
                                 "  name: String!\n" +
                                 "  values: [String]\n" +
@@ -98,9 +100,9 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
     }
 
     @Override
-    public Function2<String, Boolean, Response> grammarToJson()
+    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
     {
-        return (a, b) -> graphQLGrammar.grammarToJson(a, null, b);
+        return (a) -> graphQLGrammar.grammarToJson(a, null);
     }
 
     @Override
@@ -110,9 +112,9 @@ public class TestGrammarApi extends TestGrammar<ExecutableDocument>
     }
 
     @Override
-    public Function2<Map<String, String>, Boolean, Response> grammarToJsonB()
+    public Function<Map<String, GrammarAPI.ParserInput>, Response> grammarToJsonB()
     {
-        return (a, b) -> graphQLGrammar.grammarToJsonBatch(a, null, b);
+        return (a) -> graphQLGrammar.grammarToJsonBatch(a, null);
     }
 
     @Override

--- a/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementGrammarToJson.java
+++ b/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementGrammarToJson.java
@@ -13,11 +13,9 @@ import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -36,7 +34,8 @@ public class RelationalOperationElementGrammarToJson extends GrammarAPI
     public Response relationalOperationElement(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b, c) -> RelationalGrammarParserExtension.parseRelationalOperationElement(a, b, c), pm, "Grammar to Json : RelationalOperationElement");
+        return grammarToJson(input,
+            RelationalGrammarParserExtension::parseRelationalOperationElement, pm, "Grammar to Json : RelationalOperationElement");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -51,6 +50,7 @@ public class RelationalOperationElementGrammarToJson extends GrammarAPI
     public Response relationalOperationElementBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b, c) -> RelationalGrammarParserExtension.parseRelationalOperationElement(a, b, c), new TypedMap(), pm, "Grammar to Json : RelationalOperationElement Batch");
+        return grammarToJsonBatch(input,
+            RelationalGrammarParserExtension::parseRelationalOperationElement, new TypedMap(), pm, "Grammar to Json : RelationalOperationElement Batch");
     }
 }

--- a/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementGrammarToJson.java
+++ b/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementGrammarToJson.java
@@ -13,9 +13,11 @@ import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -29,13 +31,18 @@ public class RelationalOperationElementGrammarToJson extends GrammarAPI
     @POST
     @Path("relationalOperationElement")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text for relational operation elements")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response relationalOperationElement(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response relationalOperationElement(String text,
+                                               @DefaultValue("") @ApiParam("The source ID to be used by the parser") @QueryParam("sourceId") String sourceId,
+                                               @DefaultValue("0") @ApiParam("The line number the parser will offset by") @QueryParam("lineOffset") int lineOffset,
+                                               @DefaultValue("0") @ApiParam("The column number the parser will offset by") @QueryParam("columnOffset") int columnOffset,
+                                               @DefaultValue("true") @QueryParam("returnSourceInformation") boolean returnSourceInformation,
+                                               @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input,
-            RelationalGrammarParserExtension::parseRelationalOperationElement, pm, "Grammar to Json : RelationalOperationElement");
+        return grammarToJson(text,
+            (a) -> RelationalGrammarParserExtension.parseRelationalOperationElement(a, sourceId, lineOffset, columnOffset, returnSourceInformation), pm, "Grammar to Json : RelationalOperationElement");
     }
 
     // Required so that Jackson properly includes _type for the top level element

--- a/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementGrammarToJson.java
+++ b/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementGrammarToJson.java
@@ -1,31 +1,23 @@
 package org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
 import org.finos.legend.engine.language.pure.grammar.from.RelationalGrammarParserExtension;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
-import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement;
-import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
-import org.finos.legend.engine.shared.core.api.grammar.ParserError;
-import org.finos.legend.engine.shared.core.api.result.ManageConstantResult;
-import org.finos.legend.engine.shared.core.kerberos.ProfileManagerHelper;
-import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
-import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionTool;
-import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -39,12 +31,12 @@ public class RelationalOperationElementGrammarToJson extends GrammarAPI
     @POST
     @Path("relationalOperationElement")
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text for relational operation elements")
-    @Consumes({MediaType.TEXT_PLAIN, APPLICATION_ZLIB})
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response relationalOperationElement(String input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response relationalOperationElement(ParserInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(input, (a, b) -> RelationalGrammarParserExtension.parseRelationalOperationElement(a, b), pm, returnSourceInfo, "Grammar to Json : RelationalOperationElement");
+        return grammarToJson(input, (a, b, c) -> RelationalGrammarParserExtension.parseRelationalOperationElement(a, b, c), pm, "Grammar to Json : RelationalOperationElement");
     }
 
     // Required so that Jackson properly includes _type for the top level element
@@ -56,9 +48,9 @@ public class RelationalOperationElementGrammarToJson extends GrammarAPI
     @ApiOperation(value = "Generates Pure protocol JSON from Pure language text for relational operation elements")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response relationalOperationElementBatch(Map<String, String> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @QueryParam("returnSourceInfo") boolean returnSourceInfo)
+    public Response relationalOperationElementBatch(Map<String, ParserInput> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         PureGrammarParserExtensions.logExtensionList();
-        return grammarToJsonBatch(input, (a, b) -> RelationalGrammarParserExtension.parseRelationalOperationElement(a, b), new TypedMap(), pm, returnSourceInfo, "Grammar to Json : RelationalOperationElement Batch");
+        return grammarToJsonBatch(input, (a, b, c) -> RelationalGrammarParserExtension.parseRelationalOperationElement(a, b, c), new TypedMap(), pm, "Grammar to Json : RelationalOperationElement Batch");
     }
 }

--- a/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementJsonToGrammar.java
+++ b/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/RelationalOperationElementJsonToGrammar.java
@@ -12,7 +12,6 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.MapIterate;
-import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
 import org.finos.legend.engine.language.pure.grammar.to.RelationalGrammarComposerExtension;
 import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtensionLoader;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement;
@@ -25,7 +24,12 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -37,11 +41,13 @@ import static org.finos.legend.engine.shared.core.operational.http.InflateInterc
 public class RelationalOperationElementJsonToGrammar
 {
     @POST
-    @Path("relationalOperationElement/{renderStyle}")
+    @Path("relationalOperationElement")
     @ApiOperation(value = "Generates Pure language text from Pure protocol JSON for relational operation elements")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.TEXT_PLAIN)
-    public Response relationalOperationElement(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, RelationalOperationElement input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response relationalOperationElement(RelationalOperationElement input,
+                                               @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                               @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         try (Scope scope = GlobalTracer.get().buildSpan("Service: jsonToGrammar relationalOperationElement").startActive(true))
@@ -56,11 +62,13 @@ public class RelationalOperationElementJsonToGrammar
     }
 
     @POST
-    @Path("relationalOperationElement/{renderStyle}/batch")
+    @Path("relationalOperationElement/batch")
     @ApiOperation(value = "Generates Pure language text from Pure protocol JSON for relational operation elements")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response relationalOperationElementBatch(@PathParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle, Map<String, RelationalOperationElement> input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response relationalOperationElementBatch(Map<String, RelationalOperationElement> input,
+                                                    @QueryParam("renderStyle") @DefaultValue("PRETTY") RenderStyle renderStyle,
+                                                    @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         try (Scope scope = GlobalTracer.get().buildSpan("Service: jsonToGrammar relationalOperationElement").startActive(true))

--- a/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/TransformRelationalOperationElementGrammarToJson.java
+++ b/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/TransformRelationalOperationElementGrammarToJson.java
@@ -55,7 +55,7 @@ public class TransformRelationalOperationElementGrammarToJson
             {
                 try
                 {
-                    RelationalOperationElement operation = RelationalGrammarParserExtension.parseRelationalOperationElement(key, value, returnSourceInfo);
+                    RelationalOperationElement operation = RelationalGrammarParserExtension.parseRelationalOperationElement(value, key, 0, 0, returnSourceInfo);
                     operations.put(key, operation);
                 }
                 catch (Exception e)

--- a/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/TransformRelationalOperationElementGrammarToJson.java
+++ b/legend-engine-xt-relationalStore-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/relationalOperationElement/TransformRelationalOperationElementGrammarToJson.java
@@ -55,7 +55,7 @@ public class TransformRelationalOperationElementGrammarToJson
             {
                 try
                 {
-                    RelationalOperationElement operation = RelationalGrammarParserExtension.parseRelationalOperationElement(value, returnSourceInfo);
+                    RelationalOperationElement operation = RelationalGrammarParserExtension.parseRelationalOperationElement(key, value, returnSourceInfo);
                     operations.put(key, operation);
                 }
                 catch (Exception e)

--- a/legend-engine-xt-relationalStore-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
+++ b/legend-engine-xt-relationalStore-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
@@ -11,6 +11,7 @@ import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
 import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
+import org.finos.legend.engine.shared.core.function.Function5;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -68,13 +69,13 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     }
 
     @Override
-    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
+    public Function5<String, String, Integer, Integer, Boolean, Response> grammarToJson()
     {
-        return (a) -> grammarToJson.relationalOperationElement(a, null);
+        return (a, b, c, d, e) -> grammarToJson.relationalOperationElement(a, b, c, d, e, null);
     }
 
     @Override
-    public Function2<RenderStyle, RelationalOperationElement, Response> jsonToGrammar()
+    public Function2<RelationalOperationElement, RenderStyle, Response> jsonToGrammar()
     {
         return (a, b) -> jsonToGrammar.relationalOperationElement(a, b, null);
     }
@@ -86,7 +87,7 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     }
 
     @Override
-    public Function2<RenderStyle, Map<String, RelationalOperationElement>, Response> jsonToGrammarB()
+    public Function2<Map<String, RelationalOperationElement>, RenderStyle, Response> jsonToGrammarB()
     {
         return (a, b) -> jsonToGrammar.relationalOperationElementBatch(a, b, null);
     }

--- a/legend-engine-xt-relationalStore-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
+++ b/legend-engine-xt-relationalStore-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
@@ -1,5 +1,6 @@
 package org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test;
 
+import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.RelationalOperationElementGrammarToJson;
@@ -8,6 +9,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement;
 import org.finos.legend.engine.shared.core.api.TestGrammar;
 import org.finos.legend.engine.shared.core.api.grammar.BatchResult;
+import org.finos.legend.engine.shared.core.api.grammar.GrammarAPI;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
 import org.junit.Test;
 
@@ -31,18 +33,19 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     @Test
     public void testBatch()
     {
-        testBatch(with(Tuples.pair("1", "add(1, 2)"),
-                       Tuples.pair("2", "'4'")));
+        testBatch(createBatchInput(Tuples.pair("1", "add(1, 2)"),
+            Tuples.pair("2", "'4'")));
     }
 
     @Test
     public void testBatchError()
     {
-        testBatchError( with(Tuples.pair("1", "add(1"),
-                             Tuples.pair("2", "'4'")),
-                        with(Tuples.pair("1", "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":10,\"endLine\":1,\"sourceId\":\"\",\"startColumn\":6,\"startLine\":1}}"),
-                             Tuples.pair("2", "'4'"))
-                );
+        testBatchError(createBatchInput(Tuples.pair("1", "add(1"),
+                Tuples.pair("2", "'4'")),
+            createExpectedBatchResult(Tuples.pair("1",
+                    "{\"message\":\"Unexpected token\",\"sourceInformation\":{\"endColumn\":10,\"endLine\":1,\"sourceId\":\"\",\"startColumn\":6,\"startLine\":1}}"),
+                Tuples.pair("2", "'4'"))
+        );
     }
 
     private static final RelationalOperationElementGrammarToJson grammarToJson = new RelationalOperationElementGrammarToJson();
@@ -55,7 +58,8 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     }
 
     public static class MyClass extends BatchResult<RelationalOperationElement>
-    {}
+    {
+    }
 
     @Override
     public Class getBatchResultSpecializedClass()
@@ -64,9 +68,9 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     }
 
     @Override
-    public Function2<String, Boolean, Response> grammarToJson()
+    public Function<GrammarAPI.ParserInput, Response> grammarToJson()
     {
-        return (a, b) -> grammarToJson.relationalOperationElement(a, null, b);
+        return (a) -> grammarToJson.relationalOperationElement(a, null);
     }
 
     @Override
@@ -76,9 +80,9 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     }
 
     @Override
-    public Function2<Map<String, String>, Boolean, Response> grammarToJsonB()
+    public Function<Map<String, GrammarAPI.ParserInput>, Response> grammarToJsonB()
     {
-        return (a, b) -> grammarToJson.relationalOperationElementBatch(a, null, b);
+        return (a) -> grammarToJson.relationalOperationElementBatch(a, null);
     }
 
     @Override

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
@@ -345,10 +345,10 @@ public class RelationalGrammarParserExtension implements IRelationalGrammarParse
         return new SourceCodeParserInfo(connectionValueSourceCode.code, input, connectionValueSourceCode.sourceInformation, connectionValueSourceCode.walkerSourceInformation, lexer, parser, parser.definition());
     }
 
-    public static RelationalOperationElement parseRelationalOperationElement(String code, String sourceId, boolean returnSourceInfo)
+    public static RelationalOperationElement parseRelationalOperationElement(String code, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
         CharStream input = CharStreams.fromString(code);
-        ParseTreeWalkerSourceInformation parseTreeWalkerSourceInformation= new ParseTreeWalkerSourceInformation.Builder(sourceId, 0, 0).withReturnSourceInfo(returnSourceInfo).build();
+        ParseTreeWalkerSourceInformation parseTreeWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(sourceId, lineOffset, columnOffset).withReturnSourceInfo(returnSourceInfo).build();
         ParserErrorListener errorListener = new ParserErrorListener(parseTreeWalkerSourceInformation);
         RelationalLexerGrammar lexer = new RelationalLexerGrammar(input);
         lexer.removeErrorListeners();

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
@@ -345,10 +345,10 @@ public class RelationalGrammarParserExtension implements IRelationalGrammarParse
         return new SourceCodeParserInfo(connectionValueSourceCode.code, input, connectionValueSourceCode.sourceInformation, connectionValueSourceCode.walkerSourceInformation, lexer, parser, parser.definition());
     }
 
-    public static RelationalOperationElement parseRelationalOperationElement(String code, boolean returnSourceInfo)
+    public static RelationalOperationElement parseRelationalOperationElement(String code, String sourceId, boolean returnSourceInfo)
     {
         CharStream input = CharStreams.fromString(code);
-        ParseTreeWalkerSourceInformation parseTreeWalkerSourceInformation= new ParseTreeWalkerSourceInformation.Builder("", 0, 0).withReturnSourceInfo(returnSourceInfo).build();
+        ParseTreeWalkerSourceInformation parseTreeWalkerSourceInformation= new ParseTreeWalkerSourceInformation.Builder(sourceId, 0, 0).withReturnSourceInfo(returnSourceInfo).build();
         ParserErrorListener errorListener = new ParserErrorListener(parseTreeWalkerSourceInformation);
         RelationalLexerGrammar lexer = new RelationalLexerGrammar(input);
         lexer.removeErrorListeners();

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
@@ -38,7 +38,7 @@ public class TestRelationalOperationElementGrammarRoundtrip
         RelationalOperationElement operation = null;
         try
         {
-            RelationalOperationElement op = RelationalGrammarParserExtension.parseRelationalOperationElement(val, true);
+            RelationalOperationElement op = RelationalGrammarParserExtension.parseRelationalOperationElement(val, "", true);
             String json = objectMapper.writeValueAsString(op);
             operation = objectMapper.readValue(json, RelationalOperationElement.class);
             if (expectedErrorMsg != null)

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
@@ -38,7 +38,7 @@ public class TestRelationalOperationElementGrammarRoundtrip
         RelationalOperationElement operation = null;
         try
         {
-            RelationalOperationElement op = RelationalGrammarParserExtension.parseRelationalOperationElement(val, "", true);
+            RelationalOperationElement op = RelationalGrammarParserExtension.parseRelationalOperationElement(val, "", 0, 0, true);
             String json = objectMapper.writeValueAsString(op);
             operation = objectMapper.readValue(json, RelationalOperationElement.class);
             if (expectedErrorMsg != null)


### PR DESCRIPTION
This is a continuation of https://github.com/finos/legend-engine/pull/595 

> This PR introduces a **BREAKING CHANGE** as it modifies the API endpoints

Support setting `sourceId` for value specification in new grammar parser APIs. Also did some minor cleanups. Instead of sending in `String` and a separate optional `boolean` flag for `returnSourceInfo`, we now bundle these and call the structure `ParserInput`

```java
class ParserSourceInformationOffset {
  public String sourceId = "";
  public int lineOffset = 0;
  public int columnOffset = 0;
}

class ParserInput {
  public String value;
  public ParserSourceInformationOffset;
  public boolean returnSourceInformation = true;
}
```

**NOTE** We leave `non-batch` APIs simple (taking everything as `query parameter`) so that it's easier to use from REST design perspective, look at the Swagger screenshot below for example

<img width="1002" alt="Screen Shot 2022-05-20 at 3 23 16 PM" src="https://user-images.githubusercontent.com/13574879/169597961-4be5ef30-419a-4f74-a101-e3a069f32ab1.png">


We also cleanup the `grammar composer` endpoints to now take `RENDER STYLE` as a `query parameter` instead of a `path parameter` to be more consistent across all grammar APIs.
