### PR TITLE
publish test results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: legend-build
+name: Build CI
 
 env:
   CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
@@ -24,6 +24,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: Build
     if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +62,7 @@ jobs:
           MAVEN_OPTS: -Xmx4000m
       - name: Build + Test
         if: (github.repository != 'finos/legend-engine') || (github.ref != 'refs/heads/master')
-        run: mvn install javadoc:javadoc
+        run: mvn install javadoc:javadoc -Dmaven.test.failure.ignore=true
         env:
           MAVEN_OPTS: -Xmx4000m
       - name: Build + Test + Maven Deploy + Sonar + Docker Snapshot
@@ -70,4 +71,16 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           MAVEN_OPTS: -Xmx4000m
-        run: mvn javadoc:javadoc deploy -P sonar,docker-snapshot
+        run: mvn javadoc:javadoc deploy -Dmaven.test.failure.ignore=true -P sonar,docker-snapshot
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: legend-engine-test-reports/surefire-reports-aggregate/*.xml
+      - name: Upload CI Event
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: event-file
+          path: ${{ github.event_path }}

--- a/.github/workflows/test-result.yml
+++ b/.github/workflows/test-result.yml
@@ -1,0 +1,42 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build CI"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Publish Test Results
+    if: github.event.workflow_run.conclusion != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Debug Only
+        run: echo ${{ github.event.workflow_run.conclusion }}
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts && cd artifacts
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1.35
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          check_name: Test Results
+          event_file: artifacts/event-file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
-![legend-build](https://github.com/finos/legend-engine/workflows/legend-build/badge.svg)
+![Build CI](https://github.com/finos/legend-engine/workflows/Builc%20CI/badge.svg)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=legend-engine&metric=security_rating&token=cbbc6d136c4f5671324244170afb9f0a6c22a7fb)](https://sonarcloud.io/dashboard?id=legend-engine)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=legend-engine&metric=bugs&token=cbbc6d136c4f5671324244170afb9f0a6c22a7fb)](https://sonarcloud.io/dashboard?id=legend-engine)
 

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,7 @@
                 <configuration>
                     <useSystemClassLoader>true</useSystemClassLoader>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
+                    <trimStackTrace>false</trimStackTrace>
                     <reportsDirectory>
                         ${project.parent.basedir}/legend-engine-test-reports/surefire-reports-aggregate
                     </reportsDirectory>


### PR DESCRIPTION
publish CI test results so we can see failure as annotations and debug quicker

plugin doc: https://github.com/marketplace/actions/publish-unit-test-results
example: https://github.com/gomichutsk-stormborn/java-sample