### PR TITLE
use parameterized test runner for db test suite 

### DIFF
--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -104,6 +104,8 @@ public class Server<T extends ServerConfiguration> extends Application<T>
 {
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger("Alloy Execution Server");
 
+    protected RelationalStoreExecutor relationalStoreExecutor ;
+
     private Environment environment;
 
     public static void main(String[] args) throws Exception
@@ -149,7 +151,7 @@ public class Server<T extends ServerConfiguration> extends Application<T>
 
         ChainFixingFilterHandler.apply(environment.getApplicationContext(), serverConfiguration.filterPriorities);
 
-        RelationalStoreExecutor relationalStoreExecutor = (RelationalStoreExecutor) Relational.build(serverConfiguration.relationalexecution);
+        relationalStoreExecutor = (RelationalStoreExecutor) Relational.build(serverConfiguration.relationalexecution);
         PlanExecutor planExecutor = PlanExecutor.newPlanExecutor(relationalStoreExecutor, ServiceStore.build(), InMemory.build());
 
         // Session Management

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/ExecuteInRelationalDb.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/ExecuteInRelationalDb.java
@@ -1,0 +1,92 @@
+package org.finos.legend.engine.server.test.shared;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.api.result.ResultManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.manager.ConnectionManagerSelector;
+import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
+import org.finos.legend.engine.shared.core.kerberos.ProfileManagerHelper;
+import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionTool;
+import org.finos.legend.engine.shared.core.operational.logs.LogInfo;
+import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileManager;
+import org.pac4j.jax.rs.annotations.Pac4JProfileManager;
+import org.slf4j.Logger;
+
+import static org.finos.legend.engine.shared.core.operational.http.InflateInterceptor.APPLICATION_ZLIB;
+
+@Api(tags = "Utilities - ExecuteInRelationalDb")
+@Path("pure/v1/utilities/tests")
+@Produces( MediaType.APPLICATION_JSON)
+public class  ExecuteInRelationalDb
+{
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger("Alloy Execution Server");
+    private static final ObjectMapper objectMapper = PureProtocolObjectMapperFactory.getNewObjectMapper();
+    ConnectionManagerSelector connectionManagerSelector;
+
+    public ExecuteInRelationalDb(ConnectionManagerSelector connectionManagerSelector)
+    {
+        this.connectionManagerSelector = connectionManagerSelector;
+    }
+
+    @POST
+    @Path("/executeInRelationalDb")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    public Response executeInRelationalDb( @Context HttpServletRequest request,
+                                       ExecuteInRelationalDbInput input,
+                                       @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    {
+        MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles( pm );
+
+        try
+        {
+            LOGGER.info( new LogInfo( profiles, LoggingEventType.EXECUTION_PLAN_EXEC_START, "" ).toString() );
+
+            try{
+                Connection jdbcConn =
+                        this.connectionManagerSelector.getDatabaseConnection( (MutableList<CommonProfile>) null,
+                                input.connection );
+
+                Statement stmt = jdbcConn.createStatement();
+
+                for(String sql : input.sqls)
+                {
+                    stmt.execute(sql);
+                }
+
+                return Response.ok().build();
+            }
+            catch( SQLException e )
+            {
+                return Response.status( 500 ).type( MediaType.APPLICATION_JSON_TYPE )
+                        .entity( new ResultManager.ErrorMessage( 20, "{\"message\":\"" +e.getMessage()+ "\"}" ) ).build();
+            }
+        }
+        catch ( Exception ex )
+        {
+            return ExceptionTool.exceptionManager( ex, LoggingEventType.EXECUTION_PLAN_EXEC_ERROR, profiles );
+        }
+    }
+}

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/ExecuteInRelationalDbInput.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/ExecuteInRelationalDbInput.java
@@ -1,0 +1,15 @@
+package org.finos.legend.engine.server.test.shared;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
+
+public class ExecuteInRelationalDbInput
+{
+    @JsonProperty
+    RelationalDatabaseConnection connection;
+
+    @JsonProperty
+    List<String> sqls;
+}

--- a/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/TestServer.java
+++ b/legend-engine-server/src/test/java/org/finos/legend/engine/server/test/shared/TestServer.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import io.dropwizard.setup.Environment;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.manager.ConnectionManagerSelector;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.DynamicTestConnection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
@@ -45,6 +46,8 @@ public class TestServer extends Server<TestServerConfiguration>
         super.run(serverConfiguration, environment);
         Vault.INSTANCE.registerImplementation(new EnvironmentVaultImplementation());
         environment.jersey().register(new TestConnectionProviderApi(getTestConnections(serverConfiguration)));
+        ConnectionManagerSelector connectionManager = relationalStoreExecutor.getStoreState().getRelationalExecutor().getConnectionManager();
+        environment.jersey().register(new ExecuteInRelationalDb(connectionManager));
     }
 
     public Map<DatabaseType, RelationalDatabaseConnection> getTestConnections (TestServerConfiguration serverConfiguration)

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/dynaFunctionTestRunner.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/dynaFunctionTestRunner.pure
@@ -24,12 +24,12 @@ import meta::relational::functions::typeInference::*;
 import meta::relational::mapping::*;
 import meta::relational::dbTestRunner::*;
 
-function meta::relational::dbTestRunner::runDynaFunctionDatabaseTest(dynaFunc:DynaFunction[1], expectedResult:Literal[1..*], testConfig:DbTestConfig[1]): String[0..1]
+function meta::relational::dbTestRunner::runDynaFunctionDatabaseTest(dynaFunc:DynaFunction[1], expectedResult:Literal[1..*], testConfig:DbTestConfig[1]): Boolean[1]
 {
   runDynaFunctionDatabaseTest($dynaFunc, $expectedResult, [] , $testConfig);
 } 
 
-function meta::relational::dbTestRunner::runDynaFunctionDatabaseTest(dynaFunc:DynaFunction[1], expectedResult:Literal[1..*], equalityComparator: Function<{Any[1..*],Any[1..*]->Boolean[1]}>[0..1] , testConfig:DbTestConfig[1]): String[0..1]
+function meta::relational::dbTestRunner::runDynaFunctionDatabaseTest(dynaFunc:DynaFunction[1], expectedResult:Literal[1..*], equalityComparator: Function<{Any[1..*],Any[1..*]->Boolean[1]}>[0..1] , testConfig:DbTestConfig[1]): Boolean[1]
 { 
   //sqlQueryGenerator
   let sqlQuery = defaultDynaFunctionSqlQueryGenerator($dynaFunc,$expectedResult, $testConfig);
@@ -38,12 +38,14 @@ function meta::relational::dbTestRunner::runDynaFunctionDatabaseTest(dynaFunc:Dy
 
   let sqlString = sqlQueryToString($sqlQuery, $testConfig.dbType, []);
 
-  if($testConfig.expectedSql->isNotEmpty() && ($testConfig.expectedSql->toOne() != $sqlString),
-    | 'Sql assert failed ,expected sql: '+ $testConfig.expectedSql->toOne()  +', actual sql : ' + $sqlString;,
-    | if($testConfig.connection->isEmpty(),
-      |   [] ,                                                     // test Connection not available ,do nothing further,
-      |  
-          let conn1= $testConfig.connection->toOne();
+  if($testConfig.expectedSql->isNotEmpty(),
+      | assertEquals($testConfig.expectedSql->toOne(), $sqlString),
+      | true
+    );
+  
+if($testConfig.connection->isEmpty(),
+    |   true ,                                                     // test Connection not available ,do nothing further,
+    |     let conn1= $testConfig.connection->toOne();
           let conn = ^$conn1(element= ^Database(name='dummyDB'));                      // overwite given connection db 
           
           let newExpectedResultTypes = $newExpectedResult->map(e|$e->inferRelationalType())->toOneMany();
@@ -51,20 +53,18 @@ function meta::relational::dbTestRunner::runDynaFunctionDatabaseTest(dynaFunc:Dy
           
           let res = executePlan($plan,defaultRelationalExtensions());
           if($res->isEmpty(),
-              | [],                                  //legend engine not available 
+              | true ,                                  //legend engine not available 
               | let areEqual = if($equalityComparator->isNotEmpty(),
                                   | $equalityComparator->toOne()->eval($res.values->toOneMany(), $newExpectedResult.value->toOneMany());, // expected values are wrapped in Literals currently
                                   | defaultEqualityComparator($res.values->toOneMany(), $newExpectedResult.value->toOneMany());
                                  );
-                  if($areEqual , 
-                    | [],
-                    | let expectedStr = $newExpectedResult.value->map(v|$v->toString())->makeString('[',', ',']');
-                      let resStr = $res.values->map(v|$v->toString())->makeString('[',', ',']');
-                      'Result assert failed ,expected Values : '+ $expectedStr  +', actual Values : ' + $resStr;
-                    );
+                  let expectedStr = $newExpectedResult.value->map(v|$v->toString())->makeString('[',', ',']');
+                  let resStr = $res.values->map(v|$v->toString())->makeString('[',', ',']');
+                  let errMsg=    'Result assert failed ,expected Values : '+ $expectedStr  +', actual Values : ' + $resStr;
+                  
+                  assert($areEqual , $errMsg);
               );
-       );
-    );
+     );
 }
 
 function meta::relational::dbTestRunner::defaultDynaFunctionSqlQueryGenerator(dynaFunc:DynaFunction[1] , expectedResult:Literal[1..*], testConfig:DbTestConfig[1]): SQLQuery[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
@@ -16,53 +16,12 @@ import meta::relational::runtime::*;
 import meta::relational::dbTestRunner::*;
 import meta::pure::alloy::connections::*;
 
-Profile meta::relational::dbTestRunner::dbTest
-{
-   stereotypes : [ Test, Ignore ];
-}
 
 Class meta::relational::dbTestRunner::DbTestConfig
 {
    dbType: DatabaseType[1];
    connection: RelationalDatabaseConnection[0..1];
    expectedSql: String[0..1];
-}
-
-function meta::relational::dbTestRunner::collectTests(pack: Package[1]): Function<{DbTestConfig[1] -> String[0..1]}>[*]
-{
-   $pack.children->map(c| $c->match([
-      f:Function<Any>[1]| if($f.stereotypes->contains(dbTest->stereotype('Test')), |$f->cast(@Function<{DbTestConfig[1] -> String[0..1]}>), |[]),
-      p:Package[1]| collectTests($p),
-      x:Any[1]| []
-   ]));
-}
-
-function meta::relational::dbTestRunner::runTestsWith(
-                                               allTests: Function<{DbTestConfig[1] -> String[0..1]}>[*],
-                                               ignoredTests : Function<{DbTestConfig[1] -> String[0..1]}>[*],
-                                               dbType: DatabaseType[1],
-                                               connection: RelationalDatabaseConnection[0..1],
-                                               expectedSqls: Map<Function<{DbTestConfig[1] -> String[0..1]}>, String>[0..1]
-                                               ): Boolean[1]
-{
-  println('Running DB Tests for : '+ $dbType->toString());
-
-  //list of failed test ids with corresponding error messages
-  let failedTests = $allTests->filter(t|!$ignoredTests->contains($t))->map(f|
-      println('   running test : '+ $f->elementToPath());
-      let result = $f->eval(^DbTestConfig(dbType=$dbType, connection=$connection, expectedSql=if($expectedSqls->isEmpty(), |[], |$expectedSqls->toOne()->get($f))));
-      if($result->isEmpty(), |[], |$f->elementToPath() + ': ' + $result->toOne());
-  );
-
-  let passed= ($allTests->size() - ($ignoredTests->size() + $failedTests->size()));
-  println('Test Summary : \n' +
-          '    Tests Passed = ' +  $passed->toString()+ '\n' +
-          '    Tests Failed = ' +  $failedTests->size()->toString() + 
-                if($failedTests->isEmpty(), |'\n' , |$failedTests->joinStrings('\n                ','\n                ','\n')) + 
-          '    Tests Ignored = ' + $ignoredTests->size()->toString() + '\n'
-          );
-          
-  assert($failedTests->isEmpty());
 }
 
 function meta::relational::dbTestRunner::getTestConnection(dbType:DatabaseType[1], extensions:meta::pure::router::extension::RouterExtension[*]):RelationalDatabaseConnection[0..1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
@@ -44,3 +44,20 @@ function meta::relational::dbTestRunner::getTestConnection(dbType:DatabaseType[1
        }
      );
 }
+
+function meta::relational::dbTestRunner::executeInRelationalDb(sqls:String[*], conn:RelationalDatabaseConnection[1], extensions:meta::pure::router::extension::RouterExtension[*]):Boolean[1]
+{
+  meta::legend::test::mayExecuteLegendTest
+     (
+       {clientVersion, serverVersion, serializationKind, host, port |
+         let fStr = 'meta::protocols::pure::'+$clientVersion+'::invocation::execution::executeInRelationalDb::executeInRelationalDb_String_MANY__RelationalDatabaseConnection_1__String_1__Integer_1__RouterExtension_MANY__Boolean_1_';
+         let xf = $fStr->pathToElement()->cast(@Function<{String[*], RelationalDatabaseConnection[1], String[1], Integer[1], meta::pure::router::extension::RouterExtension[*]->Boolean[1]}>);
+         let res= $xf->evaluate(list($sqls)->concatenate([$conn, $host, $port]->map(v|list($v)))->concatenate(list($extensions)));
+         $res->cast(@Boolean)->toOne();
+         },
+       { |
+         println('**** Warning **** : Legend Engine Server not available');
+         false;
+       }
+     );
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/invocations/execution_relation_executeInRelationalDb.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/invocations/execution_relation_executeInRelationalDb.pure
@@ -1,0 +1,44 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::alloy::connections::*;
+import meta::alloy::metadataServer::*;
+import meta::pure::functions::io::http::*;
+import meta::protocols::pure::vX_X_X::invocation::execution::executeInRelationalDb::*;
+
+function meta::protocols::pure::vX_X_X::invocation::execution::executeInRelationalDb::executeInRelationalDb(sqls:String[*], conn:RelationalDatabaseConnection[1], host:String[1], port:Integer[1], extensions:meta::pure::router::extension::RouterExtension[*]):Boolean[1]
+{
+  let conn1= $conn->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::connection::transformDatabaseConnection($extensions)
+                  ->cast(@meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::RelationalDatabaseConnection);
+  
+  let input= ^ExecuteInRelationalDbInput(sqls=$sqls, connection = $conn1)->alloyToJSON();
+  
+  let resp= executeHTTPRaw(^URL(host=$host, port=$port , path='/api/pure/v1/utilities/tests/executeInRelationalDb'),
+                             HTTPMethod.POST ,
+                             'application/json',
+                             $input
+                            );
+
+   if($resp.statusCode != 200,
+       | println($resp.statusCode->toString()+' \''+$resp.entity->replace('\\n', '\n')->replace('\\t', '')+'\''); false; ,
+       | println($resp.entity->toOne()->toString());true;
+      );
+}
+
+
+Class meta::protocols::pure::vX_X_X::invocation::execution::executeInRelationalDb::ExecuteInRelationalDbInput
+{
+  connection : meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::RelationalDatabaseConnection[1];
+  sqls : String[*];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/h2Tests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/h2Tests.pure
@@ -16,19 +16,53 @@ import meta::relational::runtime::*;
 import meta::relational::dbTestRunner::*;
 import meta::relational::tests::dbSpecificTests::H2::*;
 import meta::pure::alloy::connections::*;
+import meta::pure::test::*;
 
-function <<test.Test>> meta::relational::tests::dbSpecificTests::H2::runSQLQueryTests():Boolean[1]
+// function <<test.Test>> meta::relational::tests::dbSpecificTests::H2::runSQLQueryTests():Boolean[1]
+// {
+//   let connection = meta::relational::dbTestRunner::getTestConnection(DatabaseType.H2, meta::pure::router::extension::defaultRelationalExtensions());
+      
+//   let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::today);
+
+//   let unsupportedDynaFunctions = [];
+//   let failingSupportedDynaFunctions =['today'];
+
+//   let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
+//               let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
+//               $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
+
+//   runTestsWith($allTests, $ignoredTests, DatabaseType.H2, $connection,  []);
+// }
+
+function <<test.TestCollection>> meta::relational::tests::dbSpecificTests::H2::runSQLQueryTestsParam(): PureTestCollection[1]
 {
   let connection = meta::relational::dbTestRunner::getTestConnection(DatabaseType.H2, meta::pure::router::extension::defaultRelationalExtensions());
-      
-  let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::today);
+  
+  meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions
+          ->collectParameterizedTests('H2',
+                ^DbTestConfig(dbType=DatabaseType.H2, connection=$connection), 
+                paramCustomizationsForDynaFunctionTests_FunctionDefinition_1__DbTestConfig_1__DbTestConfig_1_,
+                parameterization1TestFilter_FunctionDefinition_1__Boolean_1_);
+}
 
-  let unsupportedDynaFunctions = [];
-  let failingSupportedDynaFunctions =['today'];
+function meta::relational::tests::dbSpecificTests::H2::paramCustomizationsForDynaFunctionTests(f:FunctionDefinition<Any>[1], dbTestConfig:DbTestConfig[1]): DbTestConfig[1]
+{
+   let expectedSqls= [
+     pair(meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testNegative_DbTestConfig_1__Boolean_1_, 'my buggy h2 sql')
+   ]->newMap();
 
-  let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
-              let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
-              $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
+  ^$dbTestConfig(expectedSql= $expectedSqls->get($f));
+}
 
-  runTestsWith($allTests, $ignoredTests, DatabaseType.H2, $connection,  []);
+function meta::relational::tests::dbSpecificTests::H2::parameterization1TestFilter(f:FunctionDefinition<Any>[1]): Boolean[1]
+{
+  // let unsupportedDynaFunctions = [];
+  // let failingSupportedDynaFunctions =['today'];
+
+  // let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
+  //             let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
+  //             $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
+
+  // !$ignoredTests->contains($f) ;
+  true;
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/redshiftTests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/redshiftTests.pure
@@ -16,25 +16,35 @@ import meta::relational::runtime::*;
 import meta::relational::dbTestRunner::*;
 import meta::pure::alloy::connections::*;
 import meta::pure::functions::meta::*;
+import meta::pure::test::*;
 
-function <<test.Test>> meta::relational::tests::dbSpecificTests::redshift::runSQLQueryTests():Boolean[1]
+// function <<test.Test>> meta::relational::tests::dbSpecificTests::redshift::runSQLQueryTests():Boolean[1]
+// {
+//   let connection= meta::relational::dbTestRunner::getTestConnection(DatabaseType.Redshift, meta::pure::router::extension::defaultRelationalExtensions());
+
+//   let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions);
+
+//   let unsupportedDynaFunctions = ['adjust', 'dayOfWeekNumber', 'dayOfMonth', 'quarter', 'quarterNumber', 'datePart',
+//                                   'dateDiff', 'firstDayOfWeek' , 'previousDayOfWeek', 'mostRecentDayOfWeek', 'firstDayOfMonth', 'firstDayOfThisMonth',
+//                                    'firstDayOfQuarter', 'firstDayOfThisQuarter', 'firstDayOfYear' , 'firstDayOfThisYear' ,
+//                                    'length', 'indexOf', 'ltrim', 'left' ];
+
+//   let failingSupportedDynaFunctions =[
+//           'joinStrings'
+//     ];
+
+//   let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
+//               let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
+//               $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
+
+//   runTestsWith($allTests, $ignoredTests, DatabaseType.Redshift, $connection,  []);
+// }
+
+function <<test.TestCollection>> meta::relational::tests::dbSpecificTests::redshift::runSQLQueryTestsParam(): PureTestCollection[1]
 {
-  let connection= meta::relational::dbTestRunner::getTestConnection(DatabaseType.Redshift, meta::pure::router::extension::defaultRelationalExtensions());
-
-  let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions);
-
-  let unsupportedDynaFunctions = ['adjust', 'dayOfWeekNumber', 'dayOfMonth', 'quarter', 'quarterNumber', 'datePart',
-                                  'dateDiff', 'firstDayOfWeek' , 'previousDayOfWeek', 'mostRecentDayOfWeek', 'firstDayOfMonth', 'firstDayOfThisMonth',
-                                   'firstDayOfQuarter', 'firstDayOfThisQuarter', 'firstDayOfYear' , 'firstDayOfThisYear' ,
-                                   'length', 'indexOf', 'ltrim', 'left' ];
-
-  let failingSupportedDynaFunctions =[
-          'joinStrings'
-    ];
-
-  let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
-              let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
-              $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
-
-  runTestsWith($allTests, $ignoredTests, DatabaseType.Redshift, $connection,  []);
+  let connection = meta::relational::dbTestRunner::getTestConnection(DatabaseType.Redshift, meta::pure::router::extension::defaultRelationalExtensions());
+  
+  meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions
+          ->collectParameterizedTests('Redshift',
+                ^DbTestConfig(dbType=DatabaseType.Redshift, connection=$connection), [], []);
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/snowflakeTests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/snowflakeTests.pure
@@ -16,31 +16,41 @@ import meta::relational::runtime::*;
 import meta::relational::dbTestRunner::*;
 import meta::relational::tests::dbSpecificTests::H2::*;
 import meta::pure::alloy::connections::*;
+import meta::pure::test::*;
 
-function <<test.Test>> meta::relational::tests::dbSpecificTests::snowflake::runSQLQueryTests():Boolean[1]
+// function <<test.Test>> meta::relational::tests::dbSpecificTests::snowflake::runSQLQueryTests():Boolean[1]
+// {
+//   let connection = meta::relational::dbTestRunner::getTestConnection(DatabaseType.Snowflake, meta::pure::router::extension::defaultRelationalExtensions());
+  
+//   let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests);
+  
+//   let unsupportedDynaFunctions = ['dayOfMonth'];
+
+//   let failingSupportedDynaFunctions =[
+//     'sqlTrue','sqlFalse',
+//     'second' , 'minute' , 'hour' , 'dayOfWeekNumber' ,'weekOfYear' ,'month', 'monthNumber', 'quarter', 'quarterNumber', 'year',            // SnowflakeSQLException: SQL compilation error: Function EXTRACT does not support VARCHAR(19) argument type"
+//     'dateDiff',               // select datediff(,'2014-12-04 14:22:23','2014-12-04 15:22:23')'    for MilloSeconds , okay for seconds, minutes, hours etc
+//     'firstDayOfWeek',         // Error : SnowflakeSQLException: SQL compilation error:Function DATE_TRUNC does not support VARCHAR(19) argument type,  SQL generated: select DATE_TRUNC('WEEK', '2014-12-04 15:22:23')
+//     'previousDayOfWeek',
+//     'firstDayOfMonth',
+//     'firstDayOfQuarter',
+//     'firstDayOfYear',
+//     'ceiling' ,                                             //SQL compilation error:Unknown function CEILING"
+//     'datePart','mostRecentDayOfWeek'                       // time zone difference between local pure ide and snowflake hosted account
+//     ];
+
+//   let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
+//               let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
+//               $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
+              
+//   runTestsWith($allTests, $ignoredTests, DatabaseType.Snowflake, $connection,  []);
+// }
+
+function <<test.TestCollection>> meta::relational::tests::dbSpecificTests::snowflake::runSQLQueryTestsParam(): PureTestCollection[1]
 {
   let connection = meta::relational::dbTestRunner::getTestConnection(DatabaseType.Snowflake, meta::pure::router::extension::defaultRelationalExtensions());
   
-  let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests);
-  
-  let unsupportedDynaFunctions = ['dayOfMonth'];
-
-  let failingSupportedDynaFunctions =[
-    'sqlTrue','sqlFalse',
-    'second' , 'minute' , 'hour' , 'dayOfWeekNumber' ,'weekOfYear' ,'month', 'monthNumber', 'quarter', 'quarterNumber', 'year',            // SnowflakeSQLException: SQL compilation error: Function EXTRACT does not support VARCHAR(19) argument type"
-    'dateDiff',               // select datediff(,'2014-12-04 14:22:23','2014-12-04 15:22:23')'    for MilloSeconds , okay for seconds, minutes, hours etc
-    'firstDayOfWeek',         // Error : SnowflakeSQLException: SQL compilation error:Function DATE_TRUNC does not support VARCHAR(19) argument type,  SQL generated: select DATE_TRUNC('WEEK', '2014-12-04 15:22:23')
-    'previousDayOfWeek',
-    'firstDayOfMonth',
-    'firstDayOfQuarter',
-    'firstDayOfYear',
-    'ceiling' ,                                             //SQL compilation error:Unknown function CEILING"
-    'datePart','mostRecentDayOfWeek'                       // time zone difference between local pure ide and snowflake hosted account
-    ];
-
-  let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
-              let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
-              $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
-              
-  runTestsWith($allTests, $ignoredTests, DatabaseType.Snowflake, $connection,  []);
+  meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions
+          ->collectParameterizedTests('Snowflake',
+                ^DbTestConfig(dbType=DatabaseType.Snowflake, connection=$connection), [], []);
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/sqlServerTests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/sqlServerTests.pure
@@ -17,31 +17,41 @@ import meta::relational::dbTestRunner::*;
 import meta::relational::tests::dbSpecificTests::SqlServer::*;
 import meta::pure::alloy::connections::*;
 import meta::pure::functions::meta::*;
+import meta::pure::test::*;
 
-function <<test.Test>> meta::relational::tests::dbSpecificTests::SqlServer::runSQLQueryTests():Boolean[1]
+// function <<test.Test>> meta::relational::tests::dbSpecificTests::SqlServer::runSQLQueryTests():Boolean[1]
+// {
+//   let connection= meta::relational::dbTestRunner::getTestConnection(DatabaseType.SqlServer, meta::pure::router::extension::defaultRelationalExtensions());
+
+//   let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests);
+
+//   let unsupportedDynaFunctions = [
+//     'indexOf',
+//     'adjust',
+//     'firstDayOfWeek',
+//     'dayOfMonth',
+//     'previousDayOfWeek',
+//     'mostRecentDayOfWeek',
+//     'mod', 'rem', 'log','joinStrings', 'dateDiff', 'sqlTrue', 'sqlFalse'
+//     ];
+
+//   let failingSupportedDynaFunctions =[ 
+//       'second', 'minute', 'hour', 'quarter', 'quarterNumber', 'year', 
+//       'firstDayOfMonth'
+//       ];
+
+//   let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
+//               let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
+//               $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
+
+//   runTestsWith($allTests, $ignoredTests, DatabaseType.SqlServer, $connection,  []);
+// }
+
+function <<test.TestCollection>> meta::relational::tests::dbSpecificTests::sqlServer::runSQLQueryTestsParam(): PureTestCollection[1]
 {
-  let connection= meta::relational::dbTestRunner::getTestConnection(DatabaseType.SqlServer, meta::pure::router::extension::defaultRelationalExtensions());
-
-  let allTests = collectTests(meta::relational::tests::dbSpecificTests::sqlQueryTests);
-
-  let unsupportedDynaFunctions = [
-    'indexOf',
-    'adjust',
-    'firstDayOfWeek',
-    'dayOfMonth',
-    'previousDayOfWeek',
-    'mostRecentDayOfWeek',
-    'mod', 'rem', 'log','joinStrings', 'dateDiff', 'sqlTrue', 'sqlFalse'
-    ];
-
-  let failingSupportedDynaFunctions =[ 
-      'second', 'minute', 'hour', 'quarter', 'quarterNumber', 'year', 
-      'firstDayOfMonth'
-      ];
-
-  let ignoredTests= $unsupportedDynaFunctions->concatenate($failingSupportedDynaFunctions)->map(dynaFuncName |
-              let dynaFuncPackageName = 'meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::' + $dynaFuncName;
-              $dynaFuncPackageName->pathToElement()->cast(@Package)->collectTests(););
-
-  runTestsWith($allTests, $ignoredTests, DatabaseType.SqlServer, $connection,  []);
+  let connection = meta::relational::dbTestRunner::getTestConnection(DatabaseType.SqlServer, meta::pure::router::extension::defaultRelationalExtensions());
+  
+  meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions
+          ->collectParameterizedTests('SqlServer',
+                ^DbTestConfig(dbType=DatabaseType.SqlServer, connection=$connection), [], []);
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/boolean.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/boolean.pure
@@ -14,17 +14,18 @@
 
 import meta::relational::metamodel::*;
 import meta::relational::dbTestRunner::*;
+import meta::pure::test::*;
 
 //operations on booleans
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqlTrue::testSqlTrue(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqlTrue::testSqlTrue(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name= 'sqlTrue');
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqlFalse::testSqlFalse(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqlFalse::testSqlFalse(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='sqlFalse');
   let expected = ^Literal(value=false);
@@ -32,21 +33,21 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 //TODO activate these tests once we have stabilised boolean datatype by providing custom boolean literal propcessors for dbs that dont support boolean datatypes
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::and::testAnd(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::and::testAnd(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='and', parameters=[^Literal(value=true), ^Literal(value=false)]);
   let expected = ^Literal(value=false);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::and::testAndWithSqlBooleanDynaFunctions(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::and::testAndWithSqlBooleanDynaFunctions(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='and', parameters=[^DynaFunction(name='sqlTrue'), ^DynaFunction(name='sqlFalse')]);
   let expected = ^Literal(value=false);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::and::testAndwithConditions(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::and::testAndwithConditions(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='and', parameters=[^DynaFunction(name='greaterThan', parameters=[^Literal(value=11), ^Literal(value=1)]),
                                                        ^DynaFunction(name='lessThan', parameters=[^Literal(value=11), ^Literal(value=1)])]);
@@ -54,14 +55,14 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::or::testOr(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::or::testOr(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='or', parameters=[^Literal(value=true), ^Literal(value=false)]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::or::testOrWithConditions(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::or::testOrWithConditions(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='or', parameters=[^DynaFunction(name='greaterThan', parameters=[^Literal(value=11), ^Literal(value=1)]),
                                                       ^DynaFunction(name='lessThan', parameters=[^Literal(value=11), ^Literal(value=1)])]);
@@ -69,14 +70,14 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::or::testOrWithSqlBooleanDynaFunctions(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::or::testOrWithSqlBooleanDynaFunctions(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='or', parameters=[^DynaFunction(name='sqlTrue'), ^DynaFunction(name='sqlFalse')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqlNull::testIsNull(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqlNull::testIsNull(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='isNull', parameters= [^DynaFunction(name='sqlNull')]);
   let expected = ^Literal(value=true);
@@ -84,28 +85,28 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 //TODO expand these tests on row results when testing with 'setup data' is available 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isNull::testSqlNull(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isNull::testSqlNull(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='isNull', parameters= [^DynaFunction(name='sqlNull')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isNotNull::testSqlNull(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isNotNull::testSqlNull(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='isNotNull', parameters= [^DynaFunction(name='sqlNull')]);
   let expected = ^Literal(value=false);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isEmpty::testSqlNull(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isEmpty::testSqlNull(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='isEmpty', parameters= [^DynaFunction(name='sqlNull')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isNotEmpty::testSqlNull(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::isNotEmpty::testSqlNull(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='isNotEmpty', parameters= [^DynaFunction(name='sqlNull')]);
   let expected = ^Literal(value=false);
@@ -115,21 +116,21 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 // Operations with Boolean Results
 
 // object equality
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::equal::testNumberEquality(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::equal::testNumberEquality(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='equal', parameters=[^Literal(value=11), ^Literal(value=11)]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::notEqual::testNumberInequality(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::notEqual::testNumberInequality(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='notEqual', parameters=[^Literal(value=11), ^Literal(value=11)]);
   let expected = ^Literal(value=false);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::notEqualAnsi::testNumberInequality(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::notEqualAnsi::testNumberInequality(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='notEqualAnsi', parameters=[^Literal(value=11), ^Literal(value=11)]);
   let expected = ^Literal(value=false);
@@ -138,28 +139,28 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 
 
 // Number comparison
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::greaterThan::testNumbers(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::greaterThan::testNumbers(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='greaterThan', parameters=[^Literal(value=11), ^Literal(value=1)]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::greaterThanEqual::testNumbers(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::greaterThanEqual::testNumbers(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='greaterThanEqual', parameters=[^Literal(value=11), ^Literal(value=1)]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::lessThan::testNumbers(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::lessThan::testNumbers(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='lessThan', parameters=[^Literal(value=1), ^Literal(value=11)]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::lessThanEqual::testNumbers(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::lessThanEqual::testNumbers(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='lessThanEqual', parameters=[^Literal(value=1), ^Literal(value=11)]);
   let expected = ^Literal(value=true);

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/date.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/date.pure
@@ -15,15 +15,16 @@
 import meta::relational::metamodel::*;
 import meta::relational::dbTestRunner::*;
 import meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::*;
+import meta::pure::test::*;
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::adjust::testAdjust(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::adjust::testAdjust(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='adjust', parameters=[^Literal(value=%2014-11-30), ^Literal(value=1), ^Literal(value=DurationUnit.DAYS)]);
   let expected = ^Literal(value=%2014-12-01);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::adjust::testAdjustWithMicroseconds(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::adjust::testAdjustWithMicroseconds(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='adjust', parameters=[^Literal(value=%2014-12-04T15:22:23), ^Literal(value=123456), ^Literal(value=DurationUnit.MICROSECONDS)]);
   let expected = ^Literal(value=%2014-12-04T15:22:23.123456000);
@@ -31,105 +32,105 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 //get datetime subpart
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::second::testSecond(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::second::testSecond(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='second', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=23);          
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::minute::testminute(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::minute::testminute(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='minute', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=22);          
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::hour::testHour(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::hour::testHour(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='hour', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=15);         
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dayOfWeekNumber::testDayOfWeekNumber(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dayOfWeekNumber::testDayOfWeekNumber(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dayOfWeekNumber', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=5);          //Thursday  - day number is db specific ?
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dayOfMonth::testDayOfMonth(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dayOfMonth::testDayOfMonth(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dayOfMonth', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=4);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::weekOfYear::testWeekOfYear(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::weekOfYear::testWeekOfYear(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='weekOfYear', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=49);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::month::testMonthAsNumber(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::month::testMonthAsNumber(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='month', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=12);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::monthNumber::testMonthNumber(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::monthNumber::testMonthNumber(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='monthNumber', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=12);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::quarter::testQuarterAsNumber(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::quarter::testQuarterAsNumber(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='quarter', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=4);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::quarterNumber::testQuarterNumber(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::quarterNumber::testQuarterNumber(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='quarterNumber', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=4);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::year::testYear(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::year::testYear(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='year', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=2014);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::datePart::testDatePartWithDateTime(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::datePart::testDatePartWithDateTime(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='datePart', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=%2014-12-04->convertToDateTime());
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::datePart::testDatePartWithStrictDate(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::datePart::testDatePartWithStrictDate(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='datePart', parameters=[^Literal(value=%2014-12-04)]);
   let expected = ^Literal(value=%2014-12-04->convertToDateTime());
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testYearsDiffPositive(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testYearsDiffPositive(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2013-12-04T15:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.YEARS) ]);
   let expected = ^Literal(value=1);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testYearsDiffZero(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testYearsDiffZero(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2014-12-04T15:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.YEARS) ]);
   let expected = ^Literal(value=0);
@@ -137,49 +138,49 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testYearsDiffNegative(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testYearsDiffNegative(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2014-12-04T15:22:23), ^Literal(value=%2013-12-04T15:22:23), ^Literal(value=DurationUnit.YEARS) ]);
   let expected = ^Literal(value=-1);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testMonthsDiff(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testMonthsDiff(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2013-12-04T15:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.MONTHS) ]);
   let expected = ^Literal(value=12);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testDaysDiff(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testDaysDiff(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2014-12-01T15:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.DAYS) ]);
   let expected = ^Literal(value=3);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testHoursDiff(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testHoursDiff(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2014-12-03T14:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.HOURS) ]);
   let expected = ^Literal(value=25);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testMinutesDiff(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testMinutesDiff(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2014-12-04T14:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.MINUTES) ]);
   let expected = ^Literal(value=60);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testSecondsDiff(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testSecondsDiff(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2014-12-04T14:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.SECONDS) ]);
   let expected = ^Literal(value=3600);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testMilliSecondsDiff(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::dateDiff::testMilliSecondsDiff(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='dateDiff', parameters=[^Literal(value=%2014-12-04T14:22:23), ^Literal(value=%2014-12-04T15:22:23), ^Literal(value=DurationUnit.MILLISECONDS) ]);
   let expected = ^Literal(value=3600000);
@@ -188,42 +189,42 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 //TODO - micro and nanoseconds are not supported by any db yet 
 
 //firstDay
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfWeek::testFirstDayOfWeek(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfWeek::testFirstDayOfWeek(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='firstDayOfWeek', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=%2014-12-01);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::previousDayOfWeek::testPreviousDayOfWeekWithDate(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::previousDayOfWeek::testPreviousDayOfWeekWithDate(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='previousDayOfWeek', parameters=[^Literal(value=%2014-12-04), ^Literal(value=DayOfWeek.Monday)]);
   let expected = ^Literal(value=%2014-12-01);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::mostRecentDayOfWeek::testMostRecentDayOfWeekWithDate(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::mostRecentDayOfWeek::testMostRecentDayOfWeekWithDate(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='mostRecentDayOfWeek', parameters=[^Literal(value=%2014-12-04), ^Literal(value=DayOfWeek.Monday)]);
   let expected = ^Literal(value=%2014-12-01);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfMonth::testFirstDayOfMonth(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfMonth::testFirstDayOfMonth(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='firstDayOfMonth', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=%2014-12-01);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfQuarter::testFirstDayOfQuarter(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfQuarter::testFirstDayOfQuarter(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='firstDayOfQuarter', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=%2014-10-01);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfYear::testFirstDayOfYear(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfYear::testFirstDayOfYear(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='firstDayOfYear', parameters=[^Literal(value=%2014-12-04T15:22:23)]);
   let expected = ^Literal(value=%2014-01-01);
@@ -232,7 +233,7 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 
 
 //variable result functions - get value from pure/legend engine and compare with value returned with db engine
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::now::testNow(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::now::testNow(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='now', parameters=[]);
   let expected = ^Literal(value=now());      
@@ -241,7 +242,7 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::today::testToday(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::today::testToday(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='today', parameters=[]);
   let expected = ^Literal(value=today()->convertToDateTime());                              
@@ -249,7 +250,7 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfThisMonth::testFirstDayOfThisMonth(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfThisMonth::testFirstDayOfThisMonth(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='firstDayOfThisMonth', parameters=[]);
   let expected = ^Literal(value=firstDayOfThisMonth()->convertToDateTime());   
@@ -257,7 +258,7 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfThisQuarter::testFirstDayOfThisQuarter(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfThisQuarter::testFirstDayOfThisQuarter(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='firstDayOfThisQuarter', parameters=[]);
   let expected = ^Literal(value=firstDayOfThisQuarter()->convertToDateTime());   
@@ -265,7 +266,7 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfThisYear::testFirstDayOfThisYear(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::firstDayOfThisYear::testFirstDayOfThisYear(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='firstDayOfThisYear', parameters=[]);
   let expected = ^Literal(value=firstDayOfThisYear()->convertToDateTime());   

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/misc.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/misc.pure
@@ -14,15 +14,16 @@
 
 import meta::relational::metamodel::*;
 import meta::relational::dbTestRunner::*;
+import meta::pure::test::*;
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::in::testIn(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::in::testIn(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='in', parameters=[^Literal(value='a'), ^LiteralList(values=[^Literal(value='a')])]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::coalesce::testCoalesce(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::coalesce::testCoalesce(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='coalesce', parameters=[^Literal(value=^SQLNull()), ^Literal(value='a')]);
   let expected = ^Literal(value='a');

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/numeric.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/numeric.pure
@@ -14,64 +14,65 @@
 
 import meta::relational::metamodel::*;
 import meta::relational::dbTestRunner::*;
+import meta::pure::test::*;
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testNegative(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testNegative(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='abs', parameters=[^Literal(value=-1)]);
   let expected = ^Literal(value=1);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testZero(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testZero(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='abs', parameters=[^Literal(value=0)]);
   let expected = ^Literal(value=0);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
   
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testPositive(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testPositive(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='abs', parameters=[^Literal(value=1)]);
   let expected = ^Literal(value=1);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::abs::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='abs', parameters=[^Literal(value=-1.011)]);
   let expected = ^Literal(value=1.011);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::mod::testIntDivisible(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::mod::testIntDivisible(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='mod', parameters=[^Literal(value=1),^Literal(value=2)]);
   let expected = ^Literal(value=1);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::mod::testIntNonDivisible(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::mod::testIntNonDivisible(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='mod', parameters=[^Literal(value=2),^Literal(value=2)]);
   let expected = ^Literal(value=0);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rem::testIntDivisible(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rem::testIntDivisible(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='rem', parameters=[^Literal(value=1),^Literal(value=2)]);
   let expected = ^Literal(value=1);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rem::testIntNonDivisible(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rem::testIntNonDivisible(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='rem', parameters=[^Literal(value=2),^Literal(value=2)]);
   let expected = ^Literal(value=0);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::pow::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::pow::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='pow', parameters=[^Literal(value=1.1), ^Literal(value=3) ]);
   let expected = ^Literal(value=1.3310000000000004);
@@ -79,7 +80,7 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::pow::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::pow::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='pow', parameters=[^Literal(value=1.8), ^Literal(value=3)]);
   let expected = ^Literal(value=5.832000000000001);
@@ -87,42 +88,42 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::exp::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::exp::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='exp', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value= 3.0041660239464334);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::exp::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::exp::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='exp', parameters=[^Literal(value=1.8)]);
   let expected = ^Literal(value=6.0496474644129465);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::log::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::log::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='log', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value=0.09531017980432493);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::log::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::log::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='log', parameters=[^Literal(value=1.8)]);
   let expected = ^Literal(value= 0.5877866649021191);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqrt::testInt1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqrt::testInt1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='sqrt', parameters=[^Literal(value=1)]);
   let expected = ^Literal(value= 1.0 );
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqrt::testInt2(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sqrt::testInt2(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='sqrt', parameters=[^Literal(value=2)]);
   let expected = ^Literal(value= 1.4142135623730951);
@@ -130,98 +131,98 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 // trigonometric functions   
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sin::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sin::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='sin', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value=0.8912073600614354);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sin::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::sin::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='sin', parameters=[^Literal(value=1.8)]);
   let expected = ^Literal(value=0.9738476308781951);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::cos::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::cos::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='cos', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value=0.4535961214255773);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::cos::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::cos::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='cos', parameters=[^Literal(value=1.8)]);
   let expected = ^Literal(value=-0.2272020946930871);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::tan::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::tan::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='tan', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value=1.9647596572486523);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::tan::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::tan::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='tan', parameters=[^Literal(value=1.8)]);
   let expected = ^Literal(value= -4.286261674628062);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::acos::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::acos::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='acos', parameters=[^Literal(value=0.5)]);
   let expected = ^Literal(value=1.0471975511965979);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::acos::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::acos::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='acos', parameters=[^Literal(value=1.0)]);
   let expected = ^Literal(value=0.0);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::asin::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::asin::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='asin', parameters=[^Literal(value=0.5)]);
   let expected = ^Literal(value= 0.5235987755982989);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::asin::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::asin::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='asin', parameters=[^Literal(value=1.0)]);
   let expected = ^Literal(value=1.5707963267948966);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='atan', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value= 0.8329812666744317);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='atan', parameters=[^Literal(value=1.8)]);
   let expected = ^Literal(value= 1.0636978224025597);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan2::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan2::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='atan2', parameters=[^Literal(value=1.1),^Literal(value=1)]);
   let expected = ^Literal(value= 0.8329812666744317);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan2::testDecimal1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::atan2::testDecimal1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='atan2', parameters=[^Literal(value=1.8),^Literal(value=2)]);
   let expected = ^Literal(value= 0.7328151017865066);
@@ -230,63 +231,63 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 
 
 //round off
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ceiling::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ceiling::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='ceiling', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value=2.0);   // TODO check 2.0 ?? 
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ceiling::testInt(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ceiling::testInt(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='ceiling', parameters=[^Literal(value=2)]);
   let expected = ^Literal(value= 2);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 } 
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ceiling::testIntAsFloat(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ceiling::testIntAsFloat(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='ceiling', parameters=[^Literal(value=2.0)]);
   let expected = ^Literal(value=2);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 } 
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::floor::testDecimal(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::floor::testDecimal(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='floor', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value=1.0);   // TODO check 2.0 ?? 
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::floor::testInt(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::floor::testInt(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='floor', parameters=[^Literal(value=2)]);
   let expected = ^Literal(value= 2);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 } 
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::floor::testIntAsFloat(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::floor::testIntAsFloat(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='floor', parameters=[^Literal(value=2.0)]);
   let expected = ^Literal(value= 2.0);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 } 
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::round::testDecimalLower(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::round::testDecimalLower(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='round', parameters=[^Literal(value=1.1)]);
   let expected = ^Literal(value=1.0);   
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::round::testDecimalUpper(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::round::testDecimalUpper(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='round', parameters=[^Literal(value=1.8)]);
   let expected = ^Literal(value=2.0);  
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::round::testInt(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::round::testInt(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='round', parameters=[^Literal(value=2.0)]);
   let expected = ^Literal(value=2.0);  

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/string.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/string.pure
@@ -14,43 +14,44 @@
 
 import meta::relational::metamodel::*;
 import meta::relational::dbTestRunner::*;
+import meta::pure::test::*;
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::concat::testSpaceBeforeSecondString(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::concat::testSpaceBeforeSecondString(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='concat', parameters=[^Literal(value='Joe'),^Literal(value=' Bloggs')]);
   let expected = ^Literal(value='Joe Bloggs');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::concat::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::concat::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='concat', parameters=[^Literal(value='Mrs'), ^Literal(value='Smith') ]);
   let expected = ^Literal(value='MrsSmith');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::joinStrings::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::joinStrings::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='joinStrings', parameters=[^Literal(value='Mrs'), ^Literal(value='-') ]);            // join a list of strings with sep??
   let expected = ^Literal(value='Mrs');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::replace::testCharReplace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::replace::testCharReplace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='replace', parameters=[^Literal(value='Joe'), ^Literal(value='J'), ^Literal(value='P') ]);           //case sensitive matching is supported by only a few dbs 
   let expected = ^Literal(value='Poe');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::replace::testStringReplace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::replace::testStringReplace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='replace', parameters=[^Literal(value='Joe Bloggs'), ^Literal(value=' Bl'), ^Literal(value='_Bl') ]);
   let expected = ^Literal(value='Joe_Bloggs');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::length::testWithString(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::length::testWithString(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='length', parameters=[^Literal(value='String Random')]);
   let expected = ^Literal(value=13);
@@ -58,21 +59,21 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 //TODO activate after length function is made uniform for different dbs , behaves differently for sqlserver for now
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::length::testWithTrailingSpaces(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::length::testWithTrailingSpaces(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='length', parameters=[^Literal(value='String Random  ')]);
   let expected = ^Literal(value=13);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::indexOf::testChar(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::indexOf::testChar(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='indexOf', parameters=[^Literal(value='String Random'),^Literal(value='o')]);
   let expected = ^Literal(value=12);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::indexOf::testString(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::indexOf::testString(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='indexOf', parameters=[^Literal(value='String Random'),^Literal(value='and')]);
   let expected = ^Literal(value=9);
@@ -80,21 +81,21 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 //TODO activate these tests once we have stabilised dynaFunction implementations for indexOf and position
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::indexOf::testCharFromAGivenStartIndexToSearchFrom(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::indexOf::testCharFromAGivenStartIndexToSearchFrom(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='indexOf', parameters=[^Literal(value='String Random'),^Literal(value='r'), ^Literal(value=6)]);
   let expected = ^Literal(value=2);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::position::testChar(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::position::testChar(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='position', parameters=[^Literal(value='String Random'),^Literal(value='o')]);
   let expected = ^Literal(value=12);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::position::testString(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::position::testString(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='position', parameters=[^Literal(value='String Random'),^Literal(value='and')]);
   let expected = ^Literal(value=9);
@@ -102,56 +103,56 @@ function <<dbTest.Ignore>> meta::relational::tests::dbSpecificTests::sqlQueryTes
 }
 
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rtrim::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rtrim::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='rtrim', parameters=[^Literal(value='Smith')]);
   let expected = ^Literal(value='Smith');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rtrim::testTrailingSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::rtrim::testTrailingSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='rtrim', parameters=[^Literal(value=' Bloggs ')]);
   let expected = ^Literal(value=' Bloggs');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ltrim::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ltrim::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='ltrim', parameters=[^Literal(value='Smith')]);
   let expected = ^Literal(value='Smith');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ltrim::testStartingSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::ltrim::testStartingSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='ltrim', parameters=[^Literal(value=' Bloggs ')]);
   let expected = ^Literal(value='Bloggs ');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::trim::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::trim::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='trim', parameters=[^Literal(value='Smith')]);
   let expected = ^Literal(value='Smith');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::trim::testSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::trim::testSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='trim', parameters=[^Literal(value=' Bloggs ')]);
   let expected = ^Literal(value='Bloggs');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::toUpper::test1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::toUpper::test1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='toUpper', parameters=[^Literal(value='Smith')]);
   let expected = ^Literal(value='SMITH');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::toLower::test1(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::toLower::test1(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='toLower', parameters=[^Literal(value='Smith')]);
   let expected = ^Literal(value='smith');
@@ -159,49 +160,49 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 //substring - for now these tests are 1 based indexing and second param is length  // ideally switch to pure style indexing
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::substring::testCustomEndIndex(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::substring::testCustomEndIndex(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='substring', parameters=[^Literal(value='Smith'), ^Literal(value=1), ^Literal(value=3)]);
   let expected = ^Literal(value='Smi');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::substring::testCustomStartIndex(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::substring::testCustomStartIndex(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='substring', parameters=[^Literal(value='Smith'), ^Literal(value=3), ^Literal(value=2)]);
   let expected = ^Literal(value='it');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::substring::testEndIndexExceedingStringLength(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::substring::testEndIndexExceedingStringLength(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='substring', parameters=[^Literal(value='Smith'), ^Literal(value=3), ^Literal(value=7)]);
   let expected = ^Literal(value='ith');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::left::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::left::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='left', parameters=[^Literal(value='Smith'), ^Literal(value=3)]);
   let expected = ^Literal(value='Smi');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::left::testSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::left::testSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='left', parameters=[^Literal(value=' Bloggs '), ^Literal(value=3)]);
   let expected = ^Literal(value=' Bl');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::right::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::right::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='right', parameters=[^Literal(value='Smith'), ^Literal(value=3)]);
   let expected = ^Literal(value='ith');
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::right::testSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::right::testSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='right', parameters=[^Literal(value=' Bloggs '), ^Literal(value=3)]);
   let expected = ^Literal(value='gs ');
@@ -209,63 +210,63 @@ function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests
 }
 
 // contains, endsWith , startsWith
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::contains::testNoSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::contains::testNoSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='contains', parameters=[^Literal(value='Bloggs'), ^Literal(value='lo')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::contains::testSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::contains::testSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='contains', parameters=[^Literal(value=' Bloggs '), ^Literal(value=' ')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::contains::testSpaceFalse(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::contains::testSpaceFalse(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='contains', parameters=[^Literal(value='Bloggs'), ^Literal(value=' ')]);
   let expected = ^Literal(value=false);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testStartsWith(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testStartsWith(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='startsWith', parameters=[^Literal(value='Bloggs'), ^Literal(value='Bl')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testNotStartsWith(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testNotStartsWith(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='startsWith', parameters=[^Literal(value='Bloggs'), ^Literal(value='gl')]);
   let expected = ^Literal(value=false);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testStartsWithSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testStartsWithSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='startsWith', parameters=[^Literal(value=' Bloggs'), ^Literal(value=' ')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::endsWith::testEndsWith(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::endsWith::testEndsWith(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='endsWith', parameters=[^Literal(value='Bloggs'), ^Literal(value='ggs')]);
   let expected = ^Literal(value=true);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::endsWith::testNotEndsWith(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::endsWith::testNotEndsWith(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='endsWith', parameters=[^Literal(value='Bloggs'), ^Literal(value='gz')]);
   let expected = ^Literal(value=false);
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $config);
 }
 
-function <<dbTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testEndsWithSpace(config:DbTestConfig[1]):String[0..1]
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::startsWith::testEndsWithSpace(config:DbTestConfig[1]):Boolean[1]
 {
   let dynaFunc = ^DynaFunction(name='endsWith', parameters=[^Literal(value=' Bloggs '), ^Literal(value=' ')]);
   let expected = ^Literal(value=true);

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>2.1.1</legend.pure.version>
+        <legend.pure.version>2.2.0</legend.pure.version>
         <legend.shared.version>0.21.0</legend.shared.version>
 
         <!-- SONAR -->


### PR DESCRIPTION
- uses parameterized test runner for dbtestSuite  defined in legend-pure 
- introduces executeinRelationalDb api which executes a bunch of sql statements from pure ide by calling corresponding engine endpoint