### PR TITLE
fix NPE exceptions when grammar parser works with external format and relational DB connections

### DIFF
--- a/.github/workflows/test-result.yml
+++ b/.github/workflows/test-result.yml
@@ -18,8 +18,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Debug Only
-        run: echo ${{ github.event.workflow_run.conclusion }}
       - name: Download and Extract Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ExternalFormatConnectionParseTreeWalker.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ExternalFormatConnectionParseTreeWalker.java
@@ -63,10 +63,7 @@ public class ExternalFormatConnectionParseTreeWalker
                 ctx.specification().getText(),
                 specification.specificationType().getText(),
                 sourceInformation,
-                new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation)
-                        .withLineOffset(sourceInformation.startLine - 1)
-                        .withColumnOffset(sourceInformation.startColumn)
-                        .build()
+                ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, ctx.getStart())
         );
 
         List<IExternalFormatGrammarParserExtension> extensions = IExternalFormatGrammarParserExtension.getExtensions();

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/CorePureGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/CorePureGrammarParser.java
@@ -261,9 +261,9 @@ public class CorePureGrammarParser implements PureGrammarParserExtension
         return aggregateSpecification;
     }
 
-    private static InputData parseObjectInputData(MappingParserGrammar.TestInputElementContext inputDataContext, ParseTreeWalkerSourceInformation sourceInformation)
+    private static InputData parseObjectInputData(MappingParserGrammar.TestInputElementContext inputDataContext, ParseTreeWalkerSourceInformation walkerSourceInformation)
     {
-        SourceInformation testInputDataSourceInformation = sourceInformation.getSourceInformation(inputDataContext);
+        SourceInformation testInputDataSourceInformation = walkerSourceInformation.getSourceInformation(inputDataContext);
         ObjectInputData objectInputData = new ObjectInputData();
         objectInputData.sourceInformation = testInputDataSourceInformation;
         try
@@ -275,7 +275,7 @@ public class CorePureGrammarParser implements PureGrammarParserExtension
             objectInputData.inputType = ObjectInputType.valueOf(inputDataContext.testInputFormat().getText());
         } catch (IllegalArgumentException e)
         {
-            throw new EngineException("Mapping test object input data does not support format '" + inputDataContext.testInputFormat().getText() + "'. Possible values: " + ArrayIterate.makeString(ObjectInputType.values(), ", "), sourceInformation.getSourceInformation(inputDataContext.testInputFormat()), EngineErrorType.PARSER);
+            throw new EngineException("Mapping test object input data does not support format '" + inputDataContext.testInputFormat().getText() + "'. Possible values: " + ArrayIterate.makeString(ObjectInputType.values(), ", "), walkerSourceInformation.getSourceInformation(inputDataContext.testInputFormat()), EngineErrorType.PARSER);
         }
         objectInputData.sourceClass = PureGrammarParserUtility.fromQualifiedName(inputDataContext.testInputSrc().qualifiedName().packagePath() == null ? Collections.emptyList() : inputDataContext.testInputSrc().qualifiedName().packagePath().identifier(), inputDataContext.testInputSrc().qualifiedName().identifier());
         objectInputData.data = ListIterate.collect(inputDataContext.testInputDataContent().STRING(), x -> PureGrammarParserUtility.fromGrammarString(x.getText(), false)).makeString("");

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ParseTreeWalkerSourceInformation.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ParseTreeWalkerSourceInformation.java
@@ -112,6 +112,23 @@ public class ParseTreeWalkerSourceInformation
         return null;
     }
 
+    /**
+     * Create a new walker source information offset by the position of the token
+     *
+     * This is useful when we create sub grammars and must pass around walker source-information
+     */
+    public static ParseTreeWalkerSourceInformation offset(ParseTreeWalkerSourceInformation walkerSourceInformation, Token token)
+    {
+        // NOTE: since we could have disabled `returnSourceInformation` in the original walker source information
+        // we must enable that in the cloned on to get a non-nullable source information to create meaningful offset
+        SourceInformation sourceInformation = new Builder(walkerSourceInformation).withReturnSourceInfo(true).build()
+            .getSourceInformation(token);
+        return new Builder(walkerSourceInformation)
+            .withLineOffset(sourceInformation.startLine - 1)
+            .withColumnOffset(sourceInformation.startColumn)
+            .build();
+    }
+
     public static class Builder
     {
         private String sourceId;

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/PureGrammarParser.java
@@ -79,6 +79,11 @@ public class PureGrammarParser
         return this.parse(code, this.parsers, sourceId, lineOffset, columnOffset, returnSourceInfo);
     }
 
+    public PureModelContextData parseModel(String code, boolean returnSourceInformation)
+    {
+        return this.parseModel(code, "", 0, 0, returnSourceInformation);
+    }
+
     public PureModelContextData parseModel(String code)
     {
         return this.parse(code, this.parsers, "", 0, 0, true);
@@ -92,6 +97,11 @@ public class PureGrammarParser
     public Lambda parseLambda(String code, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
         return new DomainParser().parseLambda(code, sourceId, lineOffset, columnOffset, returnSourceInfo);
+    }
+
+    public Lambda parseLambda(String code, String sourceId, boolean returnSourceInfo)
+    {
+        return this.parseLambda(code, sourceId, 0, 0, returnSourceInfo);
     }
 
     private PureModelContextData parse(String code, DEPRECATED_PureGrammarParserLibrary parserLibrary, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/data/embedded/HelperEmbeddedDataGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/data/embedded/HelperEmbeddedDataGrammarParser.java
@@ -47,7 +47,7 @@ public class HelperEmbeddedDataGrammarParser
      *     EmbeddedDataParser.parseEmbeddedData(ctx.embeddedData(), walkerSourceInformation)
      * </pre>
      */
-    public static EmbeddedData parseEmbeddedData(ParserRuleContext embeddedDataContext, ParseTreeWalkerSourceInformation parentSourceInformation, PureGrammarParserExtensions extensions)
+    public static EmbeddedData parseEmbeddedData(ParserRuleContext embeddedDataContext, ParseTreeWalkerSourceInformation parentWalkerSourceInformation, PureGrammarParserExtensions extensions)
     {
         List<ParseTree> children = embeddedDataContext.children;
         if (children.size() < 3 || !children.get(0).getClass().getSimpleName().equals("IdentifierContext") || !(children.get(1) instanceof TerminalNode))
@@ -67,7 +67,7 @@ public class HelperEmbeddedDataGrammarParser
         EmbeddedDataParser parser = extensions.getExtraEmbeddedDataParser(dataType);
         if (parser == null)
         {
-            throw new EngineException("Unknown embedded data type: " + dataType, parentSourceInformation.getSourceInformation(identifierContext), EngineErrorType.PARSER);
+            throw new EngineException("Unknown embedded data type: " + dataType, parentWalkerSourceInformation.getSourceInformation(identifierContext), EngineErrorType.PARSER);
         }
 
         StringBuilder builder = new StringBuilder();
@@ -77,11 +77,11 @@ public class HelperEmbeddedDataGrammarParser
 
         // prepare island grammar walker source information
         int startLine = islandOpen.getSymbol().getLine();
-        int lineOffset = parentSourceInformation.getLineOffset() + startLine - 1;
+        int lineOffset = parentWalkerSourceInformation.getLineOffset() + startLine - 1;
         // only add current walker source information column offset if this is the first line
-        int columnOffset = (startLine == 1 ? parentSourceInformation.getColumnOffset() : 0) + islandOpen.getSymbol().getCharPositionInLine() + islandOpen.getSymbol().getText().length();
-        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(parentSourceInformation).withLineOffset(lineOffset).withColumnOffset(columnOffset).build();
-        SourceInformation sourceInformation = parentSourceInformation.getSourceInformation(embeddedDataContext);
+        int columnOffset = (startLine == 1 ? parentWalkerSourceInformation.getColumnOffset() : 0) + islandOpen.getSymbol().getCharPositionInLine() + islandOpen.getSymbol().getText().length();
+        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(parentWalkerSourceInformation).withLineOffset(lineOffset).withColumnOffset(columnOffset).build();
+        SourceInformation sourceInformation = parentWalkerSourceInformation.getSourceInformation(embeddedDataContext);
 
         if (text.isEmpty())
         {

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/test/assertion/HelperTestAssertionGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/test/assertion/HelperTestAssertionGrammarParser.java
@@ -47,7 +47,7 @@ public class HelperTestAssertionGrammarParser
      *     HelperTestAssertionGrammarParser.parseTestAssertion(ctx.testAssertion(), walkerSourceInformation, extensions)
      * </pre>
      */
-    public static TestAssertion parseTestAssertion(ParserRuleContext testAssertionContext, ParseTreeWalkerSourceInformation parentSourceInformation, PureGrammarParserExtensions extensions)
+    public static TestAssertion parseTestAssertion(ParserRuleContext testAssertionContext, ParseTreeWalkerSourceInformation parentWalkerSourceInformation, PureGrammarParserExtensions extensions)
     {
         List<ParseTree> children = testAssertionContext.children;
         if (children.size() < 3 || !children.get(0).getClass().getSimpleName().equals("IdentifierContext") || !(children.get(1) instanceof TerminalNode))
@@ -67,7 +67,7 @@ public class HelperTestAssertionGrammarParser
         TestAssertionParser parser = extensions.getExtraTestAssertionParser(assertionType);
         if (parser == null)
         {
-            throw new EngineException("Unknown test assertion type: " + assertionType, parentSourceInformation.getSourceInformation(identifierContext), EngineErrorType.PARSER);
+            throw new EngineException("Unknown test assertion type: " + assertionType, parentWalkerSourceInformation.getSourceInformation(identifierContext), EngineErrorType.PARSER);
         }
 
         StringBuilder builder = new StringBuilder();
@@ -77,11 +77,11 @@ public class HelperTestAssertionGrammarParser
 
         // prepare island grammar walker source information
         int startLine = islandOpen.getSymbol().getLine();
-        int lineOffset = parentSourceInformation.getLineOffset() + startLine - 1;
+        int lineOffset = parentWalkerSourceInformation.getLineOffset() + startLine - 1;
         // only add current walker source information column offset if this is the first line
-        int columnOffset = (startLine == 1 ? parentSourceInformation.getColumnOffset() : 0) + islandOpen.getSymbol().getCharPositionInLine() + islandOpen.getSymbol().getText().length();
-        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(parentSourceInformation).withLineOffset(lineOffset).withColumnOffset(columnOffset).build();
-        SourceInformation sourceInformation = parentSourceInformation.getSourceInformation(testAssertionContext);
+        int columnOffset = (startLine == 1 ? parentWalkerSourceInformation.getColumnOffset() : 0) + islandOpen.getSymbol().getCharPositionInLine() + islandOpen.getSymbol().getText().length();
+        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(parentWalkerSourceInformation).withLineOffset(lineOffset).withColumnOffset(columnOffset).build();
+        SourceInformation sourceInformation = parentWalkerSourceInformation.getSourceInformation(testAssertionContext);
 
         if (text.isEmpty())
         {

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestGrammarRoundtrip.java
@@ -34,15 +34,6 @@ public class TestGrammarRoundtrip
 
     public static class TestGrammarRoundtripTestSuite
     {
-        /**
-         * This method is used for testing when the grammar and the protocol is 100% bijective
-         * This also checks for indentation formatting
-         */
-        public static void test(String code)
-        {
-            test(code, null);
-        }
-
         public void testFrom(String code, String expectedProtocolPath)
         {
             String expectedProtocol = new Scanner(Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream(expectedProtocolPath), "Can't find resource '" + expectedProtocolPath + "'"), "UTF-8").useDelimiter("\\A").next();
@@ -58,12 +49,22 @@ public class TestGrammarRoundtrip
             }
         }
 
+        /**
+         * This method is used for testing when the grammar and the protocol is 100% bijective
+         * This also checks for indentation formatting
+         */
+        public static void test(String code)
+        {
+            test(code, null);
+        }
+
         private static void test(String code, String message)
         {
             PureModelContextData modelData = null;
             try
             {
-                modelData = PureGrammarParser.newInstance().parseModel(code);
+                // NOTE: no need to get source information
+                modelData = PureGrammarParser.newInstance().parseModel(code, "", 0, 0, false);
                 String json = objectMapper.writeValueAsString(modelData);
                 modelData = objectMapper.readValue(json, PureModelContextData.class);
             }
@@ -103,7 +104,8 @@ public class TestGrammarRoundtrip
         private static void testFormat(String code, String unformattedCode, boolean omitSectionIndex)
         {
             PureGrammarComposer grammarTransformer = PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().build());
-            PureModelContextData parsedModel = PureGrammarParser.newInstance().parseModel(unformattedCode);
+            // NOTE: no need to get source information
+            PureModelContextData parsedModel = PureGrammarParser.newInstance().parseModel(unformattedCode, "", 0, 0, false);
             if (omitSectionIndex)
             {
                 parsedModel = PureModelContextData.newPureModelContextData(parsedModel.getSerializer(), parsedModel.getOrigin(), LazyIterate.reject(parsedModel.getElements(), e -> e instanceof SectionIndex));

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalDatabaseConnectionParseTreeWalker.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalDatabaseConnectionParseTreeWalker.java
@@ -99,10 +99,7 @@ public class RelationalDatabaseConnectionParseTreeWalker
                 spec.getText(),
                 spec.specificationType().getText(),
                 sourceInformation,
-                new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation)
-                        .withLineOffset(sourceInformation.startLine - 1)
-                        .withColumnOffset(sourceInformation.startColumn)
-                        .build()
+                ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, spec.getStart())
         );
 
         PostProcessor processor = IRelationalGrammarParserExtension.process(code, parsers);
@@ -124,10 +121,7 @@ public class RelationalDatabaseConnectionParseTreeWalker
                 ctx.specification().getText(),
                 specification.specificationType().getText(),
                 sourceInformation,
-                new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation)
-                        .withLineOffset(sourceInformation.startLine - 1)
-                        .withColumnOffset(sourceInformation.startColumn)
-                        .build()
+                ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, ctx.getStart())
         );
 
         List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();
@@ -151,10 +145,7 @@ public class RelationalDatabaseConnectionParseTreeWalker
                 ctx.specification().getText(),
                 specification.specificationType().getText(),
                 sourceInformation,
-                new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation)
-                        .withLineOffset(sourceInformation.startLine - 1)
-                        .withColumnOffset(sourceInformation.startColumn)
-                        .build()
+                ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, ctx.getStart())
         );
 
         List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
@@ -232,9 +232,9 @@ public class RelationalGrammarParserExtension implements IRelationalGrammarParse
         return Lists.immutable.with(MappingTestInputDataParser.newParser("Relational", RelationalGrammarParserExtension::parseObjectInputData));
     }
 
-    private static InputData parseObjectInputData(MappingParserGrammar.TestInputElementContext inputDataContext, ParseTreeWalkerSourceInformation sourceInformation)
+    private static InputData parseObjectInputData(MappingParserGrammar.TestInputElementContext inputDataContext, ParseTreeWalkerSourceInformation walkerSourceInformation)
     {
-        SourceInformation testInputDataSourceInformation = sourceInformation.getSourceInformation(inputDataContext);
+        SourceInformation testInputDataSourceInformation = walkerSourceInformation.getSourceInformation(inputDataContext);
         RelationalInputData relationalInputData = new RelationalInputData();
         relationalInputData.sourceInformation = testInputDataSourceInformation;
 
@@ -248,7 +248,7 @@ public class RelationalGrammarParserExtension implements IRelationalGrammarParse
         }
         catch (IllegalArgumentException e)
         {
-            throw new EngineException("Mapping test relational input data does not support format '" + inputDataContext.testInputFormat().getText() + "'. Possible values: " + ArrayIterate.makeString(RelationalInputType.values(), ", "), sourceInformation.getSourceInformation(inputDataContext.testInputFormat()), EngineErrorType.PARSER);
+            throw new EngineException("Mapping test relational input data does not support format '" + inputDataContext.testInputFormat().getText() + "'. Possible values: " + ArrayIterate.makeString(RelationalInputType.values(), ", "), walkerSourceInformation.getSourceInformation(inputDataContext.testInputFormat()), EngineErrorType.PARSER);
         }
 
         relationalInputData.database = inputDataContext.testInputSrc().getText();

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -418,10 +418,7 @@ public class RelationalParseTreeWalker
                 ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex())),
                 ctx.milestoningType().getText(),
                 sourceInformation,
-                new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation)
-                        .withLineOffset(sourceInformation.startLine - 1)
-                        .withColumnOffset(sourceInformation.startColumn)
-                        .build()
+                ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, ctx.getStart())
         );
 
         List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();

--- a/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/data/contentPattern/HelperContentPatternGrammarParser.java
+++ b/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/data/contentPattern/HelperContentPatternGrammarParser.java
@@ -47,7 +47,7 @@ public class HelperContentPatternGrammarParser
      *     HelperContentPatternGrammarParser.parseContentPattern(ctx.serviceRequestContentPattern(), walkerSourceInformation, extensions)
      * </pre>
      */
-    public static ContentPattern parseContentPattern(ParserRuleContext contentPatternContext, ParseTreeWalkerSourceInformation parentSourceInformation, PureGrammarParserExtensions extensions)
+    public static ContentPattern parseContentPattern(ParserRuleContext contentPatternContext, ParseTreeWalkerSourceInformation parentWalkerSourceInformation, PureGrammarParserExtensions extensions)
     {
         List<ParseTree> children = contentPatternContext.children;
         if (children.size() < 3 || !children.get(0).getClass().getSimpleName().equals("IdentifierContext") || !(children.get(1) instanceof TerminalNode))
@@ -67,7 +67,7 @@ public class HelperContentPatternGrammarParser
         ContentPatternGrammarParser parser = ListIterate.detect(ContentPatternParserExtensionLoader.extensions(), e -> e.getType().equals(dataType));
         if (parser == null)
         {
-            throw new EngineException("Unknown contentPattern pattern type: " + dataType, parentSourceInformation.getSourceInformation(identifierContext), EngineErrorType.PARSER);
+            throw new EngineException("Unknown contentPattern pattern type: " + dataType, parentWalkerSourceInformation.getSourceInformation(identifierContext), EngineErrorType.PARSER);
         }
 
         StringBuilder builder = new StringBuilder();
@@ -77,11 +77,11 @@ public class HelperContentPatternGrammarParser
 
         // prepare island grammar walker source information
         int startLine = islandOpen.getSymbol().getLine();
-        int lineOffset = parentSourceInformation.getLineOffset() + startLine - 1;
+        int lineOffset = parentWalkerSourceInformation.getLineOffset() + startLine - 1;
         // only add current walker source information column offset if this is the first line
-        int columnOffset = (startLine == 1 ? parentSourceInformation.getColumnOffset() : 0) + islandOpen.getSymbol().getCharPositionInLine() + islandOpen.getSymbol().getText().length();
-        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(parentSourceInformation).withLineOffset(lineOffset).withColumnOffset(columnOffset).build();
-        SourceInformation sourceInformation = parentSourceInformation.getSourceInformation(contentPatternContext);
+        int columnOffset = (startLine == 1 ? parentWalkerSourceInformation.getColumnOffset() : 0) + islandOpen.getSymbol().getCharPositionInLine() + islandOpen.getSymbol().getText().length();
+        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(parentWalkerSourceInformation).withLineOffset(lineOffset).withColumnOffset(columnOffset).build();
+        SourceInformation sourceInformation = parentWalkerSourceInformation.getSourceInformation(contentPatternContext);
 
         if (text.isEmpty())
         {


### PR DESCRIPTION
Before, if we want to call `/grammarToJson/model` with `returnSourceInformation=false`, we would get an `NullPointerException`.

We also enforce that model grammar roundtrip are to be run with `returnSourceInformation=false`, since there's no need for the source information as well as we could use that method to test for the case when `returnSourceInformation=false`

