### PR TITLE
Stricter enforce rule on execution and generation collection modules

### DIFF
--- a/legend-engine-executionPlan-dependencies/pom.xml
+++ b/legend-engine-executionPlan-dependencies/pom.xml
@@ -36,7 +36,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>

--- a/legend-engine-executionPlan-execution-api/pom.xml
+++ b/legend-engine-executionPlan-execution-api/pom.xml
@@ -36,7 +36,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>

--- a/legend-engine-executionPlan-execution-store-inMemory/pom.xml
+++ b/legend-engine-executionPlan-execution-store-inMemory/pom.xml
@@ -47,7 +47,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>

--- a/legend-engine-executionPlan-execution/pom.xml
+++ b/legend-engine-executionPlan-execution/pom.xml
@@ -47,7 +47,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>

--- a/legend-engine-extensions-collection-execution/pom.xml
+++ b/legend-engine-extensions-collection-execution/pom.xml
@@ -37,7 +37,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>
@@ -45,10 +45,11 @@
                                     <excludes>
                                         <exclude>commons-logging</exclude>
                                         <exclude>javax.mail</exclude>
-                                        <exclude>log4j:*:*:*:compile</exclude>
-                                        <exclude>org.slf4j:*:*:*:compile</exclude>
-                                        <exclude>org.finos.legend.pure:*:*:*:compile</exclude>
-                                        <exclude>org.finos.legend.pure:*:*:*:runtime</exclude>
+                                        <exclude>log4j</exclude>
+                                        <exclude>ch.qos.logback</exclude>
+                                        <exclude>org.slf4j</exclude>
+                                        <exclude>org.finos.legend.pure</exclude>
+                                        <exclude>io.dropwizard</exclude>
                                     </excludes>
                                     <includes>
                                         <!--only the specific included logging jars are allowed -->

--- a/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-extensions-collection-generation/pom.xml
@@ -26,6 +26,50 @@
     <artifactId>legend-engine-extensions-collection-generation</artifactId>
     <name>Legend Engine Extensions Collection - Generation</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
+                                </requireJavaVersion>
+                                <dependencyConvergence />
+                                <bannedDependencies>
+                                    <searchTransitive>true</searchTransitive>
+                                    <excludes>
+                                        <exclude>commons-logging</exclude>
+                                        <exclude>javax.mail</exclude>
+                                        <exclude>log4j</exclude>
+                                        <exclude>ch.qos.logback</exclude>
+                                        <exclude>org.slf4j</exclude>
+                                        <exclude>io.dropwizard</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <!--only the specific included logging jars are allowed -->
+                                        <include>org.slf4j:jul-to-slf4j:${slf4j.version}</include>
+                                        <include>org.slf4j:slf4j-api:${slf4j.version}</include>
+                                        <include>org.slf4j:jcl-over-slf4j:${slf4j.version}</include>
+                                        <include>org.slf4j:slf4j-ext:${slf4j.version}</include>
+                                    </includes>
+
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- ENGINE -->
         <dependency>

--- a/legend-engine-external-shared-format-runtime/pom.xml
+++ b/legend-engine-external-shared-format-runtime/pom.xml
@@ -64,7 +64,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>

--- a/legend-engine-xt-flatdata-runtime/pom.xml
+++ b/legend-engine-xt-flatdata-runtime/pom.xml
@@ -79,7 +79,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>

--- a/legend-engine-xt-xml-runtime/pom.xml
+++ b/legend-engine-xt-xml-runtime/pom.xml
@@ -54,7 +54,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
+        <maven.enforcer.requireJavaVersion>[11.0.10,12)</maven.enforcer.requireJavaVersion>
 
         <!-- Databases -->
         <hikaricp.version>4.0.3</hikaricp.version>
@@ -449,7 +450,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[11.0.10,12)</version>
+                                    <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>


### PR DESCRIPTION
This prevents logback and dropwizard as a dependency on the generation and execution modules that gitlab projects will depend on.  This also slightly improve how enforcer required java version is defined to ensure all definitions are using the same value. 