### PR TITLE
Fix JSON to Grammar transformation when Applied functions are passed as paramters.

### DIFF
--- a/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestJsonToGrammarApi.java
+++ b/legend-engine-language-pure-grammar-api/src/test/java/org/finos/legend/engine/language/pure/grammar/api/test/TestJsonToGrammarApi.java
@@ -485,6 +485,97 @@ public class TestJsonToGrammarApi
         testModelFromProtocol(expected, "diagramWithNoGenView.json");
     }
 
+    @Test
+    public void testToGrammarEqualsWithAppliedFunctionAsParameters()
+    {
+        testModelFromProtocol("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                        "[\n" +
+                        "  myConstraint\n" +
+                        "  (\n" +
+                        "    ~function: eq($this.var2 / $this.var1, $this.var4 / $this.var3)\n" +
+                        "    ~enforcementLevel: Error\n" +
+                        "  )\n" +
+                        "]\n" +
+                        "{\n" +
+                        "  var1: Float[1];\n" +
+                        "  var2: Float[1];\n" +
+                        "  var3: Float[1];\n" +
+                        "  var4: Float[1];\n" +
+                        "}\n",
+                "equalsWithAppliedFunctionAsParameters.json");
+    }
+
+    @Test
+    public void testToGrammarEqualsWithAppliedFunctionAndPrimitiveAsParameters()
+    {
+        testModelFromProtocol("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                        "[\n" +
+                        "  myConstraint\n" +
+                        "  (\n" +
+                        "    ~function: eq($this.var2 / $this.var1, 3)\n" +
+                        "    ~enforcementLevel: Error\n" +
+                        "  )\n" +
+                        "]\n" +
+                        "{\n" +
+                        "  var1: Float[1];\n" +
+                        "  var2: Float[1];\n" +
+                        "}\n",
+                "equalsWithAppliedFunctionAndPrimitiveAsParameters.json");
+    }
+
+    @Test
+    public void testToGrammarEqualsWithPrimitiveAndAppliedFunctionAsParameters()
+    {
+        testModelFromProtocol("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                        "[\n" +
+                        "  myConstraint\n" +
+                        "  (\n" +
+                        "    ~function: 3->eq($this.var2 / $this.var1)\n" +
+                        "    ~enforcementLevel: Error\n" +
+                        "  )\n" +
+                        "]\n" +
+                        "{\n" +
+                        "  var1: Float[1];\n" +
+                        "  var2: Float[1];\n" +
+                        "}\n",
+                "equalsWithPrimitiveAndAppliedFunctionAsParameters.json");
+    }
+
+    @Test
+    public void testToGrammarEqualsWithPrimitiveAndPrimitiveAsParameters()
+    {
+        testModelFromProtocol("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                        "[\n" +
+                        "  myConstraint\n" +
+                        "  (\n" +
+                        "    ~function: 3->eq(3) && 3->eq($this.var2 / $this.var1)\n" +
+                        "    ~enforcementLevel: Error\n" +
+                        "  )\n" +
+                        "]\n" +
+                        "{\n" +
+                        "  var1: Float[1];\n" +
+                        "  var2: Float[1];\n" +
+                        "}\n",
+                "equalsWithPrimitiveAndPrimitiveAsParameters.json");
+    }
+
+    @Test
+    public void testToGrammarIsNotEmptyWithAppliedFunctionAsParameter()
+    {
+        testModelFromProtocol("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                        "[\n" +
+                        "  myConstraint\n" +
+                        "  (\n" +
+                        "    ~function: isNotEmpty($this.var1 / 3)\n" +
+                        "    ~enforcementLevel: Error\n" +
+                        "  )\n" +
+                        "]\n" +
+                        "{\n" +
+                        "  var1: Float[1];\n" +
+                        "}\n",
+                "isNotEmptyWithAppliedFunctionAsParameter.json");
+    }
+
     private void testMappingFromProtocol(String expected, String protocolPath)
     {
         try

--- a/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithAppliedFunctionAndPrimitiveAsParameters.json
+++ b/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithAppliedFunctionAndPrimitiveAsParameters.json
@@ -1,0 +1,114 @@
+{
+  "origin": {
+    "sdlcInfo": {
+      "baseVersion": "-1",
+      "_type": "pure",
+      "version": "none",
+      "packageableElementPointers": [
+        {
+          "path": "my",
+          "type": "PACKAGE"
+        }
+      ]
+    },
+    "_type": "pointer",
+    "serializer": {
+      "name": "pure",
+      "version": "vX_X_X"
+    }
+  },
+  "elements": [
+    {
+      "superTypes": [
+        "meta::pure::metamodel::type::Any"
+      ],
+      "package": "my",
+      "_type": "class",
+      "name": "TestClass",
+      "constraints": [
+        {
+          "enforcementLevel": "Error",
+          "functionDefinition": {
+            "_type": "lambda",
+            "body": [
+              {
+                "fControl": "eq_Any_1__Any_1__Boolean_1_",
+                "function": "eq",
+                "_type": "func",
+                "parameters": [
+                  {
+                    "fControl": "divide_Number_1__Number_1__Float_1_",
+                    "function": "divide",
+                    "_type": "func",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "property": "var2",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "property": "var1",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "multiplicity": {
+                      "upperBound": 1,
+                      "lowerBound": 1
+                    },
+                    "values": [
+                      3
+                    ],
+                    "_type": "integer"
+                  }
+                ]
+              }
+            ],
+            "parameters": [
+              {
+                "_type": "var",
+                "name": "this"
+              }
+            ]
+          },
+          "name": "myConstraint"
+        }
+      ],
+      "properties": [
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var1",
+          "type": "Float"
+        },
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var2",
+          "type": "Float"
+        }
+      ]
+    }
+  ],
+  "_type": "data",
+  "serializer": {
+    "name": "pure",
+    "version": "vX_X_X"
+  }
+}

--- a/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithAppliedFunctionAsParameters.json
+++ b/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithAppliedFunctionAsParameters.json
@@ -1,0 +1,147 @@
+{
+  "origin": {
+    "sdlcInfo": {
+      "baseVersion": "-1",
+      "_type": "pure",
+      "version": "none",
+      "packageableElementPointers": [
+        {
+          "path": "my",
+          "type": "PACKAGE"
+        }
+      ]
+    },
+    "_type": "pointer",
+    "serializer": {
+      "name": "pure",
+      "version": "vX_X_X"
+    }
+  },
+  "elements": [
+    {
+      "superTypes": [
+        "meta::pure::metamodel::type::Any"
+      ],
+      "package": "my",
+      "_type": "class",
+      "name": "TestClass",
+      "constraints": [
+        {
+          "enforcementLevel": "Error",
+          "functionDefinition": {
+            "_type": "lambda",
+            "body": [
+              {
+                "fControl": "eq_Any_1__Any_1__Boolean_1_",
+                "function": "eq",
+                "_type": "func",
+                "parameters": [
+                  {
+                    "fControl": "divide_Number_1__Number_1__Float_1_",
+                    "function": "divide",
+                    "_type": "func",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "property": "var2",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "property": "var1",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "fControl": "divide_Number_1__Number_1__Float_1_",
+                    "function": "divide",
+                    "_type": "func",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "property": "var4",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "property": "var3",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "parameters": [
+              {
+                "_type": "var",
+                "name": "this"
+              }
+            ]
+          },
+          "name": "myConstraint"
+        }
+      ],
+      "properties": [
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var1",
+          "type": "Float"
+        },
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var2",
+          "type": "Float"
+        },
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var3",
+          "type": "Float"
+        },
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var4",
+          "type": "Float"
+        }
+      ]
+    }
+  ],
+  "_type": "data",
+  "serializer": {
+    "name": "pure",
+    "version": "vX_X_X"
+  }
+}

--- a/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithPrimitiveAndAppliedFunctionAsParameters.json
+++ b/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithPrimitiveAndAppliedFunctionAsParameters.json
@@ -1,0 +1,114 @@
+{
+  "origin": {
+    "sdlcInfo": {
+      "baseVersion": "-1",
+      "_type": "pure",
+      "version": "none",
+      "packageableElementPointers": [
+        {
+          "path": "my",
+          "type": "PACKAGE"
+        }
+      ]
+    },
+    "_type": "pointer",
+    "serializer": {
+      "name": "pure",
+      "version": "vX_X_X"
+    }
+  },
+  "elements": [
+    {
+      "superTypes": [
+        "meta::pure::metamodel::type::Any"
+      ],
+      "package": "my",
+      "_type": "class",
+      "name": "TestClass",
+      "constraints": [
+        {
+          "enforcementLevel": "Error",
+          "functionDefinition": {
+            "_type": "lambda",
+            "body": [
+              {
+                "fControl": "eq_Any_1__Any_1__Boolean_1_",
+                "function": "eq",
+                "_type": "func",
+                "parameters": [
+                  {
+                    "multiplicity": {
+                      "upperBound": 1,
+                      "lowerBound": 1
+                    },
+                    "values": [
+                      3
+                    ],
+                    "_type": "integer"
+                  },
+                  {
+                    "fControl": "divide_Number_1__Number_1__Float_1_",
+                    "function": "divide",
+                    "_type": "func",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "property": "var2",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "property",
+                        "property": "var1",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "parameters": [
+              {
+                "_type": "var",
+                "name": "this"
+              }
+            ]
+          },
+          "name": "myConstraint"
+        }
+      ],
+      "properties": [
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var1",
+          "type": "Float"
+        },
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var2",
+          "type": "Float"
+        }
+      ]
+    }
+  ],
+  "_type": "data",
+  "serializer": {
+    "name": "pure",
+    "version": "vX_X_X"
+  }
+}

--- a/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithPrimitiveAndPrimitiveAsParameters.json
+++ b/legend-engine-language-pure-grammar-api/src/test/resources/equalsWithPrimitiveAndPrimitiveAsParameters.json
@@ -1,0 +1,148 @@
+{
+  "origin": {
+    "sdlcInfo": {
+      "baseVersion": "-1",
+      "_type": "pure",
+      "version": "none",
+      "packageableElementPointers": [
+        {
+          "path": "my",
+          "type": "PACKAGE"
+        }
+      ]
+    },
+    "_type": "pointer",
+    "serializer": {
+      "name": "pure",
+      "version": "vX_X_X"
+    }
+  },
+  "elements": [
+    {
+      "superTypes": [
+        "meta::pure::metamodel::type::Any"
+      ],
+      "package": "my",
+      "_type": "class",
+      "name": "TestClass",
+      "constraints": [
+        {
+          "enforcementLevel": "Error",
+          "functionDefinition": {
+            "_type": "lambda",
+            "body": [
+              {
+                "fControl": "and_Boolean_1__Boolean_1__Boolean_1_",
+                "function": "and",
+                "_type": "func",
+                "parameters": [
+                  {
+                    "fControl": "eq_Any_1__Any_1__Boolean_1_",
+                    "function": "eq",
+                    "_type": "func",
+                    "parameters": [
+                      {
+                        "multiplicity": {
+                          "upperBound": 1,
+                          "lowerBound": 1
+                        },
+                        "values": [
+                          3
+                        ],
+                        "_type": "integer"
+                      },
+                      {
+                        "multiplicity": {
+                          "upperBound": 1,
+                          "lowerBound": 1
+                        },
+                        "values": [
+                          3
+                        ],
+                        "_type": "integer"
+                      }
+                    ]
+                  },
+                  {
+                    "fControl": "eq_Any_1__Any_1__Boolean_1_",
+                    "function": "eq",
+                    "_type": "func",
+                    "parameters": [
+                      {
+                        "multiplicity": {
+                          "upperBound": 1,
+                          "lowerBound": 1
+                        },
+                        "values": [
+                          3
+                        ],
+                        "_type": "integer"
+                      },
+                      {
+                        "fControl": "divide_Number_1__Number_1__Float_1_",
+                        "function": "divide",
+                        "_type": "func",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "property": "var2",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "property",
+                            "property": "var1",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "this"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "parameters": [
+              {
+                "_type": "var",
+                "name": "this"
+              }
+            ]
+          },
+          "name": "myConstraint"
+        }
+      ],
+      "properties": [
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var1",
+          "type": "Float"
+        },
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var2",
+          "type": "Float"
+        }
+      ]
+    }
+  ],
+  "_type": "data",
+  "serializer": {
+    "name": "pure",
+    "version": "vX_X_X"
+  }
+}

--- a/legend-engine-language-pure-grammar-api/src/test/resources/isNotEmptyWithAppliedFunctionAsParameter.json
+++ b/legend-engine-language-pure-grammar-api/src/test/resources/isNotEmptyWithAppliedFunctionAsParameter.json
@@ -1,0 +1,96 @@
+{
+  "origin": {
+    "sdlcInfo": {
+      "baseVersion": "-1",
+      "_type": "pure",
+      "version": "none",
+      "packageableElementPointers": [
+        {
+          "path": "my",
+          "type": "PACKAGE"
+        }
+      ]
+    },
+    "_type": "pointer",
+    "serializer": {
+      "name": "pure",
+      "version": "vX_X_X"
+    }
+  },
+  "elements": [
+    {
+      "superTypes": [
+        "meta::pure::metamodel::type::Any"
+      ],
+      "package": "my",
+      "_type": "class",
+      "name": "TestClass",
+      "constraints": [
+        {
+          "enforcementLevel": "Error",
+          "functionDefinition": {
+            "_type": "lambda",
+            "body": [
+              {
+                "fControl": "isNotEmpty_Any_$0_1$__Boolean_1_",
+                "function": "isNotEmpty",
+                "_type": "func",
+                "parameters": [
+                  {
+                    "fControl": "divide_Number_1__Number_1__Float_1_",
+                    "function": "divide",
+                    "_type": "func",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "property": "var1",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      },
+                      {
+                        "multiplicity": {
+                          "upperBound": 1,
+                          "lowerBound": 1
+                        },
+                        "values": [
+                          3
+                        ],
+                        "_type": "integer"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "parameters": [
+              {
+                "_type": "var",
+                "name": "this"
+              }
+            ]
+          },
+          "name": "myConstraint"
+        }
+      ],
+      "properties": [
+        {
+          "multiplicity": {
+            "upperBound": 1,
+            "lowerBound": 1
+          },
+          "name": "var1",
+          "type": "Float"
+        }
+      ]
+    }
+  ],
+  "_type": "data",
+  "serializer": {
+    "name": "pure",
+    "version": "vX_X_X"
+  }
+}

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
@@ -94,7 +94,7 @@ public class HelperValueSpecificationGrammarComposer
 
         // This is to accommodate for cases where the first parameter is a lambda, such as agg(), col(),
         // it would be wrong to use `->` syntax, e.g. `$x|x.prop1->col()`
-        if (firstArgument instanceof Lambda)
+        if ((firstArgument instanceof Lambda) || (firstArgument instanceof AppliedFunction && SPECIAL_INFIX.get(((AppliedFunction) firstArgument).function) != null))
         {
             return renderFunctionName(functionName, transformer) + "("
                     + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(2)) : "")

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -20,6 +20,92 @@ import org.junit.Test;
 public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
 {
     @Test
+    public void testAppliedFunctionAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: eq($this.var2 / $this.var1, $this.var4 / $this.var3)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "  var3: Float[1];\n" +
+                "  var4: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testAppliedFunctionPrimitiveAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: eq($this.var2 / $this.var1, 3)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testPrimitiveAppliedFunctionAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: 3->eq($this.var2 / $this.var1)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testPrimitivesAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: 3->eq(3) && 3->eq($this.var2 / $this.var1)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testIsNotEmptyWithAppliedFunctionsAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: isNotEmpty($this.var1 / 3)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
     public void testClass()
     {
         test("Class <<temporal.businesstemporal>> {doc.doc = 'something'} A extends B\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
@@ -27,6 +27,16 @@ public class TestLambdaRoundtrip
     private static final ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
 
     @Test
+    public void testLambdaWithINFIXoperations()
+    {
+        testLambda("|eq($this.var2 / $this.var1, $this.var4 / $this.var3)");
+        testLambda("|eq($this.var2 / $this.var1, 3)");
+        testLambda("|3->eq($this.var2 / $this.var1)");
+        testLambda("|3->eq(3) && 3->eq($this.var2 / $this.var1)");
+        testLambda("|isNotEmpty($this.var1 / 3)");
+    }
+
+    @Test
     public void testLambdaWithBodyWithNonStringTokenOnly()
     {
         testLambda("|a::X");


### PR DESCRIPTION
Fix JSON to grammar transformation when the first parameter to a function is an instance of Applied Function. Ensured correct grammar generation when using eq (equals) applied function by avoiding the `->` syntax. 