### PR TITLE
Improve tests for legend-engine-extensions-collection-generation

### DIFF
--- a/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-extensions-collection-generation/pom.xml
@@ -155,6 +155,7 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-format-avro</artifactId>
@@ -165,11 +166,12 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-language-morphir</artifactId>
+            <artifactId>legend-engine-external-format-rosetta</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-format-rosetta</artifactId>
+            <artifactId>legend-engine-external-language-morphir</artifactId>
         </dependency>
         <!-- ENGINE EXTERNAL -->
 
@@ -194,11 +196,11 @@
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-persistence-protocol</artifactId>
+            <artifactId>legend-engine-xt-persistence-grammar</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-persistence-grammar</artifactId>
+            <artifactId>legend-engine-xt-persistence-protocol</artifactId>
         </dependency>
 
         <dependency>
@@ -208,20 +210,20 @@
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-serviceStore-protocol</artifactId>
+            <artifactId>legend-engine-xt-serviceStore-grammar</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-serviceStore-grammar</artifactId>
+            <artifactId>legend-engine-xt-serviceStore-protocol</artifactId>
         </dependency>
 
         <dependency>
@@ -246,13 +248,13 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
-        <!-- DO NOT ADD NEW FURTHER TEST DEPENDENCIES -->
+        <!-- DO NOT ADD FURTHER TEST DEPENDENCIES -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- DO NOT ADD NEW FURTHER TEST DEPENDENCIES -->
+        <!-- DO NOT ADD FURTHER TEST DEPENDENCIES -->
         <!-- TEST -->
     </dependencies>
 

--- a/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-extensions-collection-generation/pom.xml
@@ -30,6 +30,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
                     <execution>
@@ -71,6 +82,17 @@
     </build>
 
     <dependencies>
+        <!-- PURE -->
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
+        </dependency>
+        <!-- PURE -->
+
         <!-- ENGINE -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -78,31 +100,16 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-generation</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-protocol-pure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-shared-format-model</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-flatdata-model</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-json-model</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-xml-model</artifactId>
+            <artifactId>legend-engine-language-pure-compiler</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -110,19 +117,11 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-language-pure-dsl-diagram</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-persistence-protocol</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-language-pure-dsl-text</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-dsl-data-space</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-diagram</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -134,12 +133,88 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-text</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-external-shared-format</artifactId>
+        </dependency>
+        <!-- ENGINE -->
+
+        <!-- ENGINE EXTERNAL -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-shared-format-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-jsonSchema</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-language-morphir</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-rosetta</artifactId>
+        </dependency>
+        <!-- ENGINE EXTERNAL -->
+
+        <!-- ENGINE XT -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-flatdata-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-flatdata-protocol</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-protocol</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-persistence-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-persistence-grammar</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-protobuf</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-serviceStore-protocol</artifactId>
@@ -148,43 +223,16 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-serviceStore-grammar</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-protocol-external-shared-format</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-flatdata-protocol</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-json-protocol</artifactId>
+            <artifactId>legend-engine-xt-xml-model</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-xml-protocol</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-format-jsonSchema</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-protobuf</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-format-avro</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-format-rosetta</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-external-language-morphir</artifactId>
-        </dependency>
-        <!-- ENGINE -->
+        <!-- ENGINE XT -->
 
         <!-- ECLIPSE COLLECTIONS -->
         <dependency>

--- a/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
+++ b/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
@@ -15,111 +15,152 @@
 package org.finos.legend.engine.extensions.collection.generation;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.factory.Sets;
-import org.finos.legend.engine.external.format.protobuf.deprecated.generation.ProtobufGenerationExtension;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.external.shared.format.extension.GenerationExtension;
 import org.finos.legend.engine.external.shared.format.model.ExternalFormatExtension;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension;
-import org.finos.legend.engine.plan.generation.extension.LegendPlanGeneratorExtension;
+import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtensionLoader;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
+import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataLazy;
+import org.finos.legend.pure.runtime.java.compiled.serialization.binary.DistributedBinaryGraphDeserializer;
+import org.finos.legend.pure.runtime.java.compiled.serialization.binary.DistributedMetadataSpecification;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.ServiceLoader;
 
 public class TestExtensions
 {
-
-    // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
-    private static final ImmutableList<Class<? extends PureProtocolExtension>> EXPECTED_PROTOCOL_EXTENSIONS = Lists.mutable.<Class<? extends PureProtocolExtension>>empty()
-            .with(org.finos.legend.engine.protocol.pure.v1.CorePureProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.DiagramProtocolExtension.class)
-            .with(org.finos.legend.engine.external.shared.ExternalFormatProtocolExtension.class)
-            .with(org.finos.legend.engine.external.format.flatdata.FlatDataProtocolExtension.class)
-            .with(org.finos.legend.engine.external.format.json.JsonProtocolExtension.class)
-            .with(org.finos.legend.engine.external.format.xml.XmlProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.GenerationProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.PersistenceProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.RelationalProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.ServiceProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.ServiceStoreProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.TextProtocolExtension.class)
-            .with(org.finos.legend.engine.protocol.pure.v1.DataSpaceProtocolExtension.class)
-            .toImmutable();
-
-    // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
-    private static final ImmutableList<Class<? extends GenerationExtension>> EXPECTED_GENERATION_EXTENSIONS = Lists.mutable.<Class<? extends GenerationExtension>>empty()
-            .with(ProtobufGenerationExtension.class)
-            .with(org.finos.legend.engine.external.format.avro.extension.AvroGenerationExtension.class)
-            .with(org.finos.legend.engine.external.format.jsonSchema.extension.JSONSchemaGenerationExtension.class)
-            .with(org.finos.legend.engine.external.format.rosetta.extension.RosettaGenerationExtension.class)
-            .with(org.finos.legend.engine.external.language.morphir.extension.MorphirGenerationExtension.class)
-            .toImmutable();
-
-
-    // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
-    private static final ImmutableList<Class<? extends PureGrammarParserExtension>> EXPECTED_GRAMMAR_EXTENSIONS = Lists.mutable.<Class<? extends PureGrammarParserExtension>>empty()
-            .with(org.finos.legend.engine.language.pure.grammar.from.CorePureGrammarParser.class)
-            .with(org.finos.legend.engine.language.pure.grammar.from.RelationalGrammarParserExtension.class)
-            .with(org.finos.legend.engine.language.pure.grammar.from.ServiceStoreGrammarParserExtension.class)
-            .with(org.finos.legend.engine.language.pure.grammar.from.ExternalFormatGrammarParserExtension.class)
-            .toImmutable();
-
-    private static final ImmutableList<Class<? extends PlanGeneratorExtension>> EXPECTED_PLAN_GENERATOR_EXTENSIONS = Lists.mutable.<Class<? extends PlanGeneratorExtension>>empty()
-            .with(LegendPlanGeneratorExtension.class)
-            .toImmutable();
-
-    private static final ImmutableList<Class<? extends ExternalFormatExtension>> EXPECTED_EXTERNAL_FORMAT_EXTENSIONS = Lists.mutable.<Class<? extends ExternalFormatExtension>>empty()
-            .with(org.finos.legend.engine.external.format.flatdata.FlatDataExternalFormatExtension.class)
-            .with(org.finos.legend.engine.external.format.json.JsonExternalFormatExtension.class)
-            .with(org.finos.legend.engine.external.format.xsd.XsdExternalFormatExtension.class)
-            .with(org.finos.legend.engine.external.format.protobuf.ProtobufFormatExtension.class)
-            .toImmutable();
-
     @Test
     public void testExpectedProtocolExtensionsArePresent()
     {
-        assertHasExtensions(PureProtocolExtensionLoader.extensions(), org.eclipse.collections.api.factory.Sets.mutable.withAll(EXPECTED_PROTOCOL_EXTENSIONS), PureProtocolExtension.class, true);
+        assertHasExtensions(getExpectedPureProtocolExtensions(), PureProtocolExtension.class);
+        assertHasExtensions(PureProtocolExtensionLoader.extensions(), getExpectedPureProtocolExtensions(), PureProtocolExtension.class);
     }
 
     @Test
     public void testExpectedGenerationExtension()
     {
-        assertHasExtensions(org.eclipse.collections.api.factory.Sets.mutable.withAll(EXPECTED_GENERATION_EXTENSIONS), GenerationExtension.class, true);
+        assertHasExtensions(getExpectedGenerationExtensions(), GenerationExtension.class);
     }
 
     @Test
     public void testExpectedGrammarExtensionsArePresent()
     {
-        assertHasExtensions(org.eclipse.collections.api.factory.Sets.mutable.withAll(EXPECTED_GRAMMAR_EXTENSIONS), PureGrammarParserExtension.class, false);
+        assertHasExtensions(getExpectedGrammarParserExtensions(), PureGrammarParserExtension.class);
+        assertHasExtensions(getExpectedGrammarComposerExtensions(), PureGrammarComposerExtension.class);
     }
 
     @Test
     public void testPlanGeneratorExtensionArePresent()
     {
-        assertHasExtensions(Sets.mutable.withAll(EXPECTED_PLAN_GENERATOR_EXTENSIONS), PlanGeneratorExtension.class, true);
+        assertHasExtensions(getExpectedPlanGeneratorExtensions(), PlanGeneratorExtension.class);
     }
 
     @Test
     public void testExpectedExternalFormatExtensionsArePresent()
     {
-        assertHasExtensions(org.eclipse.collections.api.factory.Sets.mutable.withAll(EXPECTED_EXTERNAL_FORMAT_EXTENSIONS), ExternalFormatExtension.class, true);
+        assertHasExtensions(getExpectedExternalFormatExtensions(), ExternalFormatExtension.class);
     }
 
-    private <T> void assertHasExtensions(Iterable<? extends Class<? extends T>> expectedExtensionClasses, Class<T> extensionClass, boolean failOnAdditional)
+    @Test
+    public void testCodeRepositories()
     {
-
-        assertHasExtensions(Lists.mutable.withAll(ServiceLoader.load(extensionClass)), expectedExtensionClasses, extensionClass, failOnAdditional);
+        Assert.assertEquals(Lists.mutable.withAll(getExpectedCodeRepositories()).sortThis(), CodeRepositoryProviderHelper.findCodeRepositories().collect(CodeRepository::getName, Lists.mutable.empty()).sortThis());
     }
 
-    private <T> void assertHasExtensions(List<T> availableClasses, Iterable<? extends Class<? extends T>> expectedExtensionClasses, Class<T> extensionClass, boolean failOnAdditional)
+    @Test
+    public void testMetadataSpecifications()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Iterable<String> expectedRepos = getExpectedCodeRepositories();
+
+        MutableSet<String> allSpecNames = Iterate.collect(DistributedMetadataSpecification.loadAllSpecifications(classLoader), DistributedMetadataSpecification::getName, Sets.mutable.empty());
+        Assert.assertEquals(Lists.fixedSize.empty(), Iterate.reject(expectedRepos, allSpecNames::contains, Lists.mutable.empty()));
+
+        MutableSet<String> specNames = Iterate.collect(DistributedMetadataSpecification.loadSpecifications(classLoader, expectedRepos), DistributedMetadataSpecification::getName, Sets.mutable.empty());
+        Assert.assertEquals(Sets.mutable.withAll(expectedRepos).with("platform"), specNames);
+    }
+
+    @Test
+    public void testMetadataDeserializer()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        DistributedBinaryGraphDeserializer deserializer = DistributedBinaryGraphDeserializer.newBuilder(classLoader).withMetadataNames(getExpectedCodeRepositories()).build();
+
+        Assert.assertTrue(deserializer.hasClassifier("meta::pure::metamodel::type::Class"));
+        Assert.assertTrue(deserializer.hasInstance("meta::pure::metamodel::type::Class", "Root::meta::pure::metamodel::type::Class"));
+
+        MutableSet<String> expectedClassifiers = Iterate.flatCollect(PureProtocolExtensionLoader.extensions(), ext -> ext.getExtraProtocolToClassifierPathMap().values(), Sets.mutable.empty());
+        Assert.assertEquals(
+                Lists.fixedSize.empty(),
+                expectedClassifiers.reject(cl -> deserializer.hasInstance("meta::pure::metamodel::type::Class", "Root::" + cl), Lists.mutable.empty()));
+    }
+
+    @Test
+    public void testMetadata()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        MetadataLazy metadataLazy = MetadataLazy.fromClassLoader(classLoader, getExpectedCodeRepositories());
+        MutableSet<String> expectedClassifiers = Iterate.flatCollect(PureProtocolExtensionLoader.extensions(), ext -> ext.getExtraProtocolToClassifierPathMap().values(), Sets.mutable.empty());
+        Assert.assertEquals(
+                Lists.fixedSize.empty(),
+                expectedClassifiers.select(cl ->
+                {
+                    try
+                    {
+                        return metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "Root::" + cl) == null;
+                    }
+                    catch (DistributedBinaryGraphDeserializer.UnknownInstanceException ignore)
+                    {
+                        return true;
+                    }
+                }, Lists.mutable.empty()));
+    }
+
+    @Test
+    public void testPureModel()
+    {
+        PureModel pureModel = new PureModel(PureModelContextData.newPureModelContextData(), Lists.immutable.empty(), DeploymentMode.PROD);
+        MutableSet<String> expectedClassifiers = Iterate.flatCollect(PureProtocolExtensionLoader.extensions(), ext -> ext.getExtraProtocolToClassifierPathMap().values(), Sets.mutable.empty());
+        Assert.assertEquals(
+                Lists.fixedSize.empty(),
+                expectedClassifiers.select(cl ->
+                {
+                    try
+                    {
+                        return pureModel.getClass(cl) == null;
+                    }
+                    catch (EngineException e)
+                    {
+                        String cantFindMessage = "Can't find class '" + cl + "'";
+                        if (cantFindMessage.equals(e.getMessage()))
+                        {
+                            return true;
+                        }
+                        throw e;
+                    }
+                }, Lists.mutable.empty()));
+    }
+
+    protected <T> void assertHasExtensions(Iterable<? extends Class<? extends T>> expectedExtensionClasses, Class<T> extensionClass)
+    {
+        assertHasExtensions(Lists.mutable.withAll(ServiceLoader.load(extensionClass)), expectedExtensionClasses, extensionClass);
+    }
+
+    protected <T> void assertHasExtensions(Iterable<? extends T> availableClasses, Iterable<? extends Class<? extends T>> expectedExtensionClasses, Class<T> extensionClass)
     {
         MutableSet<Class<? extends T>> missingClasses = Sets.mutable.withAll(expectedExtensionClasses);
         MutableList<Class<?>> unexpectedClasses = Lists.mutable.empty();
@@ -131,10 +172,101 @@ public class TestExtensions
             }
         });
         Assert.assertEquals("Missing extensions for " + extensionClass.getName(), Collections.emptySet(), missingClasses);
-        if (failOnAdditional)
-        {
-            Assert.assertEquals("Unexpected extensions for " + extensionClass.getName(), Collections.emptyList(), unexpectedClasses);
-        }
+        Assert.assertEquals("Unexpected extensions for " + extensionClass.getName(), Collections.emptyList(), unexpectedClasses);
     }
 
+    protected Iterable<? extends Class<? extends PureProtocolExtension>> getExpectedPureProtocolExtensions()
+    {
+        // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
+        return Lists.mutable.<Class<? extends PureProtocolExtension>>empty()
+                .with(org.finos.legend.engine.protocol.pure.v1.CorePureProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.DataSpaceProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.DiagramProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.GenerationProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.PersistenceProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.RelationalProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.ServiceProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.ServiceStoreProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.TextProtocolExtension.class)
+                .with(org.finos.legend.engine.external.shared.ExternalFormatProtocolExtension.class)
+                .with(org.finos.legend.engine.external.format.flatdata.FlatDataProtocolExtension.class)
+                .with(org.finos.legend.engine.external.format.json.JsonProtocolExtension.class)
+                .with(org.finos.legend.engine.external.format.xml.XmlProtocolExtension.class);
+    }
+
+    protected Iterable<? extends Class<? extends GenerationExtension>> getExpectedGenerationExtensions()
+    {
+        // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
+        return Lists.mutable.<Class<? extends GenerationExtension>>empty()
+                .with(org.finos.legend.engine.external.format.protobuf.deprecated.generation.ProtobufGenerationExtension.class)
+                .with(org.finos.legend.engine.external.format.avro.extension.AvroGenerationExtension.class)
+                .with(org.finos.legend.engine.external.format.jsonSchema.extension.JSONSchemaGenerationExtension.class)
+                .with(org.finos.legend.engine.external.format.rosetta.extension.RosettaGenerationExtension.class)
+                .with(org.finos.legend.engine.external.language.morphir.extension.MorphirGenerationExtension.class);
+    }
+
+    protected Iterable<? extends Class<? extends PureGrammarParserExtension>> getExpectedGrammarParserExtensions()
+    {
+        // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
+        return Lists.mutable.<Class<? extends PureGrammarParserExtension>>empty()
+                .with(org.finos.legend.engine.language.pure.grammar.from.CorePureGrammarParser.class)
+                .with(org.finos.legend.engine.language.pure.dsl.dataSpace.grammar.from.DataSpaceParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.diagram.grammar.from.DiagramParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.from.ExternalFormatConnectionGrammarParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.from.ExternalFormatGrammarParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.generation.grammar.from.GenerationParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.persistence.grammar.from.PersistenceParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.from.RelationalGrammarParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.service.grammar.from.ServiceParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.from.ServiceStoreGrammarParserExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.text.grammar.from.TextParserExtension.class);
+    }
+
+    protected Iterable<? extends Class<? extends PureGrammarComposerExtension>> getExpectedGrammarComposerExtensions()
+    {
+        // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
+        return Lists.mutable.<Class<? extends PureGrammarComposerExtension>>empty()
+                .with(org.finos.legend.engine.language.pure.grammar.to.CorePureGrammarComposer.class)
+                .with(org.finos.legend.engine.language.pure.dsl.dataSpace.grammar.to.DataSpaceGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.diagram.grammar.to.DiagramGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.to.ExternalFormatGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.generation.grammar.to.GenerationGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.persistence.grammar.to.PersistenceGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.to.RelationalGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.service.grammar.to.ServiceGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.to.ServiceStoreGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.dsl.text.grammar.to.TextGrammarComposerExtension.class);
+    }
+
+    protected Iterable<? extends Class<? extends PlanGeneratorExtension>> getExpectedPlanGeneratorExtensions()
+    {
+        // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
+        return Lists.mutable.<Class<? extends PlanGeneratorExtension>>empty()
+                .with(org.finos.legend.engine.plan.generation.extension.LegendPlanGeneratorExtension.class);
+    }
+
+    protected Iterable<? extends Class<? extends ExternalFormatExtension<?, ?, ?>>> getExpectedExternalFormatExtensions()
+    {
+        // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
+        return Lists.mutable.<Class<? extends ExternalFormatExtension<?, ?, ?>>>empty()
+                .with(org.finos.legend.engine.external.format.flatdata.FlatDataExternalFormatExtension.class)
+                .with(org.finos.legend.engine.external.format.json.JsonExternalFormatExtension.class)
+                .with(org.finos.legend.engine.external.format.xsd.XsdExternalFormatExtension.class)
+                .with(org.finos.legend.engine.external.format.protobuf.ProtobufFormatExtension.class);
+    }
+
+    protected Iterable<String> getExpectedCodeRepositories()
+    {
+        // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
+        return Lists.mutable.<String>empty()
+                .with("core")
+                .with("core_external_format_flatdata")
+                .with("core_external_format_json")
+                .with("core_external_format_protobuf")
+                .with("core_external_format_xml")
+                .with("core_external_shared")
+                .with("core_persistence")
+                .with("core_relational")
+                .with("core_servicestore");
+    }
 }

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ExternalFormatConnectionGrammarParserExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/from/ExternalFormatConnectionGrammarParserExtension.java
@@ -68,13 +68,11 @@ public class ExternalFormatConnectionGrammarParserExtension implements IExternal
         {
             ExternalSourceSpecificationParseTreeWalker walker = new ExternalSourceSpecificationParseTreeWalker();
 
-            switch (code.getType())
+            if ("UrlStream".equals(code.getType()))
             {
-                case "UrlStream":
-                    return parseDataSourceSpecification(code, p -> walker.visitUrlStreamExternalSourceSpecification(code, p.urlStreamExternalSourceSpecification()));
-                default:
-                    return null;
+                return parseDataSourceSpecification(code, p -> walker.visitUrlStreamExternalSourceSpecification(code, p.urlStreamExternalSourceSpecification()));
             }
+            return null;
         });
     }
 

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/to/ExternalFormatGrammarComposerExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/grammar/to/ExternalFormatGrammarComposerExtension.java
@@ -17,8 +17,10 @@ package org.finos.legend.engine.language.pure.grammar.to;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.grammar.from.ExternalFormatGrammarParserExtension;
@@ -33,52 +35,38 @@ import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shar
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.ExternalSource;
 import org.finos.legend.engine.protocol.pure.v1.packageableElement.external.shared.UrlStreamExternalSource;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.convertString;
-import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.getTabString;
 
 public class ExternalFormatGrammarComposerExtension implements IExternalFormatGrammarComposerExtension
 {
     @Override
     public List<Function3<List<PackageableElement>, PureGrammarComposerContext, String, String>> getExtraSectionComposers()
     {
-        return Lists.mutable.with((elements, context, sectionName) ->
-        {
-            if (!ExternalFormatGrammarParserExtension.NAME.equals(sectionName))
-            {
-                return null;
-            }
-            return ListIterate.collect(elements, ExternalFormatGrammarComposerExtension::renderElement).makeString("\n\n");
-        });
+        return Collections.singletonList((elements, context, sectionName) -> ExternalFormatGrammarParserExtension.NAME.equals(sectionName)
+                ? LazyIterate.collect(elements, ExternalFormatGrammarComposerExtension::renderElement).makeString("\n\n")
+                : null);
     }
 
     @Override
     public List<Function3<List<PackageableElement>, PureGrammarComposerContext, List<String>, PureGrammarComposerExtension.PureFreeSectionGrammarComposerResult>> getExtraFreeSectionComposers()
     {
-        return org.eclipse.collections.impl.factory.Lists.mutable.with((elements, context, composedSections) ->
+        return Collections.singletonList((elements, context, composedSections) ->
         {
-            List<PackageableElement> composableElements = ListIterate.selectInstancesOf(elements, ExternalFormatSchemaSet.class)
-                    .collect(PackageableElement.class::cast)
-                    .withAll(ListIterate.selectInstancesOf(elements, Binding.class));
+            MutableList<PackageableElement> composableElements = Iterate.select(elements, e -> (e instanceof ExternalFormatSchemaSet) || (e instanceof Binding), Lists.mutable.empty());
             return composableElements.isEmpty()
                     ? null
-                    : new PureFreeSectionGrammarComposerResult(LazyIterate.collect(composableElements, ExternalFormatGrammarComposerExtension::renderElement).makeString("###" + ExternalFormatGrammarParserExtension.NAME + "\n", "\n\n", ""), composableElements);
+                    : new PureFreeSectionGrammarComposerResult(composableElements.asLazy().collect(ExternalFormatGrammarComposerExtension::renderElement).makeString("###" + ExternalFormatGrammarParserExtension.NAME + "\n", "\n\n", ""), composableElements);
         });
     }
 
     @Override
     public List<Function2<Connection, PureGrammarComposerContext, Pair<String, String>>> getExtraConnectionValueComposers()
     {
-        return Lists.mutable.with((connectionValue, context) ->
-        {
-            if (connectionValue instanceof ExternalFormatConnection)
-            {
-                return renderExternalFormatConnection((ExternalFormatConnection) connectionValue, context);
-            }
-            return null;
-        });
+        return Collections.singletonList((connectionValue, context) -> (connectionValue instanceof ExternalFormatConnection)
+                ? renderExternalFormatConnection((ExternalFormatConnection) connectionValue, context)
+                : null);
     }
 
     private Pair<String, String> renderExternalFormatConnection(ExternalFormatConnection connection, PureGrammarComposerContext context)
@@ -92,28 +80,25 @@ public class ExternalFormatGrammarComposerExtension implements IExternalFormatGr
         return Tuples.pair(
                 ExternalFormatGrammarParserExtension.EXTERNAL_FORMAT_CONNECTION_TYPE,
                 context.getIndentationString() + "{\n" +
-                        (connection.element == null ? "" : context.getIndentationString() + getTabString(1) + "store: " + connection.element + ";\n") +
-                        context.getIndentationString() + getTabString(1) + "source: " + specification + ";\n" +
+                        (connection.element == null ? "" : context.getIndentationString() + PureGrammarComposerUtility.getTabString(1) + "store: " + connection.element + ";\n") +
+                        context.getIndentationString() + PureGrammarComposerUtility.getTabString(1) + "source: " + specification + ";\n" +
                         context.getIndentationString() + "}");
     }
 
     @Override
     public List<Function2<ExternalSource, PureGrammarComposerContext, String>> getExtraExternalSourceSpecificationComposers()
     {
-        return Lists.mutable.with((specification, context) ->
-        {
-            if (specification instanceof UrlStreamExternalSource)
-            {
-                UrlStreamExternalSource spec = (UrlStreamExternalSource) specification;
-                int baseIndentation = 1;
-                return "UrlStream\n" +
-                        context.getIndentationString() + getTabString(1) + "{\n" +
-                        context.getIndentationString() + getTabString(2) + "url: " + convertString(spec.url, true) + ";\n" +
-                        context.getIndentationString() + getTabString(1) + "}";
-            }
+        return Collections.singletonList((specification, context) -> (specification instanceof UrlStreamExternalSource)
+                ? composeUrlStreamExternalSource((UrlStreamExternalSource) specification, context)
+                : null);
+    }
 
-            return null;
-        });
+    private String composeUrlStreamExternalSource(UrlStreamExternalSource spec, PureGrammarComposerContext context)
+    {
+        return "UrlStream\n" +
+                context.getIndentationString() + PureGrammarComposerUtility.getTabString(1) + "{\n" +
+                context.getIndentationString() + PureGrammarComposerUtility.getTabString(2) + "url: " + PureGrammarComposerUtility.convertString(spec.url, true) + ";\n" +
+                context.getIndentationString() + PureGrammarComposerUtility.getTabString(1) + "}";
     }
 
     private static String renderElement(PackageableElement element)
@@ -122,7 +107,7 @@ public class ExternalFormatGrammarComposerExtension implements IExternalFormatGr
         {
             return renderSchemaSet((ExternalFormatSchemaSet) element);
         }
-        else if (element instanceof Binding)
+        if (element instanceof Binding)
         {
             return renderSchemaBinding((Binding) element);
         }

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
@@ -15,8 +15,7 @@
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.UserDefinedFunctionHandler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.inference.TypeAndMultiplicity;
@@ -44,6 +43,8 @@ import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_Tag_Im
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_TaggedValue_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_function_ConcreteFunctionDefinition_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relationship_Association_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_section_SectionIndex;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_section_SectionIndex_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enum_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl;
@@ -151,6 +152,7 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
         return res;
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public PackageableElement visit(Association srcAssociation)
     {
@@ -199,7 +201,7 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
         ctx.flushVariable("this");
         return association._name(srcAssociation.name)
                 ._originalMilestonedProperties(ListIterate.collect(srcAssociation.originalMilestonedProperties, HelperModelBuilder.processProperty(this.context, this.context.pureModel.getGenericTypeFromIndex(srcAssociation.properties.get(0).type), association)))
-                ._properties(FastList.newListWith(property1, property2))
+                ._properties(Lists.mutable.with(property1, property2))
                 ._qualifiedProperties(qualifiedProperties)
                 ._stereotypes(ListIterate.collect(srcAssociation.stereotypes, s -> this.context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
                 ._taggedValues(ListIterate.collect(srcAssociation.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("")._tag(this.context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.sourceInformation))._value(t.value)))
@@ -297,19 +299,18 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     @Override
     public PackageableElement visit(SectionIndex sectionIndex)
     {
-        // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
         org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(sectionIndex._package);
-        PackageableElement stub = new Root_meta_pure_metamodel_PackageableElement_Impl("")._package(pack)._name(sectionIndex.name);
+        Root_meta_pure_metamodel_section_SectionIndex stub = new Root_meta_pure_metamodel_section_SectionIndex_Impl("")._package(pack)._name(sectionIndex.name);
         pack._childrenAdd(stub);
         // NOTE: we don't really need to add section index to the PURE graph
-        ListIterate.forEach(sectionIndex.sections, section -> ListIterate.forEach(section.elements, elementPath -> this.context.pureModel.sectionsIndex.putIfAbsent(elementPath, section)));
+        sectionIndex.sections.forEach(section -> section.elements.forEach(elementPath -> this.context.pureModel.sectionsIndex.putIfAbsent(elementPath, section)));
         return stub;
     }
 
     @Override
     public PackageableElement visit(DataElement dataElement)
     {
-        final Root_meta_pure_data_DataElement compiled = new Root_meta_pure_data_DataElement_Impl(dataElement.name);
+        Root_meta_pure_data_DataElement compiled = new Root_meta_pure_data_DataElement_Impl(dataElement.name);
         GenericType mappingGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("")._rawType(this.context.pureModel.getType("meta::pure::data::DataElement"));
         org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(dataElement._package);
         compiled._name(dataElement.name)

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFourthPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFourthPassBuilder.java
@@ -99,7 +99,7 @@ public class PackageableElementFourthPassBuilder implements PackageableElementVi
                 throw new EngineException(e.getMessage(), property.sourceInformation, EngineErrorType.COMPILATION);
             }
             ctx.flushVariable("this");
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty<?> prop = targetClass._qualifiedProperties().select(o -> HelperModelBuilder.isCompatibleDerivedProperty(o, property)).getFirst();
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty<?> prop = targetClass._qualifiedProperties().detect(o -> HelperModelBuilder.isCompatibleDerivedProperty(o, property));
             HelperModelBuilder.checkCompatibility(this.context, body.getLast()._genericType()._rawType(), body.getLast()._multiplicity(), prop._genericType()._rawType(), prop._multiplicity(), "Error in derived property '" + srcClass.name + "." + property.name + "'", property.body.get(property.body.size() - 1).sourceInformation);
             ctx.pop();
             return prop._expressionSequence(body);

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
@@ -80,6 +80,7 @@ public class PackageableElementSecondPassBuilder implements PackageableElementVi
         return null;
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public PackageableElement visit(Class srcClass)
     {
@@ -136,8 +137,8 @@ public class PackageableElementSecondPassBuilder implements PackageableElementVi
 
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association association = this.context.pureModel.getAssociation(this.context.pureModel.buildPackageString(srcAssociation._package, srcAssociation.name), srcAssociation.sourceInformation);
 
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class class1 = this.context.resolveClass(property0Ref, srcAssociation.properties.get(0).sourceInformation);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class class2 = this.context.resolveClass(property1Ref, srcAssociation.properties.get(1).sourceInformation);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> class1 = this.context.resolveClass(property0Ref, srcAssociation.properties.get(0).sourceInformation);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> class2 = this.context.resolveClass(property1Ref, srcAssociation.properties.get(1).sourceInformation);
 
         MutableList<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?>> properties = association._properties().toList();
         MutableList<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?>> originalMilestonedProperties = association._originalMilestonedProperties().toList();

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementThirdPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementThirdPassBuilder.java
@@ -88,7 +88,7 @@ public class PackageableElementThirdPassBuilder implements PackageableElementVis
             ctx.push("Qualified Property " + property.name);
             ListIterate.collect(property.parameters, expression -> expression.accept(new ValueSpecificationBuilder(this.context, Lists.mutable.empty(), ctx)));
             MutableList<ValueSpecification> body = ListIterate.collect(property.body, expression -> expression.accept(new ValueSpecificationBuilder(this.context, Lists.mutable.empty(), ctx)));
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty prop = association._qualifiedProperties().select(o -> o._name().equals(property.name)).getFirst();
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty<?> prop = association._qualifiedProperties().detect(o -> o._name().equals(property.name));
             ctx.pop();
             ctx.flushVariable("this");
             return prop._expressionSequence(body);

--- a/legend-engine-language-pure-dsl-data-space/pom.xml
+++ b/legend-engine-language-pure-dsl-data-space/pom.xml
@@ -105,6 +105,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- ANTLR -->

--- a/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/compiler/toPureGraph/DataSpaceCompilerExtension.java
+++ b/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/compiler/toPureGraph/DataSpaceCompilerExtension.java
@@ -14,27 +14,26 @@
 
 package org.finos.legend.engine.language.pure.dsl.dataSpace.compiler.toPureGraph;
 
+import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpace;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
-import org.finos.legend.pure.generated.Root_meta_pure_metamodel_PackageableElement_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpace_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_TaggedValue_Impl;
 
 import java.util.Collections;
-import java.util.List;
 
 public class DataSpaceCompilerExtension implements CompilerExtension
 {
     @Override
     public Iterable<? extends Processor<?>> getExtraProcessors()
     {
-        // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
         return Collections.singletonList(Processor.newProcessor(
                 DataSpace.class,
-                (dataSpace, context) -> new Root_meta_pure_metamodel_PackageableElement_Impl("")
+                (dataSpace, context) -> new Root_meta_pure_metamodel_dataSpace_DataSpace_Impl("")
                         ._stereotypes(ListIterate.collect(dataSpace.stereotypes, s -> context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
                         ._taggedValues(ListIterate.collect(dataSpace.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("")._tag(context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value))),
                 (dataSpace, context) ->
@@ -43,8 +42,7 @@ public class DataSpaceCompilerExtension implements CompilerExtension
                     {
                         throw new EngineException("Data space must have at least one execution context", dataSpace.sourceInformation, EngineErrorType.COMPILATION);
                     }
-                    List<String> executionContextNames = ListIterate.collect(dataSpace.executionContexts, executionContext -> executionContext.name).distinct();
-                    if (!executionContextNames.contains(dataSpace.defaultExecutionContext))
+                    if ((dataSpace.defaultExecutionContext != null) && Iterate.noneSatisfy(dataSpace.executionContexts, c -> dataSpace.defaultExecutionContext.equals(c.name)))
                     {
                         throw new EngineException("Default execution context does not match any existing execution contexts", dataSpace.sourceInformation, EngineErrorType.COMPILATION);
                     }

--- a/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/grammar/to/DataSpaceGrammarComposerExtension.java
+++ b/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/language/pure/dsl/dataSpace/grammar/to/DataSpaceGrammarComposerExtension.java
@@ -15,7 +15,7 @@
 package org.finos.legend.engine.language.pure.dsl.dataSpace.grammar.to;
 
 import org.eclipse.collections.api.block.function.Function3;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.dsl.dataSpace.grammar.from.DataSpaceParserExtension;
@@ -39,7 +39,7 @@ public class DataSpaceGrammarComposerExtension implements PureGrammarComposerExt
     @Override
     public List<Function3<List<PackageableElement>, PureGrammarComposerContext, String, String>> getExtraSectionComposers()
     {
-        return Lists.mutable.with((elements, context, sectionName) ->
+        return Lists.fixedSize.with((elements, context, sectionName) ->
         {
             if (!DataSpaceParserExtension.NAME.equals(sectionName))
             {
@@ -59,7 +59,7 @@ public class DataSpaceGrammarComposerExtension implements PureGrammarComposerExt
     @Override
     public List<Function3<List<PackageableElement>, PureGrammarComposerContext, List<String>, PureFreeSectionGrammarComposerResult>> getExtraFreeSectionComposers()
     {
-        return Lists.mutable.with((elements, context, composedSections) ->
+        return Lists.fixedSize.with((elements, context, composedSections) ->
         {
             List<DataSpace> composableElements = ListIterate.selectInstancesOf(elements, DataSpace.class);
             return composableElements.isEmpty() ? null : new PureFreeSectionGrammarComposerResult(LazyIterate.collect(composableElements, DataSpaceGrammarComposerExtension::renderDataSpace).makeString("###" + DataSpaceParserExtension.NAME + "\n", "\n\n", ""), composableElements);

--- a/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/protocol/pure/v1/DataSpaceProtocolExtension.java
+++ b/legend-engine-language-pure-dsl-data-space/src/main/java/org/finos/legend/engine/protocol/pure/v1/DataSpaceProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
@@ -32,12 +30,10 @@ public class DataSpaceProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(DataSpace.class, "dataSpace")
-                        )).build()
+        return Lists.fixedSize.with(() -> Lists.mutable.with(
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(DataSpace.class, "dataSpace")
+                        .build()
         ));
     }
 

--- a/legend-engine-language-pure-dsl-diagram/pom.xml
+++ b/legend-engine-language-pure-dsl-diagram/pom.xml
@@ -78,10 +78,6 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
-        </dependency>
         <!-- PURE -->
 
         <!-- ENGINE -->
@@ -104,6 +100,10 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
         </dependency>
         <!-- ENGINE -->
 

--- a/legend-engine-language-pure-dsl-diagram/src/main/java/org/finos/legend/engine/language/pure/dsl/diagram/compiler/toPureGraph/DiagramCompilerExtension.java
+++ b/legend-engine-language-pure-dsl-diagram/src/main/java/org/finos/legend/engine/language/pure/dsl/diagram/compiler/toPureGraph/DiagramCompilerExtension.java
@@ -17,7 +17,7 @@ package org.finos.legend.engine.language.pure.dsl.diagram.compiler.toPureGraph;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.diagram.Diagram;
-import org.finos.legend.pure.generated.Root_meta_pure_metamodel_PackageableElement_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_diagram_Diagram_Impl;
 
 import java.util.Collections;
 
@@ -26,11 +26,7 @@ public class DiagramCompilerExtension implements CompilerExtension
     @Override
     public Iterable<? extends Processor<?>> getExtraProcessors()
     {
-        return Collections.singletonList(Processor.newProcessor(Diagram.class, (diagram, context) ->
-                {
-                    // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
-                    return new Root_meta_pure_metamodel_PackageableElement_Impl("");
-                },
+        return Collections.singletonList(Processor.newProcessor(Diagram.class, (diagram, context) -> new Root_meta_pure_metamodel_diagram_Diagram_Impl(""),
                 (diagram, context) ->
                 {
                     diagram.classViews.forEach(view -> HelperDiagramBuilder.processClassView(view, context));

--- a/legend-engine-language-pure-dsl-diagram/src/main/java/org/finos/legend/engine/language/pure/dsl/diagram/grammar/from/DiagramParserExtension.java
+++ b/legend-engine-language-pure-dsl-diagram/src/main/java/org/finos/legend/engine/language/pure/dsl/diagram/grammar/from/DiagramParserExtension.java
@@ -17,7 +17,7 @@ package org.finos.legend.engine.language.pure.dsl.diagram.grammar.from;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.grammar.from.ParserErrorListener;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserContext;
 import org.finos.legend.engine.language.pure.grammar.from.SectionSourceCode;

--- a/legend-engine-language-pure-dsl-diagram/src/main/java/org/finos/legend/engine/protocol/pure/v1/DiagramProtocolExtension.java
+++ b/legend-engine-language-pure-dsl-diagram/src/main/java/org/finos/legend/engine/protocol/pure/v1/DiagramProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
@@ -32,12 +30,10 @@ public class DiagramProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(Diagram.class, "diagram")
-                        )).build()
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(Diagram.class, "diagram")
+                        .build()
         ));
     }
 

--- a/legend-engine-language-pure-dsl-generation/src/main/java/org/finos/legend/engine/protocol/pure/v1/GenerationProtocolExtension.java
+++ b/legend-engine-language-pure-dsl-generation/src/main/java/org/finos/legend/engine/protocol/pure/v1/GenerationProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
@@ -33,13 +31,11 @@ public class GenerationProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(GenerationSpecification.class, "generationSpecification"),
-                                Tuples.pair(FileGenerationSpecification.class, "fileGeneration")
-                        )).build()
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(GenerationSpecification.class, "generationSpecification")
+                        .withSubtype(FileGenerationSpecification.class, "fileGeneration")
+                        .build()
         ));
     }
 

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/ServiceProtocolExtension.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/ServiceProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
@@ -44,36 +42,26 @@ public class ServiceProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(Service.class, "service")
-                        )).build(),
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(Execution.class)
+        return Lists.fixedSize.with(() -> Lists.mutable.with(
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(Service.class, "service")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(Execution.class)
                         .withDefaultSubType(PureSingleExecution.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(PureSingleExecution.class, "pureSingleExecution"),
-                                Tuples.pair(PureMultiExecution.class, "pureMultiExecution")
-                        )).build(),
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ServiceTest_Legacy.class)
+                        .withSubtype(PureSingleExecution.class, "pureSingleExecution")
+                        .withSubtype(PureMultiExecution.class, "pureMultiExecution")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(ServiceTest_Legacy.class)
                         .withDefaultSubType(SingleExecutionTest.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(SingleExecutionTest.class, "singleExecutionTest"),
-                                Tuples.pair(MultiExecutionTest.class, "multiExecutionTest")
-                        )).build(),
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(TestSuite.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ServiceTestSuite.class, "serviceTestSuite")
-                        )).build(),
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(Test.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ServiceTest.class, "serviceTest")
-                        )).build()
+                        .withSubtype(SingleExecutionTest.class, "singleExecutionTest")
+                        .withSubtype(MultiExecutionTest.class, "multiExecutionTest")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(TestSuite.class)
+                        .withSubtype(ServiceTestSuite.class, "serviceTestSuite")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(Test.class)
+                        .withSubtype(ServiceTest.class, "serviceTest")
+                        .build()
         ));
     }
 

--- a/legend-engine-language-pure-dsl-text/pom.xml
+++ b/legend-engine-language-pure-dsl-text/pom.xml
@@ -78,10 +78,6 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
-        </dependency>
         <!-- PURE -->
 
         <!-- ENGINE -->
@@ -100,6 +96,10 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
         </dependency>
         <!-- ENGINE -->
 

--- a/legend-engine-language-pure-dsl-text/src/main/java/org/finos/legend/engine/language/pure/dsl/text/compiler/toPureGraph/TextCompilerExtension.java
+++ b/legend-engine-language-pure-dsl-text/src/main/java/org/finos/legend/engine/language/pure/dsl/text/compiler/toPureGraph/TextCompilerExtension.java
@@ -17,7 +17,7 @@ package org.finos.legend.engine.language.pure.dsl.text.compiler.toPureGraph;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.text.Text;
-import org.finos.legend.pure.generated.Root_meta_pure_metamodel_PackageableElement_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_text_Text_Impl;
 
 import java.util.Collections;
 
@@ -26,7 +26,6 @@ public class TextCompilerExtension implements CompilerExtension
     @Override
     public Iterable<? extends Processor<?>> getExtraProcessors()
     {
-        // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
-        return Collections.singletonList(Processor.newProcessor(Text.class, (text, context) -> new Root_meta_pure_metamodel_PackageableElement_Impl("")));
+        return Collections.singletonList(Processor.newProcessor(Text.class, (text, context) -> new Root_meta_pure_metamodel_text_Text_Impl("")._type(text.type)._content(text.content)));
     }
 }

--- a/legend-engine-language-pure-dsl-text/src/main/java/org/finos/legend/engine/protocol/pure/v1/TextProtocolExtension.java
+++ b/legend-engine-language-pure-dsl-text/src/main/java/org/finos/legend/engine/protocol/pure/v1/TextProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
@@ -32,12 +30,10 @@ public class TextProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(Text.class, "text")
-                        )).build()
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(Text.class, "text")
+                        .build()
         ));
     }
 

--- a/legend-engine-protocol-external-shared-format/pom.xml
+++ b/legend-engine-protocol-external-shared-format/pom.xml
@@ -43,10 +43,6 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.collections</groupId>
-            <artifactId>eclipse-collections</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- JACKSON -->

--- a/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/external/shared/ExternalFormatProtocolExtension.java
+++ b/legend-engine-protocol-external-shared-format/src/main/java/org/finos/legend/engine/external/shared/ExternalFormatProtocolExtension.java
@@ -16,8 +16,6 @@ package org.finos.legend.engine.external.shared;
 
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNode;
@@ -38,27 +36,21 @@ public class ExternalFormatProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder.newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ExternalFormatSchemaSet.class, "externalFormatSchemaSet"),
-                                Tuples.pair(Binding.class, "binding")
-                        )).build(),
-                ProtocolSubTypeInfo.Builder.newInstance(Connection.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ExternalFormatConnection.class, "ExternalFormatConnection")
-                        )).build(),
-
-                ProtocolSubTypeInfo.Builder.newInstance(ExternalSource.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(UrlStreamExternalSource.class, "urlStream")
-                        )).build(),
-                ProtocolSubTypeInfo.Builder.newInstance(ExecutionNode.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(DataQualityExecutionNode.class, "dataQuality"),
-                                Tuples.pair(UrlStreamExecutionNode.class, "urlStream")
-                        )).build()
-
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(ExternalFormatSchemaSet.class, "externalFormatSchemaSet")
+                        .withSubtype(Binding.class, "binding")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(Connection.class)
+                        .withSubtype(ExternalFormatConnection.class, "ExternalFormatConnection")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(ExternalSource.class)
+                        .withSubtype(UrlStreamExternalSource.class, "urlStream")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(ExecutionNode.class)
+                        .withSubtype(DataQualityExecutionNode.class, "dataQuality")
+                        .withSubtype(UrlStreamExecutionNode.class, "urlStream")
+                        .build()
         ));
     }
 }

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/CorePureProtocolExtension.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/CorePureProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.data.DataElementReference;
@@ -54,47 +52,35 @@ public class CorePureProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(SectionIndex.class, "sectionIndex"),
-                                // Domain
-                                Tuples.pair(Profile.class, "profile"),
-                                Tuples.pair(Enumeration.class, "Enumeration"),
-                                Tuples.pair(Class.class, "class"),
-                                Tuples.pair(Association.class, "association"),
-                                Tuples.pair(Function.class, "function"),
-                                Tuples.pair(Measure.class, "measure"),
-                                Tuples.pair(Unit.class, "unit")
-                        ))
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(SectionIndex.class, "sectionIndex")
+                        // Domain
+                        .withSubtype(Profile.class, "profile")
+                        .withSubtype(Enumeration.class, "Enumeration")
+                        .withSubtype(Class.class, "class")
+                        .withSubtype(Association.class, "association")
+                        .withSubtype(Function.class, "function")
+                        .withSubtype(Measure.class, "measure")
+                        .withSubtype(Unit.class, "unit")
                         .build(),
                 // Runtime
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(Runtime.class)
+                ProtocolSubTypeInfo.newBuilder(Runtime.class)
                         .withDefaultSubType(LegacyRuntime.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(LegacyRuntime.class, "legacyRuntime"),
-                                Tuples.pair(EngineRuntime.class, "engineRuntime"),
-                                Tuples.pair(RuntimePointer.class, "runtimePointer")
-                        ))
+                        .withSubtype(LegacyRuntime.class, "legacyRuntime")
+                        .withSubtype(EngineRuntime.class, "engineRuntime")
+                        .withSubtype(RuntimePointer.class, "runtimePointer")
                         .build(),
                 // Embedded Data
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(EmbeddedData.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ExternalFormatData.class, "externalFormat"),
-                                Tuples.pair(ModelStoreData.class, "modelStore"),
-                                Tuples.pair(DataElementReference.class, "reference")
-                        ))
+                ProtocolSubTypeInfo.newBuilder(EmbeddedData.class)
+                        .withSubtype(ExternalFormatData.class, "externalFormat")
+                        .withSubtype(ModelStoreData.class, "modelStore")
+                        .withSubtype(DataElementReference.class, "reference")
                         .build(),
                 // Test Assertion
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(TestAssertion.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(EqualTo.class, "equalTo"),
-                                Tuples.pair(EqualToJson.class, "equalToJson")
-                        ))
+                ProtocolSubTypeInfo.newBuilder(TestAssertion.class)
+                        .withSubtype(EqualTo.class, "equalTo")
+                        .withSubtype(EqualToJson.class, "equalToJson")
                         .build()
         ));
     }
@@ -102,7 +88,7 @@ public class CorePureProtocolExtension implements PureProtocolExtension
     @Override
     public Map<java.lang.Class<? extends PackageableElement>, String> getExtraProtocolToClassifierPathMap()
     {
-        return Maps.mutable.<java.lang.Class<? extends PackageableElement>, String>ofInitialCapacity(11)
+        return Maps.mutable.<java.lang.Class<? extends PackageableElement>, String>ofInitialCapacity(12)
                 .withKeyValue(Association.class, "meta::pure::metamodel::relationship::Association")
                 .withKeyValue(Class.class, "meta::pure::metamodel::type::Class")
                 .withKeyValue(Enumeration.class, "meta::pure::metamodel::type::Enumeration")
@@ -114,7 +100,6 @@ public class CorePureProtocolExtension implements PureProtocolExtension
                 .withKeyValue(Profile.class, "meta::pure::metamodel::extension::Profile")
                 .withKeyValue(SectionIndex.class, "meta::pure::metamodel::section::SectionIndex")
                 .withKeyValue(Unit.class, "meta::pure::metamodel::type::Unit")
-                .withKeyValue(DataElement.class, "meta::testable::DataElement");
+                .withKeyValue(DataElement.class, "meta::pure::data::DataElement");
     }
-
 }

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/ProtocolToClassifierPathLoader.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/ProtocolToClassifierPathLoader.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 public class ProtocolToClassifierPathLoader
 {
-
     public static Map<Class<? extends PackageableElement>, String> getProtocolClassToClassifierMap()
     {
         Map<Class<? extends PackageableElement>, String> protocolToClassifierMap = Maps.mutable.empty();
@@ -40,5 +39,4 @@ public class ProtocolToClassifierPathLoader
         }
         return protocolToClassifierMap;
     }
-
 }

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/extension/ProtocolSubTypeInfo.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/extension/ProtocolSubTypeInfo.java
@@ -15,16 +15,18 @@
 package org.finos.legend.engine.protocol.pure.v1.extension;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class ProtocolSubTypeInfo<T>
 {
     private final Class<T> superType;
     private final Class<? extends T> defaultSubType;
-    private final List<Pair<Class<? extends T>, String>> subTypes;
+    private final MutableList<Pair<Class<? extends T>, String>> subTypes;
 
     private ProtocolSubTypeInfo(ProtocolSubTypeInfo.Builder<T> builder)
     {
@@ -35,17 +37,17 @@ public class ProtocolSubTypeInfo<T>
 
     public Class<T> getSuperType()
     {
-        return superType;
+        return this.superType;
     }
 
     public Class<? extends T> getDefaultSubType()
     {
-        return defaultSubType;
+        return this.defaultSubType;
     }
 
     public List<Pair<Class<? extends T>, String>> getSubTypes()
     {
-        return subTypes;
+        return this.subTypes.asUnmodifiable();
     }
 
     public SimpleModule registerDefaultSubType()
@@ -57,11 +59,16 @@ public class ProtocolSubTypeInfo<T>
         return new SimpleModule().addAbstractTypeMapping(this.superType, this.defaultSubType);
     }
 
+    public static <T> Builder<T> newBuilder(Class<T> superType)
+    {
+        return Builder.newInstance(superType);
+    }
+
     public static class Builder<T>
     {
         private final Class<T> superType;
         private Class<? extends T> defaultSubType;
-        private List<Pair<Class<? extends T>, String>> subTypes = new ArrayList<>();
+        private final MutableList<Pair<Class<? extends T>, String>> subTypes = Lists.mutable.empty();
 
         private Builder(Class<T> superType)
         {
@@ -84,9 +91,15 @@ public class ProtocolSubTypeInfo<T>
             return this;
         }
 
-        public Builder<T> withSubtypes(List<Pair<Class<? extends T>, String>> subTypes)
+        public Builder<T> withSubtypes(Iterable<? extends Pair<Class<? extends T>, String>> subTypes)
         {
-            this.subTypes = subTypes;
+            this.subTypes.addAllIterable(subTypes);
+            return this;
+        }
+
+        public Builder<T> withSubtype(Class<? extends T> type, String name)
+        {
+            this.subTypes.add(Tuples.pair(type, name));
             return this;
         }
     }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/diagram/diagram.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/diagram/diagram.pure
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2022 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // stub
-Class meta::pure::metamodel::dataSpace::DataSpace extends PackageableElement
+Class meta::pure::metamodel::diagram::Diagram extends PackageableElement
 {
 
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/section/section.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/section/section.pure
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2022 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // stub
-Class meta::pure::metamodel::dataSpace::DataSpace extends PackageableElement
+Class meta::pure::metamodel::section::SectionIndex extends PackageableElement
 {
 
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/text/text.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/text/text.pure
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2022 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// stub
-Class meta::pure::metamodel::dataSpace::DataSpace extends PackageableElement
+Class meta::pure::metamodel::text::Text extends PackageableElement
 {
-
+    type : String[1];
+    content : String[1];
 }

--- a/legend-engine-xt-flatdata-protocol/pom.xml
+++ b/legend-engine-xt-flatdata-protocol/pom.xml
@@ -44,10 +44,6 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.collections</groupId>
-            <artifactId>eclipse-collections</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- JACKSON -->

--- a/legend-engine-xt-flatdata-protocol/src/main/java/org/finos/legend/engine/external/format/flatdata/FlatDataProtocolExtension.java
+++ b/legend-engine-xt-flatdata-protocol/src/main/java/org/finos/legend/engine/external/format/flatdata/FlatDataProtocolExtension.java
@@ -16,8 +16,6 @@ package org.finos.legend.engine.external.format.flatdata;
 
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNode;
@@ -31,12 +29,11 @@ public class FlatDataProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder.newInstance(ExecutionNode.class)
-                                           .withSubtypes(FastList.newListWith(
-                                                   Tuples.pair(FlatDataSerializeExecutionNode.class, "flatDataSerialize"),
-                                                   Tuples.pair(FlatDataDeserializeExecutionNode.class, "flatDataDeserialize")
-                                           )).build()
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(ExecutionNode.class)
+                        .withSubtype(FlatDataSerializeExecutionNode.class, "flatDataSerialize")
+                        .withSubtype(FlatDataDeserializeExecutionNode.class, "flatDataDeserialize")
+                        .build()
         ));
     }
 }

--- a/legend-engine-xt-json-protocol/pom.xml
+++ b/legend-engine-xt-json-protocol/pom.xml
@@ -45,10 +45,6 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.collections</groupId>
-            <artifactId>eclipse-collections</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- JACKSON -->

--- a/legend-engine-xt-json-protocol/src/main/java/org/finos/legend/engine/external/format/json/JsonProtocolExtension.java
+++ b/legend-engine-xt-json-protocol/src/main/java/org/finos/legend/engine/external/format/json/JsonProtocolExtension.java
@@ -16,8 +16,6 @@ package org.finos.legend.engine.external.format.json;
 
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNode;
@@ -33,16 +31,14 @@ public class JsonProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder.newInstance(ExecutionNode.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(JsonSerializeExecutionNode.class, "jsonSerialize"),
-                                Tuples.pair(JsonDeserializeExecutionNode.class, "jsonDeserialize")
-                        )).build(),
-                ProtocolSubTypeInfo.Builder.newInstance(PathReference.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(JsonPathReference.class, "json")
-                        )).build()
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(ExecutionNode.class)
+                        .withSubtype(JsonSerializeExecutionNode.class, "jsonSerialize")
+                        .withSubtype(JsonDeserializeExecutionNode.class, "jsonDeserialize")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(PathReference.class)
+                        .withSubtype(JsonPathReference.class, "json")
+                        .build()
         ));
     }
 }

--- a/legend-engine-xt-persistence-protocol/pom.xml
+++ b/legend-engine-xt-persistence-protocol/pom.xml
@@ -50,10 +50,6 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.collections</groupId>
-            <artifactId>eclipse-collections</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->

--- a/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/PersistenceProtocolExtension.java
+++ b/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/PersistenceProtocolExtension.java
@@ -17,7 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
@@ -32,9 +31,8 @@ public class PersistenceProtocolExtension implements PureProtocolExtension
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
         return Lists.fixedSize.of(() -> Lists.fixedSize.of(
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(Lists.fixedSize.of(Tuples.pair(Persistence.class, "persistence")))
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(Persistence.class, "persistence")
                         .build()
         ));
     }
@@ -42,7 +40,6 @@ public class PersistenceProtocolExtension implements PureProtocolExtension
     @Override
     public Map<Class<? extends PackageableElement>, String> getExtraProtocolToClassifierPathMap()
     {
-        return Maps.mutable.with(
-                Persistence.class, "meta::pure::persistence::metamodel::Persistence");
+        return Maps.mutable.with(Persistence.class, "meta::pure::persistence::metamodel::Persistence");
     }
 }

--- a/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/RelationalProtocolExtension.java
+++ b/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/RelationalProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.RelationResultType;
@@ -92,130 +90,101 @@ public class RelationalProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
                 // Packageable element
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(Database.class, "relational")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(Database.class, "relational")
+                        .build(),
                 // Value specification
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ValueSpecification.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(DatabaseInstance.class, "databaseInstance")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ValueSpecification.class)
+                        .withSubtype(DatabaseInstance.class, "databaseInstance")
+                        .build(),
                 // Class mapping
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ClassMapping.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RootRelationalClassMapping.class, "relational"),
-                                Tuples.pair(RelationalClassMapping.class, "embedded")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ClassMapping.class)
+                        .withSubtype(RootRelationalClassMapping.class, "relational")
+                        .withSubtype(RelationalClassMapping.class, "embedded")
+                        .build(),
                 // Mapping Test InputData
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(InputData.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RelationalInputData.class, "relational")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(InputData.class)
+                        .withSubtype(RelationalInputData.class, "relational")
+                        .build(),
                 // Association mapping
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(AssociationMapping.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RelationalAssociationMapping.class, "relational")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(AssociationMapping.class)
+                        .withSubtype(RelationalAssociationMapping.class, "relational")
+                        .build(),
                 // Property mapping
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PropertyMapping.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RelationalPropertyMapping.class, "relationalPropertyMapping"),
-                                Tuples.pair(EmbeddedRelationalPropertyMapping.class, "embeddedPropertyMapping"),
-                                Tuples.pair(InlineEmbeddedPropertyMapping.class, "inlineEmbeddedPropertyMapping"),
-                                Tuples.pair(OtherwiseEmbeddedRelationalPropertyMapping.class, "otherwiseEmbeddedPropertyMapping")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(PropertyMapping.class)
+                        .withSubtype(RelationalPropertyMapping.class, "relationalPropertyMapping")
+                        .withSubtype(EmbeddedRelationalPropertyMapping.class, "embeddedPropertyMapping")
+                        .withSubtype(InlineEmbeddedPropertyMapping.class, "inlineEmbeddedPropertyMapping")
+                        .withSubtype(OtherwiseEmbeddedRelationalPropertyMapping.class, "otherwiseEmbeddedPropertyMapping")
+                        .build(),
                 // Connection
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(Connection.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RelationalDatabaseConnection.class, "RelationalDatabaseConnection")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(Connection.class)
+                        .withSubtype(RelationalDatabaseConnection.class, "RelationalDatabaseConnection")
+                        .build(),
                 // Execution context
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ExecutionContext.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RelationalExecutionContext.class, "RelationalExecutionContext")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ExecutionContext.class)
+                        .withSubtype(RelationalExecutionContext.class, "RelationalExecutionContext")
+                        .build(),
                 // Execution plan result type
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ResultType.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RelationResultType.class, "relation")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ResultType.class)
+                        .withSubtype(RelationResultType.class, "relation")
+                        .build(),
                 // Execution plan node
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ExecutionNode.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RelationalExecutionNode.class, "relational"),
-                                Tuples.pair(RelationalTdsInstantiationExecutionNode.class, "relationalTdsInstantiation"),
-                                Tuples.pair(RelationalClassInstantiationExecutionNode.class, "relationalClassInstantiation"),
-                                Tuples.pair(RelationalRelationDataInstantiationExecutionNode.class, "relationalRelationDataInstantiation"),
-                                Tuples.pair(RelationalDataTypeInstantiationExecutionNode.class, "relationalDataTypeInstantiation"),
-                                Tuples.pair(RelationalRootGraphFetchExecutionNode.class, "relationalRootGraphFetchExecutionNode"),
-                                Tuples.pair(RelationalCrossRootGraphFetchExecutionNode.class, "relationalCrossRootGraphFetchExecutionNode"),
-                                Tuples.pair(RelationalTempTableGraphFetchExecutionNode.class, "relationalTempTableGraphFetchExecutionNode"),
-                                Tuples.pair(RelationalGraphFetchExecutionNode.class, "relationalGraphFetchExecutionNode"),
-                                Tuples.pair(RelationalBlockExecutionNode.class, "relationalBlock"),
-                                Tuples.pair(CreateAndPopulateTempTableExecutionNode.class, "createAndPopulateTempTable"),
-                                Tuples.pair(SQLExecutionNode.class, "sql"),
-                                Tuples.pair(RelationalPrimitiveQueryGraphFetchExecutionNode.class, "relationalPrimitiveQueryGraphFetch"),
-                                Tuples.pair(RelationalClassQueryTempTableGraphFetchExecutionNode.class, "relationalClassQueryTempTableGraphFetch"),
-                                Tuples.pair(RelationalRootQueryTempTableGraphFetchExecutionNode.class, "relationalRootQueryTempTableGraphFetch"),
-                                Tuples.pair(RelationalCrossRootQueryTempTableGraphFetchExecutionNode.class, "relationalCrossRootQueryTempTableGraphFetch")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ExecutionNode.class)
+                        .withSubtype(RelationalExecutionNode.class, "relational")
+                        .withSubtype(RelationalTdsInstantiationExecutionNode.class, "relationalTdsInstantiation")
+                        .withSubtype(RelationalClassInstantiationExecutionNode.class, "relationalClassInstantiation")
+                        .withSubtype(RelationalRelationDataInstantiationExecutionNode.class, "relationalRelationDataInstantiation")
+                        .withSubtype(RelationalDataTypeInstantiationExecutionNode.class, "relationalDataTypeInstantiation")
+                        .withSubtype(RelationalRootGraphFetchExecutionNode.class, "relationalRootGraphFetchExecutionNode")
+                        .withSubtype(RelationalCrossRootGraphFetchExecutionNode.class, "relationalCrossRootGraphFetchExecutionNode")
+                        .withSubtype(RelationalTempTableGraphFetchExecutionNode.class, "relationalTempTableGraphFetchExecutionNode")
+                        .withSubtype(RelationalGraphFetchExecutionNode.class, "relationalGraphFetchExecutionNode")
+                        .withSubtype(RelationalBlockExecutionNode.class, "relationalBlock")
+                        .withSubtype(CreateAndPopulateTempTableExecutionNode.class, "createAndPopulateTempTable")
+                        .withSubtype(SQLExecutionNode.class, "sql")
+                        .withSubtype(RelationalPrimitiveQueryGraphFetchExecutionNode.class, "relationalPrimitiveQueryGraphFetch")
+                        .withSubtype(RelationalClassQueryTempTableGraphFetchExecutionNode.class, "relationalClassQueryTempTableGraphFetch")
+                        .withSubtype(RelationalRootQueryTempTableGraphFetchExecutionNode.class, "relationalRootQueryTempTableGraphFetch")
+                        .withSubtype(RelationalCrossRootQueryTempTableGraphFetchExecutionNode.class, "relationalCrossRootQueryTempTableGraphFetch")
+                        .build(),
 
                 //DatasourceSpecification
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(DatasourceSpecification.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(LocalH2DatasourceSpecification.class, "h2Local"),
-                                Tuples.pair(StaticDatasourceSpecification.class, "static"),
-                                Tuples.pair(EmbeddedH2DatasourceSpecification.class, "h2Embedded"),
-                                Tuples.pair(SnowflakeDatasourceSpecification.class, "snowflake"),
-                                Tuples.pair(BigQueryDatasourceSpecification.class, "bigQuery"),
-                                Tuples.pair(DatabricksDatasourceSpecification.class, "databricks"),
-                                Tuples.pair(RedshiftDatasourceSpecification.class, "redshift")
-
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(DatasourceSpecification.class)
+                        .withSubtype(LocalH2DatasourceSpecification.class, "h2Local")
+                        .withSubtype(StaticDatasourceSpecification.class, "static")
+                        .withSubtype(EmbeddedH2DatasourceSpecification.class, "h2Embedded")
+                        .withSubtype(SnowflakeDatasourceSpecification.class, "snowflake")
+                        .withSubtype(BigQueryDatasourceSpecification.class, "bigQuery")
+                        .withSubtype(DatabricksDatasourceSpecification.class, "databricks")
+                        .withSubtype(RedshiftDatasourceSpecification.class, "redshift")
+                        .build(),
 
                 // AuthenticationStrategy
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(AuthenticationStrategy.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(DefaultH2AuthenticationStrategy.class, "h2Default"),
-                                Tuples.pair(TestDatabaseAuthenticationStrategy.class, "test"),
-                                Tuples.pair(DelegatedKerberosAuthenticationStrategy.class, "delegatedKerberos"),
-                                Tuples.pair(UserNamePasswordAuthenticationStrategy.class, "userNamePassword"),
-                                Tuples.pair(SnowflakePublicAuthenticationStrategy.class, "snowflakePublic"),
-                                Tuples.pair(GCPApplicationDefaultCredentialsAuthenticationStrategy.class, "gcpApplicationDefaultCredentials"),
-                                Tuples.pair(ApiTokenAuthenticationStrategy.class, "apiToken"),
-                                Tuples.pair(GCPWorkloadIdentityFederationAuthenticationStrategy.class, "gcpWorkloadIdentityFederation")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(AuthenticationStrategy.class)
+                        .withSubtype(DefaultH2AuthenticationStrategy.class, "h2Default")
+                        .withSubtype(TestDatabaseAuthenticationStrategy.class, "test")
+                        .withSubtype(DelegatedKerberosAuthenticationStrategy.class, "delegatedKerberos")
+                        .withSubtype(UserNamePasswordAuthenticationStrategy.class, "userNamePassword")
+                        .withSubtype(SnowflakePublicAuthenticationStrategy.class, "snowflakePublic")
+                        .withSubtype(GCPApplicationDefaultCredentialsAuthenticationStrategy.class, "gcpApplicationDefaultCredentials")
+                        .withSubtype(ApiTokenAuthenticationStrategy.class, "apiToken")
+                        .withSubtype(GCPWorkloadIdentityFederationAuthenticationStrategy.class, "gcpWorkloadIdentityFederation")
+                        .build(),
 
                 //Post Processor
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PostProcessor.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(MapperPostProcessor.class, "mapper")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(PostProcessor.class)
+                        .withSubtype(MapperPostProcessor.class, "mapper")
+                        .build(),
 
                 //Post Processor Parameter
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(Milestoning.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(BusinessMilestoning.class, "businessMilestoning"),
-                                Tuples.pair(BusinessSnapshotMilestoning.class, "businessSnapshotMilestoning"),
-                                Tuples.pair(ProcessingMilestoning.class, "processingMilestoning")
-                        )).build()
+                ProtocolSubTypeInfo.newBuilder(Milestoning.class)
+                        .withSubtype(BusinessMilestoning.class, "businessMilestoning")
+                        .withSubtype(BusinessSnapshotMilestoning.class, "businessSnapshotMilestoning")
+                        .withSubtype(ProcessingMilestoning.class, "processingMilestoning")
+                        .build()
         ));
     }
 
@@ -224,5 +193,4 @@ public class RelationalProtocolExtension implements PureProtocolExtension
     {
         return Maps.mutable.with(Database.class, "meta::relational::metamodel::Database");
     }
-
 }

--- a/legend-engine-xt-serviceStore-protocol/pom.xml
+++ b/legend-engine-xt-serviceStore-protocol/pom.xml
@@ -51,10 +51,6 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.collections</groupId>
-            <artifactId>eclipse-collections</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
     </dependencies>

--- a/legend-engine-xt-serviceStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/ServiceStoreProtocolExtension.java
+++ b/legend-engine-xt-serviceStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/ServiceStoreProtocolExtension.java
@@ -17,8 +17,6 @@ package org.finos.legend.engine.protocol.pure.v1;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedData;
@@ -44,45 +42,33 @@ public class ServiceStoreProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
                 // Class mapping
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ClassMapping.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RootServiceStoreClassMapping.class, "serviceStore")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ClassMapping.class)
+                        .withSubtype(RootServiceStoreClassMapping.class, "serviceStore")
+                        .build(),
                 // Connection
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(Connection.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ServiceStoreConnection.class, "serviceStore")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(Connection.class)
+                        .withSubtype(ServiceStoreConnection.class, "serviceStore")
+                        .build(),
                 // Content pattern
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ContentPattern.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(EqualToPattern.class, "equalTo"),
-                                Tuples.pair(EqualToJsonPattern.class, "equalToJson")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ContentPattern.class)
+                        .withSubtype(EqualToPattern.class, "equalTo")
+                        .withSubtype(EqualToJsonPattern.class, "equalToJson")
+                        .build(),
                 // Embedded Data
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(EmbeddedData.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ServiceStoreEmbeddedData.class, "serviceStore")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(EmbeddedData.class)
+                        .withSubtype(ServiceStoreEmbeddedData.class, "serviceStore")
+                        .build(),
                 // Execution Nodes
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(ExecutionNode.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(RestServiceExecutionNode.class, "restService"),
-                                Tuples.pair(ServiceParametersResolutionExecutionNode.class, "serviceParametersResolution")
-                        )).build(),
+                ProtocolSubTypeInfo.newBuilder(ExecutionNode.class)
+                        .withSubtype(RestServiceExecutionNode.class, "restService")
+                        .withSubtype(ServiceParametersResolutionExecutionNode.class, "serviceParametersResolution")
+                        .build(),
                 // Packageable element
-                ProtocolSubTypeInfo.Builder
-                        .newInstance(PackageableElement.class)
-                        .withSubtypes(FastList.newListWith(
-                                Tuples.pair(ServiceStore.class, "serviceStore")
-                        )).build()
+                ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
+                        .withSubtype(ServiceStore.class, "serviceStore")
+                        .build()
         ));
     }
 

--- a/legend-engine-xt-xml-protocol/pom.xml
+++ b/legend-engine-xt-xml-protocol/pom.xml
@@ -44,10 +44,6 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.collections</groupId>
-            <artifactId>eclipse-collections</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- JACKSON -->

--- a/legend-engine-xt-xml-protocol/src/main/java/org/finos/legend/engine/external/format/xml/XmlProtocolExtension.java
+++ b/legend-engine-xt-xml-protocol/src/main/java/org/finos/legend/engine/external/format/xml/XmlProtocolExtension.java
@@ -16,8 +16,6 @@ package org.finos.legend.engine.external.format.xml;
 
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNode;
@@ -31,12 +29,11 @@ public class XmlProtocolExtension implements PureProtocolExtension
     @Override
     public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
     {
-        return Lists.mutable.with(() -> Lists.mutable.with(
-                ProtocolSubTypeInfo.Builder.newInstance(ExecutionNode.class)
-                                           .withSubtypes(FastList.newListWith(
-                                                   Tuples.pair(XmlSerializeExecutionNode.class, "xmlSerialize"),
-                                                   Tuples.pair(XmlDeserializeExecutionNode.class, "xmlDeserialize")
-                                           )).build()
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                ProtocolSubTypeInfo.newBuilder(ExecutionNode.class)
+                        .withSubtype(XmlSerializeExecutionNode.class, "xmlSerialize")
+                        .withSubtype(XmlDeserializeExecutionNode.class, "xmlDeserialize")
+                        .build()
         ));
     }
 }


### PR DESCRIPTION
Improve tests for legend-engine-extensions-collection-generation so that we test not only the presence of the extension classes, but also that we can load the metadata and build a Pure model.