### PR TITLE
Fix JSON to Grammar transformation when Applied functions are passed as parameters.

### DIFF
--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
@@ -94,7 +94,7 @@ public class HelperValueSpecificationGrammarComposer
 
         // This is to accommodate for cases where the first parameter is a lambda, such as agg(), col(),
         // it would be wrong to use `->` syntax, e.g. `$x|x.prop1->col()`
-        if (firstArgument instanceof Lambda)
+        if ((firstArgument instanceof Lambda) || (firstArgument instanceof AppliedFunction && SPECIAL_INFIX.get(((AppliedFunction) firstArgument).function) != null))
         {
             return renderFunctionName(functionName, transformer) + "("
                     + (transformer.isRenderingPretty() ? transformer.returnChar() + DEPRECATED_PureGrammarComposerCore.computeIndentationString(transformer, getTabSize(2)) : "")

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -20,6 +20,92 @@ import org.junit.Test;
 public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
 {
     @Test
+    public void testAppliedFunctionAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: eq($this.var2 / $this.var1, $this.var4 / $this.var3)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "  var3: Float[1];\n" +
+                "  var4: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testAppliedFunctionPrimitiveAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: eq($this.var2 / $this.var1, 3)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testPrimitiveAppliedFunctionAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: 3->eq($this.var2 / $this.var1)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testPrimitivesAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: 3->eq(3) && 3->eq($this.var2 / $this.var1)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "  var2: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testIsNotEmptyWithAppliedFunctionsAsParameters()
+    {
+        test("Class my::TestClass extends meta::pure::metamodel::type::Any\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~function: isNotEmpty($this.var1 / 3)\n" +
+                "    ~enforcementLevel: Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "}\n");
+    }
+
+    @Test
     public void testClass()
     {
         test("Class <<temporal.businesstemporal>> {doc.doc = 'something'} A extends B\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
@@ -27,6 +27,16 @@ public class TestLambdaRoundtrip
     private static final ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
 
     @Test
+    public void testLambdaWithINFIXoperations()
+    {
+        testLambda("|eq($this.var2 / $this.var1, $this.var4 / $this.var3)");
+        testLambda("|eq($this.var2 / $this.var1, 3)");
+        testLambda("|3->eq($this.var2 / $this.var1)");
+        testLambda("|3->eq(3) && 3->eq($this.var2 / $this.var1)");
+        testLambda("|isNotEmpty($this.var1 / 3)");
+    }
+
+    @Test
     public void testLambdaWithBodyWithNonStringTokenOnly()
     {
         testLambda("|a::X");


### PR DESCRIPTION
- Fix JSON to grammar transformation when the first parameter to a function is an instance of Applied Function. 
- Ensured correct grammar generation when using eq (equals) applied function by avoiding the -> syntax.