### PR TITLE
minor testable api fixes

### DIFF
--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/CorePureProtocolExtension.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/CorePureProtocolExtension.java
@@ -46,6 +46,14 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.TestAsserti
 
 import java.util.List;
 import java.util.Map;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertFail;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertPass;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertionStatus;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.EqualToJsonAssertFail;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestFailed;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestPassed;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 
 public class CorePureProtocolExtension implements PureProtocolExtension
 {
@@ -78,10 +86,21 @@ public class CorePureProtocolExtension implements PureProtocolExtension
                         .withSubtype(DataElementReference.class, "reference")
                         .build(),
                 // Test Assertion
-                ProtocolSubTypeInfo.newBuilder(TestAssertion.class)
-                        .withSubtype(EqualTo.class, "equalTo")
-                        .withSubtype(EqualToJson.class, "equalToJson")
-                        .build()
+            ProtocolSubTypeInfo.newBuilder(TestAssertion.class)
+                .withSubtype(EqualTo.class, "equalTo")
+                .withSubtype(EqualToJson.class, "equalToJson")
+                .build(),
+                // Test Result
+                ProtocolSubTypeInfo.newBuilder(TestResult.class)
+                    .withSubtype(TestError.class, "testError")
+                    .withSubtype(TestPassed.class, "testPassed")
+                    .withSubtype(TestFailed.class, "testFailed")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(AssertionStatus.class)
+                        .withSubtype(AssertPass.class, "assertPass")
+                        .withSubtype(AssertFail.class, "assertFail")
+                        .withSubtype(EqualToJsonAssertFail.class, "equalToJsonAssertFail")
+                    .build()
         ));
     }
 

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/test/assertion/status/AssertionStatus.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/test/assertion/status/AssertionStatus.java
@@ -15,7 +15,9 @@
 package org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type")
 public abstract class AssertionStatus
 {
     @JsonProperty(required = true)

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/test/result/TestResult.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/test/result/TestResult.java
@@ -15,8 +15,10 @@
 package org.finos.legend.engine.protocol.pure.v1.model.test.result;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTestId;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type")
 public class TestResult
 {
     @JsonProperty(required = true)

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -263,6 +263,10 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-testable</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -87,6 +87,7 @@ import org.finos.legend.engine.shared.core.url.EngineUrlStreamHandlerFactory;
 import org.finos.legend.engine.shared.core.vault.Vault;
 import org.finos.legend.engine.shared.core.vault.VaultConfiguration;
 import org.finos.legend.engine.shared.core.vault.VaultFactory;
+import org.finos.legend.engine.testable.api.Testable;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.server.pac4j.LegendPac4jBundle;
 import org.finos.legend.server.shared.bundles.ChainFixingFilterHandler;
@@ -223,6 +224,9 @@ public class Server<T extends ServerConfiguration> extends Application<T>
         // Analytics
         environment.jersey().register(new DiagramAnalytics(modelManager));
         environment.jersey().register(new DataSpaceAnalytics(modelManager));
+
+        // Testable
+        environment.jersey().register(new Testable(modelManager));
 
         enableCors(environment);
     }

--- a/legend-engine-testable/pom.xml
+++ b/legend-engine-testable/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>legend-engine-pure-code-compiled-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <version>${legend.pure.version}</version>
+        </dependency>
 
         <!-- ENGINE -->
         <dependency>
@@ -105,6 +110,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <!-- JACKSON -->
 

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/TestableRunner.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/TestableRunner.java
@@ -24,9 +24,9 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextPo
 import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTestId;
 import org.finos.legend.engine.testable.extension.TestRunner;
 import org.finos.legend.engine.testable.extension.TestableRunnerExtensionLoader;
-import org.finos.legend.engine.testable.model.DoTestsInput;
-import org.finos.legend.engine.testable.model.DoTestsResult;
-import org.finos.legend.engine.testable.model.DoTestsTestableInput;
+import org.finos.legend.engine.testable.model.RunTestsInput;
+import org.finos.legend.engine.testable.model.RunTestsResult;
+import org.finos.legend.engine.testable.model.RunTestsTestableInput;
 import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
 import org.finos.legend.pure.generated.Root_meta_pure_test_Test;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
@@ -47,16 +47,21 @@ public class TestableRunner
         this.modelManager = modelManager;
     }
 
-    public DoTestsResult doTests(DoTestsInput input, MutableList<CommonProfile> profiles)
+    public RunTestsResult doTests(RunTestsInput input, MutableList<CommonProfile> profiles)
     {
         Pair<PureModelContextData, PureModel> modelAndData = modelManager.loadModelAndData(input.model, input.model instanceof PureModelContextPointer ? ((PureModelContextPointer) input.model).serializer.version : null, profiles, null);
         PureModel pureModel = modelAndData.getTwo();
         PureModelContextData data = modelAndData.getOne();
 
-        DoTestsResult doTestsResult = new DoTestsResult();
-        for (DoTestsTestableInput testableInput : input.testables)
+        RunTestsResult runTestsResult = new RunTestsResult();
+        for (RunTestsTestableInput testableInput : input.testables)
         {
-            Root_meta_pure_test_Testable testable = (Root_meta_pure_test_Testable) pureModel.getPackageableElement(testableInput.testable);
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement packageableElement = pureModel.getPackageableElement(testableInput.testable);
+            if (!(packageableElement instanceof  Root_meta_pure_test_Testable))
+            {
+                throw new UnsupportedOperationException("Element '" + testableInput.testable + "' is not a testable element");
+            }
+            Root_meta_pure_test_Testable testable = (Root_meta_pure_test_Testable) packageableElement;
             List<AtomicTestId> testIds = testableInput.unitTestIds;
             List<String> atomicTestIds = ListIterate.collect(testIds, id -> id.atomicTestId);
             Map<String, List<AtomicTestId>> testIdsBySuiteId = testIds.stream().collect(groupingBy(testId -> testId.testSuiteId));
@@ -64,9 +69,10 @@ public class TestableRunner
             TestRunner testRunner = TestableRunnerExtensionLoader.forTestable(testable);
             for (Root_meta_pure_test_Test test : testable._tests())
             {
+                // We run all testIds if no `unitTestIds` are provided
                 if ((test instanceof Root_meta_pure_test_AtomicTest) && (testIds.isEmpty() || atomicTestIds.contains(test._id())))
                 {
-                    doTestsResult.results.add(testRunner.executeAtomicTest((Root_meta_pure_test_AtomicTest) test, pureModel, data));
+                    runTestsResult.results.add(testRunner.executeAtomicTest((Root_meta_pure_test_AtomicTest) test, pureModel, data));
                 }
                 if ((test instanceof Root_meta_pure_test_TestSuite) && (testIds.isEmpty() || testIdsBySuiteId.get(test._id()) != null))
                 {
@@ -86,11 +92,11 @@ public class TestableRunner
                     {
                         updatedTestIds = testIdsBySuiteId.get(test._id());
                     }
-                    doTestsResult.results.addAll(testRunner.executeTestSuite(testSuite, updatedTestIds, pureModel, data));
+                    runTestsResult.results.addAll(testRunner.executeTestSuite(testSuite, updatedTestIds, pureModel, data));
                 }
             }
         }
 
-        return doTestsResult;
+        return runTestsResult;
     }
 }

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/model/RunTestsInput.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/model/RunTestsInput.java
@@ -15,15 +15,15 @@
 package org.finos.legend.engine.testable.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTestId;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContext;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class DoTestsTestableInput
+public class RunTestsInput
 {
     @JsonProperty(required = true)
-    public String testable;
+    public PureModelContext model;
 
-    public List<AtomicTestId> unitTestIds = new ArrayList<>();
+    public List<RunTestsTestableInput> testables = new ArrayList<>();
 }

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/model/RunTestsResult.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/model/RunTestsResult.java
@@ -19,7 +19,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DoTestsResult
+public class RunTestsResult
 {
     public List<TestResult> results = new ArrayList<>();
 }

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/model/RunTestsTestableInput.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/model/RunTestsTestableInput.java
@@ -15,15 +15,15 @@
 package org.finos.legend.engine.testable.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContext;
+import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTestId;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class DoTestsInput
+public class RunTestsTestableInput
 {
     @JsonProperty(required = true)
-    public PureModelContext model;
+    public String testable;
 
-    public List<DoTestsTestableInput> testables = new ArrayList<>();
+    public List<AtomicTestId> unitTestIds = new ArrayList<>();
 }


### PR DESCRIPTION
- rename `doTest` to `runTest`
- wire up subType Jackson decorators for test assertion and test results
- handle zipkin input for testable inputs
