### PR TITLE
Cleanup mapping analytics API and allow searching for queries by version

### DIFF
--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
@@ -188,8 +188,8 @@ public class QueryStoreManager
     }
 
     public List<Query> getQueries(
-        QuerySearchSpecification searchSpecification,
-        String currentUser
+            QuerySearchSpecification searchSpecification,
+            String currentUser
     )
     {
         List<Bson> filters = new ArrayList<>();
@@ -205,26 +205,35 @@ public class QueryStoreManager
         if (searchSpecification.projectCoordinates != null && !searchSpecification.projectCoordinates.isEmpty())
         {
             filters.add(Filters.or(
-                ListIterate.collect(searchSpecification.projectCoordinates, projectCoordinate ->
-                    Filters.and(Filters.eq("groupId", projectCoordinate.groupId), Filters.eq("artifactId", projectCoordinate.artifactId)))));
+                    ListIterate.collect(searchSpecification.projectCoordinates, projectCoordinate ->
+                            projectCoordinate.version != null
+                                    ? Filters.and(
+                                    Filters.eq("groupId", projectCoordinate.groupId),
+                                    Filters.eq("artifactId", projectCoordinate.artifactId),
+                                    Filters.eq("versionId", projectCoordinate.version)
+                            ) : Filters.and(
+                                    Filters.eq("groupId", projectCoordinate.groupId),
+                                    Filters.eq("artifactId", projectCoordinate.artifactId)
+                            )
+                    )));
         }
         if (searchSpecification.taggedValues != null && !searchSpecification.taggedValues.isEmpty())
         {
             filters.add(Filters.or(
-                ListIterate.collect(searchSpecification.taggedValues, taggedValue ->
-                    Filters.and(Filters.eq("taggedValues.tag.profile", taggedValue.tag.profile), Filters.eq("taggedValues.tag.value", taggedValue.tag.value), Filters.eq("taggedValues.value", taggedValue.value)))));
+                    ListIterate.collect(searchSpecification.taggedValues, taggedValue ->
+                            Filters.and(Filters.eq("taggedValues.tag.profile", taggedValue.tag.profile), Filters.eq("taggedValues.tag.value", taggedValue.tag.value), Filters.eq("taggedValues.value", taggedValue.value)))));
         }
         if (searchSpecification.stereotypes != null && !searchSpecification.stereotypes.isEmpty())
         {
             filters.add(Filters.or(
-                ListIterate.collect(searchSpecification.stereotypes, stereotype ->
-                    Filters.and(Filters.eq("stereotypes.profile", stereotype.profile), Filters.eq("stereotypes.value", stereotype.value)))));
+                    ListIterate.collect(searchSpecification.stereotypes, stereotype ->
+                            Filters.and(Filters.eq("stereotypes.profile", stereotype.profile), Filters.eq("stereotypes.value", stereotype.value)))));
         }
         return LazyIterate.collect(this.getQueryCollection()
-            .find(filters.isEmpty() ? EMPTY_FILTER : Filters.and(filters))
-            // NOTE: return a light version of the query to save bandwidth
-            .projection(Projections.include("id", "name", "versionId", "groupId", "artifactId", "owner"))
-            .limit(Math.min(MAX_NUMBER_OF_QUERIES, searchSpecification.limit == null ? Integer.MAX_VALUE : searchSpecification.limit)), QueryStoreManager::documentToQuery).toList();
+                .find(filters.isEmpty() ? EMPTY_FILTER : Filters.and(filters))
+                // NOTE: return a light version of the query to save bandwidth
+                .projection(Projections.include("id", "name", "versionId", "groupId", "artifactId", "owner"))
+                .limit(Math.min(MAX_NUMBER_OF_QUERIES, searchSpecification.limit == null ? Integer.MAX_VALUE : searchSpecification.limit)), QueryStoreManager::documentToQuery).toList();
     }
 
     public Query getQuery(String queryId)
@@ -331,7 +340,7 @@ public class QueryStoreManager
             filters.add(Filters.lte("timestamp", until));
         }
         return LazyIterate.collect(this.getQueryEventCollection()
-            .find(filters.isEmpty() ? EMPTY_FILTER : Filters.and(filters))
-            .limit(Math.min(MAX_NUMBER_OF_EVENTS, limit == null ? Integer.MAX_VALUE : limit)), QueryStoreManager::documentToQueryEvent).toList();
+                .find(filters.isEmpty() ? EMPTY_FILTER : Filters.and(filters))
+                .limit(Math.min(MAX_NUMBER_OF_EVENTS, limit == null ? Integer.MAX_VALUE : limit)), QueryStoreManager::documentToQueryEvent).toList();
     }
 }

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryProjectCoordinates.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryProjectCoordinates.java
@@ -18,4 +18,5 @@ public class QueryProjectCoordinates
 {
     public String groupId;
     public String artifactId;
+    public String version;
 }

--- a/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
+++ b/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
@@ -136,6 +136,12 @@ public class TestQueryStoreManager
             return this;
         }
 
+        TestQueryBuilder withVersionId(String versionId)
+        {
+            this.versionId = versionId;
+            return this;
+        }
+
         TestQueryBuilder withTaggedValues(List<TaggedValue> taggedValues)
         {
             this.taggedValues = taggedValues;
@@ -167,11 +173,12 @@ public class TestQueryStoreManager
         }
     }
 
-    private static QueryProjectCoordinates createTestQueryProjectCoordinate(String groupId, String artifactId)
+    private static QueryProjectCoordinates createTestQueryProjectCoordinate(String groupId, String artifactId, String version)
     {
         QueryProjectCoordinates coordinate = new QueryProjectCoordinates();
         coordinate.groupId = groupId;
         coordinate.artifactId = artifactId;
+        coordinate.version = version;
         return coordinate;
     }
 
@@ -341,23 +348,29 @@ public class TestQueryStoreManager
         Query testQuery1 = TestQueryBuilder.create("1", "query1", currentUser).withGroupId("test").withArtifactId("test").build();
         Query testQuery2 = TestQueryBuilder.create("2", "query2", currentUser).withGroupId("test").withArtifactId("test").build();
         Query testQuery3 = TestQueryBuilder.create("3", "query3", currentUser).withGroupId("something").withArtifactId("something").build();
+        Query testQuery4 = TestQueryBuilder.create("4", "query4", currentUser).withGroupId("something.another").withArtifactId("something-another").withVersionId("1.0.0").build();
         queryStoreManager.createQuery(testQuery1, currentUser);
         queryStoreManager.createQuery(testQuery2, currentUser);
         queryStoreManager.createQuery(testQuery3, currentUser);
+        queryStoreManager.createQuery(testQuery4, currentUser);
 
         // When no projects specified, return all queries
-        Assert.assertEquals(3, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().build(), currentUser).size());
+        Assert.assertEquals(4, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().build(), currentUser).size());
 
-        QueryProjectCoordinates coordinate1 = createTestQueryProjectCoordinate("notfound", "notfound");
+        QueryProjectCoordinates coordinate1 = createTestQueryProjectCoordinate("notfound", "notfound", null);
         Assert.assertEquals(0, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withProjectCoordinates(Lists.fixedSize.of(coordinate1)).build(), currentUser).size());
 
-        QueryProjectCoordinates coordinate2 = createTestQueryProjectCoordinate("test", "test");
+        QueryProjectCoordinates coordinate2 = createTestQueryProjectCoordinate("test", "test", null);
         Assert.assertEquals(2, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withProjectCoordinates(Lists.fixedSize.of(coordinate2)).build(), currentUser).size());
         Assert.assertEquals(2, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withProjectCoordinates(Lists.fixedSize.of(coordinate1, coordinate2)).build(), currentUser).size());
 
-        QueryProjectCoordinates coordinate3 = createTestQueryProjectCoordinate("something", "something");
+        QueryProjectCoordinates coordinate3 = createTestQueryProjectCoordinate("something", "something", null);
         Assert.assertEquals(1, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withProjectCoordinates(Lists.fixedSize.of(coordinate3)).build(), currentUser).size());
         Assert.assertEquals(3, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withProjectCoordinates(Lists.fixedSize.of(coordinate1, coordinate2, coordinate3)).build(), currentUser).size());
+
+        QueryProjectCoordinates coordinate4 = createTestQueryProjectCoordinate("something.another", "something-another", "1.0.0");
+        Assert.assertEquals(1, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withProjectCoordinates(Lists.fixedSize.of(coordinate4)).build(), currentUser).size());
+        Assert.assertEquals(4, queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withProjectCoordinates(Lists.fixedSize.of(coordinate1, coordinate2, coordinate3, coordinate4)).build(), currentUser).size());
     }
 
     @Test

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -31,7 +31,7 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
-import org.finos.legend.engine.api.MappingAnalytics;
+import org.finos.legend.engine.api.analytics.MappingAnalytics;
 import org.finos.legend.engine.application.query.api.ApplicationQuery;
 import org.finos.legend.engine.application.query.configuration.ApplicationQueryConfiguration;
 import org.finos.legend.engine.authentication.LegendDefaultDatabaseAuthenticationFlowProviderConfiguration;

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/MappingAnalytics.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/MappingAnalytics.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api;
+package org.finos.legend.engine.api.analytics;
 
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
@@ -22,10 +22,10 @@ import io.swagger.annotations.ApiParam;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.finos.legend.engine.api.model.MappingModelCoverageAnalysisInput;
-import org.finos.legend.engine.api.model.MappingModelCoverageAnalysisResult;
-import org.finos.legend.engine.api.model.MappingRuntimeCompatibilityAnalysisInput;
-import org.finos.legend.engine.api.model.MappingRuntimeCompatibilityAnalysisResult;
+import org.finos.legend.engine.api.analytics.model.MappingModelCoverageAnalysisInput;
+import org.finos.legend.engine.api.analytics.model.MappingModelCoverageAnalysisResult;
+import org.finos.legend.engine.api.analytics.model.MappingRuntimeCompatibilityAnalysisInput;
+import org.finos.legend.engine.api.analytics.model.MappingRuntimeCompatibilityAnalysisResult;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperRuntimeBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -53,7 +53,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.finos.legend.engine.api.MappingAnalyticsHelper.buildMappedEntity;
+import static org.finos.legend.engine.api.analytics.MappingAnalyticsHelper.buildMappedEntity;
 
 @Api(tags = "Analytics - Model")
 @Path("pure/v1/analytics/mapping")

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/MappingAnalyticsHelper.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/MappingAnalyticsHelper.java
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api;
+package org.finos.legend.engine.api.analytics;
 
-import org.finos.legend.engine.api.model.EntityMappedProperty;
-import org.finos.legend.engine.api.model.EnumMappedProperty;
-import org.finos.legend.engine.api.model.MappedEntity;
-import org.finos.legend.engine.api.model.MappedEntityInfo;
-import org.finos.legend.engine.api.model.MappedProperty;
-import org.finos.legend.engine.api.model.MappedPropertyInfo;
-import org.finos.legend.engine.api.model.MappedPropertyType;
+import org.finos.legend.engine.api.analytics.model.EntityMappedProperty;
+import org.finos.legend.engine.api.analytics.model.EnumMappedProperty;
+import org.finos.legend.engine.api.analytics.model.MappedEntity;
+import org.finos.legend.engine.api.analytics.model.MappedEntityInfo;
+import org.finos.legend.engine.api.analytics.model.MappedProperty;
+import org.finos.legend.engine.api.analytics.model.MappedPropertyInfo;
+import org.finos.legend.engine.api.analytics.model.MappedPropertyType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 import org.finos.legend.pure.generated.Root_meta_analytics_mapping_modelCoverage_EntityMappedProperty;
 import org.finos.legend.pure.generated.Root_meta_analytics_mapping_modelCoverage_EnumMappedProperty;

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/EntityMappedProperty.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/EntityMappedProperty.java
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package org.finos.legend.engine.api.analytics.model;
 
-package org.finos.legend.engine.api.model;
-
-public class EnumMappedProperty extends MappedProperty
+public class EntityMappedProperty extends MappedProperty
 {
-    public String enumPath;
+    public String entityPath;
+    public String subType;
 
-    public EnumMappedProperty(String name, String enumName)
+    public EntityMappedProperty(String name, String entityPath, String subType)
     {
         super(name);
-        this.enumPath = enumName;
+        this.entityPath = entityPath;
+        this.subType = subType;
     }
 }

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/EnumMappedProperty.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/EnumMappedProperty.java
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
 
-import java.util.List;
+package org.finos.legend.engine.api.analytics.model;
 
-public class MappingRuntimeCompatibilityAnalysisResult
+public class EnumMappedProperty extends MappedProperty
 {
-    public List<String> runtimes;
+    public String enumPath;
 
-    public MappingRuntimeCompatibilityAnalysisResult(List<String> runtimes)
+    public EnumMappedProperty(String name, String enumName)
     {
-        this.runtimes = runtimes;
+        super(name);
+        this.enumPath = enumName;
     }
 }

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedEntity.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedEntity.java
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
-public enum MappedPropertyType
+import java.util.List;
+
+public class MappedEntity
 {
-    String,
-    Integer,
-    Boolean,
-    Float,
-    Date,
-    DateTime,
-    Enumeration,
-    Entity,
-    Number
+    public String path;
+    public List<MappedProperty> properties;
+    public MappedEntityInfo info;
+
+    public MappedEntity(String path, List<MappedProperty> properties)
+    {
+        this.path = path;
+        this.properties = properties;
+    }
 }

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedEntityInfo.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedEntityInfo.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
 import java.util.List;
 

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedProperty.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedProperty.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedPropertyInfo.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedPropertyInfo.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedPropertyType.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappedPropertyType.java
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
-public class EntityMappedProperty extends MappedProperty
+public enum MappedPropertyType
 {
-    public String entityPath;
-    public String subType;
-
-    public EntityMappedProperty(String name, String entityPath, String subType)
-    {
-        super(name);
-        this.entityPath = entityPath;
-        this.subType = subType;
-    }
+    String,
+    Integer,
+    Boolean,
+    Float,
+    Date,
+    DateTime,
+    Enumeration,
+    Entity,
+    Number
 }

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingModelCoverageAnalysisInput.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingModelCoverageAnalysisInput.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingModelCoverageAnalysisResult.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingModelCoverageAnalysisResult.java
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
 import java.util.List;
 
-public class MappedEntity
+public class MappingModelCoverageAnalysisResult
 {
-    public String path;
-    public List<MappedProperty> properties;
-    public MappedEntityInfo info;
+    public List<MappedEntity> mappedEntities;
 
-    public MappedEntity(String path, List<MappedProperty> properties)
+    public MappingModelCoverageAnalysisResult()
     {
-        this.path = path;
-        this.properties = properties;
+        // DO NOT DELETE: this resets the default constructor for Jackson
+    }
+
+    public MappingModelCoverageAnalysisResult(List<MappedEntity> mappedEntities)
+    {
+        this.mappedEntities = mappedEntities;
     }
 }

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingRuntimeCompatibilityAnalysisInput.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingRuntimeCompatibilityAnalysisInput.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingRuntimeCompatibilityAnalysisResult.java
+++ b/legend-engine-xt-analytics-mapping-api/src/main/java/org/finos/legend/engine/api/analytics/model/MappingRuntimeCompatibilityAnalysisResult.java
@@ -12,21 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.api.model;
+package org.finos.legend.engine.api.analytics.model;
 
 import java.util.List;
 
-public class MappingModelCoverageAnalysisResult
+public class MappingRuntimeCompatibilityAnalysisResult
 {
-    public List<MappedEntity> mappedEntities;
+    public List<String> runtimes;
 
-    public MappingModelCoverageAnalysisResult()
+    public MappingRuntimeCompatibilityAnalysisResult(List<String> runtimes)
     {
-        // DO NOT DELETE: this resets the default constructor for Jackson
-    }
-
-    public MappingModelCoverageAnalysisResult(List<MappedEntity> mappedEntities)
-    {
-        this.mappedEntities = mappedEntities;
+        this.runtimes = runtimes;
     }
 }

--- a/legend-engine-xt-analytics-mapping-api/src/test/java/org/finos/legend/engine/api/analytics/test/TestMappingAnalyticsApi.java
+++ b/legend-engine-xt-analytics-mapping-api/src/test/java/org/finos/legend/engine/api/analytics/test/TestMappingAnalyticsApi.java
@@ -15,8 +15,8 @@
 package org.finos.legend.engine.api.analytics.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.finos.legend.engine.api.MappingAnalytics;
-import org.finos.legend.engine.api.model.MappingRuntimeCompatibilityAnalysisInput;
+import org.finos.legend.engine.api.analytics.MappingAnalytics;
+import org.finos.legend.engine.api.analytics.model.MappingRuntimeCompatibilityAnalysisInput;
 import org.finos.legend.engine.language.pure.modelManager.ModelManager;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;


### PR DESCRIPTION
- [x] Move `MappingAnalytics` API to the right package `org.finos.legend.engine.api.analytics` - similar to other analytics
- [x] Allow searching for queries by version