### PR TITLE
Part I - return multiplicity should govern Service's json response format

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/ExecutionNodeSerializerHelper.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/ExecutionNodeSerializerHelper.java
@@ -91,15 +91,25 @@ public class ExecutionNodeSerializerHelper
                 if (iter.hasNext())
                 {
                     T first = iter.next();
-                    if (iter.hasNext())
+                    if (this.config != null && this.config.alwaysWrapResultWithBrackets)
                     {
                         generator.writeStartArray();
-                    }
-                    serializer.serialize(first);
-                    if (iter.hasNext())
-                    {
+                        serializer.serialize(first);
                         iter.forEachRemaining(serializer::serialize);
                         generator.writeEndArray();
+                    }
+                    else
+                    {
+                        if (iter.hasNext())
+                        {
+                            generator.writeStartArray();
+                        }
+                        serializer.serialize(first);
+                        if (iter.hasNext())
+                        {
+                            iter.forEachRemaining(serializer::serialize);
+                            generator.writeEndArray();
+                        }
                     }
                 }
                 else

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -347,6 +347,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         config._removePropertiesWithEmptySets(serializationConfig.removePropertiesWithEmptySets);
         config._fullyQualifiedTypePath(serializationConfig.fullyQualifiedTypePath);
         config._includeObjectReference(serializationConfig.includeObjectReference);
+        config._alwaysWrapResultWithBrackets(serializationConfig.alwaysWrapResultWithBrackets);
         return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("")
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::graphFetch::execution::AlloySerializationConfig"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/valueSpecification/raw/SerializationConfig.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/valueSpecification/raw/SerializationConfig.java
@@ -26,6 +26,7 @@ public class SerializationConfig extends ValueSpecification
     public boolean removePropertiesWithEmptySets;
     public boolean fullyQualifiedTypePath;
     public boolean includeObjectReference;
+    public boolean alwaysWrapResultWithBrackets = false;
 
     @Override
     public <T> T accept(ValueSpecificationVisitor<T> visitor)

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphFetch.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphFetch.pure
@@ -72,6 +72,7 @@ Class meta::pure::graphFetch::execution::AlloySerializationConfig
     removePropertiesWithEmptySets: Boolean[0..1];
     fullyQualifiedTypePath: Boolean[0..1];
     includeObjectReference: Boolean[0..1];
+    alwaysWrapResultWithBrackets: Boolean[0..1];
 }
 
 function meta::pure::graphFetch::execution::defaultAlloyConfig(): meta::pure::graphFetch::execution::AlloySerializationConfig[1]
@@ -83,7 +84,8 @@ function meta::pure::graphFetch::execution::defaultAlloyConfig(): meta::pure::gr
       removePropertiesWithNullValues = true,
       removePropertiesWithEmptySets = false,
       fullyQualifiedTypePath = true,
-      includeObjectReference = false
+      includeObjectReference = false,
+      alwaysWrapResultWithBrackets = false
    );
 }
 
@@ -105,6 +107,20 @@ function meta::pure::graphFetch::execution::alloyConfig(includeType:Boolean[1], 
    );
 }
 
+function meta::pure::graphFetch::execution::alloyConfig(includeType:Boolean[1], includeEnumType:Boolean[1], removePropertiesWithNullValues:Boolean[1],  removePropertiesWithEmptySets:Boolean[1], includeObjectReference:Boolean[1], alwaysWrapResultWithBrackets:Boolean[1]): meta::pure::graphFetch::execution::AlloySerializationConfig[1]
+{
+   ^meta::pure::graphFetch::execution::AlloySerializationConfig(
+      typeKeyName = '@type',
+      includeType = $includeType,
+      includeEnumType = $includeEnumType,
+      removePropertiesWithNullValues = $removePropertiesWithNullValues,
+      removePropertiesWithEmptySets = $removePropertiesWithEmptySets,
+      fullyQualifiedTypePath = true,
+      includeObjectReference = $includeObjectReference,
+      alwaysWrapResultWithBrackets = $alwaysWrapResultWithBrackets
+   );
+}
+
 function meta::pure::graphFetch::execution::alloyConfig(includeType:Boolean[1], includeEnumType:Boolean[1], removePropertiesWithNullValues:Boolean[1],  removePropertiesWithEmptySets:Boolean[1], typeString:String[1], fullyQualifiedTypePath:Boolean[1]): meta::pure::graphFetch::execution::AlloySerializationConfig[1]
 {
   meta::pure::graphFetch::execution::alloyConfig($includeType, $includeEnumType, $removePropertiesWithNullValues, $removePropertiesWithEmptySets, $typeString, $fullyQualifiedTypePath, false);
@@ -120,6 +136,20 @@ function meta::pure::graphFetch::execution::alloyConfig(includeType:Boolean[1], 
       removePropertiesWithEmptySets = $removePropertiesWithEmptySets,
       fullyQualifiedTypePath = $fullyQualifiedTypePath,
       includeObjectReference = $includeObjectReference
+   );
+}
+
+function meta::pure::graphFetch::execution::alloyConfig(includeType:Boolean[1], includeEnumType:Boolean[1], removePropertiesWithNullValues:Boolean[1],  removePropertiesWithEmptySets:Boolean[1], typeString:String[1], fullyQualifiedTypePath:Boolean[1], includeObjectReference:Boolean[1], alwaysWrapResultWithBrackets:Boolean[1]): meta::pure::graphFetch::execution::AlloySerializationConfig[1]
+{
+   ^meta::pure::graphFetch::execution::AlloySerializationConfig(
+      typeKeyName = $typeString,
+      includeType = $includeType,
+      includeEnumType = $includeEnumType,
+      removePropertiesWithNullValues = $removePropertiesWithNullValues,
+      removePropertiesWithEmptySets = $removePropertiesWithEmptySets,
+      fullyQualifiedTypePath = $fullyQualifiedTypePath,
+      includeObjectReference = $includeObjectReference,
+      alwaysWrapResultWithBrackets = $alwaysWrapResultWithBrackets
    );
 }
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/metamodel.pure
@@ -506,6 +506,7 @@ Class meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::AlloySe
     removePropertiesWithEmptySets: Boolean[0..1];
     fullyQualifiedTypePath: Boolean[0..1];
     includeObjectReference: Boolean[0..1];
+    alwaysWrapResultWithBrackets: Boolean[0..1];
 }
 
 Enum meta::protocols::pure::vX_X_X::metamodel::objectReference::AlloyObjectReferenceType

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/valueSpecification.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/valueSpecification.pure
@@ -448,7 +448,8 @@ function <<access.private>> meta::protocols::pure::vX_X_X::transformation::fromP
                         removePropertiesWithNullValues = $a.removePropertiesWithNullValues,
                         removePropertiesWithEmptySets = $a.removePropertiesWithEmptySets,
                         fullyQualifiedTypePath = $a.fullyQualifiedTypePath,
-                        includeObjectReference = $a.includeObjectReference
+                        includeObjectReference = $a.includeObjectReference,
+                        alwaysWrapResultWithBrackets = $a.alwaysWrapResultWithBrackets
                      ),
                   g:GraphFetchTree[1]|
                      $g->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree($inScope, $open, $extensions),


### PR DESCRIPTION
The current behavior of alloy service for graphFetch is inconsistent. For multiplicity one, it will return one object.
For multiplicity 0 or many, it will wrap results with brackets.

To be backward compatible, we introduced a flag in AlloyConfig.
Now,  Users could set this config to true to always wrap results with brackets.