### PR TITLE
Fix handling of filter duplicates attribute in persistence DSL.

### DIFF
--- a/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/from/PersistenceParseTreeWalker.java
+++ b/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/from/PersistenceParseTreeWalker.java
@@ -672,9 +672,22 @@ public class PersistenceParseTreeWalker
 
         // filter duplicates
         PersistenceParserGrammar.FilterDuplicatesContext filterDuplicatesContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.filterDuplicates(), "filterDuplicates", appendOnly.sourceInformation);
-        appendOnly.filterDuplicates = Boolean.parseBoolean(filterDuplicatesContext.FILTER_DUPLICATES().getText());
+        appendOnly.filterDuplicates = visitFilterDuplicates(filterDuplicatesContext);
 
         return appendOnly;
+    }
+
+    private boolean visitFilterDuplicates(PersistenceParserGrammar.FilterDuplicatesContext filterDuplicatesContext)
+    {
+        if (filterDuplicatesContext.TRUE() != null)
+        {
+            return true;
+        }
+        else if (filterDuplicatesContext.FALSE() != null)
+        {
+            return false;
+        }
+        throw new EngineException("Unrecognized value for filter duplicates", walkerSourceInformation.getSourceInformation(filterDuplicatesContext), EngineErrorType.PARSER);
     }
 
     // merge strategy

--- a/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarParser.java
+++ b/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarParser.java
@@ -2496,6 +2496,32 @@ public class TestPersistenceGrammarParser extends TestGrammarParser.TestGrammarP
                 "    }\n" +
                 "  }\n" +
                 "}\n", "PARSER error at [19:17-24:5]: Field 'filterDuplicates' should be specified only once");
+
+        test("###Persistence\n" +
+                "\n" +
+                "Persistence test::TestPersistence \n" +
+                "{\n" +
+                "  doc: 'This is test documentation.';\n" +
+                "  trigger: Manual;\n" +
+                "  service: test::Service;\n" +
+                "  persister: Batch\n" +
+                "  {\n" +
+                "    sink: Relational\n" +
+                "    {\n" +
+                "      database: test::Database;\n" +
+                "    }\n" +
+                "    targetShape: Flat\n" +
+                "    {\n" +
+                "      targetName: 'TestDataset1';\n" +
+                "      modelClass: test::ModelClass;\n" +
+                "    }\n" +
+                "    ingestMode: AppendOnly\n" +
+                "    {\n" +
+                "      auditing: None;\n" +
+                "      filterDuplicates: true;\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n");
     }
 
     @Test

--- a/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarRoundtrip.java
+++ b/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarRoundtrip.java
@@ -340,6 +340,51 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
                 "    ];\n" +
                 "  }\n" +
                 "}\n");
+
+        test("###Persistence\n" +
+                "import test::*;\n" +
+                "Persistence test::TestPersistence\n" +
+                "{\n" +
+                "  doc: 'test doc';\n" +
+                "  trigger: Manual;\n" +
+                "  service: test::service::Service;\n" +
+                "  persister: Batch\n" +
+                "  {\n" +
+                "    sink: Relational\n" +
+                "    {\n" +
+                "      database: test::Database;\n" +
+                "    }\n" +
+                "    ingestMode: AppendOnly\n" +
+                "    {\n" +
+                "      auditing: None;\n" +
+                "      filterDuplicates: true;\n" +
+                "    }\n" +
+                "    targetShape: Flat\n" +
+                "    {\n" +
+                "      modelClass: test::ModelClass;\n" +
+                "      targetName: 'TestDataset1';\n" +
+                "      partitionFields: [propertyA, propertyB];\n" +
+                "      deduplicationStrategy: MaxVersion\n" +
+                "      {\n" +
+                "        versionField: version;\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "  notifier:\n" +
+                "  {\n" +
+                "    notifyees:\n" +
+                "    [\n" +
+                "      Email\n" +
+                "      {\n" +
+                "        address: 'x.y@z.com';\n" +
+                "      },\n" +
+                "      PagerDuty\n" +
+                "      {\n" +
+                "        url: 'https://x.com';\n" +
+                "      }\n" +
+                "    ];\n" +
+                "  }\n" +
+                "}\n");
     }
 
     @Test


### PR DESCRIPTION
Users who select ingestMode = AppendOnly are not able to set filterDuplicates equal to true.