### PR TITLE
Add protocol models for externalize & internalize nodes

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocol/vX_X_X/models/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocol/vX_X_X/models/executionPlan.pure
@@ -13,9 +13,24 @@
 // limitations under the License.
 
 import meta::protocols::pure::vX_X_X::metamodel::executionPlan::*;
+import meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::*;
 import meta::protocols::pure::vX_X_X::transformation::fromPureGraph::external::shared::format::*;
 import meta::pure::mapping::*;
 import meta::pure::extension::*;
+
+Class meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::ExternalFormatExternalizeExecutionNode extends ExecutionNode
+{
+   contentType : String[1];
+   checked     : Boolean[1];
+   binding     : String[1];
+}
+
+Class meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::ExternalFormatInternalizeExecutionNode extends ExecutionNode
+{
+   contentType : String[1];
+   binding     : String[1];
+   tree        : RootGraphFetchTree[0..1];
+}
 
 Class meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::ExternalFormatSerializeExecutionNode extends ExecutionNode
 {


### PR DESCRIPTION
Prepare for external format refactor. These models will be needed in a protocol version for the refactoring.