### PR TITLE
Fix FreeMarker in SQL generation as part of execution plan for property With Path.

### DIFF
--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -251,6 +251,18 @@ public class TestServiceRunner
     }
 
     @Test
+    public void testSimpleServiceWithMultiplePureExpressionsHavingPropertyWithPath()
+    {
+        SimpleServiceWithMultiplePureExpressions simpleServiceWithMultiplePureExpressions = new SimpleServiceWithMultiplePureExpressions();
+        ServiceRunnerInput serviceRunnerInput = ServiceRunnerInput
+                .newInstance()
+                .withSerializationFormat(SerializationFormat.PURE);
+
+        String result = simpleServiceWithMultiplePureExpressions.run(serviceRunnerInput);
+        Assert.assertEquals("{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}",result);
+    }
+
+    @Test
     public void testSimpleRelationalServiceExecution()
     {
         RelationalExecutionConfiguration relationalExecutionConfiguration = RelationalExecutionConfiguration.newInstance()
@@ -508,6 +520,22 @@ public class TestServiceRunner
         SimpleRelationalServiceWithUserRunner()
         {
             super("test::Service", buildPlanForFetchFunction("/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure", "test::fetchWithUserId"), true);
+        }
+
+        @Override
+        public void run(ServiceRunnerInput serviceRunnerInput, OutputStream outputStream)
+        {
+            newExecutionBuilder()
+                    .withServiceRunnerInput(serviceRunnerInput)
+                    .executeToStream(outputStream);
+        }
+    }
+
+    private static class SimpleServiceWithMultiplePureExpressions extends AbstractServicePlanExecutor
+    {
+        SimpleServiceWithMultiplePureExpressions()
+        {
+            super("test::Service", buildPlanForFetchFunction("/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure", "test::testMultiExpressionQueryWithPropertyPath"), true);
         }
 
         @Override

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure
@@ -25,7 +25,13 @@ Database test::DB
     SALARY FLOAT,
     DOB DATE,
     EMPLOYMENT_DATETIME TIMESTAMP,
-    ACTIVE_EMPLOYMENT VARCHAR(100)
+    ACTIVE_EMPLOYMENT VARCHAR(100),
+    YEAR_OF_START INT
+  )
+  Table fiscalCalendarTable
+  (
+    ID INTEGER PRIMARY KEY,
+    FISCAL_YEAR_VALUE INT
   )
 )
 
@@ -41,6 +47,18 @@ Class test::Person
   dob : Date[0..1];
   employmentDateTime : DateTime[0..1];
   activeEmployment : Boolean[1];
+  yearOfStart : Integer[1];
+}
+
+Class test::FiscalCalendar
+{
+   calendarID: Integer[1];
+   fiscalYear: test::FiscalYear[1];
+}
+
+Class test::FiscalYear
+{
+  value: Integer[1];
 }
 
 function test::fetch(ip: String[*]): String[1]
@@ -90,6 +108,12 @@ function test::fetchWithUserId(): String[1]
    test::Person.all()->filter(p|$p.firstName->toLower() == $currentUser)->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#);
 }
 
+function test::testMultiExpressionQueryWithPropertyPath(): Any[*]
+{
+    let endDateCalendar = test::FiscalCalendar.all()->filter(x|$x.fiscalYear.value == 2015)->toOne()->graphFetch(#{test::FiscalCalendar{fiscalYear{value}}}#);
+    test::Person.all()->filter(x|$x.yearOfStart == $endDateCalendar->toOne().fiscalYear.value)->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#);
+}
+
 ###Mapping
 Mapping test::Map
 (
@@ -107,8 +131,23 @@ Mapping test::Map
     salary : [test::DB]personTable.SALARY,
     dob : [test::DB]personTable.DOB,
     employmentDateTime : [test::DB]personTable.EMPLOYMENT_DATETIME,
-    activeEmployment : case(equal([test::DB]personTable.ACTIVE_EMPLOYMENT,'Y'),'true','false')
+    activeEmployment : case(equal([test::DB]personTable.ACTIVE_EMPLOYMENT,'Y'),'true','false'),
+    yearOfStart : [test::DB]personTable.YEAR_OF_START
+
   }
+
+  *test::FiscalCalendar: Relational
+    {
+      ~primaryKey
+      (
+        [test::DB]fiscalCalendarTable.ID
+      )
+      ~mainTable [test::DB]fiscalCalendarTable
+      fiscalYear
+      (
+        value: [test::DB]fiscalCalendarTable.FISCAL_YEAR_VALUE
+      )
+    }
 )
 
 ###Runtime
@@ -130,7 +169,7 @@ Runtime test::Runtime
           type: H2;
           specification: LocalH2
           {
-            testDataSetupCSV: 'default\npersonTable\nID,FIRSTNAME,LASTNAME,CITY,AGE,SALARY,DOB,EMPLOYMENT_DATETIME,ACTIVE_EMPLOYMENT\n1,Peter,Smith,New York,,,1982-01-20,2012-05-20T13:10:52.501,\n2,John,Johnson,,35,80000.75,,2005-03-15T18:47:52,N\n3,Bob,Stevens,Dallas,25,75000.75,1997-12-16,,Y\n---';
+            testDataSetupCSV: 'default\nfiscalCalendarTable\nID,FISCAL_YEAR_VALUE\n111,2015\n222,2005\n333,2010\n---\ndefault\npersonTable\nID,FIRSTNAME,LASTNAME,CITY,AGE,SALARY,DOB,EMPLOYMENT_DATETIME,ACTIVE_EMPLOYMENT,YEAR_OF_START\n1,Peter,Smith,New York,,,1982-01-20,2012-05-20T13:10:52.501,,2015\n2,John,Johnson,,35,80000.75,,2005-03-15T18:47:52,N,2005\n3,Bob,Stevens,Dallas,25,75000.75,1997-12-16,,Y,2010\n---';
           };
           auth: DefaultH2;
         }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -729,6 +729,50 @@ function <<test.Test>> meta::pure::executionPlan::tests::testLessThanGreaterThan
    assertPlanGenerationForOptionalParameterWithGreaterThanLessThan($func, DatabaseType.H2, $expectedPlan); 
 }
 
+function <<test.Test>> meta::pure::executionPlan::tests::testPlanGenerationForMultipleExpressionsWithPropertyPath():Boolean[1]
+{
+  let query = {|
+            let endDateCalendar = FiscalCalendarDate.all()->filter(x|$x.fiscalYear.value == 2015)->toOne();
+            IncomeFunction.all()->filter(x|$x.incomeYear == $endDateCalendar->toOne().fiscalYear.value);
+            };
+  let generatedPlan = executionPlan($query, myMapping,meta::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+  let result = $generatedPlan->planToString(meta::relational::extension::relationalExtensions()); 
+
+  let expectedPlan = 'Sequence\n'+
+                '(\n'+
+                '  type = Class[impls=(meta::relational::tests::groupBy::datePeriods::domain::IncomeFunction | myMapping.meta_relational_tests_groupBy_datePeriods_domain_IncomeFunction)]\n'+
+                '  resultSizeRange = *\n'+
+                '  (\n'+
+                '    Allocation\n'+
+                '    (\n'+
+                '      type = Class[impls=(meta::relational::tests::groupBy::datePeriods::domain::FiscalCalendarDate | myMapping.meta_relational_tests_groupBy_datePeriods_domain_FiscalCalendarDate)]\n'+
+                '      resultSizeRange = 1\n'+
+                '      name = endDateCalendar\n'+
+                '      value = \n'+
+                '        (\n'+
+                '          Relational\n'+
+                '          (\n'+
+                '            type = Class[impls=(meta::relational::tests::groupBy::datePeriods::domain::FiscalCalendarDate | myMapping.meta_relational_tests_groupBy_datePeriods_domain_FiscalCalendarDate)]\n'+
+                '            resultSizeRange = 1\n'+
+                '            resultColumns = [("pk_0", DATE), ("pk_1", VARCHAR(15)), ("date", DATE), ("weekStart", DATE), ("weekEnd", DATE), ("day", INT), ("week", INT), ("dayOfWeekNumber", INT), ("yearEnd", DATE), ("yearStart", DATE)]\n'+
+                '            sql = select "root"."date" as "pk_0", "root"."calendar name" as "pk_1", "root"."date" as "date", "root"."fiscal week start" as "weekStart", "root"."fiscal week end" as "weekEnd", "root"."fiscal day" as "day", "root"."fiscal week" as "week", "root"."fiscal day of week" as "dayOfWeekNumber", "root"."fiscal year end" as "yearEnd", "root"."fiscal year start" as "yearStart" from calendar as "root" where "root"."fiscal year" = 2015\n'+
+                '            connection = TestDatabaseConnection(type = "H2")\n'+
+                '          )\n'+
+                '        )\n'+
+                '    )\n'+
+                '    Relational\n'+
+                '    (\n'+
+                '      type = Class[impls=(meta::relational::tests::groupBy::datePeriods::domain::IncomeFunction | myMapping.meta_relational_tests_groupBy_datePeriods_domain_IncomeFunction)]\n'+
+                '      resultSizeRange = *\n'+
+                '      resultColumns = [("pk_0", INT), ("code", INT), ("name", VARCHAR(30)), ("incomeYear", INT)]\n'+
+                '      sql = select "root".code as "pk_0", "root".code as "code", "root".name as "name", "root".year as "incomeYear" from INCOME_FUNCTION as "root" where "root".year = ${endDateCalendar.fiscalYear.value}\n'+
+                '      connection = TestDatabaseConnection(type = "H2")\n'+
+                '    )\n'+
+                '  )\n'+
+               ')\n';
+   assertEquals($expectedPlan, $result);
+}
+
 function <<test.Test>> meta::pure::executionPlan::tests::datetime::testPlanForDateTimeConstantParameterNoTimeZone():Boolean[1]
 {
    let planWithString = executionPlanForQueryWithDateTimeConstantForDatabaseConnectionTimeZone(%2019-4-8T18:00:00, []);
@@ -916,7 +960,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testClassPropertyOpenVa
             '      type = Class[impls=(meta::relational::tests::groupBy::datePeriods::domain::SalesCredit | myMapping.meta_relational_tests_groupBy_datePeriods_domain_SalesCredit)]\n' +
             '      resultSizeRange = *\n'+
             '      resultColumns = [("pk_0", INT), ("grossValue", DOUBLE)]\n'+
-            '      sql = select \"root\".key as \"pk_0\", \"root\".credits as \"grossValue\" from SALES_GCS as \"root\" left outer join calendar as \"calendar_0\" on (\"root\".tradeDate = \"calendar_0\".\"date\") where \"calendar_0\".\"date\" < \'${reportEndDate[\"date\"]}\'\n' +
+            '      sql = select \"root\".key as \"pk_0\", \"root\".credits as \"grossValue\" from SALES_GCS as \"root\" left outer join calendar as \"calendar_0\" on (\"root\".tradeDate = \"calendar_0\".\"date\") where \"calendar_0\".\"date\" < \'${reportEndDate.date}\'\n' +
             '      connection = TestDatabaseConnection(type = \"H2\")\n' +
             '    )\n' +
             '  )\n' +
@@ -964,7 +1008,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testGroupByWithOpenVari
       '    (\n'+
       '      type = TDS[(Sales Division, String, VARCHAR(30), ""), (Income Function, Number, FLOAT, "")]\n'+
       '      resultColumns = [("Sales Division", VARCHAR(30)), ("Income Function", "")]\n'+
-      '      sql = select "org_chart_entity_0".name as "Sales Division", sum(case when "calendar_0"."fiscal day" <= ${reportEndDate["day"]} then "root".credits else 0.0 end) as "Income Function" from SALES_GCS as "root" left outer join ORG_CHART_ENTITY as "org_chart_entity_0" on ("root".division_id = "org_chart_entity_0".oe_id) left outer join calendar as "calendar_0" on ("root".tradeDate = "calendar_0"."date") group by "Sales Division"\n'+
+      '      sql = select "org_chart_entity_0".name as "Sales Division", sum(case when "calendar_0"."fiscal day" <= ${reportEndDate.day} then "root".credits else 0.0 end) as "Income Function" from SALES_GCS as "root" left outer join ORG_CHART_ENTITY as "org_chart_entity_0" on ("root".division_id = "org_chart_entity_0".oe_id) left outer join calendar as "calendar_0" on ("root".tradeDate = "calendar_0"."date") group by "Sales Division"\n'+
       '      connection = TestDatabaseConnection(type = "H2")\n'+
       '    )\n'+
       '  )\n'+
@@ -1029,7 +1073,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testGroupByWithTwoOpenV
       '    (\n'+
       '      type = TDS[(Sales Division, String, VARCHAR(30), ""), (Income Function, Number, FLOAT, "")]\n'+
       '      resultColumns = [("Sales Division", VARCHAR(30)), ("Income Function", "")]\n'+
-      '      sql = select "org_chart_entity_0".name as "Sales Division", sum(case when "calendar_0"."fiscal day" <= ${reportEndDate["day"]} then "root".credits else 0.0 end) as "Income Function" from SALES_GCS as "root" left outer join ORG_CHART_ENTITY as "org_chart_entity_0" on ("root".division_id = "org_chart_entity_0".oe_id) left outer join calendar as "calendar_0" on ("root".tradeDate = "calendar_0"."date") where ("calendar_0"."date" > \'${startDate}\' and "calendar_0"."date" <= \'${reportEndDate["date"]}\') group by "Sales Division"\n'+
+      '      sql = select "org_chart_entity_0".name as "Sales Division", sum(case when "calendar_0"."fiscal day" <= ${reportEndDate.day} then "root".credits else 0.0 end) as "Income Function" from SALES_GCS as "root" left outer join ORG_CHART_ENTITY as "org_chart_entity_0" on ("root".division_id = "org_chart_entity_0".oe_id) left outer join calendar as "calendar_0" on ("root".tradeDate = "calendar_0"."date") where ("calendar_0"."date" > \'${startDate}\' and "calendar_0"."date" <= \'${reportEndDate.date}\') group by "Sales Division"\n'+
       '      connection = TestDatabaseConnection(type = "H2")\n'+
       '    )\n'+
       '  )\n'+

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -421,7 +421,7 @@ function meta::relational::functions::sqlQueryToString::convertPlaceHolderToSQLS
 function meta::relational::functions::sqlQueryToString::processPlaceHolder(v:VarPlaceHolder[1], type:Type[1], prefix:String[1], suffix:String[1], dbTimeZone:String[0..1]): String[1]
 {
    let noPropertyPath              = $v.propertyPath->isEmpty();
-   let placeHolderWithPath         = $v.name+if($noPropertyPath,|'',|'[\"')+$v.propertyPath->map(p|$p.name)->joinStrings('.')+if($noPropertyPath,|'',|'\"]');
+   let placeHolderWithPath         = $v.name+if($noPropertyPath,|'',|'.')+$v.propertyPath->map(p|$p.name)->joinStrings('.');
    let resolvedPlaceHolder         = if($type == String,
                                            | $placeHolderWithPath->convertStringToSQLString(),
                                            | $placeHolderWithPath);

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/query/datePeriods.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/query/datePeriods.pure
@@ -414,9 +414,9 @@ function meta::relational::tests::groupBy::datePeriods::createTablesAndFillDb():
 
    meta::relational::functions::toDDL::dropAndCreateTableInDb(myDB, 'INCOME_FUNCTION', $connection);
 
-   executeInDb('insert into INCOME_FUNCTION (code, name) values (1001, \'Income Function 1\');', $connection);
-   executeInDb('insert into INCOME_FUNCTION (code, name) values (1002, \'Income Function 2\');', $connection);
-   executeInDb('insert into INCOME_FUNCTION (code, name) values (1003, \'Income Function 3\');', $connection);
+   executeInDb('insert into INCOME_FUNCTION (code, name, year) values (1001, \'Income Function 1\', 2015);', $connection);
+   executeInDb('insert into INCOME_FUNCTION (code, name, year) values (1002, \'Income Function 2\', 2005);', $connection);
+   executeInDb('insert into INCOME_FUNCTION (code, name, year) values (1003, \'Income Function 3\', 2010);', $connection);
 
 
    meta::relational::functions::toDDL::dropAndCreateTableInDb(myDB, 'ORG_CHART_ENTITY', $connection);
@@ -437,20 +437,20 @@ function meta::relational::tests::groupBy::datePeriods::createTablesAndFillDb():
 
    meta::relational::functions::toDDL::dropAndCreateTableInDb(myDB, 'calendar', $connection);
 
-   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
-               ' values (\'NYC\', \'2015-01-05\', \'2015-01-05\', \'2015-01-09\', 1, 1,\'2015-01-01\', \'2015-12-31\', 1);', $connection);
-   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
-               ' values (\'NYC\', \'2015-01-06\', \'2015-01-05\', \'2015-01-09\', 2, 1,\'2015-01-01\', \'2015-12-31\', 1);', $connection);
-   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
-               ' values (\'NYC\', \'2015-02-01\', \'2015-02-02\', \'2015-02-06\', 21, 6,\'2015-01-01\', \'2015-12-31\', 1);', $connection);
-   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
-               ' values (\'NYC\', \'2015-02-07\', \'2015-02-09\', \'2015-02-13\', 26, 7,\'2015-01-01\', \'2015-12-31\', 2);', $connection);
-   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
-               ' values (\'NYC\', \'2015-02-08\', \'2015-02-09\', \'2015-02-13\', 26, 7,\'2015-01-01\', \'2015-12-31\', 2);', $connection);
-   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
-               ' values (\'NYC\', \'2015-02-24\', \'2015-02-23\', \'2015-02-27\', 36, 9,\'2015-01-01\', \'2015-12-31\', 3);', $connection);               
-   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
-               ' values (\'NYC\', \'2015-02-25\', \'2015-02-23\', \'2015-02-27\', 37, 9,\'2015-01-01\', \'2015-12-31\', 3);', $connection);            
+   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
+               ' values (\'NYC\', \'2015-01-05\', \'2015-01-05\', \'2015-01-09\', 1, 1, 2015, \'2015-01-01\', \'2015-12-31\', 1);', $connection);
+   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
+               ' values (\'NYC\', \'2015-01-06\', \'2015-01-05\', \'2015-01-09\', 2, 1, 2015, \'2015-01-01\', \'2015-12-31\', 1);', $connection);
+   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
+               ' values (\'NYC\', \'2015-02-01\', \'2015-02-02\', \'2015-02-06\', 21, 6, 2015, \'2015-01-01\', \'2015-12-31\', 1);', $connection);
+   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
+               ' values (\'NYC\', \'2015-02-07\', \'2015-02-09\', \'2015-02-13\', 26, 7, 2015, \'2015-01-01\', \'2015-12-31\', 2);', $connection);
+   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
+               ' values (\'NYC\', \'2015-02-08\', \'2015-02-09\', \'2015-02-13\', 26, 7, 2015, \'2015-01-01\', \'2015-12-31\', 2);', $connection);
+   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
+               ' values (\'NYC\', \'2015-02-24\', \'2015-02-23\', \'2015-02-27\', 36, 9, 2015, \'2015-01-01\', \'2015-12-31\', 3);', $connection);               
+   executeInDb('insert into calendar ("calendar name", "date", "fiscal week start", "fiscal week end", "fiscal day", "fiscal week", "fiscal year", "fiscal year start", "fiscal year end", "fiscal day of week")' + 
+               ' values (\'NYC\', \'2015-02-25\', \'2015-02-23\', \'2015-02-27\', 37, 9, 2015, \'2015-01-01\', \'2015-12-31\', 3);', $connection);            
    
 
    true;
@@ -469,6 +469,7 @@ Class meta::relational::tests::groupBy::datePeriods::domain::IncomeFunction
 {
    code:Integer[1];
    name:String[1];
+   incomeYear: Integer[1];
 }
 
 Class meta::relational::tests::groupBy::datePeriods::domain::Division
@@ -504,6 +505,7 @@ Class meta::relational::tests::groupBy::datePeriods::domain::FiscalCalendarDate
    
    yearStart: Date[1];
    yearEnd: Date[1];
+   fiscalYear: FiscalYear[1];
    
    isYtdAsFloat(reportEndDate: FiscalCalendarDate[1])
    {
@@ -541,6 +543,11 @@ Class meta::relational::tests::groupBy::datePeriods::domain::FiscalCalendarDate
    
 }
 
+Class meta::relational::tests::groupBy::datePeriods::domain::FiscalYear
+{
+  value: Integer[1];
+}
+
 ###Relational
 
 Database meta::relational::tests::groupBy::datePeriods::store::myDB
@@ -555,7 +562,7 @@ Database meta::relational::tests::groupBy::datePeriods::store::myDB
                   "fiscal day name"  VARCHAR(16), "fiscal month name"  VARCHAR(16), "fiscal year display"  VARCHAR(8), "fiscal quarter display"  VARCHAR(2), "fiscal month display"  VARCHAR(8), "fiscal week display"  VARCHAR(2), "fiscal day display"  VARCHAR(3), 
                   "is holiday"  VARCHAR(1), "name of day"  VARCHAR(9), "calendar name"  VARCHAR(15) PRIMARY KEY, "region"  VARCHAR(15))
                   
-    Table INCOME_FUNCTION(code INTEGER PRIMARY KEY, name VARCHAR(30))
+    Table INCOME_FUNCTION(code INTEGER PRIMARY KEY, name VARCHAR(30), year INTEGER)
     
     Table SALES_GCS(key INTEGER PRIMARY KEY, if_code INTEGER, division_id INTEGER, credits DOUBLE, tradeDate DATE)
     
@@ -588,7 +595,11 @@ Mapping meta::relational::tests::groupBy::datePeriods::mapping::myMapping
           week: "fiscal week",
           dayOfWeekNumber: "fiscal day of week",
           yearEnd: "fiscal year end",
-          yearStart: "fiscal year start"
+          yearStart: "fiscal year start",
+          fiscalYear
+          (
+            value: "fiscal year"
+          )
           
        )
     }
@@ -598,7 +609,8 @@ Mapping meta::relational::tests::groupBy::datePeriods::mapping::myMapping
        scope([myDB]INCOME_FUNCTION)
        (
           code: code,
-          name: name
+          name: name,
+          incomeYear: year
        ),
        salesCredits: [myDB]@SALES_GC_TO_IF
     }


### PR DESCRIPTION
Fixed the FreeMarker syntax in SQL generation as part of execution plan for property With Path to generate a valid SQL.