### PR TITLE
Standardize compile error handling to avoid infinite loop when serializing

### DIFF
--- a/legend-engine-language-pure-compiler-api/pom.xml
+++ b/legend-engine-language-pure-compiler-api/pom.xml
@@ -145,6 +145,11 @@
             <artifactId>legend-pure-m3-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-language-pure-compiler-api/src/main/java/org/finos/legend/engine/language/pure/compiler/api/Compile.java
+++ b/legend-engine-language-pure-compiler-api/src/main/java/org/finos/legend/engine/language/pure/compiler/api/Compile.java
@@ -124,16 +124,9 @@ public class Compile
 
     private Response handleException(UriInfo uriInfo, MutableList<CommonProfile> profiles, long start, Exception ex)
     {
-        if (ex instanceof EngineException)
-        {
-            MetricsHandler.incrementErrorCount(uriInfo != null ? uriInfo.getPath() : null, Response.Status.BAD_REQUEST.getStatusCode());
-            return Response.status(Response.Status.BAD_REQUEST).entity(ex).build();
-        }
-        else
-        {
-            Response errorResponse = ExceptionTool.exceptionManager(ex, LoggingEventType.COMPILE_ERROR, profiles);
-            MetricsHandler.incrementErrorCount(uriInfo != null ? uriInfo.getPath() : null, errorResponse.getStatus());
-            return errorResponse;
-        }
+        Response.Status status = ex instanceof EngineException ? Response.Status.BAD_REQUEST : Response.Status.INTERNAL_SERVER_ERROR;
+        Response errorResponse = ExceptionTool.exceptionManager(ex, LoggingEventType.COMPILE_ERROR, status, profiles);
+        MetricsHandler.incrementErrorCount(uriInfo != null ? uriInfo.getPath() : null, errorResponse.getStatus());
+        return errorResponse;
     }
 }


### PR DESCRIPTION
If EngineException cause is a PureExcetpion, jackson fails to serialize the response given self reference on some of the get methods.