### PR TITLE
Added Validation for Projection with M2M Mappings (not supported yet)

### DIFF
--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -495,6 +495,21 @@ public class TestServiceRunner
         Assert.assertEquals("{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}", result);
     }
 
+    @Test
+    public void testM2MWithProject()
+    {
+        Exception e1 = Assert.assertThrows(RuntimeException.class, () -> new SimpleM2MServiceRunnerWithProjection());
+        Assert.assertEquals("Assert failure at (resource:/platform/pure/corefunctions/test.pure line:22 column:5), \"Projection not currently supported with Model to Model mapping: This connection is not currently supported with ModelToModel mapping and projection, consider using 'GraphFetch' instead of 'Projection' - may alternatively use 'ModelConnection' or 'ModelChainConnection' in place of this connection\"", e1.getMessage());
+    }
+
+    private static class SimpleM2MServiceRunnerWithProjection extends AbstractServicePlanExecutor
+    {
+        SimpleM2MServiceRunnerWithProjection()
+        {
+            super("test::Service", buildPlanForFetchFunction("/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure", "test::functionWithProjectOnM2M"), true);
+        }
+    }
+
     private static class SimpleOptionalParameterServiceRunner extends AbstractServicePlanExecutor
     {
         private String argName;

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure
@@ -33,6 +33,10 @@ function test::functionWithBatchSize(input: String[1]): String[1]
    test::Person.all()->graphFetch(#{test::Person{firstName,lastName}}#, 10)->serialize(#{test::Person{firstName,lastName}}#)
 }
 
+function test::functionWithProjectOnM2M(input: String[1]): meta::pure::tds::TabularDataSet[1]
+{
+   test::Person.all()->project(p|$p.firstName,'firstName')
+}
 
 ###Mapping
 Mapping test::Map

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
@@ -164,7 +164,8 @@ function meta::pure::mapping::modelToModel::planExecutionPure(sq:meta::pure::map
    let connection = $runtime->toOne()->connectionByElement($sq.store);
    $connection->match([
       mc: ModelConnection[1]| planExecutionInMemory($sq, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mc, $runtime, $exeCtx, $extensions, $debug),
-      mcc: ModelChainConnection[1]| planExecutionChain($sq, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mcc, $runtime, $exeCtx, $extensions, $debug)
+      mcc: ModelChainConnection[1]| planExecutionChain($sq, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mcc, $runtime, $exeCtx, $extensions, $debug),
+      c: Connection[1]| assert(false, 'Projection not currently supported with Model to Model mapping: This connection is not currently supported with ModelToModel mapping and projection, consider using \'GraphFetch\' instead of \'Projection\' - may alternatively use \'ModelConnection\' or \'ModelChainConnection\' in place of this connection'); ^ExecutionNode<>(resultType=^ResultType(type=Any));
    ]);
 }
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/storeContract.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/storeContract.pure
@@ -22,7 +22,7 @@ function meta::pure::mapping::modelToModel::contract::modelStoreContract():Store
      id = 'modelStore',
      executeStoreQuery = meta::pure::mapping::modelToModel::contract::execution_StoreQuery_1__RoutedValueSpecification_$0_1$__Mapping_1__Runtime_1__ExecutionContext_1__Extension_MANY__DebugContext_1__Result_1_,
      supports = meta::pure::mapping::modelToModel::contract::supports_FunctionExpression_1__Boolean_1_,
-     
+
      planExecution = meta::pure::mapping::modelToModel::contract::planExecution_StoreQuery_1__RoutedValueSpecification_$0_1$__Mapping_$0_1$__Runtime_$0_1$__ExecutionContext_1__Extension_MANY__DebugContext_1__ExecutionNode_1_,
      planGraphFetchExecution = meta::pure::mapping::modelToModel::contract::planGraphFetchExecution_ClusteredGraphFetchTree_1__String_MANY__Boolean_1__Boolean_1__StoreQuery_1__RoutedValueSpecification_$0_1$__Mapping_1__Runtime_1__ExecutionContext_1__Extension_MANY__DebugContext_1__LocalGraphFetchExecutionNode_1_,
      planCrossGraphFetchExecution = meta::pure::mapping::modelToModel::contract::planCrossGraphFetchExecution_ClusteredGraphFetchTree_1__String_MANY__String_1__Boolean_1__Boolean_1__Map_1__Mapping_1__Runtime_1__ExecutionContext_1__Extension_MANY__DebugContext_1__LocalGraphFetchExecutionNode_1_,
@@ -43,7 +43,8 @@ function meta::pure::mapping::modelToModel::contract::execution(sq:meta::pure::m
    $connection->match(
                         [
                            mc:ModelConnection[1]| executeInMemory($sq.fe, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mc, $runtime, $sq.advancedRouting->toOne(), $exeCtx, $extensions, $debug),
-                           mcc:ModelChainConnection[1]| executeChain($sq, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mcc, $runtime, $exeCtx, $extensions, $debug)
+                           mcc:ModelChainConnection[1]| executeChain($sq, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mcc, $runtime, $exeCtx, $extensions, $debug),
+                           c: Connection[1]| assert(false, 'Projection not currently supported with Model to Model mapping: This connection is not currently supported with ModelToModel mapping and projection, consider using \'GraphFetch\' instead of \'Projection\' - may alternatively use \'ModelConnection\' or \'ModelChainConnection\' in place of this connection'); ^Result<Any|*>(values=Any);
                         ]
                );
 }


### PR DESCRIPTION
Projection is not currently supported with M2M Mappings in Studio (calls JSONModelConnection), added descriptive validation (old cryptic message: "Cannot find match: JSONModelConnection instance of...")