### PR TITLE
Ensure collection parameter and optional parameters with TimeZone are handled when null.

### DIFF
--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -127,10 +127,52 @@ public class TestServiceRunner
     }
 
     @Test
+    public void testSimpleServiceForOptionalDateTimeWithTimeZone()
+    {
+        this.testOptionalParameter("test::fetchOptionalEmploymentDateTimeWithTZ", "optionalDateTimeWithTZ", "2012-05-20T03:10:52.501", "{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"employmentDateTime\":\"2012-05-20T13:10:52.501000000\"}", "{\"firstName\":\"Bob\",\"lastName\":\"Stevens\",\"employmentDateTime\":null}");
+    }
+
+    @Test
     public void testSimpleServiceForOptionalBoolean()
     {
         this.testOptionalParameter("test::fetchOptionalActiveEmployment", "optionalActiveEmployment", true, "{\"firstName\":\"Bob\",\"lastName\":\"Stevens\"}", "[]");
         this.testOptionalParameter("test::fetchOptionalActiveEmployment", "optionalActiveEmployment", false, "[{\"firstName\":\"Peter\",\"lastName\":\"Smith\"},{\"firstName\":\"John\",\"lastName\":\"Johnson\"}]", "[]");
+    }
+
+    @Test
+    public void testSimpleServiceForOptionalString_Many()
+    {
+        this.testOptionalParameter("test::fetchOptionalCityMany", "optionalCity", Arrays.asList("New York","Dallas"), "[{\"firstName\":\"Peter\",\"lastName\":\"Smith\"},{\"firstName\":\"Bob\",\"lastName\":\"Stevens\"}]", "[]");
+    }
+
+    @Test
+    public void testSimpleServiceForOptionalInteger_Many()
+    {
+        this.testOptionalParameter("test::fetchOptionalAgeMany", "optionalAge", Arrays.asList(25,35), "[{\"firstName\":\"John\",\"lastName\":\"Johnson\"},{\"firstName\":\"Bob\",\"lastName\":\"Stevens\"}]", "[]");
+    }
+
+    @Test
+    public void testSimpleServiceForOptionalFloat_Many()
+    {
+        this.testOptionalParameter("test::fetchOptionalSalaryMany", "optionalSalary", Arrays.asList(80000.75,75000.75), "[{\"firstName\":\"John\",\"lastName\":\"Johnson\",\"salary\":80000.75},{\"firstName\":\"Bob\",\"lastName\":\"Stevens\",\"salary\":75000.75}]", "[]");
+    }
+
+    @Test
+    public void testSimpleServiceForOptionalDate_Many()
+    {
+        this.testOptionalParameter("test::fetchOptionalDobMany", "optionalDate", Arrays.asList("1982-01-20","1997-12-16"), "[{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"dob\":\"1982-01-20\"},{\"firstName\":\"Bob\",\"lastName\":\"Stevens\",\"dob\":\"1997-12-16\"}]", "[]");
+    }
+
+    @Test
+    public void testSimpleServiceForOptionalDateTimeWithNoTZ_Many()
+    {
+        this.testOptionalParameter("test::fetchOptionalDateTimeWithNoTZMany", "optionalDateTime", Arrays.asList("2005-03-15T18:47:52", "2012-05-20T13:10:52.501"), "[{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"employmentDateTime\":\"2012-05-20T13:10:52.501000000\"},{\"firstName\":\"John\",\"lastName\":\"Johnson\",\"employmentDateTime\":\"2005-03-15T18:47:52.000000000\"}]", "[]");
+    }
+
+    @Test
+    public void testSimpleServiceForOptionalDateTimeWithTZ_Many()
+    {
+        this.testOptionalParameter("test::fetchOptionalDateTimeWithTZMany", "optionalDateTime", Arrays.asList("2005-03-15T08:47:52", "2012-05-20T03:10:52.501"), "[{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"employmentDateTime\":\"2012-05-20T13:10:52.501000000\"},{\"firstName\":\"John\",\"lastName\":\"Johnson\",\"employmentDateTime\":\"2005-03-15T18:47:52.000000000\"}]", "[]");
     }
 
     @Test

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleRelationalService.pure
@@ -34,7 +34,16 @@ Database test::DB
     FISCAL_YEAR_VALUE INT
   )
 )
-
+Database test::DB2
+(
+  Table employmentTable
+   (
+     EMP_ID INTEGER PRIMARY KEY,
+     FIRSTNAME VARCHAR(100),
+     LASTNAME VARCHAR(100),
+     EMPLOYMENT_DATETIME TIMESTAMP
+   )
+)
 
 ###Pure
 Class test::Person
@@ -59,6 +68,13 @@ Class test::FiscalCalendar
 Class test::FiscalYear
 {
   value: Integer[1];
+}
+
+Class test::Employment
+{
+  firstName: String[1];
+  lastName: String[1];
+  employmentDateTime : DateTime[0..1];
 }
 
 function test::fetch(ip: String[*]): String[1]
@@ -91,6 +107,11 @@ function test::fetchOptionalEmploymentDateTime(optionalDateTime:DateTime[0..1]):
     test::Person.all()->filter(p|$p.employmentDateTime==$optionalDateTime)->graphFetch(#{test::Person{firstName,lastName,employmentDateTime}}#)->serialize(#{test::Person{firstName,lastName,employmentDateTime}}#)
 }
 
+function test::fetchOptionalEmploymentDateTimeWithTZ(optionalDateTimeWithTZ:DateTime[0..1]):Any[*]
+{
+    test::Employment.all()->filter(e|$e.employmentDateTime==$optionalDateTimeWithTZ)->graphFetch(#{test::Employment{firstName,lastName,employmentDateTime}}#)->serialize(#{test::Employment{firstName,lastName,employmentDateTime}}#)
+}
+
 function test::fetchOptionalActiveEmployment(optionalActiveEmployment:Boolean[0..1]):Any[*]
 {
     test::Person.all()->filter(p|$p.activeEmployment==$optionalActiveEmployment)->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#)
@@ -112,6 +133,36 @@ function test::testMultiExpressionQueryWithPropertyPath(): Any[*]
 {
     let endDateCalendar = test::FiscalCalendar.all()->filter(x|$x.fiscalYear.value == 2015)->toOne()->graphFetch(#{test::FiscalCalendar{fiscalYear{value}}}#);
     test::Person.all()->filter(x|$x.yearOfStart == $endDateCalendar->toOne().fiscalYear.value)->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#);
+}
+
+function test::fetchOptionalCityMany(optionalCity:String[*]):Any[*]
+{
+    test::Person.all()->filter(p|$p.city->in($optionalCity))->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#)
+}
+
+function test::fetchOptionalAgeMany(optionalAge:Integer[*]):Any[*]
+{
+    test::Person.all()->filter(p|$p.age->in($optionalAge))->graphFetch(#{test::Person{firstName,lastName}}#)->serialize(#{test::Person{firstName,lastName}}#)
+}
+
+function test::fetchOptionalSalaryMany(optionalSalary:Float[*]):Any[*]
+{
+    test::Person.all()->filter(p|$p.salary->in($optionalSalary))->graphFetch(#{test::Person{firstName,lastName,salary}}#)->serialize(#{test::Person{firstName,lastName,salary}}#)
+}
+
+function test::fetchOptionalDobMany(optionalDate:Date[*]):Any[*]
+{
+    test::Person.all()->filter(p|$p.dob->in($optionalDate))->graphFetch(#{test::Person{firstName,lastName,dob}}#)->serialize(#{test::Person{firstName,lastName,dob}}#)
+}
+
+function test::fetchOptionalDateTimeWithNoTZMany(optionalDateTime:DateTime[*]):Any[*]
+{
+    test::Person.all()->filter(p|$p.employmentDateTime->in($optionalDateTime))->graphFetch(#{test::Person{firstName,lastName,employmentDateTime}}#)->serialize(#{test::Person{firstName,lastName,employmentDateTime}}#)
+}
+
+function test::fetchOptionalDateTimeWithTZMany(optionalDateTime:DateTime[*]):Any[*]
+{
+    test::Employment.all()->filter(e|$e.employmentDateTime->in($optionalDateTime))->graphFetch(#{test::Employment{firstName,lastName,employmentDateTime}}#)->serialize(#{test::Employment{firstName,lastName,employmentDateTime}}#)
 }
 
 ###Mapping
@@ -148,6 +199,18 @@ Mapping test::Map
         value: [test::DB]fiscalCalendarTable.FISCAL_YEAR_VALUE
       )
     }
+
+  *test::Employment: Relational
+    {
+      ~primaryKey
+      (
+        [test::DB2]employmentTable.EMP_ID
+      )
+      ~mainTable [test::DB2]employmentTable
+      firstName: [test::DB2]employmentTable.FIRSTNAME,
+      lastName: [test::DB2]employmentTable.LASTNAME,
+      employmentDateTime : [test::DB2]employmentTable.EMPLOYMENT_DATETIME
+    }
 )
 
 ###Runtime
@@ -170,6 +233,23 @@ Runtime test::Runtime
           specification: LocalH2
           {
             testDataSetupCSV: 'default\nfiscalCalendarTable\nID,FISCAL_YEAR_VALUE\n111,2015\n222,2005\n333,2010\n---\ndefault\npersonTable\nID,FIRSTNAME,LASTNAME,CITY,AGE,SALARY,DOB,EMPLOYMENT_DATETIME,ACTIVE_EMPLOYMENT,YEAR_OF_START\n1,Peter,Smith,New York,,,1982-01-20,2012-05-20T13:10:52.501,,2015\n2,John,Johnson,,35,80000.75,,2005-03-15T18:47:52,N,2005\n3,Bob,Stevens,Dallas,25,75000.75,1997-12-16,,Y,2010\n---';
+          };
+          auth: DefaultH2;
+        }
+      }#
+    ],
+    test::DB2:
+    [
+      connection_2:
+      #{
+        RelationalDatabaseConnection
+        {
+          store: test::DB2;
+          type: H2;
+          timezone:+1000;
+          specification: LocalH2
+          {
+            testDataSetupCSV: 'default\nemploymentTable\nEMP_ID,FIRSTNAME,LASTNAME,EMPLOYMENT_DATETIME\n1,Peter,Smith,2012-05-20T13:10:52.501\n2,John,Johnson,2005-03-15T18:47:52\n3,Bob,Stevens,\n---';
           };
           auth: DefaultH2;
         }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_execution.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_execution.pure
@@ -63,7 +63,7 @@ function meta::pure::executionPlan::buildVariableTemplateString(name:String[1], 
 
 function meta::pure::executionPlan::buildVariableCollectionSizeString(name:String[1]): String[1]
 {
-   '${collectionSize('+$name+')}'
+   '${collectionSize('+$name+'![])}'
 }
 
 function meta::pure::executionPlan::allNodes(node: ExecutionNode[1], extensions:meta::pure::extension::Extension[*]): ExecutionNode[*]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -80,12 +80,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root"."time" as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root"."active" = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root"."active" = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root"."time" as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root"."active" = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root"."active" = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "SybaseIQ")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.SybaseIQ, $expectedPlan);                     
 }
 
@@ -103,12 +102,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "DB2")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-                                   
    assertPlanGenerationForOptionalParameter(DatabaseType.DB2, $expectedPlan);
 }
 
@@ -126,12 +124,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "Sybase")\n'+
                      '    )\n'+
                      '  )\n'+
-                     ')\n'; 
-   
+                     ')\n';
    assertPlanGenerationForOptionalParameter(DatabaseType.Sybase, $expectedPlan); 
 }
 
@@ -149,12 +146,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select `root`.time as `Time` from interactionTable as `root` where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'`root`.ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'`root`.ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select `root`.time as `Time` from interactionTable as `root` where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'`root`.ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'`root`.ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "MemSQL")\n'+
                      '    )\n'+
                      '  )\n'+
-                     ')\n'; 
-   
+                     ')\n';
    assertPlanGenerationForOptionalParameter(DatabaseType.MemSQL, $expectedPlan);
 }
 
@@ -172,12 +168,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "Snowflake")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.Snowflake, $expectedPlan);
 }
 
@@ -195,12 +190,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "" "" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "" "" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "Presto")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.Presto, $expectedPlan);
 }
 
@@ -218,12 +212,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "Redshift")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.Redshift, $expectedPlan);
 }
 
@@ -241,12 +234,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select `root`.time as `Time` from interactionTable as `root` where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'`root`.ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'`root`.ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select `root`.time as `Time` from interactionTable as `root` where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'`root`.ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'`root`.ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "BigQuery")\n'+
                      '    )\n'+
                      '  )\n'+
-                     ')\n'; 
-   
+                     ')\n';
    assertPlanGenerationForOptionalParameter(DatabaseType.BigQuery, $expectedPlan);
 }
 
@@ -264,12 +256,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "Composite")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.Composite, $expectedPlan);
 }
 
@@ -287,12 +278,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "Hive")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.Hive, $expectedPlan);
 }
 
@@ -310,12 +300,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "Text\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = Text\\\'Y\\\' then Text\\\'true\\\' else Text\\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "Boolean\\\'" "\\\'" "null")}\', \'case when "root".active = Text\\\'Y\\\' then Text\\\'true\\\' else Text\\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "Text\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = Text\\\'Y\\\' then Text\\\'true\\\' else Text\\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "Boolean\\\'" "\\\'" "null")}\', \'case when "root".active = Text\\\'Y\\\' then Text\\\'true\\\' else Text\\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "Postgres")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.Postgres, $expectedPlan);
 }
 
@@ -333,12 +322,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "H2")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameter(DatabaseType.H2, $expectedPlan);
 }
 
@@ -357,12 +345,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                   '    (\n'+
                   '      type = TDS[(Name, String, VARCHAR(200), "")]\n'+
                   '      resultColumns = [("Name", VARCHAR(200))]\n'+
-                  '      sql = select "root".NAME as "Name" from addressTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalStreet![], \'"root".STREET = ${varPlaceHolderToString(optionalStreet![]  "\\\'" "\\\'" "null")}\', \'"root".STREET is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalStreet![], \'${varPlaceHolderToString(optionalStreet![]  "\\\'" "\\\'" "null")} = "root".STREET\', \'"root".STREET is null\')}))\n'+
+                  '      sql = select "root".NAME as "Name" from addressTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalStreet![], \'"root".STREET = ${varPlaceHolderToString(optionalStreet![] "\\\'" "\\\'" "null")}\', \'"root".STREET is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalStreet![], \'${varPlaceHolderToString(optionalStreet![] "\\\'" "\\\'" "null")} = "root".STREET\', \'"root".STREET is null\')}))\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
@@ -385,12 +372,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                   '      type = Class[impls=(meta::relational::tests::model::simple::Order | simpleRelationalMapping.meta_relational_tests_model_simple_Order)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("id", INT), ("quantity", INT), ("date", DATE), ("settlementDateTime", TIMESTAMP), ("pnl", FLOAT), ("zeroPnl", "")]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime", "orderpnlview_0".pnl as "pnl", case when "orderpnlview_0".pnl = 0 then \'true\' else \'false\' end as "zeroPnl" from orderTable as "root" left outer join (select distinct "root".ORDER_ID as ORDER_ID, "root".pnl as pnl, "accounttable_0".ID as accountId, "salespersontable_0".NAME as supportContact, "salespersontable_0".PERSON_ID as supportContactId from orderPnlTable as "root" left outer join orderTable as "ordertable_1" on ("root".ORDER_ID = "ordertable_1".ID) left outer join accountTable as "accounttable_0" on ("ordertable_1".accountID = "accounttable_0".ID) left outer join salesPersonTable as "salespersontable_0" on ("ordertable_1".accountID = "salespersontable_0".ACCOUNT_ID) where "root".pnl > 0) as "orderpnlview_0" on ("orderpnlview_0".ORDER_ID = "root".ID) where (${optionalVarPlaceHolderOperationSelector(optionalPnl![], \'"orderPnlView_d#2_d#2_m5".pnl = ${varPlaceHolderToString(optionalPnl![]  "" "" "null")}\', \'"orderPnlView_d#2_d#2_m5".pnl is null\')})\n'+
+                  '      sql = select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime", "orderpnlview_0".pnl as "pnl", case when "orderpnlview_0".pnl = 0 then \'true\' else \'false\' end as "zeroPnl" from orderTable as "root" left outer join (select distinct "root".ORDER_ID as ORDER_ID, "root".pnl as pnl, "accounttable_0".ID as accountId, "salespersontable_0".NAME as supportContact, "salespersontable_0".PERSON_ID as supportContactId from orderPnlTable as "root" left outer join orderTable as "ordertable_1" on ("root".ORDER_ID = "ordertable_1".ID) left outer join accountTable as "accounttable_0" on ("ordertable_1".accountID = "accounttable_0".ID) left outer join salesPersonTable as "salespersontable_0" on ("ordertable_1".accountID = "salespersontable_0".ACCOUNT_ID) where "root".pnl > 0) as "orderpnlview_0" on ("orderpnlview_0".ORDER_ID = "root".ID) where (${optionalVarPlaceHolderOperationSelector(optionalPnl![], \'"orderPnlView_d#2_d#2_m5".pnl = ${varPlaceHolderToString(optionalPnl![] "" "" "null")}\', \'"orderPnlView_d#2_d#2_m5".pnl is null\')})\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
@@ -413,13 +399,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                   '      type = Class[impls=(meta::relational::tests::model::simple::Person | simpleRelationalMappingInc.meta_relational_tests_model_simple_Person)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("firstName", VARCHAR(200)), ("age", INT), ("lastName", VARCHAR(200))]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".FIRSTNAME as "firstName", "root".AGE as "age", "root".LASTNAME as "lastName" from personTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalAge![], \'"root".AGE = ${varPlaceHolderToString(optionalAge![]  "" "" "null")}\', \'"root".AGE is null\')})\n'+
+                  '      sql = select "root".ID as "pk_0", "root".FIRSTNAME as "firstName", "root".AGE as "age", "root".LASTNAME as "lastName" from personTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalAge![], \'"root".AGE = ${varPlaceHolderToString(optionalAge![] "" "" "null")}\', \'"root".AGE is null\')})\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
@@ -442,21 +426,18 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                   '      type = Class[impls=(meta::relational::tests::model::simple::Location | simpleRelationalMappingInc.meta_relational_tests_model_simple_Location)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("place", VARCHAR(200)), ("censusdate", DATE)]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".PLACE as "place", "root".date as "censusdate" from locationTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalCensusDate![], \'"root".date = ${varPlaceHolderToString(optionalCensusDate![]  "\\\'" "\\\'" "null")}\', \'"root".date is null\')})\n'+
+                  '      sql = select "root".ID as "pk_0", "root".PLACE as "place", "root".date as "censusdate" from locationTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalCensusDate![], \'"root".date = ${varPlaceHolderToString(optionalCensusDate![] "\\\'" "\\\'" "null")}\', \'"root".date is null\')})\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOptionalParameterDateTimeWithNoTimeZone():Boolean[1]
 {
-   let connectionWithNoTimeZone = ^TestDatabaseConnection(element = db, type=DatabaseType.H2);
-   let runtime = ^Runtime(connections = $connectionWithNoTimeZone);
-   let generatedPlan = executionPlan({optionalSettlementDateTime:DateTime[0..1]|Order.all()->filter(o|$o.settlementDateTime == $optionalSettlementDateTime)}, simpleRelationalMapping, $runtime, meta::relational::extension::relationalExtensions());
+   let generatedPlan = executionPlan({optionalSettlementDateTime:DateTime[0..1]|Order.all()->filter(o|$o.settlementDateTime == $optionalSettlementDateTime)}, simpleRelationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.H2)), meta::relational::extension::relationalExtensions());
    let result = $generatedPlan->planToString(meta::relational::extension::relationalExtensions());
    let expected = 'Sequence\n'+
                   '(\n'+
@@ -472,25 +453,39 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOpt
                   '      type = Class[impls=(meta::relational::tests::model::simple::Order | simpleRelationalMapping.meta_relational_tests_model_simple_Order)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("id", INT), ("quantity", INT), ("date", DATE), ("settlementDateTime", TIMESTAMP), ("pnl", FLOAT), ("zeroPnl", "")]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime", "orderpnlview_0".pnl as "pnl", case when "orderpnlview_0".pnl = 0 then \'true\' else \'false\' end as "zeroPnl" from orderTable as "root" left outer join (select distinct "root".ORDER_ID as ORDER_ID, "root".pnl as pnl, "accounttable_0".ID as accountId, "salespersontable_0".NAME as supportContact, "salespersontable_0".PERSON_ID as supportContactId from orderPnlTable as "root" left outer join orderTable as "ordertable_1" on ("root".ORDER_ID = "ordertable_1".ID) left outer join accountTable as "accounttable_0" on ("ordertable_1".accountID = "accounttable_0".ID) left outer join salesPersonTable as "salespersontable_0" on ("ordertable_1".accountID = "salespersontable_0".ACCOUNT_ID) where "root".pnl > 0) as "orderpnlview_0" on ("orderpnlview_0".ORDER_ID = "root".ID) where (${optionalVarPlaceHolderOperationSelector(optionalSettlementDateTime![], \'"root".settlementDateTime = ${varPlaceHolderToString(optionalSettlementDateTime![]  "\\\'" "\\\'" "null")}\', \'"root".settlementDateTime is null\')})\n'+
-                  '      connection = TestDatabaseConnection(type = "H2")\n'+
+                  '      sql = select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime", "orderpnlview_0".pnl as "pnl", case when "orderpnlview_0".pnl = 0 then \'true\' else \'false\' end as "zeroPnl" from orderTable as "root" left outer join (select distinct "root".ORDER_ID as ORDER_ID, "root".pnl as pnl, "accounttable_0".ID as accountId, "salespersontable_0".NAME as supportContact, "salespersontable_0".PERSON_ID as supportContactId from orderPnlTable as "root" left outer join orderTable as "ordertable_1" on ("root".ORDER_ID = "ordertable_1".ID) left outer join accountTable as "accounttable_0" on ("ordertable_1".accountID = "accounttable_0".ID) left outer join salesPersonTable as "salespersontable_0" on ("ordertable_1".accountID = "salespersontable_0".ACCOUNT_ID) where "root".pnl > 0) as "orderpnlview_0" on ("orderpnlview_0".ORDER_ID = "root".ID) where (${optionalVarPlaceHolderOperationSelector(optionalSettlementDateTime![], \'"root".settlementDateTime = ${varPlaceHolderToString(optionalSettlementDateTime![] "\\\'" "\\\'" "null")}\', \'"root".settlementDateTime is null\')})\n'+
+                  '      connection = DatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
 
-function <<test.Test, test.ToFix>> meta::pure::executionPlan::tests::testFilterEqualsWithOptionalParameterDateTimeWithTimeZone():Boolean[1]
+function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithOptionalParameterDateTimeWithTimeZone():Boolean[1]
 {
-   // VarPlaceHolder logic for DateTime datatype when timeZone is provided is not handled when its multiplicity has lowerBound as Zero.
-   // Should return a SQL that can handle the case when DateTime variable with TimeZone does not have a value during execution.
-   let connectionEST = ^TestDatabaseConnection(element = db, type=DatabaseType.H2, timeZone='US/Arizona');
-   let runtime = ^Runtime(connections = $connectionEST);
-   let generatedPlan = executionPlan({optionalSettlementDateTime:DateTime[0..1]|Order.all()->filter(o|$o.settlementDateTime == $optionalSettlementDateTime)}, simpleRelationalMapping, $runtime, meta::relational::extension::relationalExtensions());
+   let generatedPlan = executionPlan({optionalSettlementDateTime:DateTime[0..1]|Order.all()->filter(o|$o.settlementDateTime == $optionalSettlementDateTime)}, simpleRelationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.H2, timeZone='US/Arizona')), meta::relational::extension::relationalExtensions());
    let result = $generatedPlan->planToString(meta::relational::extension::relationalExtensions());
-   false;
+   let expected = 'Sequence\n'+
+                  '(\n'+
+                  '  type = Class[impls=(meta::relational::tests::model::simple::Order | simpleRelationalMapping.meta_relational_tests_model_simple_Order)]\n'+
+                  '  resultSizeRange = *\n'+
+                  '  (\n'+
+                  '    FunctionParametersValidationNode\n'+
+                  '    (\n'+
+                  '      functionParameters = [optionalSettlementDateTime:DateTime[0..1]]\n'+
+                  '    )\n'+
+                  '    Relational\n'+
+                  '    (\n'+
+                  '      type = Class[impls=(meta::relational::tests::model::simple::Order | simpleRelationalMapping.meta_relational_tests_model_simple_Order)]\n'+
+                  '      resultSizeRange = *\n'+
+                  '      resultColumns = [("pk_0", INT), ("id", INT), ("quantity", INT), ("date", DATE), ("settlementDateTime", TIMESTAMP), ("pnl", FLOAT), ("zeroPnl", "")]\n'+
+                  '      sql = select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime", "orderpnlview_0".pnl as "pnl", case when "orderpnlview_0".pnl = 0 then \'true\' else \'false\' end as "zeroPnl" from orderTable as "root" left outer join (select distinct "root".ORDER_ID as ORDER_ID, "root".pnl as pnl, "accounttable_0".ID as accountId, "salespersontable_0".NAME as supportContact, "salespersontable_0".PERSON_ID as supportContactId from orderPnlTable as "root" left outer join orderTable as "ordertable_1" on ("root".ORDER_ID = "ordertable_1".ID) left outer join accountTable as "accounttable_0" on ("ordertable_1".accountID = "accounttable_0".ID) left outer join salesPersonTable as "salespersontable_0" on ("ordertable_1".accountID = "salespersontable_0".ACCOUNT_ID) where "root".pnl > 0) as "orderpnlview_0" on ("orderpnlview_0".ORDER_ID = "root".ID) where (${optionalVarPlaceHolderOperationSelector(optionalSettlementDateTime![], \'"root".settlementDateTime = ${varPlaceHolderToString(GMTtoTZ( "[US/Arizona]" optionalSettlementDateTime![]) "\\\'" "\\\'" "null")}\', \'"root".settlementDateTime is null\')})\n'+
+                  '      connection = DatabaseConnection(type = "H2")\n'+
+                  '    )\n'+
+                  '  )\n'+
+                  ')\n';
+   assertEquals($expected, $result);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwoOptionalParametersString():Boolean[1]
@@ -511,7 +506,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwo
                   '      type = Class[impls=(meta::relational::tests::model::simple::Address | simpleRelationalMappingInc.meta_relational_tests_model_simple_Address)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("name", VARCHAR(200)), ("street", VARCHAR(100)), ("type", INT), ("comments", VARCHAR(100))]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalLeft![], optionalVarPlaceHolderOperationSelector(optionalRight![], \'${varPlaceHolderToString(optionalLeft![]  "\\\'" "\\\'" "null")} = ${varPlaceHolderToString(optionalRight![]  "\\\'" "\\\'" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalRight![], \'1 = 0\', \'1 = 1\'))})\n'+
+                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalLeft![], optionalVarPlaceHolderOperationSelector(optionalRight![], \'${varPlaceHolderToString(optionalLeft![] "\\\'" "\\\'" "null")} = ${varPlaceHolderToString(optionalRight![] "\\\'" "\\\'" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalRight![], \'1 = 0\', \'1 = 1\'))})\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
@@ -538,7 +533,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwo
                   '      type = Class[impls=(meta::relational::tests::model::simple::Address | simpleRelationalMappingInc.meta_relational_tests_model_simple_Address)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("name", VARCHAR(200)), ("street", VARCHAR(100)), ("type", INT), ("comments", VARCHAR(100))]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalIntLeft![], optionalVarPlaceHolderOperationSelector(optionalIntRight![], \'${varPlaceHolderToString(optionalIntLeft![]  "" "" "null")} = ${varPlaceHolderToString(optionalIntRight![]  "" "" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalIntRight![], \'1 = 0\', \'1 = 1\'))})\n'+
+                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalIntLeft![], optionalVarPlaceHolderOperationSelector(optionalIntRight![], \'${varPlaceHolderToString(optionalIntLeft![] "" "" "null")} = ${varPlaceHolderToString(optionalIntRight![] "" "" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalIntRight![], \'1 = 0\', \'1 = 1\'))})\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
@@ -565,12 +560,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwo
                   '      type = Class[impls=(meta::relational::tests::model::simple::Address | simpleRelationalMappingInc.meta_relational_tests_model_simple_Address)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("name", VARCHAR(200)), ("street", VARCHAR(100)), ("type", INT), ("comments", VARCHAR(100))]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalFloatLeft![], optionalVarPlaceHolderOperationSelector(optionalFloatRight![], \'${varPlaceHolderToString(optionalFloatLeft![]  "" "" "null")} = ${varPlaceHolderToString(optionalFloatRight![]  "" "" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalFloatRight![], \'1 = 0\', \'1 = 1\'))})\n'+
+                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalFloatLeft![], optionalVarPlaceHolderOperationSelector(optionalFloatRight![], \'${varPlaceHolderToString(optionalFloatLeft![] "" "" "null")} = ${varPlaceHolderToString(optionalFloatRight![] "" "" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalFloatRight![], \'1 = 0\', \'1 = 1\'))})\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
@@ -593,21 +587,18 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwo
                   '      type = Class[impls=(meta::relational::tests::model::simple::Address | simpleRelationalMappingInc.meta_relational_tests_model_simple_Address)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("name", VARCHAR(200)), ("street", VARCHAR(100)), ("type", INT), ("comments", VARCHAR(100))]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalDateLeft![], optionalVarPlaceHolderOperationSelector(optionalDateRight![], \'${varPlaceHolderToString(optionalDateLeft![]  "\\\'" "\\\'" "null")} = ${varPlaceHolderToString(optionalDateRight![]  "\\\'" "\\\'" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalDateRight![], \'1 = 0\', \'1 = 1\'))})\n'+
+                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalDateLeft![], optionalVarPlaceHolderOperationSelector(optionalDateRight![], \'${varPlaceHolderToString(optionalDateLeft![] "\\\'" "\\\'" "null")} = ${varPlaceHolderToString(optionalDateRight![] "\\\'" "\\\'" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalDateRight![], \'1 = 0\', \'1 = 1\'))})\n'+
                   '      connection = TestDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwoOptionalParametersDateTimeWithNoTimeZone():Boolean[1]
 {
-   let connectionWithNoTimeZone = ^TestDatabaseConnection(element = db, type=DatabaseType.H2);
-   let runtime = ^Runtime(connections = $connectionWithNoTimeZone);
-   let generatedPlan = executionPlan({optionalLeft: DateTime[0..1], optionalRight :DateTime[0..1]|Address.all()->filter(a|$optionalLeft==$optionalRight)}, simpleRelationalMapping, $runtime, meta::relational::extension::relationalExtensions());
+   let generatedPlan = executionPlan({optionalLeft: DateTime[0..1], optionalRight :DateTime[0..1]|Address.all()->filter(a|$optionalLeft==$optionalRight)}, simpleRelationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.H2)), meta::relational::extension::relationalExtensions());
    let result = $generatedPlan->planToString(meta::relational::extension::relationalExtensions());
    let expected = 'Sequence\n'+
                   '(\n'+
@@ -623,17 +614,42 @@ function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwo
                   '      type = Class[impls=(meta::relational::tests::model::simple::Address | simpleRelationalMappingInc.meta_relational_tests_model_simple_Address)]\n'+
                   '      resultSizeRange = *\n'+
                   '      resultColumns = [("pk_0", INT), ("name", VARCHAR(200)), ("street", VARCHAR(100)), ("type", INT), ("comments", VARCHAR(100))]\n'+
-                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalLeft![], optionalVarPlaceHolderOperationSelector(optionalRight![], \'${varPlaceHolderToString(optionalLeft![]  "\\\'" "\\\'" "null")} = ${varPlaceHolderToString(optionalRight![]  "\\\'" "\\\'" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalRight![], \'1 = 0\', \'1 = 1\'))})\n'+
-                  '      connection = TestDatabaseConnection(type = "H2")\n'+
+                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalLeft![], optionalVarPlaceHolderOperationSelector(optionalRight![], \'${varPlaceHolderToString(optionalLeft![] "\\\'" "\\\'" "null")} = ${varPlaceHolderToString(optionalRight![] "\\\'" "\\\'" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalRight![], \'1 = 0\', \'1 = 1\'))})\n'+
+                  '      connection = DatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+
                   ')\n';
-
    assertEquals($expected, $result);
    assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }
 
-function <<test.Test>> meta::pure::executionPlan::tests::testGreaterThanLessThanEqualsWithOptionalParameter_SybaseIQ():Boolean[1]      
+function <<test.Test>> meta::pure::executionPlan::tests::testFilterEqualsWithTwoOptionalParameterDateTimeWithTimeZone():Boolean[1]
+{
+   let generatedPlan = executionPlan({optionalLeft: DateTime[0..1], optionalRight :DateTime[0..1]|Address.all()->filter(a|$optionalLeft==$optionalRight)}, simpleRelationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.H2, timeZone='US/Arizona')), meta::relational::extension::relationalExtensions());
+   let result = $generatedPlan->planToString(meta::relational::extension::relationalExtensions());
+   let expected = 'Sequence\n'+
+                  '(\n'+
+                  '  type = Class[impls=(meta::relational::tests::model::simple::Address | simpleRelationalMappingInc.meta_relational_tests_model_simple_Address)]\n'+
+                  '  resultSizeRange = *\n'+
+                  '  (\n'+
+                  '    FunctionParametersValidationNode\n'+
+                  '    (\n'+
+                  '      functionParameters = [optionalLeft:DateTime[0..1], optionalRight:DateTime[0..1]]\n'+
+                  '    )\n'+
+                  '    Relational\n'+
+                  '    (\n'+
+                  '      type = Class[impls=(meta::relational::tests::model::simple::Address | simpleRelationalMappingInc.meta_relational_tests_model_simple_Address)]\n'+
+                  '      resultSizeRange = *\n'+
+                  '      resultColumns = [("pk_0", INT), ("name", VARCHAR(200)), ("street", VARCHAR(100)), ("type", INT), ("comments", VARCHAR(100))]\n'+
+                  '      sql = select "root".ID as "pk_0", "root".NAME as "name", "root".STREET as "street", "root".TYPE as "type", "root".COMMENTS as "comments" from addressTable as "root" where (${optionalVarPlaceHolderOperationSelector(optionalLeft![], optionalVarPlaceHolderOperationSelector(optionalRight![], \'${varPlaceHolderToString(GMTtoTZ( "[US/Arizona]" optionalLeft![]) "\\\'" "\\\'" "null")} = ${varPlaceHolderToString(GMTtoTZ( "[US/Arizona]" optionalRight![]) "\\\'" "\\\'" "null")}\', \'1 = 0\'), optionalVarPlaceHolderOperationSelector(optionalRight![], \'1 = 0\', \'1 = 1\'))})\n'+
+                  '      connection = DatabaseConnection(type = "H2")\n'+
+                  '    )\n'+
+                  '  )\n'+
+                  ')\n';
+   assertEquals($expected, $result);
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::testGreaterThanLessThanEqualsWithOptionalParameter_SybaseIQ():Boolean[1]
 {  
    let func = {optionalAgeLowerLimit: Integer[0..1], optionalAgeHigherLimit: Integer[0..1]|Person.all()->filter(p|$p.age>$optionalAgeLowerLimit && ($p.age<=$optionalAgeHigherLimit))->project(col(a|$a.firstName, 'firstName'))};
    let expectedPlan ='Sequence\n'+
@@ -648,13 +664,12 @@ function <<test.Test>> meta::pure::executionPlan::tests::testGreaterThanLessThan
                      '    (\n'+
                      '      type = TDS[(firstName, String, VARCHAR(200), "")]\n'+
                      '      resultColumns = [("firstName", VARCHAR(200))]\n'+
-                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")} is not null) and "root".AGE > ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")} is not null) and "root".AGE <= ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")}))\n'+
+                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")} is not null) and "root".AGE > ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")} is not null) and "root".AGE <= ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")}))\n'+
                      '      connection = DatabaseConnection(type = "SybaseIQ")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
-   assertPlanGenerationForOptionalParameterWithGreaterThanLessThan($func, DatabaseType.SybaseIQ, $expectedPlan); 
+   assertPlanGenerationForOptionalParameterWithGreaterThanLessThan($func, DatabaseType.SybaseIQ, $expectedPlan);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testGreaterThanLessThanEqualsWithOptionalParameter_H2():Boolean[1]      
@@ -672,12 +687,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testGreaterThanLessThan
                      '    (\n'+
                      '      type = TDS[(firstName, String, VARCHAR(200), "")]\n'+
                      '      resultColumns = [("firstName", VARCHAR(200))]\n'+
-                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")} is not null) and "root".AGE > ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")} is not null) and "root".AGE <= ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")}))\n'+
+                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")} is not null) and "root".AGE > ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")} is not null) and "root".AGE <= ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")}))\n'+
                      '      connection = DatabaseConnection(type = "H2")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameterWithGreaterThanLessThan($func, DatabaseType.H2, $expectedPlan); 
 }
 
@@ -696,12 +710,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testLessThanGreaterThan
                      '    (\n'+
                      '      type = TDS[(firstName, String, VARCHAR(200), "")]\n'+
                      '      resultColumns = [("firstName", VARCHAR(200))]\n'+
-                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")} is not null) and "root".AGE < ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")} is not null) and "root".AGE >= ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")}))\n'+
+                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")} is not null) and "root".AGE < ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")} is not null) and "root".AGE >= ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")}))\n'+
                      '      connection = DatabaseConnection(type = "SybaseIQ")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameterWithGreaterThanLessThan($func, DatabaseType.SybaseIQ, $expectedPlan); 
 }
 
@@ -720,12 +733,11 @@ function <<test.Test>> meta::pure::executionPlan::tests::testLessThanGreaterThan
                      '    (\n'+
                      '      type = TDS[(firstName, String, VARCHAR(200), "")]\n'+
                      '      resultColumns = [("firstName", VARCHAR(200))]\n'+
-                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")} is not null) and "root".AGE < ${varPlaceHolderToString(optionalAgeLowerLimit![]  "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")} is not null) and "root".AGE >= ${varPlaceHolderToString(optionalAgeHigherLimit![]  "" "" "null")}))\n'+
+                     '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where ((("root".AGE is not null and ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")} is not null) and "root".AGE < ${varPlaceHolderToString(optionalAgeLowerLimit![] "" "" "null")}) and (("root".AGE is not null and ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")} is not null) and "root".AGE >= ${varPlaceHolderToString(optionalAgeHigherLimit![] "" "" "null")}))\n'+
                      '      connection = DatabaseConnection(type = "H2")\n'+
                      '    )\n'+
                      '  )\n'+
                      ')\n';
-   
    assertPlanGenerationForOptionalParameterWithGreaterThanLessThan($func, DatabaseType.H2, $expectedPlan); 
 }
 
@@ -800,7 +812,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::datetime::testPlanForDa
    let expected = 'Relational (   type = Class[impls=(meta::relational::tests::model::simple::Order | simpleRelationalMapping.meta_relational_tests_model_simple_Order)]   resultSizeRange = *   resultColumns = [("pk_0", INT), ("id", INT), ("quantity", INT), ("date", DATE), ("settlementDateTime", TIMESTAMP), ("pnl", FLOAT), ("zeroPnl", "")]   sql = select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime", "orderpnlview_0".pnl as "pnl", case when "orderpnlview_0".pnl = 0 then \'true\' else \'false\' end as "zeroPnl" from orderTable as "root" left outer join (select distinct "root".ORDER_ID as ORDER_ID, "root".pnl as pnl, "accounttable_0".ID as accountId, "salespersontable_0".NAME as supportContact, "salespersontable_0".PERSON_ID as supportContactId from orderPnlTable as "root" left outer join orderTable as "ordertable_1" on ("root".ORDER_ID = "ordertable_1".ID) left outer join accountTable as "accounttable_0" on ("ordertable_1".accountID = "accounttable_0".ID) left outer join salesPersonTable as "salespersontable_0" on ("ordertable_1".accountID = "salespersontable_0".ACCOUNT_ID) where "root".pnl > 0) as "orderpnlview_0" on ("orderpnlview_0".ORDER_ID = "root".ID) where "root".settlementDateTime = \'2019-04-08 13:00:00\'   connection = TestDatabaseConnection(type = "H2") ) ';
    assertEquals($expected, $planAsString);
    assert($planAsString->indexOf('settlementDateTime = \'2019-04-08 13:00:00\'') != -1);
-   assertSameElements(['<#function GMTtoTZ tz paramDate><#return (tz+" "+paramDate)?date.@alloyDate></#function><#function renderCollectionWithTz collection timeZone separator prefix suffix defaultValue><#assign result = [] /><#list collection as c><#assign result = [prefix + (timeZone+" "+c)?date.@alloyDate + suffix] + result></#list><#return result?reverse?join(separator, defaultValue)></#function>',
+   assertSameElements(['<#function GMTtoTZ tz paramDate><#if paramDate?is_enumerable && !paramDate?has_content><#return paramDate><#else><#return (tz+" "+paramDate)?date.@alloyDate></#if></#function><#function renderCollectionWithTz collection timeZone separator prefix suffix defaultValue><#assign result = [] /><#list collection as c><#assign result = [prefix + (timeZone+" "+c)?date.@alloyDate + suffix] + result></#list><#return result?reverse?join(separator, defaultValue)></#function>',
                        '<#function renderCollection collection separator prefix suffix defaultValue><#if collection?size == 0><#return defaultValue></#if><#return prefix + collection?join(suffix + separator + prefix) + suffix></#function>',
                        '<#function collectionSize collection> <#return collection?size?c> </#function>',
                        '<#function optionalVarPlaceHolderOperationSelector optionalParameter trueClause falseClause><#if optionalParameter?has_content || optionalParameter?is_string><#return trueClause><#else><#return falseClause></#if></#function>',
@@ -825,7 +837,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::datetime::testPlanForDa
    let expected = 'Sequence (   type = Class[impls=(meta::relational::tests::model::simple::Order | simpleRelationalMapping.meta_relational_tests_model_simple_Order)]   resultSizeRange = *   (     FunctionParametersValidationNode     (       functionParameters = [dt:DateTime[1]]     )     Relational     (       type = Class[impls=(meta::relational::tests::model::simple::Order | simpleRelationalMapping.meta_relational_tests_model_simple_Order)]       resultSizeRange = *       resultColumns = [("pk_0", INT), ("id", INT), ("quantity", INT), ("date", DATE), ("settlementDateTime", TIMESTAMP), ("pnl", FLOAT), ("zeroPnl", "")]       sql = select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime", "orderpnlview_0".pnl as "pnl", case when "orderpnlview_0".pnl = 0 then \'true\' else \'false\' end as "zeroPnl" from orderTable as "root" left outer join (select distinct "root".ORDER_ID as ORDER_ID, "root".pnl as pnl, "accounttable_0".ID as accountId, "salespersontable_0".NAME as supportContact, "salespersontable_0".PERSON_ID as supportContactId from orderPnlTable as "root" left outer join orderTable as "ordertable_1" on ("root".ORDER_ID = "ordertable_1".ID) left outer join accountTable as "accounttable_0" on ("ordertable_1".accountID = "accounttable_0".ID) left outer join salesPersonTable as "salespersontable_0" on ("ordertable_1".accountID = "salespersontable_0".ACCOUNT_ID) where "root".pnl > 0) as "orderpnlview_0" on ("orderpnlview_0".ORDER_ID = "root".ID) where "root".settlementDateTime = \'${GMTtoTZ( "[US/Arizona]" dt)}\'       connection = TestDatabaseConnection(type = "H2")     )   ) ) ';
    assertEquals($expected, $planAsString);
    assert($planAsString->indexOf('settlementDateTime = \'${GMTtoTZ( "[US/Arizona]" dt)}\'') != -1);
-   assertSameElements(['<#function GMTtoTZ tz paramDate><#return (tz+" "+paramDate)?date.@alloyDate></#function><#function renderCollectionWithTz collection timeZone separator prefix suffix defaultValue><#assign result = [] /><#list collection as c><#assign result = [prefix + (timeZone+" "+c)?date.@alloyDate + suffix] + result></#list><#return result?reverse?join(separator, defaultValue)></#function>',
+   assertSameElements(['<#function GMTtoTZ tz paramDate><#if paramDate?is_enumerable && !paramDate?has_content><#return paramDate><#else><#return (tz+" "+paramDate)?date.@alloyDate></#if></#function><#function renderCollectionWithTz collection timeZone separator prefix suffix defaultValue><#assign result = [] /><#list collection as c><#assign result = [prefix + (timeZone+" "+c)?date.@alloyDate + suffix] + result></#list><#return result?reverse?join(separator, defaultValue)></#function>',
                        '<#function renderCollection collection separator prefix suffix defaultValue><#if collection?size == 0><#return defaultValue></#if><#return prefix + collection?join(suffix + separator + prefix) + suffix></#function>',
                        '<#function collectionSize collection> <#return collection?size?c> </#function>',
                        '<#function optionalVarPlaceHolderOperationSelector optionalParameter trueClause falseClause><#if optionalParameter?has_content || optionalParameter?is_string><#return trueClause><#else><#return falseClause></#if></#function>',
@@ -2153,7 +2165,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       {name:String[*] |_Person.all()->filter(x | $x.fullName->in($name))->project([x | $x.fullName], ['fullName']);},
       meta::pure::mapping::modelToModel::test::shared::relationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.MemSQL)), meta::relational::extension::relationalExtensions()
    );
-   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name)?number)>1048576))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="MemSQL"))Constant(type=Stringvalues=[select`temptableforin_name_0`.ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas`temptableforin_name_0`]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select`root`.fullnameas`fullName`fromPersonas`root`where`root`.fullnamein(${inFilterClause_name})connection=DatabaseConnection(type="MemSQL"))))';
+   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name![])?number)>1048576))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="MemSQL"))Constant(type=Stringvalues=[select`temptableforin_name_0`.ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas`temptableforin_name_0`]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name![]",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select`root`.fullnameas`fullName`fromPersonas`root`where`root`.fullnamein(${inFilterClause_name})connection=DatabaseConnection(type="MemSQL"))))';
    assertEquals($expected, $res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions()));
 }
 
@@ -2163,7 +2175,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       {name:String[*] |_Person.all()->filter(x | !$x.fullName->in($name))->project([x | $x.fullName], ['fullName']);},
       meta::pure::mapping::modelToModel::test::shared::relationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.Snowflake)), meta::relational::extension::relationalExtensions()
    );
-   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name)?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where("root".fullnamenotin(${inFilterClause_name})OR"root".fullnameisnull)connection=DatabaseConnection(type="Snowflake"))))';
+   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name![])?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name![]",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where("root".fullnamenotin(${inFilterClause_name})OR"root".fullnameisnull)connection=DatabaseConnection(type="Snowflake"))))';
    assertEquals($expected, $res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions()));
 }
 
@@ -2173,7 +2185,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       {lengths:Integer[*] |_Person.all()->filter(x | $x.fullName->length()->in($lengths))->project([x | $x.fullName], ['fullName']);},
       meta::pure::mapping::modelToModel::test::shared::relationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.H2)), meta::relational::extension::relationalExtensions()
    );
-   let expected = 'Sequence(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[lengths:Integer[*]])Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"wherechar_length("root".fullname)in(${renderCollection(lengths",""""""null")})connection=DatabaseConnection(type="H2"))))';
+   let expected = 'Sequence(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[lengths:Integer[*]])Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"wherechar_length("root".fullname)in(${renderCollection(lengths![]",""""""null")})connection=DatabaseConnection(type="H2"))))';
    assertEquals($expected, $res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions()));
 }
 
@@ -2183,7 +2195,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       {lengths:Integer[*] |_Person.all()->filter(x | $x.fullName->length()->in($lengths))->project([x | $x.fullName], ['fullName']);},
       meta::pure::mapping::modelToModel::test::shared::relationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.MemSQL)), meta::relational::extension::relationalExtensions()
    );
-   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[lengths:Integer[*]])Allocation(type=Stringname=inFilterClause_lengthsvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(lengths,"Stream")||((collectionSize(lengths)?number)>1048576))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[lengths]tempTableName=tempTableForIn_lengthstempTableColumns=[(ColumnForStoringInCollection,INT)]connection=DatabaseConnection(type="MemSQL"))Constant(type=Stringvalues=[select`temptableforin_lengths_0`.ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_lengthsas`temptableforin_lengths_0`]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(lengths",""""""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select`root`.fullnameas`fullName`fromPersonas`root`wherechar_length(`root`.fullname)in(${inFilterClause_lengths})connection=DatabaseConnection(type="MemSQL"))))';
+   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[lengths:Integer[*]])Allocation(type=Stringname=inFilterClause_lengthsvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(lengths,"Stream")||((collectionSize(lengths![])?number)>1048576))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[lengths]tempTableName=tempTableForIn_lengthstempTableColumns=[(ColumnForStoringInCollection,INT)]connection=DatabaseConnection(type="MemSQL"))Constant(type=Stringvalues=[select`temptableforin_lengths_0`.ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_lengthsas`temptableforin_lengths_0`]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(lengths![]",""""""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select`root`.fullnameas`fullName`fromPersonas`root`wherechar_length(`root`.fullname)in(${inFilterClause_lengths})connection=DatabaseConnection(type="MemSQL"))))';
    assertEquals($expected, $res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions()));
 }
 
@@ -2193,7 +2205,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       {name:String[*] |_Person.all()->filter(x | $x.fullName->in($name))->filter(x | $x.fullName->in(['A', 'B']))->project([x | $x.fullName], ['fullName']);},
       meta::pure::mapping::modelToModel::test::shared::relationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.SybaseIQ)), meta::relational::extension::relationalExtensions()
    );
-   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name)?number)>250000))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="SybaseIQ"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where"root".fullnamein(${inFilterClause_name})and"root".fullnamein(\'A\',\'B\')connection=DatabaseConnection(type="SybaseIQ"))))';
+   let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name![])?number)>250000))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="SybaseIQ"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name![]",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where"root".fullnamein(${inFilterClause_name})and"root".fullnamein(\'A\',\'B\')connection=DatabaseConnection(type="SybaseIQ"))))';
    assertEquals($expected, $res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions()));
 }
 
@@ -2203,8 +2215,8 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       {name:String[*], name1:String[*]|_Person.all()->filter(x | $x.fullName->in($name))->filter(x | $x.fullName->in($name1))->project([x | $x.fullName], ['fullName']);},
       meta::pure::mapping::modelToModel::test::shared::relationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.DB2)), meta::relational::extension::relationalExtensions()
    );
-   let expected = ['RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*],name1:String[*]])Allocation(type=Stringname=inFilterClause_name1value=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name1,"Stream")||((collectionSize(name1)?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name1]tempTableName=tempTableForIn_name1tempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name1_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_name1as"temptableforin_name1_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name1",""\'""\'""null")}])))))Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name)?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where"root".fullnamein(${inFilterClause_name})and"root".fullnamein(${inFilterClause_name1})connection=DatabaseConnection(type="DB2"))))',
-      'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*],name1:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name)?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name",""\'""\'""null")}])))))Allocation(type=Stringname=inFilterClause_name1value=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name1,"Stream")||((collectionSize(name1)?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name1]tempTableName=tempTableForIn_name1tempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name1_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_name1as"temptableforin_name1_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name1",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where"root".fullnamein(${inFilterClause_name})and"root".fullnamein(${inFilterClause_name1})connection=DatabaseConnection(type="DB2"))))'];
+   let expected = ['RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*],name1:String[*]])Allocation(type=Stringname=inFilterClause_name1value=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name1,"Stream")||((collectionSize(name1![])?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name1]tempTableName=tempTableForIn_name1tempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name1_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_name1as"temptableforin_name1_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name1![]",""\'""\'""null")}])))))Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name![])?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name![]",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where"root".fullnamein(${inFilterClause_name})and"root".fullnamein(${inFilterClause_name1})connection=DatabaseConnection(type="DB2"))))',
+      'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[*],name1:String[*]])Allocation(type=Stringname=inFilterClause_namevalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name,"Stream")||((collectionSize(name![])?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name]tempTableName=tempTableForIn_nametempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_nameas"temptableforin_name_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name![]",""\'""\'""null")}])))))Allocation(type=Stringname=inFilterClause_name1value=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(name1,"Stream")||((collectionSize(name1![])?number)>32767))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name1]tempTableName=tempTableForIn_name1tempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=DatabaseConnection(type="DB2"))Constant(type=Stringvalues=[select"temptableforin_name1_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_name1as"temptableforin_name1_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(name1![]",""\'""\'""null")}])))))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where"root".fullnamein(${inFilterClause_name})and"root".fullnamein(${inFilterClause_name1})connection=DatabaseConnection(type="DB2"))))'];
    assert($expected->contains($res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions())));
 }
 
@@ -2212,8 +2224,8 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
 {
    let res = executionPlan({ids:Integer[*], dates:Date[*]|Trade.all()->filter(t|$t.settlementDateTime->in($dates) && $t.id->in($ids))->project([x | $x.id], ['TradeId'])},
                            simpleRelationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.Snowflake)), meta::relational::extension::relationalExtensions());
-   let expected = ['RelationalBlockExecutionNode(type=TDS[(TradeId,Integer,INT,"")](FunctionParametersValidationNode(functionParameters=[ids:Integer[*],dates:Date[*]])Allocation(type=Stringname=inFilterClause_datesvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(dates,"Stream")||((collectionSize(dates)?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[dates]tempTableName=tempTableForIn_datestempTableColumns=[(ColumnForStoringInCollection,TIMESTAMP)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_dates_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_datesas"temptableforin_dates_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(dates",""\'""\'""null")}])))))Allocation(type=Stringname=inFilterClause_idsvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(ids,"Stream")||((collectionSize(ids)?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[ids]tempTableName=tempTableForIn_idstempTableColumns=[(ColumnForStoringInCollection,INT)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_ids_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_idsas"temptableforin_ids_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(ids",""""""null")}])))))Relational(type=TDS[(TradeId,Integer,INT,"")]resultColumns=[("TradeId",INT)]sql=select"root".IDas"TradeId"fromtradeTableas"root"where("root".settlementDateTimein(${inFilterClause_dates})and"root".IDin(${inFilterClause_ids}))connection=DatabaseConnection(type="Snowflake"))))',
-      'RelationalBlockExecutionNode(type=TDS[(TradeId,Integer,INT,"")](FunctionParametersValidationNode(functionParameters=[ids:Integer[*],dates:Date[*]])Allocation(type=Stringname=inFilterClause_idsvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(ids,"Stream")||((collectionSize(ids)?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[ids]tempTableName=tempTableForIn_idstempTableColumns=[(ColumnForStoringInCollection,INT)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_ids_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_idsas"temptableforin_ids_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(ids",""""""null")}])))))Allocation(type=Stringname=inFilterClause_datesvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(dates,"Stream")||((collectionSize(dates)?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[dates]tempTableName=tempTableForIn_datestempTableColumns=[(ColumnForStoringInCollection,TIMESTAMP)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_dates_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_datesas"temptableforin_dates_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(dates",""\'""\'""null")}])))))Relational(type=TDS[(TradeId,Integer,INT,"")]resultColumns=[("TradeId",INT)]sql=select"root".IDas"TradeId"fromtradeTableas"root"where("root".settlementDateTimein(${inFilterClause_dates})and"root".IDin(${inFilterClause_ids}))connection=DatabaseConnection(type="Snowflake"))))'];
+   let expected = ['RelationalBlockExecutionNode(type=TDS[(TradeId,Integer,INT,"")](FunctionParametersValidationNode(functionParameters=[ids:Integer[*],dates:Date[*]])Allocation(type=Stringname=inFilterClause_datesvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(dates,"Stream")||((collectionSize(dates![])?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[dates]tempTableName=tempTableForIn_datestempTableColumns=[(ColumnForStoringInCollection,TIMESTAMP)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_dates_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_datesas"temptableforin_dates_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(dates![]",""\'""\'""null")}])))))Allocation(type=Stringname=inFilterClause_idsvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(ids,"Stream")||((collectionSize(ids![])?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[ids]tempTableName=tempTableForIn_idstempTableColumns=[(ColumnForStoringInCollection,INT)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_ids_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_idsas"temptableforin_ids_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(ids![]",""""""null")}])))))Relational(type=TDS[(TradeId,Integer,INT,"")]resultColumns=[("TradeId",INT)]sql=select"root".IDas"TradeId"fromtradeTableas"root"where("root".settlementDateTimein(${inFilterClause_dates})and"root".IDin(${inFilterClause_ids}))connection=DatabaseConnection(type="Snowflake"))))',
+                   'RelationalBlockExecutionNode(type=TDS[(TradeId,Integer,INT,"")](FunctionParametersValidationNode(functionParameters=[ids:Integer[*],dates:Date[*]])Allocation(type=Stringname=inFilterClause_idsvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(ids,"Stream")||((collectionSize(ids![])?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[ids]tempTableName=tempTableForIn_idstempTableColumns=[(ColumnForStoringInCollection,INT)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_ids_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_idsas"temptableforin_ids_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(ids![]",""""""null")}])))))Allocation(type=Stringname=inFilterClause_datesvalue=(FreeMarkerConditionalExecutionNode(type=Stringcondition=${(instanceOf(dates,"Stream")||((collectionSize(dates![])?number)>16348))?c}trueBlock=(Sequence(type=String(CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[dates]tempTableName=tempTableForIn_datestempTableColumns=[(ColumnForStoringInCollection,TIMESTAMP)]connection=DatabaseConnection(type="Snowflake"))Constant(type=Stringvalues=[select"temptableforin_dates_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_datesas"temptableforin_dates_0"]))))falseBlock=(Constant(type=Stringvalues=[${renderCollection(dates![]",""\'""\'""null")}])))))Relational(type=TDS[(TradeId,Integer,INT,"")]resultColumns=[("TradeId",INT)]sql=select"root".IDas"TradeId"fromtradeTableas"root"where("root".settlementDateTimein(${inFilterClause_dates})and"root".IDin(${inFilterClause_ids}))connection=DatabaseConnection(type="Snowflake"))))'];
    assert($expected->contains($res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions())));
 }
 
@@ -2223,6 +2235,30 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
                            meta::pure::mapping::modelToModel::test::shared::relationalMapping, ^Runtime(connections=^TestDatabaseConnection(element = relationalDB, type=DatabaseType.H2)), meta::relational::extension::relationalExtensions());
    let expected = 'RelationalBlockExecutionNode(type=TDS[(fullName,String,VARCHAR(1000),"")](FunctionParametersValidationNode(functionParameters=[name:String[1]])Allocation(type=meta::pure::functions::collection::Listname=tempVarForIn_4value=(Constant(type=meta::pure::functions::collection::Listvalues=[[[John,Peter,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50]]])))CreateAndPopulateTempTable(type=meta::pure::router::VoidinputVarNames=[name,tempVarForIn_4]tempTableName=tempTableForIn_4tempTableColumns=[(ColumnForStoringInCollection,VARCHAR(200))]connection=TestDatabaseConnection(type="H2"))Relational(type=TDS[(fullName,String,VARCHAR(1000),"")]resultColumns=[("fullName",VARCHAR(1000))]sql=select"root".fullnameas"fullName"fromPersonas"root"where"root".fullnamein(select"temptableforin_4_0".ColumnForStoringInCollectionasColumnForStoringInCollectionfromtempTableForIn_4as"temptableforin_4_0")connection=TestDatabaseConnection(type="H2"))))';
    assertEquals($expected, $res->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions()));
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::testPlanGenerationForInWithCollectionParameterHavingTimeZoneForH2():Boolean[1]
+{
+   let generatedPlan = executionPlan({optionalDateTime:DateTime[*] |Trade.all()->filter(t|$t.settlementDateTime->in($optionalDateTime))->project([x | $x.id], ['TradeId'])}, simpleRelationalMapping, ^Runtime(connections=^DatabaseConnection(element = relationalDB, type=DatabaseType.H2, timeZone='US/Arizona')), meta::relational::extension::relationalExtensions());
+   let result = $generatedPlan->planToString(meta::relational::extension::relationalExtensions());
+   let expectedPlan ='Sequence\n'+
+                     '(\n'+
+                     '  type = TDS[(TradeId, Integer, INT, "")]\n'+
+                     '  (\n'+
+                     '    FunctionParametersValidationNode\n'+
+                     '    (\n'+
+                     '      functionParameters = [optionalDateTime:DateTime[*]]\n'+
+                     '    )\n'+
+                     '    Relational\n'+
+                     '    (\n'+
+                     '      type = TDS[(TradeId, Integer, INT, "")]\n'+
+                     '      resultColumns = [("TradeId", INT)]\n'+
+                     '      sql = select "root".ID as "TradeId" from tradeTable as "root" where "root".settlementDateTime in (${renderCollectionWithTz(optionalDateTime![] "[US/Arizona]" "," "\'" "\'" "null")})\n'+
+                     '      connection = DatabaseConnection(type = "H2")\n'+
+                     '    )\n'+
+                     '  )\n'+
+                     ')\n';
+   assertEquals($expectedPlan, $result);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenerationForInWithTimeZone():Boolean[1]
@@ -2244,7 +2280,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       '    (\n'+
       '      type = TDS[(TradeId, Integer, INT, \"\")]\n'+
       '      resultColumns = [(\"TradeId\", INT)]\n'+
-      '      sql = select \"root\".ID as \"TradeId\" from tradeTable as \"root\" where \"root\".settlementDateTime in (${renderCollectionWithTz(dates \"[US/Arizona]\" \",\" \"Timestamp\'\" \"\'\" \"null\")})\n'+
+      '      sql = select \"root\".ID as \"TradeId\" from tradeTable as \"root\" where \"root\".settlementDateTime in (${renderCollectionWithTz(dates![] \"[US/Arizona]\" \",\" \"Timestamp\'\" \"\'\" \"null\")})\n'+
       '      connection = DatabaseConnection(type = \"Presto\")\n'+
       '    )\n'+
       '  )\n'+
@@ -2271,7 +2307,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testExecutionPlanGenera
       '    (\n'+
       '      type = TDS[(TradeId, Integer, INT, \"\")]\n'+
       '      resultColumns = [(\"TradeId\", INT)]\n'+
-      '      sql = select \"root\".ID as \"TradeId\" from tradeTable as \"root\" where \"root\".tradeDate in (${renderCollection(dates \",\" \"convert(DATE, \'\" \"\', 101)\" \"null\")})\n'+
+      '      sql = select \"root\".ID as \"TradeId\" from tradeTable as \"root\" where \"root\".tradeDate in (${renderCollection(dates![] \",\" \"convert(DATE, \'\" \"\', 101)\" \"null\")})\n'+
       '      connection = DatabaseConnection(type = \"Sybase\")\n'+
       '    )\n'+
       '  )\n'+

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testIsEmpty1.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testIsEmpty1.pure
@@ -87,7 +87,7 @@ function <<test.Test>> meta::relational::tests::query::filter::isempty::testIsEm
 {
    let result = executionPlan(input:String[*]| Firm.all()->filter(f| $input->isEmpty())->project([f | $f.legalName],['name'])
                                     , simpleRelationalMapping, testRuntime(), meta::relational::extension::relationalExtensions());
-   let expected = 'Sequence(type=TDS[(name,String,VARCHAR(200),"")](FunctionParametersValidationNode(functionParameters=[input:String[*]])Relational(type=TDS[(name,String,VARCHAR(200),"")]resultColumns=[("name",VARCHAR(200))]sql=select"root".LEGALNAMEas"name"fromfirmTableas"root"where(${collectionSize(input)})=0connection=TestDatabaseConnection(type="H2"))))';
+   let expected = 'Sequence(type=TDS[(name,String,VARCHAR(200),"")](FunctionParametersValidationNode(functionParameters=[input:String[*]])Relational(type=TDS[(name,String,VARCHAR(200),"")]resultColumns=[("name",VARCHAR(200))]sql=select"root".LEGALNAMEas"name"fromfirmTableas"root"where(${collectionSize(input![])})=0connection=TestDatabaseConnection(type="H2"))))';
    assertEquals($expected, $result->planToStringWithoutFormatting(meta::relational::extension::relationalExtensions()));
    assertSameElements(templateFunctionsList(), $result.processingTemplateFunctions);
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/processInOperation.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/processInOperation.pure
@@ -145,7 +145,7 @@ function meta::relational::postProcessor::generatePostProcessorResult(changedFun
 
                            let executionNodeToBeAdded               = if($collectionValues->size() > $dbThreshold,
                                                                               | $allocationNode->concatenate($createAndPopulateTempTableNode),
-                                                                              | let conditionString            = $varPlaceHoldersInCollection->map(var | 'collectionSize(' + $var.name + ')?number')
+                                                                              | let conditionString            = $varPlaceHoldersInCollection->map(var | 'collectionSize(' + $var.name +'![])?number')
                                                                                                                                        ->concatenate(if($collectionValuesWithoutVarPlaceHolder->isEmpty(), | [], |$collectionValuesWithoutVarPlaceHolder->size()->toString()))
                                                                                                                                        ->joinStrings('((' ,' + ',') > ' + $dbThreshold->toString() + ')');
                                                                                 let conditionWithStreamHandled = $varPlaceHoldersInCollection->map(var | 'instanceOf(' +$var.name + ', "Stream")')->concatenate($conditionString)->joinStrings('(', ' || ', ')');

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
@@ -212,7 +212,12 @@ function meta::relational::mapping::collectionRenderFunction():String[1]
 
 function meta::relational::mapping::utcToTimeZoneSupportFunction():String[1]
 {
-   '<#function GMTtoTZ tz paramDate><#return (tz+" "+paramDate)?date.@alloyDate></#function>'+
+   '<#function GMTtoTZ tz paramDate>'+
+      '<#if paramDate?is_enumerable && !paramDate?has_content>'+
+         '<#return paramDate>'+
+      '<#else>' +
+         '<#return (tz+" "+paramDate)?date.@alloyDate></#if></#function>'+
+
    '<#function renderCollectionWithTz collection timeZone separator prefix suffix defaultValue>'+
       '<#assign result = [] />'+
       '<#list collection as c>'+

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -421,20 +421,21 @@ function meta::relational::functions::sqlQueryToString::convertPlaceHolderToSQLS
 function meta::relational::functions::sqlQueryToString::processPlaceHolder(v:VarPlaceHolder[1], type:Type[1], prefix:String[1], suffix:String[1], dbTimeZone:String[0..1]): String[1]
 {
    let noPropertyPath              = $v.propertyPath->isEmpty();
+   let optionalHandler             = if($v->isOptionalPlaceHolder() && $noPropertyPath,|'![]',|'');
    let placeHolderWithPath         = $v.name+if($noPropertyPath,|'',|'.')+$v.propertyPath->map(p|$p.name)->joinStrings('.');
    let resolvedPlaceHolder         = if($type == String,
                                            | $placeHolderWithPath->convertStringToSQLString(),
-                                           | $placeHolderWithPath);
+                                           | $placeHolderWithPath) + $optionalHandler;
 
    let isPossibleDateTimeType      = [Date, DateTime]->contains($v.type);
    let possiblyApplyDateTzFunction = if($isPossibleDateTimeType,| processDatePlaceHolder($resolvedPlaceHolder, $dbTimeZone),| $resolvedPlaceHolder);
 
    if($v->isCollectionPlaceHolder(),
       |if($resolvedPlaceHolder == $possiblyApplyDateTzFunction,
-         |'${renderCollection('+$resolvedPlaceHolder + ' \",\" \"' + $prefix + '\" \"'+ $suffix + '\" ' + placeHolderDefaultValue() +')}',
-         |'${renderCollectionWithTz('+ $resolvedPlaceHolder + ' "['+$dbTimeZone->toOne()+']" '+ '\",\" \"' + $prefix + '\" \"'+ $suffix + '\" ' + placeHolderDefaultValue() +')}'),
-      |if($v.multiplicity->isNotEmpty() && $v.multiplicity->toOne()->isZeroOne() && $resolvedPlaceHolder == $possiblyApplyDateTzFunction,
-          |'${varPlaceHolderToString(' + $possiblyApplyDateTzFunction + '![] ' + ' \"' + $prefix + '\" \"'+ $suffix + '\" '+ placeHolderDefaultValue()+')}',
+         |'${renderCollection('+ $resolvedPlaceHolder + ' \",\" \"' + $prefix + '\" \"' + $suffix + '\" ' + placeHolderDefaultValue() +')}',
+         |'${renderCollectionWithTz('+ $resolvedPlaceHolder + ' "['+ $dbTimeZone->toOne() + ']" ' + '\",\" \"' + $prefix + '\" \"' + $suffix + '\" ' + placeHolderDefaultValue() +')}'),
+      |if($v->isOptionalPlaceHolder(),
+          |'${varPlaceHolderToString(' + $possiblyApplyDateTzFunction + ' \"' + $prefix + '\" \"'+ $suffix + '\" '+ placeHolderDefaultValue()+')}',
           |$prefix + '${'+$possiblyApplyDateTzFunction+'}' + $suffix)
       );
 }
@@ -461,7 +462,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
 
    let processedParams = $freeMarkerOp.parameters->map(p | $p->match([
                                                                f:FreeMarkerOperationHolder[1] | $f->processFreeMarkerOperationHolder($dbConfig, $format, $generationState, $config, true, $extensions);,
-                                                               l:Literal[1]                   | $l.value->match([v:VarPlaceHolder[1] | if($v.multiplicity->isNotEmpty() && $v.multiplicity->toOne()->isZeroOne(), |$v.name + '![]', |$v.name);,
+                                                               l:Literal[1]                   | $l.value->match([v:VarPlaceHolder[1] | if($v->isOptionalPlaceHolder(), |$v.name + '![]', |$v.name);,
                                                                                                                  a:Any[1]            | $a->toString();]),
                                                                a:RelationalOperationElement[1]| '\'' + $a->processOperation($dbConfig, $format, $generationState, $config, $extensions)->replace('\'', '\\\'') + '\'';
    ]));
@@ -490,6 +491,11 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
    let isNonSystemTz = $dbTimeZone->isNotEmpty() && !meta::pure::functions::date::systemDefaultTimeZones()->contains($dbTimeZone->toOne());
    if($isNonSystemTz,|'GMTtoTZ( "['+$dbTimeZone->toOne()+']" '+$dateParameter+')'
                     ,| $dateParameter);
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::isOptionalPlaceHolder(v:VarPlaceHolder[1]):Boolean[1]
+{
+   $v.multiplicity->isNotEmpty() && eq($v.multiplicity->toOne()->meta::pure::functions::multiplicity::getLowerBound(), 0);
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::isCollectionPlaceHolder(v:VarPlaceHolder[1]):Boolean[1]

--- a/legend-engine-xt-relationalStore-sqlserver-pure/src/main/resources/core_relational_sqlserver/relational/tests/dbSpecificTests/customSqlServerTests.pure
+++ b/legend-engine-xt-relationalStore-sqlserver-pure/src/main/resources/core_relational_sqlserver/relational/tests/dbSpecificTests/customSqlServerTests.pure
@@ -125,7 +125,7 @@ function <<test.Test>> meta::relational::tests::dbSpecificTests::sqlServer::test
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![]  "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![]  "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select "root".time as "Time" from interactionTable as "root" where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'"root".ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" "null")}\', \'"root".ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" "null")}\', \'case when "root".active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "SqlServer")\n'+
                      '    )\n'+
                      '  )\n'+


### PR DESCRIPTION
Ensure collection parameter and optional parameters with TimeZone are handled correctly on the execution plan when null/not provided by user WITH User Tests.

#### What type of PR is this?
 
Feature enhancement.

#### What does this PR do / why is it needed ?

- These changes provide additional support for optionality for collection parameters on an execution plan. This gives users flexibility to not provide any value for the optional parameter during plan execution.
- Provided support on the execution plan for Optional Datetime Parameter with TimeZone present, when null or not provided by the end user.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
- Fixes the issue of plan execution failure in case the service has an optional collection parameter of multiplicity [*] and user does not provide any parameter to the service.

- Fixes the issue of plan execution failure in case the service has datetime parameter with a timezone involved having multiplicity [0..1] and is not provided by the user.  

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
