### PR TITLE
Add support for defaultIfEmpty function in M2M mappings

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
@@ -566,6 +566,7 @@ public class Handlers
         register("meta::pure::functions::collection::tail_T_MANY__T_MANY_", true, ps -> res(ps.get(0)._genericType(), "zeroMany"));
         register("meta::pure::functions::collection::head_T_MANY__T_$0_1$_", false, ps -> res(ps.get(0)._genericType(), "zeroOne"));
         register("meta::pure::functions::collection::oneOf_Boolean_MANY__Boolean_1_", false, ps -> res("Boolean", "one"));
+        register("meta::pure::functions::collection::defaultIfEmpty_T_MANY__T_$1_MANY$__T_$1_MANY$_", false, ps -> res(MostCommonType.mostCommon(Lists.fixedSize.of(ps.get(0)._genericType(), ps.get(1)._genericType()), pureModel), "oneMany"));
 
         register("meta::pure::functions::string::isUUID_String_$0_1$__Boolean_1_", false, ps -> res("Boolean", "one"));
         register("meta::json::schema::mapSchema_String_1__Type_1__DiscriminatorMapping_1_", false, ps -> res("meta::json::schema::DiscriminatorMapping", "one"));
@@ -1598,6 +1599,7 @@ public class Handlers
         map.put("meta::pure::functions::collection::containsAny_Any_MANY__Any_MANY__Boolean_1_", (List<ValueSpecification> ps) -> ps.size() == 2);
         map.put("meta::pure::functions::collection::contains_Any_MANY__Any_1__Boolean_1_", (List<ValueSpecification> ps) -> ps.size() == 2 && isOne(ps.get(1)._multiplicity()));
         map.put("meta::pure::functions::collection::count_Any_MANY__Integer_1_", (List<ValueSpecification> ps) -> ps.size() == 1);
+        map.put("meta::pure::functions::collection::defaultIfEmpty_T_MANY__T_$1_MANY$__T_$1_MANY$_", (List<ValueSpecification> ps) -> ps.size() == 2 && matchOneMany(ps.get(1)._multiplicity()));
         map.put("meta::pure::functions::collection::distinct_T_MANY__T_MANY_", (List<ValueSpecification> ps) -> ps.size() == 1);
         map.put("meta::pure::functions::collection::dropAt_T_MANY__Integer_1__Integer_1__T_MANY_", (List<ValueSpecification> ps) -> ps.size() == 3 && isOne(ps.get(1)._multiplicity()) && ("Nil".equals(ps.get(1)._genericType()._rawType()._name()) || "Integer".equals(ps.get(1)._genericType()._rawType()._name())) && isOne(ps.get(2)._multiplicity()) && ("Nil".equals(ps.get(2)._genericType()._rawType()._name()) || "Integer".equals(ps.get(2)._genericType()._rawType()._name())));
         map.put("meta::pure::functions::collection::dropAt_T_MANY__Integer_1__T_MANY_", (List<ValueSpecification> ps) -> ps.size() == 2 && isOne(ps.get(1)._multiplicity()) && ("Nil".equals(ps.get(1)._genericType()._rawType()._name()) || "Integer".equals(ps.get(1)._genericType()._rawType()._name())));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/collectionsLibrary.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/collectionsLibrary.pure
@@ -74,6 +74,7 @@ function meta::pure::executionPlan::engine::java::registerCollectionsLibrary(con
          fc3(slice_T_MANY__Integer_1__Integer_1__T_MANY_,                        {ctx,collection,limit1,limit2 | $collection->j_streamOf()->js_skip(pinToZero($limit1))->js_limit($limit2->j_minus(pinToZero($limit1)))}),
          fc2(take_T_MANY__Integer_1__T_MANY_,                                    {ctx,collection,limit         | $collection->j_streamOf()->js_limit($limit)}),
          fc2(union_T_MANY__T_MANY__T_MANY_,                                      {ctx,collection1,collection2  | javaStream()->j_invoke('concat', [$collection1->j_streamOf(), $collection2->j_streamOf()], javaStream($ctx.returnType()->elementType()))->js_distinct()}),
+         fc2(defaultIfEmpty_T_MANY__T_$1_MANY$__T_$1_MANY$_,                     {ctx,collection1,collection2  | j_conditional($collection1->j_streamOf()->js_count()->j_eq(j_int(0)), $library->j_invoke('toOneMany', $collection2, $ctx.returnType()), $library->j_invoke('toOneMany', $collection1, $ctx.returnType()))}),
 
          fc2(contains_Any_MANY__Any_1__Boolean_1_,                               {ctx,collection,obj           | if($collection.type->isJavaList(), |$collection->j_invoke('contains', $obj), |javaObjects()->j_invoke('equals', [$collection, $obj]))}),
          fc2(exists_T_MANY__Function_1__Boolean_1_,                              {ctx,collection,func          | $collection->j_streamOf()->js_anyMatch($func)}),

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/functionInMapping.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/functionInMapping.pure
@@ -50,6 +50,31 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canUseFunctionsInAMappin
    assert(jsonEquivalent($expected->parseJSON(), $json->parseJSON()));   
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{  serverVersion.start='v1_19_0',
+   doc.doc='Given: a mapping that calls a function: defaultIfEmpty.',
+   doc.doc='When:  the mapping is executed using graphFetch',
+   doc.doc='Then:  the mapping executes successfully'
+}
+meta::pure::mapping::modelToModel::test::alloy::simple::testDefaultIfEmptyFunctionUsageInMapping(): Boolean[1]
+{
+   let tree = #{FirstEmployee {name} }#;
+
+   let result = execute(
+      |FirstEmployee.all()->graphFetch($tree)->serialize($tree),
+      defaultIfEmptyMapping,
+      testJsonRuntime(Firm, '[' +
+         '{"name": "FirmX", "employees": [{"firstName": "Peter", "lastName": "Smith"}, {"firstName": "John", "lastName": "Johnson"}]},' +
+         '{"name": "FirmA", "employees": [{"firstName": "Fabrice", "lastName": "Roberts"}]}' +
+      ']'),
+      meta::pure::extension::defaultExtensions()
+   );
+
+   let json = $result.values->toOne();
+   let expected = '[{"name":"Johnson"},{"name":"Unknown"}]';
+   assert(jsonEquivalent($expected->parseJSON(), $json->parseJSON()));   
+}
+
 Class meta::pure::mapping::modelToModel::test::alloy::simple::function::Firm
 {
   name: String[1];
@@ -75,5 +100,16 @@ Mapping meta::pure::mapping::modelToModel::test::alloy::simple::function::m1
   {
     ~src meta::pure::mapping::modelToModel::test::alloy::simple::function::Firm
     name: $src.employees->at(0).lastName
+  }
+)
+
+###Mapping
+   
+Mapping meta::pure::mapping::modelToModel::test::alloy::simple::function::defaultIfEmptyMapping
+(
+  *meta::pure::mapping::modelToModel::test::alloy::simple::function::FirstEmployee[test_FirstEmployee]: Pure
+  {
+    ~src meta::pure::mapping::modelToModel::test::alloy::simple::function::Firm
+    name: $src.employees->filter(e | $e.firstName == 'John').lastName->defaultIfEmpty('Unknown')->at(0)
   }
 )


### PR DESCRIPTION

### What type of PR is this?
Enhancement

### What does this PR do / why is it needed ?
This PR adds Java generation for _defualtIfEmpty_ function making it usable in M2M mappings. With _defaultIfEmpty_ function, users can avoid _isEmpty_ _if_ checks, thereby making the code clean and more readable.

### Which issue(s) this PR fixes:

### Other notes for reviewers

### Does this PR introduce a user-facing change?
Yes, users can now use _defaultIfEmpty_ function in their Studio projects and services