### PR TITLE
Enable server to read configuration via environment variables

### DIFF
--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -419,6 +419,10 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
         </dependency>

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -17,6 +17,8 @@ package org.finos.legend.engine.server;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -135,6 +137,9 @@ public class Server<T extends ServerConfiguration> extends Application<T>
         bootstrap.addBundle(new SessionAttributeBundle());
         bootstrap.addBundle(new MultiPartBundle());
         bootstrap.addBundle(new ErrorHandlingBundle<T>(serverConfiguration -> serverConfiguration.errorhandlingconfiguration));
+
+        // Enable variable substitution with environment variables
+        bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(true)));
 
         PureProtocolObjectMapperFactory.withPureProtocolExtensions(bootstrap.getObjectMapper());
         VaultFactory.withVaultConfigurationExtensions(bootstrap.getObjectMapper());

--- a/pom.xml
+++ b/pom.xml
@@ -1724,6 +1724,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-configuration</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jersey</artifactId>
                 <version>${dropwizard.version}</version>
                 <exclusions>


### PR DESCRIPTION
#### What type of PR is this?

Enhancement
#### What does this PR do / why is it needed ?

This PR enables the engine serve to source its configuration from environment variables.

This is useful in cases where the runtime configuration is dynamic and injected as part of the runtime environment. E.g. instead of hard coding the Gitlab OAuth client id and secret in the server's config file, they can be injected into the runtime (e.g. Docker) as env variables. The server config file can then refer to these environment variables.

#### Which issue(s) this PR fixes:

Not applicable.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No