### PR TITLE
Use separate github env for release and allow manual running of integration tests

### DIFF
--- a/.github/workflows/database-bigquery-integration-test.yml
+++ b/.github/workflows/database-bigquery-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-bigquery-integration-test.yml
+++ b/.github/workflows/database-bigquery-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -46,6 +51,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-databricks-integration-test.yml
+++ b/.github/workflows/database-databricks-integration-test.yml
@@ -63,7 +63,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-databricks-integration-test.yml
+++ b/.github/workflows/database-databricks-integration-test.yml
@@ -26,6 +26,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -57,6 +62,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-databricks-sql-generation-integration-test.yml
+++ b/.github/workflows/database-databricks-sql-generation-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-databricks-sql-generation-integration-test.yml
+++ b/.github/workflows/database-databricks-sql-generation-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -46,6 +51,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-mssqlserver-integration-test.yml
+++ b/.github/workflows/database-mssqlserver-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-mssqlserver-integration-test.yml
+++ b/.github/workflows/database-mssqlserver-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -46,6 +51,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
+++ b/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
+++ b/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -46,6 +51,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-postgresql-integration-test.yml
+++ b/.github/workflows/database-postgresql-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-postgresql-integration-test.yml
+++ b/.github/workflows/database-postgresql-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -46,6 +51,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-postgresql-sql-generation-integration-test.yml
+++ b/.github/workflows/database-postgresql-sql-generation-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -45,6 +50,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-postgresql-sql-generation-integration-test.yml
+++ b/.github/workflows/database-postgresql-sql-generation-integration-test.yml
@@ -51,7 +51,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-redshift-integration-test.yml
+++ b/.github/workflows/database-redshift-integration-test.yml
@@ -22,6 +22,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -45,6 +50,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-redshift-integration-test.yml
+++ b/.github/workflows/database-redshift-integration-test.yml
@@ -51,7 +51,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-redshift-sql-generation-integration-test.yml
+++ b/.github/workflows/database-redshift-sql-generation-integration-test.yml
@@ -22,6 +22,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -45,6 +50,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-redshift-sql-generation-integration-test.yml
+++ b/.github/workflows/database-redshift-sql-generation-integration-test.yml
@@ -51,7 +51,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-snowflake-integration-test.yml
+++ b/.github/workflows/database-snowflake-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-snowflake-integration-test.yml
+++ b/.github/workflows/database-snowflake-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -46,6 +51,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/database-snowflake-sql-generation-integration-test.yml
+++ b/.github/workflows/database-snowflake-sql-generation-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
       - name: Download patch
-        if: ${{ github.event.inputs.pullRequestId }} != ''
+        if: github.event.inputs.pullRequestId != ''
         run: |
           wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
           git apply run.diff

--- a/.github/workflows/database-snowflake-sql-generation-integration-test.yml
+++ b/.github/workflows/database-snowflake-sql-generation-integration-test.yml
@@ -23,6 +23,11 @@ env:
 on:
   schedule:
     - cron: "0 0 * * *" # every day at 00:00 on default/base branch
+  workflow_dispatch:
+    inputs:
+      pullRequestId:
+        description: "Pull request id"
+        required: false
 
 jobs:
   build:
@@ -46,6 +51,11 @@ jobs:
           git config --global committer.name "FINOS Admin"
           git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global author.name "${GITHUB_ACTOR}"
+      - name: Download patch
+        if: ${{ github.event.inputs.pullRequestId }} != ''
+        run: |
+          wget --output-document=run.diff http://patch-diff.githubusercontent.com/raw/finos/legend-engine/pull/${{ github.event.inputs.pullRequestId }}.diff
+          git apply run.diff
       - name: Print out mvn version
         run: mvn -v
       - name: Download deps and plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: RELEASE
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: RELEASE
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
#### What type of PR is this?

Github Setup

#### What does this PR do / why is it needed ?

It allows us to support 2 groups of permissions on github, ones who can do releases, and ones who can run integration tests. We need to give more people write access to legend repo to run integration tests. But, without this separation, they can do releases too.

#### Which issue(s) this PR fixes:
None

#### Does this PR introduce a user-facing change?
No, only developers who run github workflows might be affected
