### PR TITLE
Pure Embedded Grammar Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/lib
 **/surefire-reports-aggregate
 **/dependency-reduced-pom.xml
+**/*.tokens
 
 # VS Code ignores
 .vscode
@@ -17,3 +18,5 @@
 /legend-engine-shared-core/src/main/resources/legendExecutionVersion.json
 /legend-engine.ipr
 /legend-engine.iws
+/legend-engine-language-pure-grammar/gen/
+/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/core/gen/

--- a/legend-engine-language-pure-compiler/pom.xml
+++ b/legend-engine-language-pure-compiler/pom.xml
@@ -170,6 +170,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-extension-external-json</artifactId>
             <scope>test</scope>

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/EmbeddedPureCompilerExtension.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/EmbeddedPureCompilerExtension.java
@@ -1,0 +1,53 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.compiler.test.fromGrammar;
+
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.ProcessingContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
+import org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions.NewValueSpecification;
+import org.finos.legend.engine.shared.core.function.Function4;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+
+import java.util.Collections;
+import java.util.List;
+
+public class EmbeddedPureCompilerExtension implements CompilerExtension
+{
+    @Override
+    public Iterable<? extends Processor<?>> getExtraProcessors()
+    {
+        return Lists.mutable.empty();
+    }
+
+    @Override
+    public List<Function4<org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification, CompileContext, List<String>, ProcessingContext, ValueSpecification>> getExtraValueSpecificationProcessors()
+    {
+        return Collections.singletonList((valueSpecification, context, openVariables, processingContext) ->
+        {
+            if (valueSpecification instanceof NewValueSpecification)
+            {
+                return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+                        ._genericType(context.pureModel.getGenericType("String"))
+                        ._multiplicity(context.pureModel.getMultiplicity("one"))
+                        ._values(Lists.mutable.with(((NewValueSpecification) valueSpecification).x));
+            }
+            return null;
+        });
+    }
+}

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -2243,4 +2243,13 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "    main::Person.all(%2020-12-12, %2020-12-13).firm(%latest, %latest)  \n" +
                 "} \n");
     }
+
+    @Test
+    public void testCompilationForEmbeddedPureExtension()
+    {
+        test("function x::f(): Any[*]\n" +
+                "{\n" +
+                "   let x = #Test{My random Parser #Test{ OK OK } Yo}#;" +
+                "}\n");
+    }
 }

--- a/legend-engine-language-pure-compiler/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
+++ b/legend-engine-language-pure-compiler/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.compiler.test.fromGrammar.EmbeddedPureCompilerExtension

--- a/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/core/CoreLexerGrammar.g4
+++ b/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/core/CoreLexerGrammar.g4
@@ -8,7 +8,7 @@ import CoreFragmentGrammar;
 WHITESPACE:                                 Whitespace      -> skip;
 COMMENT:                                    Comment         -> skip;
 LINE_COMMENT:                               LineComment     -> skip;
-ISLAND_OPEN:                                '#{'            -> pushMode (ISLAND_MODE);
+ISLAND_OPEN:                                '#'  (~[#{])* '{'-> pushMode (ISLAND_MODE);
 
 
 // -------------------------------------- TYPE --------------------------------------

--- a/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/core/M3ParserGrammar.g4
+++ b/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/core/M3ParserGrammar.g4
@@ -177,13 +177,13 @@ booleanPart:                                    (AND expression) | (OR  expressi
 ;
 functionVariableExpression:                     identifier COLON type multiplicity
 ;
-dsl:                                            dslGraphFetch | dslNavigationPath
+dsl:                                            dslExtension | dslNavigationPath
 ;
 dslNavigationPath:                              NAVIGATION_PATH_BLOCK
 ;
-dslGraphFetch:                                  ISLAND_OPEN (dslContent)*
+dslExtension:                                   ISLAND_OPEN (dslExtensionContent)*
 ;
-dslContent:                                     ISLAND_START | ISLAND_BRACE_OPEN | ISLAND_CONTENT | ISLAND_HASH | ISLAND_BRACE_CLOSE | ISLAND_END
+dslExtensionContent:                            ISLAND_START | ISLAND_BRACE_OPEN | ISLAND_CONTENT | ISLAND_HASH | ISLAND_BRACE_CLOSE | ISLAND_END
 ;
 type:                                           (qualifiedName (LESS_THAN typeArguments? (PIPE multiplicityArguments)? GREATER_THAN)?)
                                                 |

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/domain/DomainParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/domain/DomainParser.java
@@ -80,7 +80,7 @@ public class DomainParser implements DEPRECATED_SectionGrammarParser
 
     public Lambda parseLambda(String code, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-        return parseLambda(code, new PureGrammarParserContext(PureGrammarParserExtensions.fromExtensions(Lists.immutable.empty())), sourceId, lineOffset, columnOffset, returnSourceInfo);
+        return parseLambda(code, new PureGrammarParserContext(PureGrammarParserExtensions.fromAvailableExtensions()), sourceId, lineOffset, columnOffset, returnSourceInfo);
     }
 
     public Lambda parseLambda(String code, PureGrammarParserContext parserContext, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
@@ -124,22 +124,12 @@ public class DomainParser implements DEPRECATED_SectionGrammarParser
 
     public RootGraphFetchTree parseGraphFetch(String input, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-//        PureGrammarParserContext parserContext =  new PureGrammarParserContext(PureGrammarParserExtensions.fromExtensions(Lists.immutable.empty()));
-//        ParseTreeWalkerSourceInformation lambdaWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(s, 0, 0).withReturnSourceInfo(returnSourceInfo).build();
-//        String prefix = "function go():Any[*]{let x = ";
-//        String fullCode = prefix + input + ";}";
-//        ParseTreeWalkerSourceInformation walkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(lambdaWalkerSourceInformation)
-//                // NOTE: as we prepend the lambda with this prefix, we need to subtract this prefix length from the column offset
-//                .withColumnOffset(lambdaWalkerSourceInformation.getColumnOffset() - prefix.length()).build();
-//        SourceCodeParserInfo sectionParserInfo = this.getParserInfo(fullCode, null, walkerSourceInformation, true);
-//        DomainParseTreeWalker walker = new DomainParseTreeWalker(walkerSourceInformation, parserContext, (ImportAwareCodeSection) null);
         return (RootGraphFetchTree) parseValueSpecification(input, sourceId, lineOffset, columnOffset, returnSourceInfo);
-        //walker.combinedExpression(((DomainParserGrammar.DefinitionContext) sectionParserInfo.rootContext).elementDefinition(0).functionDefinition().codeBlock().programLine(0).letExpression().combinedExpression(), "", Lists.mutable.empty(), null, "", false, returnSourceInfo);
     }
 
     public ValueSpecification parseValueSpecification(String input, String sourceId, int lineOffset, int columnOffset, boolean returnSourceInfo)
     {
-        PureGrammarParserContext parserContext = new PureGrammarParserContext(PureGrammarParserExtensions.fromExtensions(Lists.immutable.empty()));
+        PureGrammarParserContext parserContext = new PureGrammarParserContext(PureGrammarParserExtensions.fromAvailableExtensions());
         ParseTreeWalkerSourceInformation lambdaWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(sourceId, lineOffset, columnOffset).withReturnSourceInfo(returnSourceInfo).build();
         String prefix = "function go():Any[*]{let x = ";
         String fullCode = prefix + input + ";}";
@@ -148,6 +138,6 @@ public class DomainParser implements DEPRECATED_SectionGrammarParser
                 .withColumnOffset(lambdaWalkerSourceInformation.getColumnOffset() - prefix.length()).build();
         SourceCodeParserInfo sectionParserInfo = this.getParserInfo(fullCode, null, walkerSourceInformation, true);
         DomainParseTreeWalker walker = new DomainParseTreeWalker(walkerSourceInformation, parserContext, null);
-        return (ValueSpecification) walker.combinedExpression(((DomainParserGrammar.DefinitionContext) sectionParserInfo.rootContext).elementDefinition(0).functionDefinition().codeBlock().programLine(0).letExpression().combinedExpression(), "", Lists.mutable.empty(), null, "", false, returnSourceInfo);
+        return walker.combinedExpression(((DomainParserGrammar.DefinitionContext) sectionParserInfo.rootContext).elementDefinition(0).functionDefinition().codeBlock().programLine(0).letExpression().combinedExpression(), "", Lists.mutable.empty(), null, "", false, returnSourceInfo);
     }
 }

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/EmbeddedPureParser.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/EmbeddedPureParser.java
@@ -1,0 +1,28 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.from.extension;
+
+import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
+
+public interface EmbeddedPureParser
+{
+    String getType();
+
+    ListIterable<ValueSpecification> parse(String code, ParseTreeWalkerSourceInformation walkerSourceInformation, SourceInformation sourceInformation, PureGrammarParserExtensions extensions);
+
+}

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtension.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtension.java
@@ -46,6 +46,11 @@ public interface PureGrammarParserExtension
         return Collections.emptyList();
     }
 
+    default Iterable<? extends EmbeddedPureParser> getExtraEmbeddedPureParsers()
+    {
+        return Collections.emptyList();
+    }
+
     default Iterable<? extends TestAssertionParser> getExtraTestAssertionParsers()
     {
         return Collections.emptyList();

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtensions.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtensions.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.language.pure.grammar.from.extension;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -37,6 +38,7 @@ public class PureGrammarParserExtensions
     private final MapIterable<String, MappingElementParser> mappingElementParsers;
     private final MapIterable<String, MappingTestInputDataParser> mappingTestInputDataParsers;
     private final MapIterable<String, EmbeddedDataParser> embeddedDataParsers;
+    private final MapIterable<String, EmbeddedPureParser> embeddedPureParsers;
     private final MapIterable<String, TestAssertionParser> testAssertionParsers;
 
     private PureGrammarParserExtensions(Iterable<? extends PureGrammarParserExtension> extensions)
@@ -48,6 +50,7 @@ public class PureGrammarParserExtensions
         this.mappingTestInputDataParsers = indexExtraMappingTestInputDataParsers(this.extensions);
         this.embeddedDataParsers = indexEmbeddedDataParsers(this.extensions);
         this.testAssertionParsers = indexTestAssertionDataParsers(this.extensions);
+        this.embeddedPureParsers = indexEmbeddedPureParsers(this.extensions);
     }
 
     public List<PureGrammarParserExtension> getExtensions()
@@ -78,6 +81,16 @@ public class PureGrammarParserExtensions
     public EmbeddedDataParser getExtraEmbeddedDataParser(String type)
     {
         return this.embeddedDataParsers.get(type);
+    }
+
+    public EmbeddedPureParser getExtraEmbeddedPureParser(String type)
+    {
+        return this.embeddedPureParsers.get(type);
+    }
+
+    public RichIterable<EmbeddedPureParser> getExtraEmbeddedPureParsers()
+    {
+        return this.embeddedPureParsers.valuesView();
     }
 
     public TestAssertionParser getExtraTestAssertionParser(String type)
@@ -141,6 +154,13 @@ public class PureGrammarParserExtensions
         return indexByKey(LazyIterate.flatCollect(extensions, PureGrammarParserExtension::getExtraEmbeddedDataParsers),
                 EmbeddedDataParser::getType,
                 "Conflicting parsers for embedded data type");
+    }
+
+    private static MapIterable<String, EmbeddedPureParser> indexEmbeddedPureParsers(Iterable<? extends PureGrammarParserExtension> extensions)
+    {
+        return indexByKey(LazyIterate.flatCollect(extensions, PureGrammarParserExtension::getExtraEmbeddedPureParsers),
+                EmbeddedPureParser::getType,
+                "Conflicting parsers for embedded pure type");
     }
 
     private static MapIterable<String, TestAssertionParser> indexTestAssertionDataParsers(Iterable<? extends PureGrammarParserExtension> extensions)

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
@@ -626,7 +626,9 @@ public final class DEPRECATED_PureGrammarComposerCore implements
     @Override
     public String visit(ValueSpecification valueSpecification)
     {
-        return unsupported(valueSpecification.getClass());
+        PureGrammarComposerContext context = this.toContext();
+        Optional<String> valueSpecString = context.extraEmbeddedPureComposers.stream().map(composer -> composer.value(valueSpecification, context)).filter(Objects::nonNull).findFirst();
+        return valueSpecString.orElseGet(() -> unsupported(valueSpecification.getClass()));
     }
 
     @Override

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerContext.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerContext.java
@@ -28,6 +28,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.TestAssertion;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 import org.finos.legend.engine.shared.core.api.grammar.RenderStyle;
 
 import java.util.List;
@@ -58,6 +59,7 @@ public class PureGrammarComposerContext
     public final List<Function2<InputData, PureGrammarComposerContext, String>> extraMappingTestInputDataComposers;
     public final List<Function2<EmbeddedData, PureGrammarComposerContext, ContentWithType>> extraEmbeddedDataComposers;
     public final List<Function2<TestAssertion, PureGrammarComposerContext, ContentWithType>> extraTestAssertionComposers;
+    public final List<Function2<ValueSpecification, PureGrammarComposerContext, String>> extraEmbeddedPureComposers;
 
     protected PureGrammarComposerContext(Builder builder)
     {
@@ -75,6 +77,7 @@ public class PureGrammarComposerContext
         this.extraConnectionValueComposers = ListIterate.flatCollect(this.extensions, PureGrammarComposerExtension::getExtraConnectionValueComposers);
         this.extraMappingTestInputDataComposers = ListIterate.flatCollect(this.extensions, PureGrammarComposerExtension::getExtraMappingTestInputDataComposers);
         this.extraEmbeddedDataComposers = ListIterate.flatCollect(this.extensions, PureGrammarComposerExtension::getExtraEmbeddedDataComposers);
+        this.extraEmbeddedPureComposers = ListIterate.flatCollect(this.extensions, PureGrammarComposerExtension::getExtraEmbeddedPureComposers);
         this.extraTestAssertionComposers = ListIterate.flatCollect(this.extensions, PureGrammarComposerExtension::getExtraTestAssertionComposers);
     }
 

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/extension/PureGrammarComposerExtension.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/extension/PureGrammarComposerExtension.java
@@ -25,6 +25,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.TestAssertion;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,6 +81,11 @@ public interface PureGrammarComposerExtension
     }
 
     default List<Function2<EmbeddedData, PureGrammarComposerContext, ContentWithType>> getExtraEmbeddedDataComposers()
+    {
+        return new ArrayList<>();
+    }
+
+    default List<Function2<ValueSpecification, PureGrammarComposerContext, String>> getExtraEmbeddedPureComposers()
     {
         return new ArrayList<>();
     }

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/parser/TestEmbeddedPureExtension.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/parser/TestEmbeddedPureExtension.java
@@ -1,0 +1,59 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.test.parser;
+
+import org.antlr.v4.runtime.Vocabulary;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
+import org.finos.legend.engine.language.pure.grammar.from.antlr4.domain.DomainParserGrammar;
+import org.finos.legend.engine.language.pure.grammar.test.TestGrammarParser;
+import org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions.NewValueSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TestEmbeddedPureExtension extends TestGrammarParser.TestGrammarParserTestSuite
+{
+    @Override
+    public Vocabulary getParserGrammarVocabulary()
+    {
+        return DomainParserGrammar.VOCABULARY;
+    }
+
+    @Override
+    public String getParserGrammarIdentifierInclusionTestCode(List<String> keywords)
+    {
+        return null;
+    }
+
+    @Test
+    public void testUnknownExtension()
+    {
+        test("function f(): Any[*]\n" +
+                "{\n" +
+                "   let x = #Unknown{My random Parser #Test{ OK OK } Yo}#\n" +
+                "}\n", "PARSER error at [6:12-56]: Can't find an embedded Pure parser for the type 'Unknown' available ones: [Test]");
+    }
+
+    @Test
+    public void testParseValueSpecification()
+    {
+        ValueSpecification vs = PureGrammarParser.newInstance().parseValueSpecification("#Test{My random Parser #Test{ OK OK } Yo}#", "", 1, 1, false);
+        NewValueSpecification nv = (NewValueSpecification)vs;
+        Assert.assertEquals("My random Parser #Test{ OK OK } Yo", nv.x);
+    }
+
+}

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/TestExtendableEmbedded.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/TestExtendableEmbedded.java
@@ -1,0 +1,48 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded;
+
+import org.finos.legend.engine.language.pure.grammar.test.TestGrammarRoundtrip;
+import org.junit.Test;
+
+public class TestExtendableEmbedded extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
+{
+    @Test
+    public void testGraphQLDefault()
+    {
+        test("function f(): Any[*]\n" +
+                "{\n" +
+                "   let x = #{a{a}}#\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testTestExtension()
+    {
+        test("function f(): Any[*]\n" +
+                "{\n" +
+                "   let x = #Test{My random Parser Yo}#\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testTestNestedExtension()
+    {
+        test("function f(): Any[*]\n" +
+                "{\n" +
+                "   let x = #Test{My random Parser #Test{ OK OK } Yo}#\n" +
+                "}\n");
+    }
+}

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/EmbeddedPureParserExtension.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/EmbeddedPureParserExtension.java
@@ -1,0 +1,38 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions;
+
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
+import org.finos.legend.engine.language.pure.grammar.from.extension.EmbeddedPureParser;
+import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
+
+public class EmbeddedPureParserExtension implements EmbeddedPureParser
+{
+    @Override
+    public String getType()
+    {
+        return "Test";
+    }
+
+    @Override
+    public ListIterable<ValueSpecification> parse(String code, ParseTreeWalkerSourceInformation walkerSourceInformation, SourceInformation sourceInformation, PureGrammarParserExtensions extensions)
+    {
+        return Lists.mutable.with(new NewValueSpecification(code));
+    }
+}

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/GrammarComposerExtension.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/GrammarComposerExtension.java
@@ -1,0 +1,39 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
+import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
+
+import java.util.List;
+
+public class GrammarComposerExtension implements PureGrammarComposerExtension
+{
+    @Override
+    public List<Function2<ValueSpecification, PureGrammarComposerContext, String>> getExtraEmbeddedPureComposers()
+    {
+        return Lists.mutable.with((elements, context) ->
+        {
+            if (elements instanceof NewValueSpecification)
+            {
+                return "#Test{" + ((NewValueSpecification) elements).x + "}#";
+            }
+            return null;
+        });
+    }
+}

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/GrammarParserExtension.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/GrammarParserExtension.java
@@ -12,10 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import meta::json::*;
-import meta::alloy::metadataServer::*;
-import meta::pure::mapping::*;
+package org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions;
 
-native function meta::legend::compile(s:String[1]):PackageableElement[*];
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.language.pure.grammar.from.extension.EmbeddedPureParser;
+import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension;
 
-native function meta::legend::compileVS(s:String[1]):Any[1];
+public class GrammarParserExtension implements PureGrammarParserExtension
+{
+    @Override
+    public Iterable<? extends EmbeddedPureParser> getExtraEmbeddedPureParsers()
+    {
+        return Lists.mutable.with(new EmbeddedPureParserExtension());
+    }
+}

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/NewValueSpecification.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/NewValueSpecification.java
@@ -1,0 +1,38 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions;
+
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecificationVisitor;
+
+public class NewValueSpecification extends ValueSpecification
+{
+    public String x;
+
+    public NewValueSpecification()
+    {
+    }
+
+    public NewValueSpecification(String x)
+    {
+        this.x = x;
+    }
+
+    @Override
+    public <T> T accept(ValueSpecificationVisitor<T> visitor)
+    {
+        return visitor.visit(this);
+    }
+}

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/ProtocolExtension.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/embedded/extensions/ProtocolExtension.java
@@ -1,0 +1,37 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions;
+
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
+import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
+
+import java.util.List;
+
+public class ProtocolExtension implements PureProtocolExtension
+{
+    public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
+    {
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                // Value specification
+                ProtocolSubTypeInfo.newBuilder(ValueSpecification.class)
+                        .withSubtype(NewValueSpecification.class, "testVS")
+                        .build()
+        ));
+    }
+
+}

--- a/legend-engine-language-pure-grammar/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension
+++ b/legend-engine-language-pure-grammar/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions.GrammarParserExtension

--- a/legend-engine-language-pure-grammar/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension
+++ b/legend-engine-language-pure-grammar/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions.GrammarComposerExtension

--- a/legend-engine-language-pure-grammar/src/test/resources/META-INF/services/org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension
+++ b/legend-engine-language-pure-grammar/src/test/resources/META-INF/services/org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.grammar.test.roundtrip.embedded.extensions.ProtocolExtension

--- a/legend-engine-pure-runtime-compiler/pom.xml
+++ b/legend-engine-pure-runtime-compiler/pom.xml
@@ -166,5 +166,17 @@
             <artifactId>legend-engine-xt-text-compiler</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-compiler</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/compiled/CompileExtensionCompiled.java
+++ b/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/compiled/CompileExtensionCompiled.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.pure.runtime.compiler.compiled;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.pure.runtime.compiler.compiled.natives.LegendCompile;
+import org.finos.legend.engine.pure.runtime.compiler.compiled.natives.LegendCompileVS;
 import org.finos.legend.pure.runtime.java.compiled.extension.BaseCompiledExtension;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtension;
 
@@ -24,7 +25,7 @@ public class CompileExtensionCompiled extends BaseCompiledExtension
     public CompileExtensionCompiled()
     {
         super(
-                Lists.fixedSize.with(new LegendCompile()),
+                Lists.fixedSize.with(new LegendCompile(), new LegendCompileVS()),
                 Lists.fixedSize.with(),
                 Lists.fixedSize.empty(),
                 Lists.fixedSize.empty());

--- a/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/compiled/natives/LegendCompileVS.java
+++ b/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/compiled/natives/LegendCompileVS.java
@@ -1,0 +1,49 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.runtime.compiler.compiled.natives;
+
+import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.generation.ProcessorContext;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.AbstractNative;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.valuespecification.ValueSpecificationProcessor;
+
+public class LegendCompileVS extends AbstractNative
+{
+    public LegendCompileVS()
+    {
+        super("compileVS_String_1__Any_1_");
+    }
+
+    @Override
+    public String build(CoreInstance topLevelElement, CoreInstance functionExpression, ListIterable<String> transformedParams, ProcessorContext processorContext)
+    {
+        final ProcessorSupport processorSupport = processorContext.getSupport();
+        final ListIterable<? extends CoreInstance> parametersValues = Instance.getValueForMetaPropertyToManyResolved(functionExpression, M3Properties.parametersValues, processorSupport);
+        String code = ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(0), processorContext);
+        return "org.finos.legend.engine.pure.runtime.compiler.compiled.natives.LegendCompileVS.compileExecVS(" + code + ", es)";
+    }
+
+    public static Object compileExecVS(String code, final ExecutionSupport es)
+    {
+        return ((InstanceValue)org.finos.legend.engine.pure.runtime.compiler.shared.LegendCompile.doCompileVS(code, ((CompiledExecutionSupport)es).getMetadataProvider().getMetadata()))._values().getFirst();
+    }
+}

--- a/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/interpreted/CompileExtensionInterpreted.java
+++ b/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/interpreted/CompileExtensionInterpreted.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.pure.runtime.compiler.interpreted;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.pure.runtime.compiler.interpreted.natives.LegendCompile;
+import org.finos.legend.engine.pure.runtime.compiler.interpreted.natives.LegendCompileVS;
 import org.finos.legend.pure.runtime.java.interpreted.extension.BaseInterpretedExtension;
 import org.finos.legend.pure.runtime.java.interpreted.extension.InterpretedExtension;
 
@@ -25,7 +26,8 @@ public class CompileExtensionInterpreted extends BaseInterpretedExtension
     public CompileExtensionInterpreted()
     {
         super(Lists.mutable.with(
-                Tuples.pair("compile_String_1__PackageableElement_MANY_", LegendCompile::new)
+                Tuples.pair("compile_String_1__PackageableElement_MANY_", LegendCompile::new),
+                Tuples.pair("compileVS_String_1__Any_1_", LegendCompileVS::new)
         ));
     }
 

--- a/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/interpreted/natives/InterpretedMetadata.java
+++ b/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/interpreted/natives/InterpretedMetadata.java
@@ -1,0 +1,71 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.runtime.compiler.interpreted.natives;
+
+import org.eclipse.collections.api.map.MapIterable;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.compiled.metadata.Metadata;
+
+public class InterpretedMetadata implements Metadata
+{
+    private ProcessorSupport processorSupport;
+
+    public InterpretedMetadata(ProcessorSupport processorSupport)
+    {
+        this.processorSupport = processorSupport;
+    }
+
+    @Override
+    public void startTransaction()
+    {
+
+    }
+
+    @Override
+    public void commitTransaction()
+    {
+
+    }
+
+    @Override
+    public void rollbackTransaction()
+    {
+
+    }
+
+    @Override
+    public CoreInstance getMetadata(String s, String s1)
+    {
+        if (s1.startsWith("Root::"))
+        {
+            s1 = s1.substring(6);
+        }
+        return _Package.getByUserPath(s1, processorSupport);
+    }
+
+    @Override
+    public MapIterable<String, CoreInstance> getMetadata(String s)
+    {
+        throw new RuntimeException("Not supported");
+    }
+
+    @Override
+    public CoreInstance getEnum(String s, String s1)
+    {
+        throw new RuntimeException("Not supported");
+    }
+}

--- a/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/interpreted/natives/LegendCompileVS.java
+++ b/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/interpreted/natives/LegendCompileVS.java
@@ -15,15 +15,12 @@
 package org.finos.legend.engine.pure.runtime.compiler.interpreted.natives;
 
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.interpreted.ExecutionSupport;
@@ -35,20 +32,16 @@ import org.finos.legend.pure.runtime.java.interpreted.profiler.Profiler;
 
 import java.util.Stack;
 
-public class LegendCompile extends NativeFunction
+public class LegendCompileVS extends NativeFunction
 {
-    private final FunctionExecutionInterpreted functionExecution;
-
-    public LegendCompile(FunctionExecutionInterpreted functionExecution, ModelRepository modelRepository)
+    public LegendCompileVS(FunctionExecutionInterpreted functionExecution, ModelRepository modelRepository)
     {
-        this.functionExecution = functionExecution;
     }
 
     @Override
     public CoreInstance execute(ListIterable<? extends CoreInstance> params, Stack<MutableMap<String, CoreInstance>> resolvedTypeParameters, Stack<MutableMap<String, CoreInstance>> resolvedMultiplicityParameters, VariableContext variableContext, CoreInstance functionExpressionToUseInStack, Profiler profiler, InstantiationContext instantiationContext, ExecutionSupport executionSupport, Context context, ProcessorSupport processorSupport) throws PureExecutionException
     {
         String code = Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.values, processorSupport).getName();
-        MutableList<PackageableElement> createdElements = org.finos.legend.engine.pure.runtime.compiler.shared.LegendCompile.doCompile(code, new InterpretedMetadata(processorSupport));
-        return ValueSpecificationBootstrap.wrapValueSpecification(createdElements, true, functionExecution.getProcessorSupport());
+        return org.finos.legend.engine.pure.runtime.compiler.shared.LegendCompile.doCompileVS(code, new InterpretedMetadata(processorSupport));
     }
 }

--- a/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/shared/LegendCompile.java
+++ b/legend-engine-pure-runtime-compiler/src/main/java/org/finos/legend/engine/pure/runtime/compiler/shared/LegendCompile.java
@@ -27,6 +27,8 @@ import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.pure.m3.coreinstance.Package;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.ModelElementAccessor;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.runtime.java.compiled.metadata.Metadata;
 
 public class LegendCompile
@@ -39,6 +41,16 @@ public class LegendCompile
         PureModel pm = org.finos.legend.engine.language.pure.compiler.Compiler.compile(data, DeploymentMode.PROD, null, "", metadata);
         // Extract Compiled created elements
         return extractCreatedElementFromCompiledGraph(data, pm);
+    }
+
+    public static ValueSpecification doCompileVS(String code, Metadata metadata)
+    {
+        // Parse
+        PureModelContextData data = PureGrammarParser.newInstance().parseModel("function a::f():Any[*]{" + code + "}");
+        // Compile
+        PureModel pm = org.finos.legend.engine.language.pure.compiler.Compiler.compile(data, DeploymentMode.PROD, null, "", metadata);
+        // Extract Compiled created elements
+        return ((ConcreteFunctionDefinition<Object>) extractCreatedElementFromCompiledGraph(data, pm).getFirst())._expressionSequence().getFirst();
     }
 
     private static MutableList<PackageableElement> extractCreatedElementFromCompiledGraph(PureModelContextData pureModelContextData, PureModel pureModel)
@@ -54,4 +66,5 @@ public class LegendCompile
                     return graphElement;
                 });
     }
+
 }

--- a/legend-engine-pure-runtime-compiler/src/test/java/org/finos/legend/engine/pure/runtime/compiler/test/LegendCompileTest.java
+++ b/legend-engine-pure-runtime-compiler/src/test/java/org/finos/legend/engine/pure/runtime/compiler/test/LegendCompileTest.java
@@ -93,6 +93,20 @@ public abstract class LegendCompileTest
                    "assertEquals('oeoeoeo', $x.content);");
     }
 
+    @Test
+    public void testValueSpecification()
+    {
+        test("let x =  meta::legend::compileVS('1');\n" +
+                   "assertEquals(1, $x);");
+    }
+
+    @Test
+    public void testValueSpecificationEmbeddedPure()
+    {
+        test("let x =  meta::legend::compileVS('#Test{X X Test}#');\n" +
+                "assertEquals('X X Test', $x);");
+    }
+
 
 
 


### PR DESCRIPTION
- Add support for Pure Embedded Grammar Extension. It is now possible to use the form #KEYWORD{TEXT}# where KEYWORD is the new grammar and TEXT is the grammar body. Example: #SQL{select * from table}#

- Add compileVS to the legend runtime compiler so that simple Value Specifications can be compiled by the Legend compiler and available in the Pure IDE light.