### PR TITLE
Fix parsing of strings in Mastery grammar

### DIFF
--- a/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/HelperMasterRecordDefinitionBuilder.java
+++ b/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/HelperMasterRecordDefinitionBuilder.java
@@ -47,6 +47,8 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 
+import static java.util.Objects.isNull;
+
 public class HelperMasterRecordDefinitionBuilder
 {
     private static final String MASTERY_PACKAGE_PREFIX = "meta::pure::mastery::metamodel";
@@ -135,7 +137,7 @@ public class HelperMasterRecordDefinitionBuilder
             pureSource._id(protocolSource.id);
             pureSource._description(protocolSource.description);
             pureSource._status(context.resolveEnumValue(KEY_TYPE_FULL_PATH, protocolSource.status.name()));
-            pureSource._parseService(buildService(protocolSource.parseService, protocolSource, context));
+            pureSource._parseService(buildOptionalService(protocolSource.parseService, protocolSource, context));
             pureSource._transformService(buildService(protocolSource.transformService, protocolSource, context));
             pureSource._sequentialData(protocolSource.sequentialData);
             pureSource._stagedLoad(protocolSource.stagedLoad);
@@ -144,6 +146,15 @@ public class HelperMasterRecordDefinitionBuilder
             pureSource._tags(ListIterate.collect(protocolSource.tags, n -> n.toString()));
             pureSource._partitions(ListIterate.collect(protocolSource.partitions, n -> this.visitPartition(n)));
             return pureSource;
+        }
+
+        public static Root_meta_legend_service_metamodel_Service buildOptionalService(String service, RecordSource protocolSource, CompileContext context)
+        {
+            if (isNull(service))
+            {
+                return null;
+            }
+            return buildService(service, protocolSource, context);
         }
 
         public static Root_meta_legend_service_metamodel_Service buildService(String service, RecordSource protocolSource, CompileContext context)

--- a/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
+++ b/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
@@ -94,10 +94,10 @@ public class MasteryParseTreeWalker
         source.sourceInformation = walkerSourceInformation.getSourceInformation(ctx);
 
         MasteryParserGrammar.IdContext idContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.id(), "id", source.sourceInformation);
-        source.id = idContext.STRING().getText();
+        source.id = PureGrammarParserUtility.fromGrammarString(idContext.STRING().getText(), true);
 
         MasteryParserGrammar.DescriptionContext descriptionContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.description(), "description", source.sourceInformation);
-        source.description = descriptionContext.STRING().getText();
+        source.description = PureGrammarParserUtility.fromGrammarString(descriptionContext.STRING().getText(), true);
 
         MasteryParserGrammar.RecordStatusContext statusContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.recordStatus(), "status", source.sourceInformation);
         source.status = visitRecordStatus(statusContext);
@@ -121,7 +121,7 @@ public class MasteryParseTreeWalker
             ListIterator stringIterator = tagsContext.STRING().listIterator();
             while (stringIterator.hasNext())
             {
-                source.tags.add(((TerminalNode) stringIterator.next()).toString());
+                source.tags.add(PureGrammarParserUtility.fromGrammarString(stringIterator.next().toString(), true));
             }
         }
 
@@ -197,7 +197,7 @@ public class MasteryParseTreeWalker
         RecordSourcePartition partition = new RecordSourcePartition();
 
         MasteryParserGrammar.IdContext idContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.id(), "id", sourceInformation);
-        partition.id = idContext.STRING().getText();
+        partition.id = PureGrammarParserUtility.fromGrammarString(idContext.STRING().getText(), true);
 
         MasteryParserGrammar.TagsContext tagsContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.tags(), "tags", sourceInformation);
         if (tagsContext != null)
@@ -205,7 +205,7 @@ public class MasteryParseTreeWalker
             ListIterator stringIterator = tagsContext.STRING().listIterator();
             while (stringIterator.hasNext())
             {
-                partition.tags.add(((TerminalNode) stringIterator.next()).toString());
+                partition.tags.add(PureGrammarParserUtility.fromGrammarString(stringIterator.next().toString(), true));
             }
         }
         return partition;

--- a/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
+++ b/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.language.pure.dsl.mastery.grammar.to;
 
+import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.grammar.to.DEPRECATED_PureGrammarComposerCore;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
@@ -29,6 +30,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mastery
 import java.util.List;
 
 import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.convertPath;
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.convertString;
 import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.getTabString;
 
 
@@ -92,8 +94,8 @@ public class HelperMasteryGrammarComposer
         @Override
         public String visit(RecordSource val)
         {
-              return getTabString(indentLevel + 2) + "id: " + val.id + ";\n" +
-                    getTabString(indentLevel + 2) + "description: " + val.description + ";\n" +
+              return getTabString(indentLevel + 2) + "id: " + convertString(val.id, true) + ";\n" +
+                    getTabString(indentLevel + 2) + "description: " + convertString(val.description, true) + ";\n" +
                     getTabString(indentLevel + 2) + "status: " + val.status + ";\n" +
                       (val.parseService != null ? (getTabString(indentLevel + 2) + "parseService: " + val.parseService + ";\n") : "") +
                       getTabString(indentLevel + 2) + "transformService: " + val.transformService + ";\n" +
@@ -123,12 +125,12 @@ public class HelperMasteryGrammarComposer
 
     private static String renderTags(Tagable tagable, int indentLevel)
     {
-        return getTabString(indentLevel) + "tags: " + tagable.getTags().toString() + ";";
+        return getTabString(indentLevel) + "tags: [" + LazyIterate.collect(tagable.getTags(), t -> convertString(t, true)).makeString(", ") + "];";
     }
 
     private static String renderPartition(RecordSourcePartition partition, int indentLevel)
     {
-        StringBuffer strBuf = new StringBuffer().append(getTabString(indentLevel + 1)).append("id: ").append(partition.id).append(";");
+        StringBuffer strBuf = new StringBuffer().append(getTabString(indentLevel + 1)).append("id: ").append(convertString(partition.id, true)).append(";");
         strBuf.append((partition.getTags() != null && !partition.getTags().isEmpty()) ? "\n" + renderTags(partition, indentLevel + 1) : "");
         return strBuf.toString();
     }

--- a/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
+++ b/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
@@ -308,44 +308,44 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
         {
             if (i == 0)
             {
-                assertEquals("\'widget-file-single-partition\'", source._id());
+                assertEquals("widget-file-single-partition", source._id());
                 assertEquals("Development", source._status().getName());
                 assertEquals(true, source._sequentialData());
                 assertEquals(false, source._stagedLoad());
                 assertEquals(true, source._createPermitted());
                 assertEquals(false, source._createBlockedException());
-                assertEquals("[\'Refinitive DSP\']", source._tags().toString());
+                assertEquals("[Refinitive DSP]", source._tags().toString());
                 ListIterate.forEachWithIndex(source._partitions().toList(), (partition, j) ->
                 {
-                    assertEquals("\'partition-1\'", partition._id());
-                    assertEquals("[\'Equity\', \'Global\', \'Full-Universe\']", partition._tags().toString());
+                    assertEquals("partition-1", partition._id());
+                    assertEquals("[Equity, Global, Full-Universe]", partition._tags().toString());
                 });
             }
             else if (i == 1)
             {
-                assertEquals("\'widget-file-multiple-partitions\'", source._id());
+                assertEquals("widget-file-multiple-partitions", source._id());
                 assertEquals("Production", source._status().getName());
                 assertEquals(false, source._sequentialData());
                 assertEquals(true, source._stagedLoad());
                 assertEquals(false, source._createPermitted());
                 assertEquals(true, source._createBlockedException());
-                assertEquals("[\'Refinitive DSP Delta Files\']", source._tags().toString());
+                assertEquals("[Refinitive DSP Delta Files]", source._tags().toString());
                 ListIterate.forEachWithIndex(source._partitions().toList(), (partition, j) ->
                 {
                     if (j == 0)
                     {
-                        assertEquals("\'ASIA-Equity\'", partition._id());
-                        assertEquals("[\'Equity\', \'ASIA\']", partition._tags().toString());
+                        assertEquals("ASIA-Equity", partition._id());
+                        assertEquals("[Equity, ASIA]", partition._tags().toString());
                     }
                     else if (j == 1)
                     {
-                        assertEquals("\'EMEA-Equity\'", partition._id());
-                        assertEquals("[\'Equity\', \'EMEA\']", partition._tags().toString());
+                        assertEquals("EMEA-Equity", partition._id());
+                        assertEquals("[Equity, EMEA]", partition._tags().toString());
                     }
                     else if (j == 2)
                     {
-                        assertEquals("\'US-Equity\'", partition._id());
-                        assertEquals("[\'Equity\', \'US\']", partition._tags().toString());
+                        assertEquals("US-Equity", partition._id());
+                        assertEquals("[Equity, US]", partition._tags().toString());
                     }
                     else
                     {
@@ -359,6 +359,19 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
                 fail("Didn't expect a source at index:" + i);
             }
         });
+    }
+
+    @Test
+    public void testMasteryMinimumCorrectModel()
+    {
+        Pair<PureModelContextData, PureModel> result = test(MINIMUM_CORRECT_MASTERY_MODEL);
+        PureModel model = result.getTwo();
+
+        PackageableElement packageableElement = model.getPackageableElement("alloy::mastery::WidgetMasterRecord");
+        assertNotNull(packageableElement);
+        assertTrue(packageableElement instanceof Root_meta_pure_mastery_metamodel_MasterRecordDefinition);
+        Root_meta_pure_mastery_metamodel_MasterRecordDefinition masterRecordDefinition = (Root_meta_pure_mastery_metamodel_MasterRecordDefinition) packageableElement;
+        assertEquals("Widget", masterRecordDefinition._modelClass()._name());
     }
 
     private void assertPureLambdas(List list)


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

- Previously Strings in Mastery grammar were being wrapper in extra quotations, this is to fix that.
- An optional service in the grammar (parse service) was throwing a null pointer in the compiler when it was not provided

