### PR TITLE
Make M2M tests use defaultExtensions

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/legendJavaPlatformBinding/bindPlanToLegendJavaPlatform.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/legendJavaPlatformBinding/bindPlanToLegendJavaPlatform.pure
@@ -27,12 +27,11 @@ import meta::pure::executionPlan::engine::java::graphFetch::common::*;
 function meta::pure::executionPlan::platformBinding::legendJava::bindPlanToLegendJavaPlatform(plan: ExecutionPlan[1], platformBindingConfig: PlatformBindingConfig[1], extensions: Extension[*], debug: DebugContext[1]): ExecutionPlan[1]
 {
    assert($platformBindingConfig->instanceOf(LegendJavaPlatformBindingConfig), | 'Expected Legend Java platform binding config');
-   
-   let newExtensions      = if($extensions->isEmpty(), | meta::pure::extension::defaultExtensions(), | $extensions); // TODO: remove after updating M2M tests to pass default extensions
-   let legendJavaConfig   = $platformBindingConfig->cast(@LegendJavaPlatformBindingConfig);
-   let generationContext  = $plan->prepareGenerationContext($legendJavaConfig, $newExtensions, $debug);
 
-   let generatedNode      = $plan.rootExecutionNode->generateLegendJavaPlatformBindingCode('root', $generationContext, $newExtensions, $debug);
+   let legendJavaConfig   = $platformBindingConfig->cast(@LegendJavaPlatformBindingConfig);
+   let generationContext  = $plan->prepareGenerationContext($legendJavaConfig, $extensions, $debug);
+
+   let generatedNode      = $plan.rootExecutionNode->generateLegendJavaPlatformBindingCode('root', $generationContext, $extensions, $debug);
 
    ^$plan
    (

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/autoMapping.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/autoMapping.pure
@@ -41,7 +41,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::mapSourceToTargetBasedOn
                                 url='data:application/json,{"name":"Acme Corp", "employees":[{"firstName":"Fred","lastName":"Bloggs", "age":37}, {"firstName":"John","lastName":"Doe", "age": 43}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected = '{"name":"Acme Corp", "employees":[{"firstName":"Fred","lastName":"Bloggs", "age":37}, {"firstName":"John","lastName":"Doe", "age": 43}]}';

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/dataQualityChain.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/dataQualityChain.pure
@@ -43,7 +43,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::dataQuality::constraintFa
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =
@@ -235,7 +235,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::dataQuality::constraintFa
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/filterChain.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/filterChain.pure
@@ -43,7 +43,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::filter::filterOnSourceToB
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =
@@ -98,7 +98,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::filter::filterOnBridgeToD
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =
@@ -213,7 +213,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::filter::filterOnBothMappi
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/parametersChain.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/parametersChain.pure
@@ -47,7 +47,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::parameters::qualifiedProp
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =
@@ -183,7 +183,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::parameters::qualifiedProp
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/simpleChain.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/simpleChain.pure
@@ -43,7 +43,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::simple::simpleChainSerial
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected = '{"name":"|$Firm1$|"}';
@@ -70,7 +70,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::simple::simpleChainSerial
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected = 
@@ -125,7 +125,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::simple::simpleChainSerial
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected = '{"name":"|$Firm1$|","employees":[{"fullName":"|$Person1$|"},{"fullName":"|$Person2$|"}]}';
@@ -155,7 +155,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::simple::simpleChainSerial
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =
@@ -234,7 +234,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::simple::simpleChainSerial
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =
@@ -285,7 +285,7 @@ meta::pure::mapping::modelToModel::test::alloy::chain::simple::simpleChainSerial
             ^JsonModelConnection(element = ^ModelStore(), class = __Firm, url = 'data:application/json,' + $sourceFirms)
          ]
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected =
@@ -409,13 +409,13 @@ meta::pure::mapping::modelToModel::test::alloy::chain::simple::testJsonModelConn
                           ]
                        );
 
-   let simpleQueryResult = execute($simpleQuery, SrcToBridgeMapping, $runtime, []).values;
+   let simpleQueryResult = execute($simpleQuery, SrcToBridgeMapping, $runtime, meta::pure::extension::defaultExtensions()).values;
    assertJsonStringsEqual(
          '{"name":"$Firm1$"}',
          $simpleQueryResult
       );
 
-   let chainedQueryResult = execute($chainedQuery, BridgeToDestMapping, $runtime, []).values;
+   let chainedQueryResult = execute($chainedQuery, BridgeToDestMapping, $runtime, meta::pure::extension::defaultExtensions()).values;
    assertJsonStringsEqual(
       '{"name":"|$Firm1$|"}',
       $chainedQueryResult

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/constraints.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/constraints.pure
@@ -33,7 +33,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testTargetConstrain
                                 url='data:application/json,{"name":"FirmX"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::Firm","message":"Constraint :[0] violated in the Class Firm"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"name\\":\\"FirmX\\"}"},"value":{"name":"FirmX","employees":[]}},"value":{"name":"FirmX"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -50,7 +50,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testQueryOnTypeWith
                                 class=_Firm, 
                                 url='data:application/json,{"name":"FirmX"}')),
                            ^ExecutionContext(enableConstraints=false),
-                         []
+                           meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"name":"FirmX"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -67,7 +67,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testQueryOnSourceTy
                                 class=_Firm2, 
                                 url='data:application/json,{"name":"FirmX"}')),
                           ^ExecutionContext(enableConstraints=false),
-                        []
+                          meta::pure::extension::defaultExtensions()
                      );
   
    assert(jsonEquivalent('{"name":"FirmX"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -85,7 +85,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testSourceConstrain
                                 url='data:application/json,{"name":"FirmX","employees":[{"firstName":"David","lastName":"Roe"}]}'
                              )
                            ),
-                         []
+                           meta::pure::extension::defaultExtensions()
                   );
    
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::_Firm2","message":"Constraint :[0] violated in the Class _Firm2"},{"path":[{"propertyName":"employees","index":0}],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::_Person2","message":"Constraint :[0] violated in the Class _Person2"}],"source":{"number":1,"record":"{\\"name\\":\\"FirmX\\",\\"employees\\":[{\\"firstName\\":\\"David\\",\\"lastName\\":\\"Roe\\"}]}"},"value":{"name":"FirmX","employees":[{"firm":null,"address":null}]}},"value":{"name":"FirmX"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -103,7 +103,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testSourceConstrain
                              url='data:application/json,{"make" : "Ford", "engineSize" : "big", "numOfDoors" : 1}'
                              )
                            ),
-                           []
+                           meta::pure::extension::defaultExtensions()
                      );
 
   assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"make\\":\\"Ford\\",\\"engineSize\\":\\"big\\",\\"numOfDoors\\":1}"},"value":{"engineSize":"big","make":"Ford"}},"value":{"engineSize":"big"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -121,7 +121,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testSourceConstrain
                              url='data:application/json,{"id":"1"}'
                              )
                            ),
-                           []
+                           meta::pure::extension::defaultExtensions()
                        );
   
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"id\\":\\"1\\"}"},"value":{"id":"1"}},"value":{"id":"1"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -139,7 +139,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testIsEqualConstrai
                              url='data:application/json,{"b":true}'
                              )
                           ),
-                          []
+                          meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent( '{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"b\\":true}"},"value":{"b":true}},"value":{"b":true}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -157,7 +157,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testIsDistinctConst
                              url='data:application/json,{"b":true}'
                              )
                          ),
-                        []
+                         meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"b\\":true}"},"value":{"b":true}},"value":{"b":true}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -175,7 +175,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnOptiona
                              url='data:application/json,{"n":5}'
                              )
                          ),
-                        []
+                         meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":5}"},"value":{"n":5}},"value":{"maybe":null,"i":5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -193,7 +193,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnOptiona
                              url='data:application/json,{"n":20}'
                              )
                          ),
-                        []
+                         meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::D","message":"Constraint :[0] violated in the Class D"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":20}"},"value":{"n":20}},"value":{"maybe":null,"i":20}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -211,7 +211,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappe
                              url='data:application/json,{"n":5}'
                              )
                          ),
-                        []
+                         meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":5}"},"value":{"n":5}},"value":{"i":5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -229,7 +229,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappe
                              url='data:application/json,{"n":20}'
                              )
                          ),
-                        []
+                         meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::E","message":"Unable to evaluate constraint [0]: No mapping for property \'expected\'"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":20}"},"value":{"n":20}},"value":{"i":20}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -248,7 +248,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappe
                              url='data:application/json,{"n":20}'
                              )
                          ),
-                        []
+                         meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::F","message":"Unable to evaluate constraint [0]: data not available - check your mappings"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":20}"},"value":{"n":20}},"value":{"i":20}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -266,7 +266,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappe
                              url='data:application/json,{"n":5}'
                              )
                          ),
-                        []
+                         meta::pure::extension::defaultExtensions()
                 );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":5}"},"value":{"n":5}},"value":{"i":5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -283,7 +283,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappe
                         class = meta::pure::mapping::modelToModel::test::alloy::constraints::From,
                         url='data:application/json,{"id":20}'
                       )),
-                      []
+                      meta::pure::extension::defaultExtensions()
   );
 
   assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::Loan","message":"Constraint :[0] violated in the Class Loan"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"id\\":20}"},"value":{"id":20}},"value":{"id":20}}'->parseJSON(),
@@ -299,7 +299,7 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testIsDistinctConst
       |Product.all()->graphFetchChecked(#{Product{id,name,synonyms{type,name}}}#)->serialize(#{Product{id,name,synonyms{type,name}}}#),
       meta::pure::mapping::modelToModel::test::alloy::constraints::ProductMapping,
       ^Runtime(connections = ^JsonModelConnection(element =^ ModelStore(), class = _Product, url = 'data:application/json,' + $inputData)),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected = '['+

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/dataQuality.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/dataQuality.pure
@@ -40,7 +40,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canUseGraphFetchChe
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":3}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -70,7 +70,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canUseGraphFetchChe
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":3}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -105,7 +105,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::constraintsPassWhen
       )
    );
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
 
    assert(true);
 }
@@ -123,7 +123,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::constraintsPassForV
    let mapping = doubleIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":3, "child" : {"s": "Hello"}}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected= 
    '{'+
@@ -151,7 +151,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::unmappedConstraintP
    let mapping = noIMapping;
    let runtime = testJsonRuntime(_Num2, '{"int":3, "child" : {"s": "Hello"}}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected= 
    '{'+
@@ -199,7 +199,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::unmappedConstraintP
    let mapping = noIViaQualifierMapping;
    let runtime = testJsonRuntime(_Num2, '{"int":3}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected= 
    '{'+
@@ -239,7 +239,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::constraintsFailForI
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":2}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -279,7 +279,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::constraintsFailForI
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":1}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -329,7 +329,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::constraintsAreInher
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":6}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -359,7 +359,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::constraintsAreInher
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":2}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -408,7 +408,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::returnCheckResultWi
    let mapping = simpleConstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":2, "b":false}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected = 
    '{'+
@@ -446,7 +446,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::returnCheckResultWi
    let mapping = constraintsLiteratureMapping;
    let runtime = testJsonRuntime(_Author, '{"name":"Plato", "books":[{"title": "Euthyphro", "pages": 20, "marketing": { "reviews": [{"by": "Socretes"},{"by": "Plato"}] }}, {"title": "Phaedo", "pages":61}]}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected= 
    '{'+
@@ -547,7 +547,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::returnCheckResultWi
    let mapping = simpleConstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":1, "b":false}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected = 
    '{'+
@@ -597,7 +597,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canDefineConstraint
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":6}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -628,7 +628,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canDefineConstraint
    let mapping = copyIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"i":2}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= 
@@ -667,7 +667,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::returnCheckResultWi
    let mapping = doubleIntegerMapping;
    let runtime = testJsonRuntime(_Num, '{"child":{}}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected= 
    '{'+
@@ -729,7 +729,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::returnCheckResultWi
    let mapping = simpleConstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":"NaN", "b":[1, false], "child":{"s":false, "d":"notadate"}}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    
    let expected= 
@@ -839,7 +839,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::returnCheckResultWi
    let mapping = simpleConstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":1, "b":false}');
 
-   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), []);
+   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected = 
    '{'+
@@ -868,7 +868,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::executionSucceedsFo
    let mapping = simpleConstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":1, "b":false}');
 
-   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), []);
+   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected = '{"i":1,"b":false}';
    assert(jsonEquivalent($expected->parseJSON(), $json->parseJSON()));
@@ -888,7 +888,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::returnCheckResultWi
    let mapping = simpleConstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":2, "b":false}');
 
-   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), []);
+   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected = 
    '{'+
@@ -917,7 +917,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::executionSucceedsFo
    let mapping = simpleConstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":2, "b":false}');
 
-   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), []);
+   let result = execute($func, $mapping, $runtime, ^ExecutionContext(enableConstraints=false), meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected = '{"i":4,"b":false}';
    assert(jsonEquivalent($expected->parseJSON(), $json->parseJSON()));
@@ -937,7 +937,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::fetchGraphIsExpande
    let mapping = constraintsLiteratureMapping;
    let runtime = testJsonRuntime(_Author, '{"name":"Plato", "books":[{"title": "Euthyphro", "pages": 20, "marketing": { "reviews": [{"by": "Socretes"},{"by": "Plato"}] }}, {"title": "Phaedo", "pages":61}]}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected= 
    '{'+
@@ -1017,7 +1017,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::fetchGraphIsExpande
    let mapping = simpleUnconstrainedDataMapping;
    let runtime = testJsonRuntime(_SomeDataConstrained, '{"i":1, "b":false}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
    let expected = 
    '{'+
@@ -1545,7 +1545,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::fetchGraphIsExpande
       |Widget.all()->graphFetchChecked($tree)->serialize($tree),
       SourceWidgetToWidget,
       testJsonRuntime(SourceWidget, '{"name":"Dave"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    let json = $result.values->toOne();
    let expected = 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/filterInMapping.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/filterInMapping.pure
@@ -34,7 +34,7 @@ meta::pure::mapping::modelToModel::test::alloy::filter::canFilterInAMapping() : 
    let mapping = filterMapping;
    let runtime = testJsonRuntime(_Person, '[{"fullName":"Pierre Doe", "firm": {"name":"X"}},{"fullName":"A. Only One", "firm": {"name":"X"}}]');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= '{"lastName":"A. Only One"}';
@@ -85,7 +85,7 @@ meta::pure::mapping::modelToModel::test::alloy::filter::canFilterInAMappingOnChi
    let mapping = filterMapping;
    let runtime = testJsonRuntime(_Firm, '{"name":"X", "employees":[{"fullName":"Pierre Doe"},{"fullName":"A. Only One"}]}');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= '{"employees"[{"lastName":"A. Only One"}]}';
@@ -106,7 +106,7 @@ meta::pure::mapping::modelToModel::test::alloy::filter::canExecuteFilterAtSetLev
    let mapping = setFilterMapping;
    let runtime = testJsonRuntime(_D, '[{"id" : 1, "e" : {"id" : 1}}, {"id" : 2, "e" : {"id" : 2}}]');
    
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected= '[{"id" : 1, "e" : null}, {"id" : 2, "e" : {"id" : 2}}]';

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/functionInMapping.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/functionInMapping.pure
@@ -33,7 +33,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canUseFunctionsInAMappin
       |FirstEmployee.all()->graphFetchChecked($tree)->serialize($tree),
       meta::pure::mapping::modelToModel::test::alloy::simple::function::m1,
       testJsonRuntime(Firm, '{"name": "firm1", "employees": [{"firstName": "Dave", "lastName": "Miles"}]}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/graphWithAssociations.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/graphWithAssociations.pure
@@ -41,7 +41,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::serializeGraphWithAssoci
                                 url='data:application/json,{"name":"Metallurgy Inc.", "employees":[{"firstName":"Pierre","lastName":"Doe"}, {"firstName":"Dave","lastName":"Miles"}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"name":"Metallurgy Inc.", "employees":[{"fullName":"Pierre Doe"}, {"fullName":"Dave Miles"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/graphWithoutAssociations.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/graphWithoutAssociations.pure
@@ -41,7 +41,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::serializeGraphWithoutAss
                                 url='data:application/json,{"name":"Metallurgy Inc.", "employees":[{"firstName":"Pierre","lastName":"Doe"}, {"firstName":"Dave","lastName":"Miles"}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"name":"Metallurgy Inc.", "employees":[{"fullName":"Pierre Doe"}, {"fullName":"Dave Miles"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/merge.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/merge.pure
@@ -112,7 +112,7 @@ meta::pure::mapping::modelToModel::test::alloy::merge::testSimplemerge():Any[*]
    ]
                ),
       
-      []);
+      meta::pure::extension::defaultExtensions());
 
    let json = $result.values->toOne();
    let expected = '{"firstName":"John","lastName":"Smith","address":{"street":"Main st"},"age":10}';
@@ -146,7 +146,7 @@ meta::pure::mapping::modelToModel::test::alloy::merge::testMergeNonRoot():Any[*]
    ]
                ),
       
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -184,7 +184,7 @@ meta::pure::mapping::modelToModel::test::alloy::merge::mergeObjectsModelChainMap
                   )
       ]
       
-   ),[]);
+   ),meta::pure::extension::defaultExtensions());
 
    let json = $result.values->toOne();
    let expected = '{"fullName":"John Smith"}';

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/multiStepFunctions.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/multiStepFunctions.pure
@@ -64,7 +64,7 @@ meta::pure::mapping::modelToModel::test::alloy::multiStep::testMultiLevelModelTo
       },
       ^Mapping(),
       ^Runtime(),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    
    let expected = '['+
@@ -116,7 +116,7 @@ meta::pure::mapping::modelToModel::test::alloy::multiStep::testMultiLevelModelTo
       },
       ^Mapping(),
       ^Runtime(),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    
    let expected = '['+

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/multiplicities.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/multiplicities.pure
@@ -41,7 +41,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::multiplicities::multipli
                                 url='data:application/json,{"sOne": "A", "sZeroOne": "B", "sMany": "C"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"s1": "A", "s2": "B", "s3": "C"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -66,7 +66,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::multiplicities::multipli
                                 url='data:application/json,{"sOne": "A", "sZeroOne": "B", "sMany": "C"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"s1": "A", "s2": "B", "s3": "C"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -91,7 +91,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::multiplicities::multipli
                                 url='data:application/json,{"sOne": "A", "sZeroOne": "B", "sMany": "C"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"s1": ["A"], "s2": ["B"], "s3": ["C"]}'->parseJSON(), $result.values->toOne()->parseJSON()));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/nilHandling.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/nilHandling.pure
@@ -34,7 +34,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canHandleNilWhileMapping
       |Target.all()->graphFetch($tree)->serialize($tree),
       mapWithNil,
       testJsonRuntime(Source, '{"i":0}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -57,7 +57,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canHandleNonNilWhileMapp
       |Target.all()->graphFetch($tree)->serialize($tree),
       mapWithNil,
       testJsonRuntime(Source, '{"i":1}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -79,7 +79,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canHandleSimplePropertyM
       |Target.all()->graphFetch($tree)->serialize($tree),
       mapToNil,
       testJsonRuntime(Source, '{"i":1}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -101,7 +101,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canHandleComplexProperty
       |Target.all()->graphFetch($tree)->serialize($tree),
       mapToNilComplexProperty,
       testJsonRuntime(Source, '{"i":1}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/propertyUnion.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/propertyUnion.pure
@@ -32,7 +32,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::testSimpleUnionAtPropert
       |TargetRoot.all()->graphFetch($tree)->serialize($tree),
       simplePropertyUnionMap,
       testJsonRuntime(Source, '{"prop":"A"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -52,7 +52,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::testMultiLevelUnion():An
       |TargetRoot.all()->graphFetch($tree)->serialize($tree),
       multiLevelUnionMapping,
       testJsonRuntime(Source, '{"prop":"A"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -72,7 +72,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::testLargeUnionAtProperty
       |TargetRoot.all()->graphFetch($tree)->serialize($tree),
       largePropertyUnionMap,
       testJsonRuntime(Source, '{"prop":"A"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -92,7 +92,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::testDisjointUnionWithOpt
       |MainClass.all()->graphFetch($tree)->serialize($tree),
       simpleDisjointUnionMap,
       testJsonRuntime(InputClass, '{"firstName":"Bob", "union1_field" : "A", "union2_field" : "B"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -399,7 +399,7 @@ meta::pure::mapping::modelToModel::test::alloy::union::testUnionSubTypeSource() 
       meta::pure::mapping::modelToModel::test::alloy::union::UnionOnSubType,
      testJsonRuntime(_S_Firm,
                              $source
-                             ),[]
+                             ),meta::pure::extension::defaultExtensions()
       );
    assert(jsonEquivalent('{"legalName":"FINOS","employees":[{"firstName":"Person Super"},{"firstName":"CC"},{"firstName":"A1A"},{"firstName":"A2A"},{"firstName":"BB"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/qualifiedProperties.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/qualifiedProperties.pure
@@ -33,7 +33,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canEvaluateAMapping
    let mapping = simplifyBook;
    let runtime = testJsonRuntime(Book, '{"title":"The Annotated Turing", "author":"Charles Petzold", "identifiers" : [ {"type":"ISBN_10", "id":"0470229055"}, {"type":"ISBN_13", "id":"978-0470229057"} ]}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected=
@@ -76,7 +76,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canEvaluateAConstra
    let mapping = simplifyBookWithConstraint;
    let runtime = testJsonRuntime(BookWithConstraint, '{"title":"The Annotated Turing", "author":"Charles Petzold", "identifiers" : [ {"type":"ISBN_10", "id":"0470229055"}, {"type":"ISBN_13", "id":"978-0470229057"} ]}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected=
@@ -120,7 +120,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canEvaluateAConstra
    let mapping = simplifyBookWithConstraint;
    let runtime = testJsonRuntime(BookWithConstraint, '{"title":"The Annotated Turing", "author":"Charles Petzold", "identifiers" : [ {"type":"ISBN_13", "id":"978-0470229057"} ]}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected=
@@ -172,7 +172,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canEvaluateAConstra
    let mapping = simplifyBookWithConstraint2;
    let runtime = testJsonRuntime(Book, '{"title":"The Annotated Turing", "author":"Charles Petzold", "identifiers" : [ {"type":"ISBN_10", "id":"0470229055"}, {"type":"ISBN_13", "id":"978-0470229057"} ]}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected=
@@ -216,7 +216,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canEvaluateAConstra
    let mapping = simplifyBookWithConstraint2;
    let runtime = testJsonRuntime(Book, '{"title":"CODE", "author":"Charles Petzold", "identifiers" : [ {"type":"ISBN_10", "id":"9780735611313"}, {"type":"ISBN_13", "id":"978-0735611313"} ]}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected=
@@ -268,7 +268,7 @@ meta::pure::mapping::modelToModel::test::alloy::dataQuality::canEvaluateAGraphFe
    let mapping = dataToBook;
    let runtime = testJsonRuntime(BookData, '{"title":"The Annotated Turing", "author":"Charles Petzold", "identifiers" : [ {"type":"ISBN_10", "id":"0470229055"}, {"type":"ISBN_13", "id":"978-0470229057"} ]}');
 
-   let result = execute($func, $mapping, $runtime, []);
+   let result = execute($func, $mapping, $runtime, meta::pure::extension::defaultExtensions());
    let json = $result.values->toOne();
 
    let expected=

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/simpleObject.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/simpleObject.pure
@@ -46,7 +46,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,{"fullName":"Pierre Doe"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"firstName":"Pierre","lastName":"Doe"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -71,7 +71,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"name":"GS","employees": [{"fullName" : "Robert T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, {"fullName" : "John T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, {"fullName" : "Den T", "aName" : "B", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonB"}, {"fullName" : "Den T", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_Person"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );      
    
    assert(jsonEquivalent('{"legalName":"GS","employees":[{"firstName":"RobertA"},{"firstName":"JohnA"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -97,7 +97,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"name":"GS","employees": [{"fullName" : "Robert T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, {"fullName" : "John T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, {"fullName" : "Den T", "aName" : "B", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonB"}, {"fullName" : "Den T", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_Person"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );      
    
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"name\\":\\"GS\\",\\"employees\\":[{\\"fullName\\":\\"Robert T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA\\"},{\\"fullName\\":\\"John T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA\\"},{\\"fullName\\":\\"Den T\\",\\"aName\\":\\"B\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonB\\"},{\\"fullName\\":\\"Den T\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_Person\\"}]}"},"value":{"name":"GS","employees":[{"aName":"A","fullName":"Robert T"},{"aName":"A","fullName":"John T"},{"fullName":"Den T"},{"fullName":"Den T"}]}},"value":{"legalName":"GS","employees":[{"firstName":"RobertA"},{"firstName":"JohnA"}]}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -122,7 +122,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"name":"GS","employees": [{"fullName" : "Robert T", "address":  {"name" : "n", "street" : "Digby"}, "aName" : "A", "vehicle": {"wheelCount" : 5}, "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, {"fullName" : "John T", "address":  {"name" : "n", "street" : "HighBury"}, "aName" : "A", "vehicle": {"wheelCount" : 7}, "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, {"fullName" : "Den T", "address":  {"name" : "n", "street" : "Cresent"}, "aName" : "B", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonB"}, {"fullName" : "Den T", "address":  {"name" : "n", "street" : "Test"}, "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_Person"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );      
    
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"name\\":\\"GS\\",\\"employees\\":[{\\"fullName\\":\\"Robert T\\",\\"address\\":{\\"name\\":\\"n\\",\\"street\\":\\"Digby\\"},\\"aName\\":\\"A\\",\\"vehicle\\":{\\"wheelCount\\":5},\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA\\"},{\\"fullName\\":\\"John T\\",\\"address\\":{\\"name\\":\\"n\\",\\"street\\":\\"HighBury\\"},\\"aName\\":\\"A\\",\\"vehicle\\":{\\"wheelCount\\":7},\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA\\"},{\\"fullName\\":\\"Den T\\",\\"address\\":{\\"name\\":\\"n\\",\\"street\\":\\"Cresent\\"},\\"aName\\":\\"B\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonB\\"},{\\"fullName\\":\\"Den T\\",\\"address\\":{\\"name\\":\\"n\\",\\"street\\":\\"Test\\"},\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_Person\\"}]}"},"value":{"name":"GS","employees":[{"address":{"street":"Digby"},"aName":"A","fullName":"Robert T","vehicle":{"wheelCount":5}},{"address":{"street":"HighBury"},"aName":"A","fullName":"John T","vehicle":{"wheelCount":7}},{"address":{"street":"Cresent"},"fullName":"Den T"},{"address":{"street":"Test"},"fullName":"Den T"}]}},"value":{"legalName":"GS","employees":[{"firstName":"Robert","lastName":"T","description":"aName:A lives at Digby and has road vehicle with wheel count:5"},{"firstName":"John","lastName":"T","description":"aName:A lives at HighBury and has road vehicle with wheel count:7"}]}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -147,7 +147,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfMultipl
                                 url='data:application/json,[{"fullName":"Pierre Doe"},{"fullName":"Dave Miles"}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('[{"firstName":"Pierre","lastName":"Doe"},{"firstName":"Dave","lastName":"Miles"}]'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -172,7 +172,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOneObject
                                 url='data:application/json,{"firstName":"Pierre","lastName":"Doe"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"fullName":"Pierre Doe"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -195,7 +195,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeMissingPr
                                 url='data:application/json,{"lastName":"Doe"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"fullName":"Somebody Doe"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -220,7 +220,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::supportForPrimitivesAndE
                                 url='data:application/json,{"i":2, "f": 2.5, "d": [0.1, 0.2], "sd": ["2018-03-12", "2019-05-30"], "dt": ["2018-03-12T13:20:21.000", "2019-05-30T04:29:01.234"], "b": [true, false, true], "c":"ROUGE", "s":["BLEU", "VERT"]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected = '{"i":4, "f": 0.4, "d": [0.2, 0.4],"sd": ["2018-03-13", "2019-05-31"], "dt": ["2018-03-12T15:20:21.000", "2019-05-30T06:29:01.234"], "b": [false, true, false], "c":"RED", "c2":"BLUE", "c3":["BLUE", "GREEN"]}';
@@ -247,7 +247,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::supportForPrimitivesAndE
                                 url='data:application/json,{"i":2, "f": 2.5, "d": [0.1, 0.2], "sd": ["2018-03-12", "2019-05-30"], "dt": ["2018-03-12T13:20:21.000", "2019-05-30T04:29:01.234"], "b": [true, false, true], "c":"ROUGE", "s":["BLEU", "VERT"]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let expected = '{"i":4, "f": 0.4, "d": [0.2, 0.4],"sd": ["2018-03-13", "2019-05-31"], "dt": ["2018-03-12T15:20:21.000", "2019-05-30T06:29:01.234"], "b": [false, true, false], "c":"RED", "c2":"BLUE", "c3":["BLUE", "GREEN"]}';
@@ -274,7 +274,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::supportForEmptyValues() 
                                 url='data:application/json,{"i":null, "f": 2.5, "d": [], "b": [false, true], "c":"ROUGE"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"i":null, "f": 0.4, "d": []}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -303,7 +303,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"address": [{"zipCode" : "10282", "coordinates" : "1", "street": "200 west", "@type":"meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::Street"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );      
    
    assert(jsonEquivalent('{"targetAddress":"200 west"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -332,7 +332,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"address": [{"zipCode" : "10282", "coordinates" : "1", "road": "200 west", "@type":"meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::Road"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );      
    
    assert(jsonEquivalent('{"targetAddress":"200 west"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -354,7 +354,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::ignoresUnwantedValues() 
       |Person.all()->graphFetch($tree)->serialize($tree),
       simpleModelMapping,
       testJsonRuntime(_S_Person, '{"fullName":"Dave Miles", "likes": ["skiing", "books"], "height": 180, "address": {"line1": "1 The Street", "line2": "Sometown"}}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -377,7 +377,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canMapToAnEnumerationNam
       |Name.all()->graphFetch($tree)->serialize($tree),
       enumNameMapping,
       testJsonRuntime(_SomeData, '{"f": 2.5, "b": [true, false, true], "c":"ROUGE"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -400,7 +400,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canUseExternalEnumInMapp
       |Name.all()->graphFetch($tree)->serialize($tree),
       externalEnumMapping,
       testJsonRuntime(_SomeData, '{"f": 2.5, "b": [true, false, true], "c":"ROUGE"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -424,7 +424,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canUseExternalEnumValues
       |Name.all()->graphFetch($tree)->serialize($tree),
       externalEnumValuesMapping,
       testJsonRuntime(_SomeData, '{"f": 2.5, "b": [true, false, true], "c":"VERT"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -485,7 +485,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::testM2MQueryWithMappingU
                                 url='data:application/json,[{"streetCluster": [{"coordinates":"22.22.22.22","zipCode":"123456","street":"Oxford"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    let json = $result.values->toOne();
    let expected= '{"streetNames":["Oxford"],"zipCodes":["123456"]}';
@@ -508,7 +508,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canUseExternalEnumValues
       |Name.all()->graphFetch($tree)->serialize($tree),
       externalEnumValuesMappingFilter,
       testJsonRuntime(_SomeData, '{"f": 2.5, "b": [true, false, true], "c":"VERT", "cs":"RED"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -536,7 +536,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"name":"GS","employees": [{"fullName" : "Robert T", "aName" : "A", "@type":"_S_PersonA"}, {"fullName" : "John T", "aName" : "A", "@type":"_S_PersonA"}, {"fullName" : "Den T", "aName" : "B", "@type":"_S_PersonB"}, {"fullName" : "Den T", "@type":"_S_Person"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"legalName":"GS","employees":[{"firstName":"RobertA"},{"firstName":"JohnA"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -561,7 +561,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"name":"GS","employees": [{"fullName" : "Robert T", "aName" : "A", "@type":"_S_PersonA"}, {"fullName" : "John T", "aName" : "A", "@type":"_S_PersonA"}, {"fullName" : "Den T", "aName" : "B", "@type":"_S_PersonB"}, {"fullName" : "Den T", "@type":"_S_Person"}]}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"name\\":\\"GS\\",\\"employees\\":[{\\"fullName\\":\\"Robert T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"_S_PersonA\\"},{\\"fullName\\":\\"John T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"_S_PersonA\\"},{\\"fullName\\":\\"Den T\\",\\"aName\\":\\"B\\",\\"@type\\":\\"_S_PersonB\\"},{\\"fullName\\":\\"Den T\\",\\"@type\\":\\"_S_Person\\"}]}"},"value":{"name":"GS","employees":[{"aName":"A","fullName":"Robert T"},{"aName":"A","fullName":"John T"},{"fullName":"Den T"},{"fullName":"Den T"}]}},"value":{"legalName":"GS","employees":[{"firstName":"RobertA"},{"firstName":"JohnA"}]}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -587,7 +587,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"friendA" : {"fullName" : "Robert T", "aName" : "A", "@type":"_S_PersonA"}, "friendB" : {"fullName" : "John T", "aName" : "A", "@type":"_S_PersonA"}}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Critical","ruleType":"NoInput","externalId":null,"id":null,"ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::Friendship","message":"No Input Available"}],"source":{"defects":[{"path":[{"propertyName":"friendA","index":null}],"enforcementLevel":"Critical","ruleType":"InvalidInput","externalId":null,"id":null,"ruleDefinerPath":"meta::pure::mapping::modelToModel::test::shared::src::_S_Person","message":"multiple class matches [meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_PersonA, meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA] for _S_PersonA"},{"path":[{"propertyName":"friendB","index":null}],"enforcementLevel":"Critical","ruleType":"InvalidInput","externalId":null,"id":null,"ruleDefinerPath":"meta::pure::mapping::modelToModel::test::shared::src::_S_Person","message":"multiple class matches [meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_PersonA, meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA] for _S_PersonA"},{"path":[],"enforcementLevel":"Critical","ruleType":"ClassStructure","externalId":null,"id":null,"ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_Friendship","message":"Invalid multiplicity for friendA: expected [1] found [0]"},{"path":[],"enforcementLevel":"Critical","ruleType":"ClassStructure","externalId":null,"id":null,"ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_Friendship","message":"Invalid multiplicity for friendB: expected [1] found [0]"}],"source":{"number":1,"record":"{\\"friendA\\":{\\"fullName\\":\\"Robert T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"_S_PersonA\\"},\\"friendB\\":{\\"fullName\\":\\"John T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"_S_PersonA\\"}}"},"value":null},"value":null}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -613,7 +613,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"friendA" : {"fullName" : "Robert T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, "friendB" : {"fullName" : "John T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_PersonA"}}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"friendA\\":{\\"fullName\\":\\"Robert T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA\\"},\\"friendB\\":{\\"fullName\\":\\"John T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_PersonA\\"}}"},"value":{"friendA":{"aName":"A","fullName":"Robert T"},"friendB":{"aName":"A","fullName":"John T"}}},"value":{"friendA":{"firstName":"RobertA"},"friendB":{"firstName":"JohnA"}}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -639,7 +639,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
                                 url='data:application/json,[{"friendA" : {"fullName" : "Robert T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA"}, "friendB" : {"fullName" : "John T", "aName" : "A", "@type":"meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_PersonA"}, "friendC" : {"friendC" : {"fullName" : "John T", "aName" : "A", "bName" : "B", "@type":"meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_PersonB"}}}]'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"friendA":{"firstName":"RobertA"},"friendC":{"firstName":"JohnB"},"friendB":{"firstName":"JohnA"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -662,7 +662,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleM2MMappingUsingExp
                               url = 'data:application/json,{"s":"test string data"}'
                              )
          ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"s\\":\\"test string data\\"}"},"value":{"s":"test string data"}},"value":{"name":"ok"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -685,7 +685,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleM2MMappingUsingImp
                               url = 'data:application/json,{"s":"test string data"}'
                              )
          ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"s\\":\\"test string data\\"}"},"value":{"s":"test string data"}},"value":{"name":"ok"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -708,7 +708,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleM2MMappingEpochDat
                               url = 'data:application/json,{"epochDate":1624268257499000000}'
                              )
          ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
   let expected = '{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"epochDate\\":1624268257499000000}"},"value":{"epochDate":1624268257499000000}},"value":{"d":"2021-06-21T09:37:37.4990000"}}';

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/sourceAssociationRequiredByMapping.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/sourceAssociationRequiredByMapping.pure
@@ -39,7 +39,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canNavigateSourceAssocia
                                 class=Firm, 
                                 url='data:application/json,{"name":"Metallurgy Inc.", "employees":[{"firstName":"Pierre","lastName":"Doe"}, {"firstName":"Dave","lastName":"Miles"}]}'
                              )
-      ),[]
+      ),meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"names":"Pierre,Dave"}'->parseJSON(), $result.values->toOne()->parseJSON()));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/testExplosion.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/testExplosion.pure
@@ -35,7 +35,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testBasicExplosion():
                                 url='data:application/json,{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA"},{"fullName":"PersonB"}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('[{"firmName":"Anonymous Company","fullName":"PersonA"},{"firmName":"Anonymous Company","fullName":"PersonB"}]'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -56,7 +56,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testMultiplePropertyE
                                 url='data:application/json,{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA","address":{"street":"first"}},{"fullName":"PersonB","address":{"street":"second"}}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('[{"firmName":"Anonymous Company","fullName":"PersonA","streetAddress":"first"},{"firmName":"Anonymous Company","fullName":"PersonB","streetAddress":"second"}]'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -77,7 +77,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testTargetConstraints
                                 url='data:application/json,{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA"},{"fullName":"PersonB"}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('[{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"hasLongName","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::explosion::FirmEmployeeWithConstraint","message":"Constraint :[hasLongName] violated in the Class FirmEmployeeWithConstraint"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"name\\":\\"Anonymous Company\\",\\"simpleEmployees\\":[{\\"fullName\\":\\"PersonA\\"},{\\"fullName\\":\\"PersonB\\"}]}"},"value":{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA"},{"fullName":"PersonB"}]}},"value":{"fullName":"PersonA","firmName":"Anonymous Company"}},{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"hasLongName","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::explosion::FirmEmployeeWithConstraint","message":"Constraint :[hasLongName] violated in the Class FirmEmployeeWithConstraint"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"name\\":\\"Anonymous Company\\",\\"simpleEmployees\\":[{\\"fullName\\":\\"PersonA\\"},{\\"fullName\\":\\"PersonB\\"}]}"},"value":{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA"},{"fullName":"PersonB"}]}},"value":{"fullName":"PersonB","firmName":"Anonymous Company"}}]'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -102,7 +102,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testMappingWithSetsUs
                                 url='data:application/json,{"fullName":"Pierre Doe"}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    assert(jsonEquivalent('{"firstName":"Pierre","lastName":"Doe"}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
@@ -126,7 +126,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testExplosionAtProper
                                 url='data:application/json,{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA","dateOfBirth":"2020-11-09","address":{"street":"first"}},{"fullName":"PersonB","dateOfBirth":"2020-11-10","address":{"street":"second"}}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    assert(jsonEquivalent('{"name": "Anonymous Company","firmEmployees": [{"firmName": "Anonymous Company","fullName": "PersonA","streetAddress": "first","dateOfBirth": "2020-11-09"},{"firmName": "Anonymous Company","fullName": "PersonB","streetAddress": "second","dateOfBirth": "2020-11-10"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
@@ -150,7 +150,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testMappingWithExplos
                                 url='data:application/json,{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA","dateOfBirth":"2020-11-09","address":{"street":"first"}},{"fullName":"PersonB","dateOfBirth":"2020-11-10","address":{"street":"second"}}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    assert(jsonEquivalent('{"name": "Anonymous Company","firmEmployees": [{"firmName": "Anonymous Company"}, {"firmName": "Anonymous Company"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
@@ -174,7 +174,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testExplosionAtProper
                                 url='data:application/json,{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA","dateOfBirth":"2020-11-09","address":{"street":"first"}},{"fullName":"PersonB","dateOfBirth":"2020-11-10","address":{"street":"second"}}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    assert(jsonEquivalent('{"name": "Anonymous Company","firmEmployees": [{"firmName": "Anonymous Company","fullName": "PersonA"},{"firmName": "Anonymous Company","fullName": "PersonB"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
@@ -198,7 +198,7 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testExplosionAtProper
                                 url='data:application/json,{"name":"Anonymous Company","simpleEmployees":[{"fullName":"PersonA","address":{"street":"first"}},{"fullName":"PersonB","dateOfBirth":"2020-11-10"}]}'
                              )
       ),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    assert(jsonEquivalent('{"name": "Anonymous Company","firmEmployees": [{"firmName": "Anonymous Company","fullName": "PersonA","streetAddress": "first","dateOfBirth": null},{"firmName": "Anonymous Company","fullName": "PersonB","streetAddress": null,"dateOfBirth": "2020-11-10"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/testUnitMeasure.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/testUnitMeasure.pure
@@ -37,7 +37,7 @@ meta::pure::mapping::modelToModel::test::alloy::units::testUnitToUnitIdentityMap
                                 class=_HealthProfile,
                                 url='data:application/json,{"fullName":"Teddy Dean","weight":{"unit":[{"unitId":"meta::pure::unit::Mass~Kilogram","exponentValue":1}],"value":5.5}}'
                              )
-      ),[]
+      ),meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"fullName":"Teddy Dean","weight":{"unit":[{"unitId":"meta::pure::unit::Mass~Kilogram","exponentValue":1}],"value":5.5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -57,7 +57,7 @@ meta::pure::mapping::modelToModel::test::alloy::units::testModelToModelMappingOf
                                 class=_HealthProfile,
                                 url='data:application/json,{"fullName":"Teddy Dean","weight":{"unit":[{"unitId":"meta::pure::unit::Mass~Kilogram","exponentValue":1}],"value":5.5}}'
                              )
-      ),[]
+      ),meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"fullName":"Teddy Dean","weightValue":5.5,"weightUnit":"meta::pure::unit::Mass~Kilogram"}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -77,7 +77,7 @@ meta::pure::mapping::modelToModel::test::alloy::units::testModelToModelMappingOf
                                 class=_DecomposedHealthProfile,
                                 url='data:application/json,{"fullName":"Teddy Dean","weightUnit":"meta::pure::unit::Mass~Kilogram","weightValue":5.5}'
                              )
-      ),[]
+      ),meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"fullName":"Teddy Dean","weight":{"unit":[{"unitId":"meta::pure::unit::Mass~Kilogram","exponentValue":1}],"value":5.5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
@@ -97,7 +97,7 @@ meta::pure::mapping::modelToModel::test::alloy::units::testModelToModelMappingOf
                                 class=_ClassWithKilogram,
                                 url='data:application/json,{"weight":{"unit":[{"unitId":"meta::pure::unit::Mass~Kilogram","exponentValue":1}],"value":5.5}}'
                              )
-      ),[]
+      ),meta::pure::extension::defaultExtensions()
    );
 
    assert(jsonEquivalent('{"weight":{"unit":[{"unitId":"meta::pure::unit::Mass~Pound", "exponentValue":1}],"value":12.12548777530369}}'->parseJSON(), $result.values->toOne()->parseJSON()));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/toFromSameName.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/toFromSameName.pure
@@ -34,7 +34,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canMapBetweenClassesWith
       |meta::pure::mapping::modelToModel::test::alloy::simple::toFromSameName::dest::domain::Person.all()->graphFetch($tree)->serialize($tree),
       meta::pure::mapping::modelToModel::test::alloy::simple::toFromSameName::personMapping,
       testJsonRuntime(meta::pure::mapping::modelToModel::test::alloy::simple::toFromSameName::src::domain::Person, '{"firstName":"Dave", "lastName":"Miles"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
    let json = $result.values->toOne();
 
@@ -56,7 +56,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canMapBetweenClassesWith
       |meta::pure::mapping::modelToModel::test::alloy::simple::toFromSameName::dest::domain::Person.all()->graphFetchChecked($tree)->serialize($tree),
       meta::pure::mapping::modelToModel::test::alloy::simple::toFromSameName::personMapping,
       testJsonRuntime(meta::pure::mapping::modelToModel::test::alloy::simple::toFromSameName::src::domain::Person, '{"firstName":"Dave", "lastName":"Miles"}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/userFunctions.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/userFunctions.pure
@@ -34,7 +34,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canEvaluateAMappingWithA
       |FirstEmployee.all()->graphFetchChecked($tree)->serialize($tree),
       m1,
       testJsonRuntime(Firm, '{"name": "firm1", "employees": [{"firstName": "Dave", "lastName": "Miles"}]}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();
@@ -65,7 +65,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::canEvaluateAConstraintWi
       |FirstEmployeeConstrained.all()->graphFetchChecked($tree)->serialize($tree),
       m2,
       testJsonRuntime(Firm, '{"name": "firm1", "employees": [{"firstName": "Dave", "lastName": "Miles"}]}'),
-      []
+      meta::pure::extension::defaultExtensions()
    );
 
    let json = $result.values->toOne();


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Model-to-model unit tests currently pass empty extensions. Though they work when run via Legend server (with plan generation happening on server), local plan generation fails due to required extensions not being passed.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
