### PR TITLE
Isolate non-terminal group by with empty columns

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testModelGroupBy.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testModelGroupBy.pure
@@ -1155,3 +1155,30 @@ function <<test.Test>> meta::relational::tests::groupBy::testGroupByIsDistinct()
    assertEquals(['Firm X|3|4|false|4|4|true', 'Firm C|1|1|true|1|1|true', 'Firm B|1|1|true|1|1|true', 'Firm A|1|1|true|1|1|true'], $result.values.rows->map(r|$r.values->makeString('|')));
    assertSameSQL('select "root".LEGALNAME as "LegalName", count(distinct("persontable_0".FIRSTNAME)) as "FirstNameDistinctCount", count("persontable_0".FIRSTNAME) as "FirstNameCount", count(distinct("persontable_0".FIRSTNAME)) = count("persontable_0".FIRSTNAME) as "IsDistinctFirstName", count(distinct("persontable_0".LASTNAME)) as "LastNameDistinctCount", count("persontable_0".LASTNAME) as "LastNameCount", count(distinct("persontable_0".LASTNAME)) = count("persontable_0".LASTNAME) as "IsDistinctLastName" from firmTable as "root" left outer join personTable as "persontable_0" on ("root".ID = "persontable_0".FIRMID) group by "LegalName" order by "LegalName" desc', $result);
 }
+
+function <<test.Test>> meta::relational::tests::groupBy::testGroupByEmptyColsTerminalOperation():Boolean[1]
+{
+   let result = execute(
+      |Firm.all()
+         ->groupBy([], [agg(x|$x.legalName, y|$y->count())], ['Firm Count']),
+      simpleRelationalMapping,
+      meta::relational::tests::testRuntime(),
+      meta::relational::extension::relationalExtensions());
+   
+   assertEquals(['4'], $result.values.rows->map(r|$r.values->makeString('|')));
+   assertSameSQL('select count("root".LEGALNAME) as "Firm Count" from firmTable as "root"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::groupBy::testGroupByEmptyColsNonTerminalOperation():Boolean[1]
+{
+   let result = execute(
+      |Firm.all()
+         ->groupBy([], [agg(x|$x.legalName, y|$y->count())], ['Firm Count'])
+         ->filter(r | $r.getInteger('Firm Count') > 10),
+      simpleRelationalMapping,
+      meta::relational::tests::testRuntime(),
+      meta::relational::extension::relationalExtensions());
+   
+   assertEquals([], $result.values.rows->map(r|$r.values->makeString('|')));
+   assertSameSQL('select "Firm Count" as "Firm Count" from (select count("root".LEGALNAME) as "Firm Count" from firmTable as "root") as "subselect" where "Firm Count" > 10', $result);
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -696,7 +696,18 @@ function  meta::relational::functions::pureToSqlQuery::processObjectGroupBy(f:Fu
                   groupBy = $merge.groupBy,
                   paths = $ids->zip($paths)
                )
+               ->isolateNonTerminalGroupByQueryWithEmptyGroupingColumns($state, $extensions) 
    );
+}
+
+function <<access.private>> meta::relational::functions::pureToSqlQuery::isolateNonTerminalGroupByQueryWithEmptyGroupingColumns(select: TdsSelectSqlQuery[1], state: State[1], extensions: Extension[*]): TdsSelectSqlQuery[1]
+{
+   // Non terminal group by operation with empty group by cols needs to be wrapped in a subselect
+   // Else, it can cause problems like 'where' clause getting generated for aggregated columns (which is invalid)
+   if ($select.groupBy->isEmpty() && ($state.functionExpressionStack->size() > 1),
+       | $select->isolateTdsSelect($extensions),
+       | $select
+   )
 }
 
 function  meta::relational::functions::pureToSqlQuery::processObjectGroupByWithWindowSubSet(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -4124,7 +4135,7 @@ function meta::relational::functions::pureToSqlQuery::processGroupBy(expression:
            select = ^$select(columns = $groupByColumns->concatenate($newColumns),
                              groupBy = $groupByColumns->cast(@Alias),
                              paths = $pathInfos
-                    )
+                    )->isolateNonTerminalGroupByQueryWithEmptyGroupingColumns($state, $extensions)
         )
       ,|
         let alias = ^TableAlias(name = 'aggreg', relationalElement=$select);
@@ -4147,7 +4158,7 @@ function meta::relational::functions::pureToSqlQuery::processGroupBy(expression:
                                     columns = $groupByAliases->concatenate($newColumns),
                                     groupBy = $groupByAliases,
                                     paths = $pathInfos
-                               ),
+                               )->isolateNonTerminalGroupByQueryWithEmptyGroupingColumns($state, $extensions),
                   currentTreeNode = if($nestedQuery.currentTreeNode->isEmpty(), | $nestedQuery.currentTreeNode, | $nestedQuery.currentTreeNode->toOne()->findOneNode($nestedQuery.select.data->toOne(), $newData))
         );
    );

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testGroupBy.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testGroupBy.pure
@@ -404,3 +404,31 @@ function <<test.Test>> meta::relational::tests::tds::groupBy::testTDSGroupByIsDi
    meta::relational::functions::asserts::assertSameSQL('select "root".LEGALNAME as "LegalName", count(distinct("persontable_0".FIRSTNAME)) = count("persontable_0".FIRSTNAME) as "FirstNameIsDistinct", count(distinct("persontable_0".LASTNAME)) = count("persontable_0".LASTNAME) as "LastNameIsDistinct" from firmTable as "root" left outer join personTable as "persontable_0" on ("root".ID = "persontable_0".FIRMID) group by "LegalName" order by "LegalName" desc', $result);
 }
 
+function <<test.Test>> meta::relational::tests::tds::groupBy::testTDSGroupByEmptyColsTerminalOperation():Boolean[1]
+{
+   let result = execute(
+      |Firm.all()
+         ->project([col(x | $x.legalName, 'Legal Name')])
+         ->groupBy([], [agg('Firm Count', x|$x, y|$y->count())]),
+      simpleRelationalMapping,
+      meta::relational::tests::testRuntime(),
+      meta::relational::extension::relationalExtensions());
+   
+   assertEquals(['4'], $result.values.rows->map(r|$r.values->makeString('|')));
+   meta::relational::functions::asserts::assertSameSQL('select count(*) as "Firm Count" from firmTable as "root"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::tds::groupBy::testTDSGroupByEmptyColsNonTerminalOperation():Boolean[1]
+{
+   let result = execute(
+      |Firm.all()
+         ->project([col(x | $x.legalName, 'Legal Name')])
+         ->groupBy([], [agg('Firm Count', x|$x, y|$y->count())])
+         ->filter(r | $r.getInteger('Firm Count') > 10),
+      simpleRelationalMapping,
+      meta::relational::tests::testRuntime(),
+      meta::relational::extension::relationalExtensions());
+   
+   assertEquals([], $result.values.rows->map(r|$r.values->makeString('|')));
+   meta::relational::functions::asserts::assertSameSQL('select "Firm Count" as "Firm Count" from (select count(*) as "Firm Count" from firmTable as "root") as "subselect" where "Firm Count" > 10', $result);
+}


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Current sql generation logic checks whether a query has a group by or not by inspecting the size of group by columns (which evaluates to false in case of empty grouping columns). This can lead to incorrect SQL when further TDS operations like `filter` are applied on top. In the case of `filter`, generated sql contains a `where` clause using an aggregated column (example: `where count(*) > 10`) which is incorrect. This PR fixes this bug by isolating such non-terminal group by queries with empty grouping columns.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No