### PR TITLE
Fix for javadoc that references classes produced by annotation processor (#921)

### DIFF
--- a/legend-engine-xt-persistence-component/pom.xml
+++ b/legend-engine-xt-persistence-component/pom.xml
@@ -37,6 +37,32 @@
         <junit-jupiter.version>5.4.0</junit-jupiter.version>
     </properties>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven.javadoc.plugin.version}</version>
+                    <configuration>
+                        <skip>${javadoc.skip}</skip>
+                        <source>8</source>
+                        <doclint>none</doclint>
+                        <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
+
+                        <additionalDependencies>
+                            <additionalDependency>
+                                <groupId>javax.annotation</groupId>
+                                <artifactId>javax.annotation-api</artifactId>
+                                <version>1.3.2</version>
+                            </additionalDependency>
+                        </additionalDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <dependencyManagement>
         <dependencies>
             <!-- IMMUTABLES -->

--- a/pom.xml
+++ b/pom.xml
@@ -336,15 +336,6 @@
                         <skip>${javadoc.skip}</skip>
                         <source>8</source>
                         <doclint>none</doclint>
-                        <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
-
-                        <additionalDependencies>
-                            <additionalDependency>
-                                <groupId>javax.annotation</groupId>
-                                <artifactId>javax.annotation-api</artifactId>
-                                <version>1.3.2</version>
-                            </additionalDependency>
-                        </additionalDependencies>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,15 @@
                         <skip>${javadoc.skip}</skip>
                         <source>8</source>
                         <doclint>none</doclint>
+                        <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
+
+                        <additionalDependencies>
+                            <additionalDependency>
+                                <groupId>javax.annotation</groupId>
+                                <artifactId>javax.annotation-api</artifactId>
+                                <version>1.3.2</version>
+                            </additionalDependency>
+                        </additionalDependencies>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
#### What type of PR is this?

<!--
Bug fix
-->

#### What does this PR do / why is it needed ?
Maven javadoc plugin requires additional configuration to resolve references to classes produced by annotation processors. PR #921 introduced use of Immutables (limited to persistence modules only) which triggered this limitation.

#### Which issue(s) this PR fixes:
Resolves a bug introduced by work on #920

#### Other notes for reviewers:
None.

#### Does this PR introduce a user-facing change?
No.