### PR TITLE
Fix Maven Deploy workflow action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,11 @@ jobs:
           DOCKER_USERNAME: finos
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           MAVEN_OPTS: -Xmx4g
-        run: mvn javadoc:javadoc deploy -P docker-snapshot
+        run: |
+          mvn compile -pl legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan
+          mvn compile -pl legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan
+          mvn compile -pl legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core
+          mvn javadoc:javadoc deploy -P docker-snapshot
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,9 +72,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           MAVEN_OPTS: -Xmx4g
         run: |
-          mvn compile -pl legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan
-          mvn compile -pl legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan
-          mvn compile -pl legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core
+          mvn install -DskipTests=true
           mvn javadoc:javadoc deploy -P docker-snapshot
       - name: Upload Test Results
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,7 @@ jobs:
           DOCKER_USERNAME: finos
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           MAVEN_OPTS: -Xmx4g
-        run: |
-          mvn install -DskipTests=true
-          mvn javadoc:javadoc deploy -P docker-snapshot
+        run: mvn install javadoc:javadoc deploy -P docker-snapshot
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v3

--- a/legend-engine-xt-persistence-component/pom.xml
+++ b/legend-engine-xt-persistence-component/pom.xml
@@ -41,31 +41,34 @@
     <properties>
         <immutable.version>2.8.2</immutable.version>
         <junit-jupiter.version>5.4.0</junit-jupiter.version>
-        <javadoc.skip>true</javadoc.skip>
     </properties>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.plugin.version}</version>
-                <configuration>
-                    <skip>${javadoc.skip}</skip>
-                    <source>8</source>
-                    <doclint>none</doclint>
-                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven.javadoc.plugin.version}</version>
+                    <configuration>
+                        <skip>${javadoc.skip}</skip>
+                        <source>8</source>
+                        <doclint>none</doclint>
+                        <sourcepath>
+                            ${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations
+                        </sourcepath>
 
-                    <additionalDependencies>
-                        <additionalDependency>
-                            <groupId>javax.annotation</groupId>
-                            <artifactId>javax.annotation-api</artifactId>
-                            <version>1.3.2</version>
-                        </additionalDependency>
-                    </additionalDependencies>
-                </configuration>
-            </plugin>
-        </plugins>
+                        <additionalDependencies>
+                            <additionalDependency>
+                                <groupId>javax.annotation</groupId>
+                                <artifactId>javax.annotation-api</artifactId>
+                                <version>1.3.2</version>
+                            </additionalDependency>
+                        </additionalDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>


### PR DESCRIPTION
#### What type of PR is this?
Bug fix

#### What does this PR do / why is it needed ?
Update definition of GH workflow action that invokes javadoc.

~~We trigger the APT code generator before running javadoc for offending xt-persistence-component modules.~~

We run a blanket install before generating javadoc.

This is necessary because source code in those modules have forward references to generated code, which trips up the javadoc.

#### Which issue(s) this PR fixes:
Addresses bug introduced in #920

#### Other notes for reviewers:
None

#### Does this PR introduce a user-facing change?
No