### PR TITLE
fix compiler for union subtypes

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingSecondPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingSecondPassBuilder.java
@@ -14,38 +14,18 @@
 
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
-import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMappingVisitor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.OperationClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.aggregationAware.AggregationAwareClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.mapping.PureInstanceClassMapping;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.mapping.PurePropertyMapping;
-import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
-import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.EnumValue;
-import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_pure_mapping_SetImplementationContainer_Impl;
-import org.finos.legend.pure.generated.core_pure_router_router_routing;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EnumerationMapping;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.InstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.OperationSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PureInstanceSetImplementation;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class ClassMappingSecondPassBuilder implements ClassMappingVisitor<SetImplementation>
 {
@@ -93,77 +73,7 @@ public class ClassMappingSecondPassBuilder implements ClassMappingVisitor<SetImp
     @Override
     public SetImplementation visit(PureInstanceClassMapping classMapping)
     {
-        PureInstanceSetImplementation s = (PureInstanceSetImplementation) parentMapping._classMappings().select(c -> c._id().equals(HelperMappingBuilder.getClassMappingId(classMapping, this.context))).getFirst();
-        s._propertyMappings().forEachWithIndex((ObjectIntProcedure<org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping>) ((p, i) ->
-        {
-            org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping pm = (org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping) p;
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?> property = pm._property();
-            SourceInformation pSourceInformation = SourceInformationHelper.fromM3SourceInformation(p.getSourceInformation());
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification last = pm._transform()._expressionSequence().getLast();
-
-            List<Type> typesToCheck;
-            if (property._genericType()._rawType()._classifierGenericType()._rawType()._name().equals("Class"))
-            {
-                SetImplementation setImplementation;
-                if (p._targetSetImplementationId() != null && !p._targetSetImplementationId().equals(""))
-                {
-                    setImplementation = parentMapping._classMappingByIdRecursive(Lists.fixedSize.with(p._targetSetImplementationId()), this.context.pureModel.getExecutionSupport()).getFirst();
-                    Assert.assertTrue(setImplementation != null, () -> "Can't find class mapping '" + p._targetSetImplementationId() + "'", pSourceInformation, EngineErrorType.COMPILATION);
-                }
-                else
-                {
-                    setImplementation = parentMapping.classMappingByClass((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<Object>) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()).getFirst();
-                    Assert.assertTrue(setImplementation != null, () -> "Can't find class mapping for '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()) + "'", pSourceInformation, EngineErrorType.COMPILATION);
-                }
-
-                List<? extends InstanceSetImplementation> setImpls = core_pure_router_router_routing.Root_meta_pure_router_routing_resolveOperation_SetImplementation_MANY__Mapping_1__InstanceSetImplementation_MANY_(Lists.immutable.of(setImplementation), parentMapping, this.context.pureModel.getExecutionSupport()).toList();
-                typesToCheck = setImpls.stream().map(setImpl -> ((PureInstanceSetImplementation) setImpl)._srcClass()).collect(Collectors.toList());
-            }
-            else if (((org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping) p)._transformer() != null)
-            {
-                EnumerationMapping<Object> m = ((EnumerationMapping<Object>) ((org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping) p)._transformer());
-                Object val = m._enumValueMappings().getFirst()._sourceValues().getFirst();
-                if (val instanceof String)
-                {
-                    typesToCheck = Collections.singletonList(this.context.pureModel.getType("String"));
-                }
-                else if (val instanceof Long)
-                {
-                    typesToCheck = Collections.singletonList(this.context.pureModel.getType("Integer"));
-                }
-                else if (val instanceof EnumValue)
-                {
-                    typesToCheck = Collections.singletonList(this.context.resolveEnumeration(((EnumValue) val).fullPath, pSourceInformation));
-                }
-                else if (val instanceof Enum)
-                {
-                    GenericType genericType = ((Enum) val)._classifierGenericType();
-                    typesToCheck = genericType != null ? Collections.singletonList(this.context.resolveEnumeration(PackageableElement.getUserPathForPackageableElement(genericType._rawType()), pSourceInformation)) : Collections.emptyList();
-                }
-                else
-                {
-                    typesToCheck = Collections.emptyList();
-                }
-            }
-            else
-            {
-                typesToCheck = Collections.singletonList(property._genericType()._rawType());
-            }
-
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity multiplicityToCheck = pm._explodeProperty() != null && pm._explodeProperty() ? this.context.pureModel.getMultiplicity("zeromany") : property._multiplicity();
-            List<ValueSpecification> lines = ((PurePropertyMapping) classMapping.propertyMappings.get(i)).transform.body;
-            typesToCheck.stream().filter(Objects::nonNull).forEach(t -> HelperModelBuilder.checkTypeCompatibility(this.context,
-                    last._genericType()._rawType(),
-                    t,
-                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
-                    lines.get(lines.size() - 1).sourceInformation));
-
-            HelperModelBuilder.checkMultiplicityCompatibility(last._multiplicity(),
-                    multiplicityToCheck,
-                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
-                    lines.get(lines.size() - 1).sourceInformation);
-        }));
-        return s;
+        return null;
     }
 
     @Override

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingThirdPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingThirdPassBuilder.java
@@ -1,0 +1,163 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMappingVisitor;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.OperationClassMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.aggregationAware.AggregationAwareClassMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.mapping.PureInstanceClassMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.mapping.PurePropertyMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.EnumValue;
+import org.finos.legend.engine.shared.core.operational.Assert;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.pure.generated.core_pure_router_router_routing;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EnumerationMapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.InstanceSetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PureInstanceSetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImplementation>
+{
+    private final CompileContext context;
+    private final Mapping parentMapping;
+
+    public ClassMappingThirdPassBuilder(CompileContext context, Mapping parentMapping)
+    {
+        this.context = context;
+        this.parentMapping = parentMapping;
+    }
+
+    // NOTE: when we remove this visitor, we can return "void"
+    @Override
+    public SetImplementation visit(ClassMapping classMapping)
+    {
+        return null;
+    }
+
+    @Override
+    public SetImplementation visit(OperationClassMapping classMapping)
+    {
+        return null;
+    }
+
+    @Override
+    public SetImplementation visit(PureInstanceClassMapping classMapping)
+    {
+        PureInstanceSetImplementation s = (PureInstanceSetImplementation) parentMapping._classMappings().select(c -> c._id().equals(HelperMappingBuilder.getClassMappingId(classMapping, this.context))).getFirst();
+        s._propertyMappings().forEachWithIndex((ObjectIntProcedure<PropertyMapping>) ((p, i) ->
+        {
+            org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping pm = (org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping) p;
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?> property = pm._property();
+            SourceInformation pSourceInformation = SourceInformationHelper.fromM3SourceInformation(p.getSourceInformation());
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification last = pm._transform()._expressionSequence().getLast();
+
+            List<Type> typesToCheck;
+            if (property._genericType()._rawType()._classifierGenericType()._rawType()._name().equals("Class"))
+            {
+                SetImplementation setImplementation;
+                if (p._targetSetImplementationId() != null && !p._targetSetImplementationId().equals(""))
+                {
+                    setImplementation = parentMapping._classMappingByIdRecursive(Lists.fixedSize.with(p._targetSetImplementationId()), this.context.pureModel.getExecutionSupport()).getFirst();
+                    Assert.assertTrue(setImplementation != null, () -> "Can't find class mapping '" + p._targetSetImplementationId() + "'", pSourceInformation, EngineErrorType.COMPILATION);
+                }
+                else
+                {
+                    setImplementation = parentMapping.classMappingByClass((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<Object>) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()).getFirst();
+                    Assert.assertTrue(setImplementation != null, () -> "Can't find class mapping for '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()) + "'", pSourceInformation, EngineErrorType.COMPILATION);
+                }
+
+                List<? extends InstanceSetImplementation> setImpls = core_pure_router_router_routing.Root_meta_pure_router_routing_resolveOperation_SetImplementation_MANY__Mapping_1__InstanceSetImplementation_MANY_(Lists.immutable.of(setImplementation), parentMapping, this.context.pureModel.getExecutionSupport()).toList();
+                typesToCheck = setImpls.stream().map(setImpl -> ((PureInstanceSetImplementation) setImpl)._srcClass()).collect(Collectors.toList());
+            }
+            else if (((org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping) p)._transformer() != null)
+            {
+                EnumerationMapping<Object> m = ((EnumerationMapping<Object>) ((org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PurePropertyMapping) p)._transformer());
+                Object val = m._enumValueMappings().getFirst()._sourceValues().getFirst();
+                if (val instanceof String)
+                {
+                    typesToCheck = Collections.singletonList(this.context.pureModel.getType("String"));
+                }
+                else if (val instanceof Long)
+                {
+                    typesToCheck = Collections.singletonList(this.context.pureModel.getType("Integer"));
+                }
+                else if (val instanceof EnumValue)
+                {
+                    typesToCheck = Collections.singletonList(this.context.resolveEnumeration(((EnumValue) val).fullPath, pSourceInformation));
+                }
+                else if (val instanceof Enum)
+                {
+                    GenericType genericType = ((Enum) val)._classifierGenericType();
+                    typesToCheck = genericType != null ? Collections.singletonList(this.context.resolveEnumeration(PackageableElement.getUserPathForPackageableElement(genericType._rawType()), pSourceInformation)) : Collections.emptyList();
+                }
+                else
+                {
+                    typesToCheck = Collections.emptyList();
+                }
+            }
+            else
+            {
+                typesToCheck = Collections.singletonList(property._genericType()._rawType());
+            }
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity multiplicityToCheck = pm._explodeProperty() != null && pm._explodeProperty() ? this.context.pureModel.getMultiplicity("zeromany") : property._multiplicity();
+            List<ValueSpecification> lines = ((PurePropertyMapping) classMapping.propertyMappings.get(i)).transform.body;
+            typesToCheck.stream().filter(Objects::nonNull).forEach(t -> checkPureMappingCompatibility(this.context,
+                    last._genericType()._rawType(),
+                    t,
+                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
+                    lines.get(lines.size() - 1).sourceInformation));
+
+            HelperModelBuilder.checkMultiplicityCompatibility(last._multiplicity(),
+                    multiplicityToCheck,
+                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
+                    lines.get(lines.size() - 1).sourceInformation);
+        }));
+        return s;
+    }
+
+
+    @Override
+    public SetImplementation visit(AggregationAwareClassMapping classMapping)
+    {
+        return null;
+    }
+
+
+    private static void checkPureMappingCompatibility(CompileContext context, Type actualReturnType, Type signatureType, String errorStub, org.finos.legend.engine.protocol.pure.v1.model.SourceInformation errorSourceInformation)
+    {
+        //In a pure mapping. The src implementation  can be anywhere in the class hierarchy of the return type
+        if (signatureType != null && !actualReturnType.equals(signatureType) && !org.finos.legend.pure.m3.navigation.type.Type.subTypeOf(actualReturnType, signatureType, context.pureModel.getExecutionSupport().getProcessorSupport()) && !org.finos.legend.pure.m3.navigation.type.Type.subTypeOf(signatureType, actualReturnType, context.pureModel.getExecutionSupport().getProcessorSupport()))
+        {
+            throw new EngineException(errorStub + " - Type error: '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) actualReturnType, context.pureModel.getExecutionSupport()) + "' is not in the class hierarchy of '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) signatureType, context.pureModel.getExecutionSupport()) + "'", errorSourceInformation, EngineErrorType.COMPILATION);
+        }
+    }
+}

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFifthPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFifthPassBuilder.java
@@ -83,7 +83,12 @@ public class PackageableElementFifthPassBuilder implements PackageableElementVis
     @Override
     public PackageableElement visit(Mapping mapping)
     {
-        return null;
+        final org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping pureMapping = this.context.pureModel.getMapping(this.context.pureModel.buildPackageString(mapping._package, mapping.name), mapping.sourceInformation);
+        if (mapping.classMappings != null)
+        {
+            mapping.classMappings.forEach(cm -> cm.accept(new ClassMappingThirdPassBuilder(this.context, pureMapping)));
+        }
+        return pureMapping;
     }
 
     @Override

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -495,6 +495,8 @@ public class PureModel implements IPureModel
         pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
         pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementThirdPassBuilder(this.getContext(el))));
         pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementFourthPassBuilder(this.getContext(el))));
+        pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementFifthPassBuilder(this.getContext(el))));
+
     }
 
     public void loadConnectionsAndRuntimes(PureModelContextDataIndex pure)

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestMappingCompilationFromGrammar.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestMappingCompilationFromGrammar.java
@@ -879,7 +879,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 // intentionally mess up spacing to check walker source information processing
                 "       lastName :          1\n" +
                 "   }\n" +
-                ")", "COMPILATION error at [7:28]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not a subtype of 'String'");
+                ")", "COMPILATION error at [7:28]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not in the class hierarchy of 'String'");
         test("Class test::Person{lastName:String[1];}\n" +
                 "###Mapping\n" +
                 "Mapping a::mapping\n" +
@@ -890,7 +890,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "       lastName :          \n" +
                 "                       1\n" +
                 "   }\n" +
-                ")", "COMPILATION error at [8:24]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not a subtype of 'String'");
+                ")", "COMPILATION error at [8:24]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not in the class hierarchy of 'String'");
         // check walker source information processing for mapping element
         test("Class test::Person{lastName:String[1];}\n" +
                 "###Mapping\n" +
@@ -899,7 +899,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "   test::Person : Pure\n" +
                 // intentionally mess up spacing to check walker source information processing for mapping element
                 "              {    lastName :              1 }\n" +
-                ")", "COMPILATION error at [6:44]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not a subtype of 'String'");
+                ")", "COMPILATION error at [6:44]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not in the class hierarchy of 'String'");
     }
 
     @Test
@@ -984,7 +984,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "   {\n" +
                 "       lastName : [1, 2]\n" +
                 "   }\n" +
-                ")", "COMPILATION error at [7:19-24]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not a subtype of 'String'");
+                ")", "COMPILATION error at [7:19-24]: Error in class mapping 'a::mapping' for property 'lastName' - Type error: 'Integer' is not in the class hierarchy of 'String'");
     }
 
     @Test
@@ -1038,7 +1038,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "       ~src test::OtherPerson\n" +
                 "       lastName : '1'\n" +
                 "   }\n" +
-                ")", "COMPILATION error at [8:25-28]: Error in class mapping 'a::mapping' for property 'employees' - Type error: 'test::SrcPerson' is not a subtype of 'test::OtherPerson'");
+                ")", "COMPILATION error at [8:25-28]: Error in class mapping 'a::mapping' for property 'employees' - Type error: 'test::SrcPerson' is not in the class hierarchy of 'test::OtherPerson'");
     }
 
     @Test
@@ -1076,7 +1076,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "       CORP : [1],\n" +
                 "       LLC : [2]\n" +
                 "   }\n" +
-                ")", "COMPILATION error at [7:41-43]: Error in class mapping 'a::mapping' for property 'incType' - Type error: 'String' is not a subtype of 'Integer'");
+                ")", "COMPILATION error at [7:41-43]: Error in class mapping 'a::mapping' for property 'incType' - Type error: 'String' is not in the class hierarchy of 'Integer'");
     }
 
     @Test
@@ -1114,7 +1114,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "       CORP : [test::Other.bla],\n" +
                 "       LLC : [test::Other.bla]\n" +
                 "   }\n" +
-                ")\n", "COMPILATION error at [7:41-43]: Error in class mapping 'a::mapping' for property 'incType' - Type error: 'String' is not a subtype of 'test::Other'");
+                ")\n", "COMPILATION error at [7:41-43]: Error in class mapping 'a::mapping' for property 'incType' - Type error: 'String' is not in the class hierarchy of 'test::Other'");
     }
 
     @Test
@@ -1133,7 +1133,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "       CORP : [test::Other.bla],\n" +
                 "       LLC : [test::Other.bla]\n" +
                 "   }\n" +
-                ")\n", "COMPILATION error at [7:55-58]: Error in class mapping 'a::mapping' for property 'incType' - Type error: 'test::IncType' is not a subtype of 'test::Other'");
+                ")\n", "COMPILATION error at [7:55-58]: Error in class mapping 'a::mapping' for property 'incType' - Type error: 'test::IncType' is not in the class hierarchy of 'test::Other'");
     }
 
     @Test
@@ -1572,4 +1572,308 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "  }\n" +
                 ")");
     }
+
+    @Test
+    public void testOperationWithSubtype()
+
+
+    {
+
+
+        String model = "###Pure\n" +
+                "Class example::Person\n" +
+                "{\n" +
+                "  firstName:String[0..1];\n" +
+                "  lastName: String[0..1];\n" +
+                "}\n" +
+                "\n" +
+                "Class example::_S_PersonA extends example::_S_Person\n" +
+                "{\n" +
+                "   aName    : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class example::_S_PersonB extends example::_S_Person\n" +
+                "{\n" +
+                "   bName    : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "Class example::_S_Person\n" +
+                "{\n" +
+                "   fullName      : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "Class example::_S_Cat\n" +
+                "{\n" +
+                "   fullName      : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "Class example::_S_Firm\n" +
+                "{\n" +
+                "  name:String[1];\n" +
+                "  sourceEmployees:example::_S_Person[*];\n" +
+                "  sourceEmployeesA:example::_S_PersonA[*];\n" +
+
+                "}\n" +
+                "\n" +
+                "Class example::Firm\n" +
+                "{\n" +
+                "\n" +
+                "  legalName:String[1];\n" +
+                "  employees:example::Person[*];\n" +
+                "}\n";
+
+        test(model + "\n###Mapping\n" +
+                "Mapping example::MappingwithNill\n" +
+                "   (\n" +
+                " example::Firm : Pure\n" +
+                "            {\n" +
+                "               ~src example::_S_Firm\n" +
+                "\n" +
+                "               legalName        : $src.name,\n" +
+                "               employees     : []\n" +
+                "            }\n" +
+                "\n" +
+                "   example::Person  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonA\n" +
+                "     ~filter $src.fullName  == 'A1 Person'\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.aName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+
+                "\n" +
+
+                ")\n");
+
+        test(model + "\n###Mapping\n" +
+                "Mapping example::MappingwithSubtype\n" +
+                "   (\n" +
+                " example::Firm : Pure\n" +
+                "            {\n" +
+                "               ~src example::_S_Firm\n" +
+                "\n" +
+                "               legalName        : $src.name,\n" +
+                "               employees     : $src.sourceEmployeesA\n" +
+                "            }\n" +
+                "\n" +
+
+                "   example::Person  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_Person\n" +
+                "     ~filter $src.fullName  == 'A1 Person'\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src->cast(@example::_S_PersonA).aName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+
+                "\n" +
+
+                ")\n");
+
+        test(model + "\n###Mapping\n" +
+                "Mapping example::UnionOnSubTypeinclude\n" +
+                "   (\n" +
+                " example::Firm : Pure\n" +
+                "            {\n" +
+                "               ~src example::_S_Firm\n" +
+                "\n" +
+                "               legalName        : $src.name,\n" +
+                "               employees[personUnion]     : $src.sourceEmployees\n" +
+                "            }\n" +
+                "\n" +
+                "   *example::Person[personUnion] : Operation {\n" +
+                "      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(A1,Cat)\n" +
+                "   }\n" +
+                "   example::Person[A1]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonA\n" +
+                "     ~filter $src.fullName  == 'A1 Person'\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.aName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+                "\n" +
+                "     example::Person[Cat]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_Cat\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')),\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+                ")\n", "COMPILATION error at [53:50-64]: Error in class mapping 'example::UnionOnSubTypeinclude' for property 'employees' - Type error: 'example::_S_Person' is not in the class hierarchy of 'example::_S_Cat'");
+
+        test(model +
+
+                "\n###Mapping\n" +
+                "Mapping example::UnionOnSubType\n" +
+                "   (\n" +
+                "include example::UnionOnSubTypeinclude " +
+                "example::Firm : Pure\n" +
+                "            {\n" +
+                "               ~src example::_S_Firm\n" +
+                "\n" +
+                "               legalName        : $src.name,\n" +
+                "               employees[personUnion]     : $src.sourceEmployees\n" +
+                "            })\n" +
+
+
+                "Mapping example::UnionOnSubTypeinclude\n" +
+                "   (\n" +
+                "   *example::Person[personUnion] : Operation {\n" +
+                "      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(A1,Cat)\n" +
+                "   }\n" +
+                "   example::Person[A1]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonA\n" +
+                "     ~filter $src.fullName  == 'A1 Person'\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.aName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+                "\n" +
+                "     example::Person[Cat]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_Cat\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')),\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+                ")\n", "COMPILATION error at [53:50-64]: Error in class mapping 'example::UnionOnSubType' for property 'employees' - Type error: 'example::_S_Person' is not in the class hierarchy of 'example::_S_Cat'");
+
+
+        test(model + "\n###Mapping\n" +
+                "Mapping example::UnionOnSubTypeinclude\n" +
+                "   (\n" +
+                " example::Firm : Pure\n" +
+                "            {\n" +
+                "               ~src example::_S_Firm\n" +
+                "\n" +
+                "               legalName        : $src.name,\n" +
+                "               employees[personUnion]     : $src.sourceEmployees\n" +
+                "            }\n" +
+                "\n" +
+                "   *example::Person[personUnion] : Operation {\n" +
+                "      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(R,A1,B)\n" +
+                "   }\n" +
+                "   example::Person[R]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_Person\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' '))+' Super',\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }" +
+                "   example::Person[A1]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonA\n" +
+                "     ~filter $src.fullName  == 'A1 Person'\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.aName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+
+                "\n" +
+                "    example::Person[B]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonB\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.bName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                ")\n");
+
+        test(model + "\n###Mapping\n" +
+                "Mapping example::UnionOnSubTypeinclude\n" +
+                "   (\n" +
+                "   *example::Person[personUnion] : Operation {\n" +
+                "      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(R,A1,B)\n" +
+                "   }\n" +
+
+                " example::Firm : Pure\n" +
+                "            {\n" +
+                "               ~src example::_S_Firm\n" +
+                "\n" +
+                "               legalName        : $src.name,\n" +
+                "               employees[personUnion]     : $src.sourceEmployees\n" +
+                "            }\n" +
+                "\n" +
+                "   example::Person[R]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_Person\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' '))+' Super',\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }" +
+
+                "   example::Person[A1]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonA\n" +
+                "     ~filter $src.fullName  == 'A1 Person'\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.aName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+
+                "\n" +
+                "    example::Person[B]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonB\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.bName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                ")\n");
+
+
+        test(model + "\n###Mapping\n" +
+                "Mapping example::UnionOnSubTypeinclude\n" +
+                "   (\n" +
+                "   *example::Person[personUnion] : Operation {\n" +
+                "      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(A1,Cat)\n" +
+                "   }\n" +
+
+                " example::Firm : Pure\n" +
+                "            {\n" +
+                "               ~src example::_S_Firm\n" +
+                "\n" +
+                "               legalName        : $src.name,\n" +
+                "               employees[personUnion]     : $src.sourceEmployees\n" +
+                "            }\n" +
+                "\n" +
+
+                "   example::Person[A1]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_PersonA\n" +
+                "     ~filter $src.fullName  == 'A1 Person'\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) + $src.aName,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+                "\n" +
+                "     example::Person[Cat]  : Pure\n" +
+                "   {\n" +
+                "      ~src example::_S_Cat\n" +
+                "      firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')) ,\n" +
+                "      lastName : $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length())\n" +
+                "\n" +
+                "   }\n" +
+                "\n" +
+                ")\n", "COMPILATION error at [56:50-64]: Error in class mapping 'example::UnionOnSubTypeinclude' for property 'employees' - Type error: 'example::_S_Person' is not in the class hierarchy of 'example::_S_Cat'");
+
+
+    }
+
+
 }

--- a/legend-engine-xt-analytics-mapping-pure/src/main/resources/core_analytics_mapping/modelCoverage/analyticsTest.pure
+++ b/legend-engine-xt-analytics-mapping-pure/src/main/resources/core_analytics_mapping/modelCoverage/analyticsTest.pure
@@ -230,6 +230,7 @@ Mapping meta::analytics::mapping::modelCoverage::test::sampleModelToModelMapping
 (
   meta::analytics::mapping::modelCoverage::test::_Person: Pure
   {
+    ~src meta::analytics::mapping::modelCoverage::test::Person
     fullName: 'Full Name'
   }
   meta::analytics::mapping::modelCoverage::test::_LegalEntity: Pure


### PR DESCRIPTION
#### What does this PR do / why is it needed ?
This change fixes compiler validation of ~src  classes in model to model mappings to align with a feature that allows src to be a subtype. of the expected type 

#### Which issue(s) this PR fixes:
Fixes an issue related to the compilation of unions in model to model mappings


#### Does this PR introduce a user-facing change?
Yes  - the compilation of model to model mappings is changed
