### PR TITLE
New protocol v1_26_0

### DIFF
--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/PureClientVersions.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/PureClientVersions.java
@@ -20,7 +20,7 @@ import org.eclipse.collections.impl.utility.ArrayIterate;
 
 public class PureClientVersions
 {
-    public static ImmutableList<String> versions = Lists.immutable.with("v1_0_0", "v1_1_0", "v1_2_0", "v1_3_0", "v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v1_8_0", "v1_9_0", "v1_10_0", "v1_11_0", "v1_12_0", "v1_13_0", "v1_14_0", "v1_15_0", "v1_16_0", "v1_17_0", "v1_18_0", "v1_19_0", "v1_20_0", "v1_21_0", "v1_22_0", "v1_23_0", "v1_24_0", "v1_25_0", "vX_X_X");
+    public static ImmutableList<String> versions = Lists.immutable.with("v1_0_0", "v1_1_0", "v1_2_0", "v1_3_0", "v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v1_8_0", "v1_9_0", "v1_10_0", "v1_11_0", "v1_12_0", "v1_13_0", "v1_14_0", "v1_15_0", "v1_16_0", "v1_17_0", "v1_18_0", "v1_19_0", "v1_20_0", "v1_21_0", "v1_22_0", "v1_23_0", "v1_24_0", "v1_25_0", "v1_26_0", "vX_X_X");
     public static ImmutableList<String> versionsSameCase = versions.collect(String::toLowerCase);
 
     static
@@ -28,7 +28,7 @@ public class PureClientVersions
         assert !hasRepeatedVersions(versions) : "Repeated version id :" + versions.toBag().selectByOccurrences(i -> i > 1).toSet().makeString("[", ", ", "]");
     }
 
-    public static String production = "v1_25_0";
+    public static String production = "v1_26_0";
 
     static boolean hasRepeatedVersions(ImmutableList<String> versions)
     {

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/extension/extension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/extension/extension.pure
@@ -1,0 +1,36 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::*;
+import meta::pure::mapping::*;
+import meta::pure::extension::*;
+
+function meta::protocols::pure::v1_26_0::external::shared::format::serializerExtension(type:String[1]): meta::pure::extension::SerializerExtension[1]
+{
+   ^meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0(
+      transfers_store_transformConnection =
+         [
+            extConnection:meta::external::shared::format::executionPlan::ExternalFormatConnection[1] | $extConnection->transformExternalFormatConnection()
+         ],
+      transfers_executionPlan_transformNode =
+         {mapping:Mapping[1], extensions:Extension[*] |
+            [
+               u:meta::external::shared::format::executionPlan::UrlStreamExecutionNode[1]                 | transformUrlStreamNode($u, $mapping, $extensions),
+               d:meta::external::shared::format::executionPlan::ExternalFormatExternalizeExecutionNode[1] | transformExternalFormatExternalizeExecutionNode($d, $mapping, $extensions),
+               s:meta::external::shared::format::executionPlan::ExternalFormatInternalizeExecutionNode[1] | transformExternalFormatInternalizeExecutionNode($s, $mapping, $extensions)
+            ]
+         }
+   );
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/models/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/models/executionPlan.pure
@@ -1,0 +1,40 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+import meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::*;
+import meta::pure::mapping::*;
+import meta::pure::extension::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalFormatExternalizeExecutionNode extends ExecutionNode
+{
+   contentType : String[1];
+   checked     : Boolean[1];
+   binding     : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalFormatInternalizeExecutionNode extends ExecutionNode
+{
+   contentType       : String[1];
+   binding           : String[1];
+   enableConstraints : Boolean[1];
+   checked           : Boolean[1];
+   tree              : RootGraphFetchTree[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::UrlStreamExecutionNode extends ExecutionNode
+{
+   url : String[1];
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/models/metamodel.pure
@@ -1,0 +1,33 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::*;
+import meta::pure::mapping::*;
+import meta::pure::extension::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalFormatConnection extends meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+   externalSource : meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalSource[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalSource
+{
+   _type: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::UrlStreamExternalSource extends meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalSource
+{
+   url : String[1];
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/transfers/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/transfers/executionPlan.pure
@@ -1,0 +1,53 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::*;
+import meta::pure::mapping::*;
+import meta::pure::extension::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::transformUrlStreamNode(node:meta::external::shared::format::executionPlan::UrlStreamExecutionNode[1], mapping:meta::pure::mapping::Mapping[1], extensions:Extension[*]): ExecutionNode[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::UrlStreamExecutionNode(
+      _type      = 'urlStream',
+      resultType = $node.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+      url        = $node.url
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::transformExternalFormatExternalizeExecutionNode(node:meta::external::shared::format::executionPlan::ExternalFormatExternalizeExecutionNode[1], mapping:meta::pure::mapping::Mapping[1], extensions:Extension[*]): ExecutionNode[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalFormatExternalizeExecutionNode(
+      _type             = 'externalFormatExternalize',
+      resultType        = $node.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+      resultSizeRange   = $node.resultSizeRange->map(s| $s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+      checked           = $node.checked,
+      binding           = $node.binding->elementToPath(),
+      contentType       = $node.binding.contentType
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::transformExternalFormatInternalizeExecutionNode(node:meta::external::shared::format::executionPlan::ExternalFormatInternalizeExecutionNode[1], mapping:meta::pure::mapping::Mapping[1], extensions:Extension[*]): ExecutionNode[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalFormatInternalizeExecutionNode(
+      _type             = 'externalFormatInternalize',
+      resultType        = $node.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+      resultSizeRange   = $node.resultSizeRange->map(s| $s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+      tree              = $node.tree->map(t| $t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], ^Map<String,List<Any>>(), $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RootGraphFetchTree),
+      binding           = $node.binding->elementToPath(),
+      enableConstraints = $node.enableConstraints,
+      checked           = $node.checked,
+      contentType       = $node.binding.contentType
+   );
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/transfers/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/protocols/pure/v1_26_0/transfers/metamodel.pure
@@ -1,0 +1,34 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::*;
+import meta::pure::mapping::*;
+import meta::pure::extension::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::shared::format::transformExternalFormatConnection(extConnection:meta::external::shared::format::executionPlan::ExternalFormatConnection[1]): meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalFormatConnection[1]
+{
+   let source = $extConnection.externalSource->match([
+      u:meta::external::shared::format::executionPlan::UrlStreamExternalSource[1] | ^meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::UrlStreamExternalSource(
+                                                                         _type = 'urlStream',
+                                                                         url   = $u.url
+                                                                      )
+   ]);
+
+   ^meta::protocols::pure::v1_26_0::metamodel::external::shared::format::executionPlan::ExternalFormatConnection(
+      element        = 'ModelStore',
+      _type          = 'ExternalFormatConnection',
+      externalSource = $source
+   );
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/extension/extension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/extension/extension.pure
@@ -1,0 +1,73 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::*;
+import meta::pure::store::*;
+import meta::pure::runtime::*;
+import meta::json::*;
+
+import meta::protocols::pure::v1_26_0::extension::*;
+
+Class meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0 extends meta::pure::extension::SerializerExtension
+{
+   moduleSerializerExtensions : ModuleSerializerExtension[*];
+
+   moduleSerializerExtension(module:String[1])
+   {
+     $this.moduleSerializerExtensions->filter(f|$f.module == $module)->first()
+   } : ModuleSerializerExtension[0..1];
+
+   transfers_execute_transformActivity : Function<{Nil[1] -> meta::pure::mapping::Activity[1]}>[*];
+   
+   transfers_mapping_transformMapping : Function<{SetImplementation[1]->Boolean[1]}>[*];
+   transfers_mapping_transformSetImplementation : Function<{Mapping[1]->Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping[1]}>[*]}>[0..1];
+   transfers_mapping_transformSetImplementation2 : Function<{Mapping[1], meta::pure::extension::Extension[*] ->Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping[1]}>[*]}>[0..1];
+   transfers_mapping_transformAssociationImplementation : Function<{Mapping[1], meta::pure::extension::Extension[*] -> Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::mapping::AssociationMapping[1]}>[*]}>[0..1];
+
+   transfers_valueSpecification_transformAny : Function<{String[*],Map<String,List<Any>>[1], Multiplicity[1], FunctionExpression[0..1], Boolean[1], meta::pure::extension::Extension[*]->Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]}>[*]}>[0..1];
+   
+   transfers_executionPlan_transformNode : Function<{Mapping[1], meta::pure::extension::Extension[*] -> Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode[1]}>[*]}>[0..1];
+   transfers_executionPlan_transformNode_GraphFetchM2MExecutionNode : Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::store::Store[1]}>[*];
+   transfers_executionPlan_transformNode_StoreStreamReadingExecutionNode : Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::store::Store[1]}>[*];
+   transfers_executionPlan_transformResultType : Function<{Mapping[1], meta::pure::extension::Extension[*] -> Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::executionPlan::ResultType[1]}>[*]}>[0..1];
+   transfers_executionPlan_transformSetImplementation : Pair<Function<{PropertyMapping[1]->Boolean[1]}>, Function<{PropertyMapping[1]->Map<String,List<String>>[1]}>>[0..1];
+   
+   transfers_store_transformStore : Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::store::Store[1]}>[*];
+   transfers_store_transformStore2 : Function<{meta::pure::extension::Extension[*] -> Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::store::Store[1]}>[*]}>[0..1];
+   transfers_store_transformConnection : Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::runtime::Connection[1]}>[*];
+   transfers_store_transformConnection2 : Function<{meta::pure::extension::Extension[*] -> Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::runtime::Connection[1]}>[*]}>[0..1];
+   
+   scan_buildBasePureModel_buildPureModelFromMapping1 : Function<{Nil[1]->Store[*]}>[*];
+   scan_buildBasePureModel_buildPureModelFromMapping2 : Store[*];
+
+   scan_buildPureModelAsText_getAllElementsFromMapping : Function<{Store[*]->Store[*]}>[0..1];
+   scan_buildPureModelAsText_getAllElementsFromMapping2 : Function<{Store[*]->PackageableElement[*]}>[0..1];
+   scan_buildPureModelAsText_getCorrectedElementSourceInformation : Function<{meta::pure::metamodel::PackageableElement[1] -> SourceInformation[1]}>[0..1];
+
+   scan_buildBasePureModel_findAllTypesFromMapping : Function<{Nil[1]->Type[*]}>[*];
+   scan_buildBasePureModel_extractStores : Function<{Mapping[1], meta::pure::extension::Extension[*] -> Function<{Nil[1]->meta::pure::store::Store[*]}>[*]}>[0..1];
+   scan_buildBasePureModel_processProperties : Function<{Mapping[1], meta::pure::extension::Extension[*] -> Function<{Nil[1]->meta::pure::store::Store[*]}>[*]}>[0..1];
+   
+   invocation_execution_execute1 : Function<{ExecutionContext[1]->Boolean[1]}>[*];
+   invocation_execution_execute2_pre : Pair<Function<{String[1]->Boolean[1]}>, Function<{String[1], JSONObject[1], Mapping[1], Runtime[1],ExtendedJSONDeserializationConfig[1],ExecutionContext[0..1]->Pair<List<Any>,List<Activity>>[1]}>>[*];
+   invocation_execution_execute2_pre2 : Function<{meta::pure::extension::Extension[*] -> Pair<Function<{String[1]->Boolean[1]}>, Function<{String[1], JSONObject[1], Mapping[1], Runtime[1],ExtendedJSONDeserializationConfig[1],ExecutionContext[0..1]->Pair<List<Any>,List<Activity>>[1]}>>[*]}>[0..1];
+   invocation_execution_execute2_post : Pair<Function<{String[1]->Boolean[1]}>, Function<{String[1], JSONObject[1], Mapping[1], Runtime[1],ExtendedJSONDeserializationConfig[1],ExecutionContext[0..1]->Pair<List<Any>,List<Activity>>[1]}>>[*];
+   invocation_execution_execute2_post2 : Function<{meta::pure::extension::Extension[*] -> Pair<Function<{String[1]->Boolean[1]}>, Function<{String[1], JSONObject[1], Mapping[1], Runtime[1],ExtendedJSONDeserializationConfig[1],ExecutionContext[0..1]->Pair<List<Any>,List<Activity>>[1]}>>[*]}>[0..1];
+   invocation_execution_transformContext : Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[1]}>[*];
+}
+
+Class meta::protocols::pure::v1_26_0::extension::ModuleSerializerExtension
+{
+    module:String[1];
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/invocations/execution.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/invocations/execution.pure
@@ -1,0 +1,263 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::*;
+import meta::alloy::metadataServer::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::*;
+import meta::pure::functions::io::http::*;
+import meta::protocols::pure::v1_26_0::invocation::execution::execute::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::context::*;
+import meta::pure::runtime::*;
+import meta::json::*;
+
+
+Enum meta::protocols::pure::v1_26_0::invocation::execution::execute::ExecutionMode
+{
+   INTERACTIVE, SEMI_INTERACTIVE, FULL_INTERACTIVE
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::processJsonStreamingResult(result:JSONObject[1]) : Pair<List<Any>,List<Activity>>[1]
+{
+   let value = $result.keyValuePairs->filter(kv |$kv.key.value == 'values').value;
+   ^Pair<List<Any>, List<Activity>>(first=^List<Any>(values=$value->toOne()->toCompactJSONString()), second=^List<Activity>(values=[]));
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::processCSV_M2M(resultType:String[1], resultClassType:Class<Any>[1], result:JSONObject[1]) : Pair<List<Any>,List<Activity>>[1]
+{
+   let extendedJSONDeserializationConfig = ^ExtendedJSONDeserializationConfig(nullReplacementInArray = ^TDSNull(), typeKeyName='', failOnUnknownProperties=true);
+   let jsonKeyValues = $result.keyValuePairs;
+   let values = $jsonKeyValues->filter(kv |$kv.key.value == 'values').value->map(v|$v->fromJSON($resultClassType,$extendedJSONDeserializationConfig));
+   let activities = $jsonKeyValues->filter(kv |$kv.key.value == ($resultType+'Activities')).value->map(a|$a->fromJSON(Activity))->cast(@Activity);
+   ^Pair<List<Any>, List<Activity>>(first=^List<Any>(values=$values), second = ^List<Activity>(values=$activities));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::context::transformContext(context:ExecutionContext[1], extensions:	meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[1]
+{
+   $context->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).invocation_execution_transformContext->concatenate([
+      a:meta::pure::runtime::ExecutionContext[1]|
+         ^meta::protocols::pure::v1_26_0::metamodel::ExecutionContext
+          (
+             queryTimeOutInSeconds = $a.queryTimeOutInSeconds,
+             enableConstraints = $a.enableConstraints,
+             _type = 'BaseExecutionContext'
+          )
+   ])->toOneMany());
+}
+
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::generatePlan(json: String[1], host: String[1], port: Integer[1]):String[1]
+{
+   let resp = executeHTTPRaw(
+      ^URL(host = $host , port = $port, path = '/api/pure/v1/execution/generatePlan'),
+      HTTPMethod.POST,
+      'application/json',
+      $json
+   );
+   assertEq(200, $resp.statusCode, | $resp.statusCode->toString()+' \''+$resp.entity+'\'');
+   $resp.entity;
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::getPlanReturnType(planJSON:String[1]) : meta::protocols::pure::v1_26_0::metamodel::executionPlan::ResultType[1]
+{
+   let rootExecNode = $planJSON->parseJSON()->cast(@JSONObject).keyValuePairs->filter(kv | $kv.key.value == 'rootExecutionNode').value;
+   let retType = $rootExecNode->cast(@JSONObject).keyValuePairs->filter(kv | $kv.key.value == 'resultType').value->cast(@JSONObject)->toOne();
+   if($retType->getValue('_type')->cast(@JSONString).value == 'partialClass',
+      | $retType->fromJSON(meta::protocols::pure::v1_26_0::metamodel::executionPlan::PartialClassResultType)->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::PartialClassResultType)->toOne();,
+      | if($retType->getValue('_type')->cast(@JSONString).value == 'class',
+           | ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::ClassResultType
+              (
+                 _type = 'class',
+                 class = $retType->getValue('class')->cast(@JSONString).value->toOne(),
+                 setImplementations = $retType->getValue('setImplementations')->cast(@JSONArray).values->map(x | $x->fromJSON(meta::protocols::pure::v1_26_0::metamodel::executionPlan::SetImplementationInfo)->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::SetImplementationInfo))
+              ),
+           | $retType->fromJSON(meta::protocols::pure::v1_26_0::metamodel::executionPlan::ResultType)->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::ResultType)->toOne();
+        );
+   );
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::executePlan(plan:meta::pure::executionPlan::ExecutionPlan[1], context: ExecutionContext[0..1], host: String[1], port: Integer[1], extensions:meta::pure::extension::Extension[*]) : meta::pure::mapping::Result<Any|*>[1]
+{
+   let planJSON = $plan->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformPlan($extensions)
+                       ->meta::json::toJSON(1000, meta::json::config(false, false, true, true));
+   let resultType = $planJSON->meta::protocols::pure::v1_26_0::invocation::execution::execute::getPlanReturnType();
+   let resultJSON = executePlan($plan, $host, $port, $extensions);
+   $resultJSON->legendBuildResultFromJSON($resultType, $plan.mapping, $plan.runtime, $context, $extensions);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::executePlan(plan:meta::pure::executionPlan::ExecutionPlan[1], host: String[1], port: Integer[1], extensions:meta::pure::extension::Extension[*]) : String[1]
+{
+   let alloyPlan = $plan->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformPlan($extensions);
+   executePlan($alloyPlan->meta::json::toJSON(1000, meta::json::config(false, false, true, true)), $host, $port);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::executePlan(planJSON:String[1], host: String[1], port: Integer[1]) : String[1]
+{
+   let resp = meta::pure::functions::io::http::executeHTTPRaw(
+      ^URL(host = $host , port = $port, path = 'api/pure/v1/execution/executePlan'),
+      HTTPMethod.POST,
+      'application/json',
+      $planJSON
+   );
+   assertEq(200, $resp.statusCode, | $resp.statusCode->toString()+' \''+$resp.entity->replace('\\n', '\n')->replace('\\t', '')+'\'');
+   $resp.entity;
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::buildExecutionInput<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], runtime:Runtime[1],  exeCtx:ExecutionContext[0..1], version:String[1], serializationKind:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+         let transformedContext = if($exeCtx->isNotEmpty(), | $exeCtx->toOne()->transformContext($extensions),| []);
+         let execMode = ExecutionMode->extractEnumValue($executionMode);
+
+         let fromMappings = findExpressionsForFunctionInFunctionDefinition($f, from_T_m__Mapping_1__Runtime_1__T_m_).parametersValues->filter(p | $p.genericType.rawType->toOne() == Mapping)->cast(@InstanceValue).values->cast(@Mapping);
+         let mappings = $m->concatenate(getMappingsFromRuntime($runtime))
+                          ->concatenate($fromMappings)
+                          ->filter(m |$m.name->isNotEmpty());
+
+
+         ^meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ExecutionInput
+         (
+            clientVersion = 'v1_26_0',
+            function = transformLambda($f, $extensions),
+            mapping = if($m.name->isEmpty(), |[], |$m->toOne()->elementToPath()),
+            runtime = if($runtime.connections->isEmpty(), |[], |transformRuntime($runtime->toOne(), $extensions)),
+            context = $transformedContext,
+            model = if($execMode == ExecutionMode.SEMI_INTERACTIVE,
+                        |let stores =  $runtime.connections.element->cast(@meta::pure::store::Store)
+                                          ->map(s|$s->findAllStoreIncludes())
+                                          ->removeDuplicates()
+                                          ->filter(s | !$s->instanceOf(meta::pure::mapping::modelToModel::ModelStore))
+                                          ->map(c|^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.STORE,path=$c->elementToPath()));
+                         let transformedMappings = $mappings->map(m|^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING,path=$m->elementToPath()));
+                         ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer
+                         (
+                            _type='pointer',
+                            serializer = ^meta::protocols::Protocol
+                                         (
+                                            name='pure',
+                                            version = 'v1_26_0'
+                                         ),
+                            sdlcInfo = ^meta::protocols::pure::v1_26_0::metamodel::PureSDLC
+                                       (
+                                          _type = 'pure',
+                                          baseVersion = '-1', //meta::vcs::svn::metamodel::getCurrentSvnRevisionNumber('/system')->toString(),
+                                          version = 'none',
+                                          packageableElementPointers = $stores->concatenate($transformedMappings)
+                                       )
+                         );,
+                        |if ($serializationKind == 'json',
+                            |$mappings->buildBasePureModelFromMapping($extensions).second,
+                            |$mappings->buildPureModelContextTextFromMappingAndQuery($f, $extensions)
+                         );
+                     )
+         )->alloyToJSON();
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::alloyExecute<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], host:String[1], port:Integer[1], version:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):meta::pure::mapping::Result<T|m>[1]
+{
+  legendExecute($f, $m, $pureRuntime, $context, $host, $port, $version, 'json', $executionMode, $extensions);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::legendExecute<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], host:String[1], port:Integer[1], version:String[1], serializationKind:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):meta::pure::mapping::Result<T|m>[1]
+{
+   let transformedContext = if($context->isNotEmpty(), | $context->toOne()->transformContext($extensions),| []);
+   let execMode = meta::protocols::pure::v1_26_0::invocation::execution::execute::ExecutionMode->extractEnumValue($executionMode);
+   let mappings = $m->concatenate(getMappingsFromRuntime($pureRuntime));
+
+
+   // This choice is made as ExecutionContext information can affect the results computed by the executionPlan endpoint
+   // If we have either of the two ExecutionContexts in the conditional - throwing the generated execution plan to the executePlan endpoint does *not* return the same results as hittign execute with function,mapping, and runtime
+   // hence we default to old behaviour in the case of AuthContext of VectorBatchQueryContext, otherwise we use the two execution plan endpoints
+   let typeAndresultJSON = if(isOptionSet('ExecPlan') && !($context->isNotEmpty() && $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).invocation_execution_execute1->fold({a,b|$a->eval($context) || $b}, false)),
+      | let planGenerated = if(isOptionSet('PlanLocal'),
+                               {|
+                                  let basicPlan = if($m.name->isEmpty(),
+                                                    |meta::pure::executionPlan::executionPlan($f, if($context->isEmpty(), |^ExecutionContext(), |$context->toOne()), $extensions, noDebug());,
+                                                    |meta::pure::executionPlan::executionPlan($f, $m, $pureRuntime, if($context->isEmpty(), |^ExecutionContext(), |$context->toOne()), $extensions, noDebug()););
+                                  let boundPlan = meta::pure::executionPlan::generatePlatformCode($basicPlan, meta::pure::executionPlan::platformBinding::legendJava::legendJavaPlatformBindingId(), ^meta::pure::executionPlan::platformBinding::legendJava::LegendJavaPlatformBindingConfig(), $extensions);
+                                  let unused    = if(isOptionSet('ShowLocalPlan'), |println($boundPlan->meta::pure::executionPlan::toString::planToString(true, $extensions)), |[]);
+                                  $boundPlan->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformPlan($extensions)->meta::json::toJSON(1000, meta::json::config(false, false, true, true));
+                               },
+                               {|
+                                  generatePlan($f, $m, $pureRuntime, $context, $host, $port, $version, $serializationKind, $executionMode, $extensions);
+                               }
+                            );
+        let resultType = $planGenerated->getPlanReturnType();
+        let result = $planGenerated->executePlan($host, $port);
+        ^Pair<Any,Any>(first=$resultType,second=$result);,
+
+      |  let alloyExecuteResult = alloyExecuteLambda($f,$m,$pureRuntime, $context, $host, $port, $version, $serializationKind, $executionMode, $extensions);
+         let retGenericType = $f.expressionSequence->evaluateAndDeactivate()->last()->toOne().genericType;
+         let retType = $retGenericType.rawType->toOne();
+         ^Pair<Any,Any>(first=$retType,second=$alloyExecuteResult);
+
+   );
+
+   let resultJSON=$typeAndresultJSON.second->cast(@String);
+   let resultClassType=$typeAndresultJSON.first;
+
+   let res= legendBuildResultFromJSON($resultJSON, $resultClassType, $m, $pureRuntime, $context, $extensions);
+   
+   let values = $res.values->cast(@T);
+   ^Result<T|m>(values=$values, activities=$res.activities);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::legendBuildResultFromJSON(resultJSON:String[1],resultClassType:Any[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], extensions:meta::pure::extension::Extension[*]):meta::pure::mapping::Result<Any|*>[1]
+{
+   let result = $resultJSON->meta::json::parseJSON()->cast(@JSONObject);
+   let builder = $result.keyValuePairs->filter(kv |$kv.key.value == 'builder').value->cast(@JSONObject);
+
+   let builderType = if($builder->isNotEmpty(), | $builder.keyValuePairs->filter(kv|$kv.key.value == '_type').value->cast(@JSONString).value->toOne(),| []);
+
+   let extendedJSONDeserializationConfig = ^ExtendedJSONDeserializationConfig(nullReplacementInArray = ^TDSNull(), typeKeyName='', failOnUnknownProperties=true);
+
+   let handlers= $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).invocation_execution_execute2_pre->concatenate(
+                 $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).invocation_execution_execute2_pre2->map(f | $f->eval($extensions)))->concatenate([
+               pair ( builderType:String[1]|$builderType->isNotEmpty() && $builderType->toOne()=='json',
+                      {resultJSON:String[1], result:JSONObject[1], m:Mapping[1], r:Runtime[1], e:ExtendedJSONDeserializationConfig[1], co:ExecutionContext[0..1]|processJsonStreamingResult($result)}),
+
+               pair ( builderType:String[1]|$builderType->isNotEmpty() && ($builderType->toOne()=='csv' || $builderType->toOne()=='modelToModel'),
+                      {resultJSON:String[1], result:JSONObject[1], m:Mapping[1], r:Runtime[1], e:ExtendedJSONDeserializationConfig[1], co:ExecutionContext[0..1]| let retType = if($resultClassType->instanceOf(meta::protocols::pure::v1_26_0::metamodel::executionPlan::ClassResultType),
+                                                             | $resultClassType->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::ClassResultType).class->pathToElement()->cast(@Class<Any>), // This case is if we hit the generatePlan/executePlan endpoint, in which case we get the type from the exec plan.
+                                                             | $resultClassType->cast(@Class<Any>)); // This case if is we hit the execute end point, in which case the type information is coming from the function
+                                            processCSV_M2M($builderType->toOne(), $retType, $result);}
+                    )
+            ]->concatenate($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).invocation_execution_execute2_post)
+             ->concatenate($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).invocation_execution_execute2_post2->map(f | $f->eval($extensions))));
+
+   let res = $handlers->filter(h|$h.first->eval($builderType))->first()->toOne().second->eval($resultJSON, $result, $m, $pureRuntime, $extendedJSONDeserializationConfig, $context);
+
+   let values = $res.first.values;
+
+   ^Result<Any|*>(values=$values, activities=$res.second.values);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::generatePlan<T|m>(f: FunctionDefinition<{->T[m]}>[1], m: Mapping[1], runtime: Runtime[1], exeCtx: ExecutionContext[0..1], host: String[1], port: Integer[1], version: String[1], serializationKind:String[1], executionMode: String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   let resultJSON = buildExecutionInput($f, $m, $runtime, $exeCtx, $version, $serializationKind, $executionMode, $extensions);
+   generatePlan($resultJSON, $host, $port);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::alloyExecuteLambda<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], host:String[1], port:Integer[1], version:String[1], serializationKind:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]) : String[1]
+{
+   let payload = buildExecutionInput($f,$m,$pureRuntime,$context,$version, $serializationKind, $executionMode, $extensions);
+
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/execution/execute'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 $payload
+                              );
+
+   assertEq(200, $resp.statusCode, | $resp.statusCode->toString()+' \''+$resp.entity+'\'');
+   $resp.entity;
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/invocations/generation.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/invocations/generation.pure
@@ -1,0 +1,29 @@
+###Pure
+
+import meta::pure::generation::metamodel::*;
+import meta::json::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::alloy::metadataServer::*;
+import meta::json::schema::generation::*;
+import meta::pure::functions::io::http::*;
+
+function  <<access.private>>  meta::protocols::pure::v1_26_0::invocation::generation::json::legendGenerateJson(input:JSONSchemaConfig[1], host:String[1], port:Integer[1]):JSONSchemaOutput[*]
+{
+   meta::protocols::pure::v1_26_0::invocation::generation::json::legendGenerateJson($input, $host, $port, 'v1');
+}
+
+function meta::protocols::pure::v1_26_0::invocation::generation::json::legendGenerateJson(jsonConfig:JSONSchemaConfig[1], host:String[1], port:Integer[1], version:String[1]):JSONSchemaOutput[*]
+{
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/schemaGeneration/jsonSchema'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 '{ "clientVersion":"v1_26_0",'+
+                                 '  "config":'+$jsonConfig->meta::protocols::pure::v1_26_0::invocation::generation::json::transformJSONSchemaConfig()->alloyToJSON()+','+
+                                 '  "model":'+if ($jsonConfig.package->isEmpty(),
+                                                  |$jsonConfig.class->toOne()->pathToElement()->toOne()->cast(@Type)->buildPureModelFromType(meta::pure::extension::defaultExtensions())->alloyToJSON(),
+                                                  |$jsonConfig.package->toOne()->pathToElement()->toOne()->cast(@Package)->buildPureModelFromPackage(meta::pure::extension::defaultExtensions())->alloyToJSON())+
+                                 '}'
+                                );
+   assertEq(200, $resp.statusCode, | $resp.entity);
+   $resp.entity->parseJSON()->fromJSON(JSONSchemaOutput, ^ExtendedJSONDeserializationConfig(nullReplacementInArray = ^TDSNull(), typeKeyName='__TYPE', failOnUnknownProperties=true))->cast(@JSONSchemaOutput);
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/invocations/testLoadModels.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/invocations/testLoadModels.pure
@@ -1,0 +1,38 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::*;
+import meta::pure::functions::io::http::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::protocols::pure::v1_26_0::invocation::testLoadModel::*;
+import meta::protocols::pure::v1_26_0::metamodel::*;
+
+function meta::protocols::pure::v1_26_0::invocation::testLoadModel::legendTestLoadModel(package:Package[1], host:String[1], port:Integer[1], version:String[1]):Boolean[1]
+{
+   $package->elementToPath()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromPackageStr([])->legendTestLoadModel($host, $port, $version);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::testLoadModel::legendTestLoadModel(mapping:Mapping[1], host:String[1], port:Integer[1], version:String[1]):Boolean[1]
+{
+   $mapping->elementToPath()->buildBasePureModelFromMappingStr([])->legendTestLoadModel($host, $port, $version);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::invocation::testLoadModel::legendTestLoadModel(context:String[1], host:String[1], port:Integer[1], version:String[1]):Boolean[1]
+{
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/compilation/compile'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 $context);
+   assertEq(200, $resp.statusCode, | $resp.entity);
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/diagram.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/diagram.pure
@@ -1,0 +1,117 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::protocols::pure::v1_26_0::metamodel::diagram::view::*;
+import meta::protocols::pure::v1_26_0::metamodel::diagram::geometry::*;
+import meta::protocols::pure::v1_26_0::metamodel::diagram::visibility::*;
+import meta::protocols::pure::v1_26_0::metamodel::diagram::rendering::*;
+
+// Diagram
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::Diagram extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+   classViews : ClassView[*];
+   propertyViews : PropertyView[*];
+   generalizationViews : GeneralizationView[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::view::ClassView
+{
+   id : String[1];
+
+   class : String[1];
+
+   position : Point[0..1];
+   rectangle : Rectangle[0..1];
+
+   hideStereotypes : Boolean[0..1];
+   hideTaggedValues : Boolean[0..1];
+   hideProperties : Boolean[0..1];
+
+   <<doc.deprecated>> rendering : Rendering[0..1];
+   <<doc.deprecated>> visibility : TypeVisibility[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::view::RelationshipView
+{
+   sourceView : String[1];
+   targetView : String[1];
+   line : Line[0..1];
+   <<doc.deprecated>> rendering : Rendering[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::view::PropertyView extends meta::protocols::pure::v1_26_0::metamodel::diagram::view::RelationshipView
+{
+   property : meta::protocols::pure::v1_26_0::metamodel::domain::PropertyPtr[1];
+   <<doc.deprecated>> visibility : PropertyVisibility[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::view::GeneralizationView extends meta::protocols::pure::v1_26_0::metamodel::diagram::view::RelationshipView
+{
+}
+
+// Visibility
+
+Class <<doc.deprecated>> meta::protocols::pure::v1_26_0::metamodel::diagram::visibility::Visibility
+{
+   stereotypes: Boolean[0..1];
+   taggedValues : Boolean[0..1];
+}
+
+Class <<doc.deprecated>> meta::protocols::pure::v1_26_0::metamodel::diagram::visibility::PropertyVisibility extends Visibility
+{
+   type: Boolean[0..1];
+   multiplicity : Boolean[0..1];
+}
+
+Class <<doc.deprecated>> meta::protocols::pure::v1_26_0::metamodel::diagram::visibility::TypeVisibility extends Visibility
+{
+   attributes: Boolean[0..1];
+}
+
+// Rendering
+
+Class <<doc.deprecated>> meta::protocols::pure::v1_26_0::metamodel::diagram::rendering::Rendering
+{
+   color : String[1];
+   lineWidth : Float[1];
+}
+
+// Geometry
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::geometry::Point
+{
+   x : Float[1];
+   y : Float[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::geometry::Rectangle
+{
+   width : Float[1];
+   height : Float[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::diagram::geometry::Line
+{
+   <<doc.deprecated>> style : LineType[0..1];
+   points : Point[*];
+}
+
+Enum <<doc.deprecated>> meta::protocols::pure::v1_26_0::metamodel::diagram::geometry::LineType
+{
+   SIMPLE,
+   RIGHT_ANGLE
+}
+

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/executionPlan.pure
@@ -1,0 +1,326 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::protocols::*;
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionPlan
+{
+   serializer : Protocol[1];
+   templateFunctions : String[*];
+   rootExecutionNode : ExecutionNode[1];
+   authDependent: Boolean[1];
+   kerberos: String [0..1];
+   globalImplementationSupport : meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformImplementation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode
+{
+   _type : String[1];
+   resultType : ResultType[1];
+   resultSizeRange : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[0..1];
+   requiredVariableInputs : meta::protocols::pure::v1_26_0::metamodel::executionPlan::VariableInput[*];
+   isChildrenExecutionParallelizable: Boolean[0..1];
+   executionNodes : ExecutionNode[*];
+   implementation : meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformImplementation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::VariableInput
+{
+   name         : String[1];
+   type         : String[1];
+   multiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::AllocationExecutionNode extends ExecutionNode
+{
+   varName : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::PureExpressionPlatformExecutionNode extends ExecutionNode
+{
+   pure : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformUnionExecutionNode extends ExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformMergeExecutionNode extends ExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::FreeMarkerConditionalExecutionNode extends ExecutionNode
+[
+   $this.freeMarkerBooleanExpression->startsWith('${(') && $this.freeMarkerBooleanExpression->endsWith(')?c}')
+]
+{
+   freeMarkerBooleanExpression   : String[1];
+   trueBlock                     : ExecutionNode[1];
+   falseBlock                    : ExecutionNode[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::VariableResolutionExecutionNode extends ExecutionNode
+{
+   varName : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformImplementation
+{
+   _type : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::JavaPlatformImplementation extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformImplementation
+{
+   classes                : JavaClass[*];
+   executionClassFullName : String[0..1];
+   executionMethodName    : String[0..1];   
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::JavaClass
+{
+   package  : String[1];
+   name     : String[1];
+   source   : String[1];
+   byteCode : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::CompiledClass
+{
+   className : String[1];
+   byteCode : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ConstantExecutionNode extends ExecutionNode
+{
+   values : Any[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::SequenceExecutionNode extends ExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::MultiResultSequenceExecutionNode extends ExecutionNode
+{
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::AggregationAwareExecutionNode extends ExecutionNode
+{
+   aggregationAwareActivity: String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ModelToModelExecutionNode extends ExecutionNode
+{
+   func : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   jsonPropertyPaths : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[*];
+   pathToMapping : String[1];
+   pathToClasses : String[*];
+   connection : meta::protocols::pure::v1_26_0::metamodel::runtime::Connection[1];
+   pureModelContextData : meta::protocols::pure::v1_26_0::metamodel::PureModelContextData[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::FunctionParametersValidationNode extends ExecutionNode
+{
+   functionParameters:meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable[*];
+   parameterValidationContext : meta::protocols::pure::v1_26_0::metamodel::executionPlan::ParameterValidationContext[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ParameterValidationContext
+{
+   _type : String[1];
+   varName: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::EnumValidationContext extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::ParameterValidationContext
+{
+   validEnumValues: String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::GlobalGraphFetchExecutionNode extends ExecutionNode
+{
+   graphFetchTree : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::GraphFetchTree[1];
+   store : String[1];
+   children : meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::GlobalGraphFetchExecutionNode[*];
+   localGraphFetchExecutionNode : meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::LocalGraphFetchExecutionNode [1];
+   parentIndex : Integer[0..1];
+   xStorePropertyMapping : meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStorePropertyMapping[0..1];
+   enableConstraints : Boolean[0..1];
+   checked           : Boolean[0..1];
+   xStorePropertyFetchDetails : meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::XStorePropertyFetchDetails[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::XStorePropertyFetchDetails
+{
+   supportsCaching         : Boolean[1];
+   propertyPath            : String[1];
+   sourceMappingId         : String[1];
+   sourceSetId             : String[1];
+   targetMappingId         : String[1];
+   targetSetId             : String[1];
+   targetPropertiesOrdered : String[*];
+   subTree                 : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::LocalGraphFetchExecutionNode extends ExecutionNode
+{
+   nodeIndex : Integer[1];
+   parentIndex : Integer[0..1];
+   graphFetchTree : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::GraphFetchTree[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::StoreStreamReadingExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode
+{
+   graphFetchTree    : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RootGraphFetchTree[1]; 
+   store             : meta::protocols::pure::v1_26_0::metamodel::store::Store[0..1];
+   connection        : meta::protocols::pure::v1_26_0::metamodel::runtime::Connection[1];
+   enableConstraints : Boolean[1];
+   checked           : Boolean[1];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::LocalGraphFetchExecutionNode
+{
+   children : meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryGraphFetchExecutionNode[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryRootGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryGraphFetchExecutionNode
+{
+   batchSize : Integer[0..1];
+   checked : Boolean[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryCrossStoreGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryRootGraphFetchExecutionNode
+{
+   supportsBatching      : Boolean[1];
+   xStorePropertyMapping : meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStorePropertyMapping[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryPropertyGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryGraphFetchExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ErrorExecutionNode extends ExecutionNode
+{
+   message : String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ResultType
+{
+   _type : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::DataTypeResultType extends ResultType
+{
+   dataType : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::VoidResultType extends ResultType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::ClassResultType extends ResultType
+{
+   class : String[1];
+   setImplementations : SetImplementationInfo[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::PartialClassResultType extends ClassResultType
+{
+   propertiesWithParameters : meta::protocols::pure::v1_26_0::metamodel::executionPlan::PropertyWithParameters[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::PropertyWithParameters
+{
+   property : String[1];
+   parameters : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::SetImplementationInfo
+{
+   class : String[1];
+   mapping : String[1];
+   id : String[1];
+   propertyMappings : meta::protocols::pure::v1_26_0::metamodel::executionPlan::PropertyMapping[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::PropertyMapping
+{
+   property : String[1];
+   type : String[1];
+   enumMapping : Map<String, List<String>>[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::TDSResultType extends ResultType
+{
+   tdsColumns : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::TDSColumn[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::PureModelContext
+{
+   _type : String[1];
+   serializer : Protocol[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer extends meta::protocols::pure::v1_26_0::metamodel::PureModelContext
+{
+   sdlcInfo : meta::protocols::pure::v1_26_0::metamodel::SDLC[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::SDLC
+{
+   _type : String[1];
+   version : String[0..1];
+   baseVersion : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::PureSDLC extends meta::protocols::pure::v1_26_0::metamodel::SDLC
+{
+   packageableElementPointers : meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::AlloySDLC extends meta::protocols::pure::v1_26_0::metamodel::SDLC
+{
+   project : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::PureModelContextData extends meta::protocols::pure::v1_26_0::metamodel::PureModelContext
+{
+   origin : meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer[0..1];
+   elements : meta::protocols::pure::v1_26_0::metamodel::PackageableElement[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::PureModelContextText extends meta::protocols::pure::v1_26_0::metamodel::PureModelContext
+{
+    code: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::PureModelContextComposite extends meta::protocols::pure::v1_26_0::metamodel::PureModelContext
+{
+   data : meta::protocols::pure::v1_26_0::metamodel::PureModelContextData[0..1];
+   pointer : meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer[0..1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::QueryExecutionInfo
+{
+   clientVersion : String[1];
+   function : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   mapping : String[1];
+   runtime : meta::protocols::pure::v1_26_0::metamodel::Runtime[1];
+   context : meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[0..1];
+   model : meta::protocols::pure::v1_26_0::metamodel::PureModelContext[1];
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/generation.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/generation.pure
@@ -1,0 +1,39 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::protocols::pure::v1_26_0::metamodel::invocation::generation::*;
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::generation::GenerationConfiguration
+{
+   class:String[0..1];
+   package: String[0..1];
+   scopeElements : String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::generation::GenerationOutput
+{
+   content:String[1];
+   fileName:String[1];
+}
+
+
+###Pure
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::generation::json::JSONSchemaConfig extends meta::protocols::pure::v1_26_0::metamodel::invocation::generation::GenerationConfiguration
+{
+    includeAllRelatedTypes:Boolean[0..1];
+    useConstraints:Boolean[0..1];
+}
+
+
+

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/metamodel.pure
@@ -1,0 +1,835 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+//-----------
+// Metamodel
+//-----------
+import meta::protocols::pure::v1_26_0::metamodel::domain::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::SourceInformation
+{
+    sourceId : String[1];
+    mainLine: Integer[1];
+    mainColumn: Integer[1];
+    startLine: Integer[1];
+    startColumn: Integer[1];
+    endLine: Integer[1];
+    endColumn: Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Domain
+{
+   classes : meta::protocols::pure::v1_26_0::metamodel::domain::Class[*];
+   associations : meta::protocols::pure::v1_26_0::metamodel::domain::Association[*];
+   enums : meta::protocols::pure::v1_26_0::metamodel::domain::Enumeration[*];
+   profiles : meta::protocols::pure::v1_26_0::metamodel::domain::Profile[*];
+   measures : meta::protocols::pure::v1_26_0::metamodel::domain::Measure[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+  _type : String[1];
+  <<equality.Key>> name : String[1];
+  <<equality.Key>> package : String[0..1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer
+{
+    type : meta::protocols::pure::v1_26_0::metamodel::PackageableElementType[0..1];
+    path : String[1];
+}
+
+Enum meta::protocols::pure::v1_26_0::metamodel::PackageableElementType
+{
+   CLASS,
+   PACKAGE,
+   STORE,
+   MAPPING,
+   SERVICE,
+   CACHE,
+   PIPELINE,
+   FLATTEN,
+   DIAGRAM,
+   DATASTORESPEC,
+   UNIT,
+   MEASURE
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::ExecutionContext
+{
+   queryTimeOutInSeconds: Integer[0..1];
+   enableConstraints: Boolean[0..1];
+     _type: String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::AuthenticationContext extends meta::protocols::pure::v1_26_0::metamodel::ExecutionContext
+{
+   runAs: String[0..1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::AnalyticsExecutionContext extends meta::protocols::pure::v1_26_0::metamodel::ExecutionContext
+{
+   useAnalytics: Boolean[1];
+   toFlowSetFunction: meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::Runtime
+{
+   _type: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::LegacyRuntime extends meta::protocols::pure::v1_26_0::metamodel::Runtime
+{
+   connections: meta::protocols::pure::v1_26_0::metamodel::runtime::Connection[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::EngineRuntime extends meta::protocols::pure::v1_26_0::metamodel::Runtime
+{
+    mappings:meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer[*];
+    connections: meta::protocols::pure::v1_26_0::metamodel::StoreConnections[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::StoreConnections
+{
+   store: meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer[1];
+   storeConnections: meta::protocols::pure::v1_26_0::metamodel::IdentifiedConnection[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::IdentifiedConnection
+{
+   id: String[1];
+   connection: meta::protocols::pure::v1_26_0::metamodel::runtime::Connection[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   stereotypes : StereotypePtr[*];
+   taggedValues : meta::protocols::pure::v1_26_0::metamodel::domain::TaggedValue[*];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Profile extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+   stereotypes : String[*];
+   tags : String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::StereotypePtr
+{
+   profile : String[1];
+   value : String[1];
+   profileSourceInformation: SourceInformation[0..1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::TagPtr
+{
+   profile : String[1];
+   value : String[1];
+   profileSourceInformation: SourceInformation[0..1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::PropertyPtr
+{
+   class : String[1];
+   property : String[1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::TaggedValue
+{
+   tag : meta::protocols::pure::v1_26_0::metamodel::domain::TagPtr[1];
+   value : String[1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Constraint
+{
+   name               : String[1];
+   functionDefinition : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   externalId         : String[0..1];
+   enforcementLevel   : String[0..1];
+   sourceInformation  : SourceInformation[0..1];
+   messageFunction    : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Class extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement, meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   superTypes : String[*];
+   constraints : Constraint[*];
+   properties : meta::protocols::pure::v1_26_0::metamodel::domain::Property[*];
+   qualifiedProperties : meta::protocols::pure::v1_26_0::metamodel::domain::QualifiedProperty[*];
+   originalMilestonedProperties : meta::protocols::pure::v1_26_0::metamodel::domain::Property[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::MappingClass extends meta::protocols::pure::v1_26_0::metamodel::domain::Class
+{
+  setImplementation : 	meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping[0..1];
+  rootClass : meta::protocols::pure::v1_26_0::metamodel::domain::Class[0..1];
+  localProperties : meta::protocols::pure::v1_26_0::metamodel::domain::Property[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Association extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement, meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   properties : meta::protocols::pure::v1_26_0::metamodel::domain::Property[*];
+   qualifiedProperties : meta::protocols::pure::v1_26_0::metamodel::domain::QualifiedProperty[*];
+   originalMilestonedProperties : meta::protocols::pure::v1_26_0::metamodel::domain::Property[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Property extends meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   defaultValue : meta::protocols::pure::v1_26_0::metamodel::domain::DefaultValue[0..1];
+   name : String[1];
+   multiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+   type : String[1];
+   propertyTypeSourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::QualifiedProperty extends meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   name : String[1];
+   parameters : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable[*];
+   returnType : String[1];
+   returnMultiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+   body : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity
+{
+   <<equality.Key>> lowerBound : Integer[0..1];
+   <<equality.Key>> upperBound : Integer[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Enumeration extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement, meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   values : meta::protocols::pure::v1_26_0::metamodel::domain::EnumValue[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::EnumValue extends meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   value : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::DefaultValue extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement, meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   value :  meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1];
+   sourceInformation : SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Measure extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+   canonicalUnit : meta::protocols::pure::v1_26_0::metamodel::domain::Unit[0..1];
+   nonCanonicalUnits : meta::protocols::pure::v1_26_0::metamodel::domain::Unit[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Unit extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+   measure : String[1];
+   conversionFunction : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[0..1];
+}
+
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   _type : String[1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   name : String[1];
+   supportsStream : Boolean[0..1];
+   // To Remove
+   multiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[0..1];
+   class : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::FunctionApplication extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   parameters : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedProperty extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::FunctionApplication
+{
+   property : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedFunction extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::FunctionApplication
+{
+   function : String[1];
+   fControl : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::UnknownAppliedFunction extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::FunctionApplication
+{
+   function : String[1];
+   returnType : String[1];
+   returnMultiplicity: meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   multiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::KeyExpression extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   add : Boolean[0..1];
+   key: meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1];
+   expression: meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1];
+}
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::HackedClassValue extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::EnumValue extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   fullPath : String[1];
+   value : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TDSAggregateValue extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   name : String[1];
+   mapFn : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   aggregateFn : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TDSSortInformation extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   column : String[1];
+   direction : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TDSColumnInformation extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   name: String[1];
+   columnFn: meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::AggregateValue extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   mapFn : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   aggregateFn : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::OlapOperation extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TdsOlapAggregation extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::OlapOperation
+{
+   function : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   columnName : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TdsOlapRank extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::OlapOperation
+{
+   function : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Whatever extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue
+{
+   class : String[1];
+   values : Any[0..1];//Map<String, meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification>[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::List extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   values : Any[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   fullPath : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RuntimeInstance extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   runtime : meta::protocols::pure::v1_26_0::metamodel::Runtime[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::ExecutionContextInstance extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   executionContext : meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Path extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   name : String[1];
+   startType : String[1];
+   path : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PathElement[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Pair extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   first : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1];
+   second : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PathElement extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PropertyPathElement extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PathElement
+{
+   property : String[1];
+   parameters : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+   parameters : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable[*];
+   body : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Collection extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   multiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+   values : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::HackedUnit extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   unitType : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::UnitType extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   unitType : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::UnitInstance extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   unitType : String[1];
+   unitValue : Number[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PrimitiveTypeRef extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification
+{
+   name : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CInteger extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue
+{
+   values : Integer[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDecimal extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue
+{
+   values : Decimal[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CString extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue
+{
+   values : String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CBoolean extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue
+{
+   values : Boolean[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CFloat extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue
+{
+   values : Float[*];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDate extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::MulRawValue
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDateTime extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDate
+{
+   values : String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CStrictDate extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDate
+{
+   values : String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CLatestDate extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDate
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::GraphFetchTree extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+    _type : String[1];
+    subTrees : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::GraphFetchTree[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RootGraphFetchTree extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::GraphFetchTree
+{
+   class : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PropertyGraphFetchTree extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::GraphFetchTree
+{
+   property   : String[1];
+   parameters : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+   alias      : String[0..1];
+   subType    : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::AlloySerializationConfig extends meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RawValue
+{
+    _type    : String[1];
+
+    typeKeyName : String[1];
+    includeType: Boolean[0..1];
+    includeEnumType: Boolean[0..1];
+    removePropertiesWithNullValues: Boolean[0..1];
+    removePropertiesWithEmptySets: Boolean[0..1];
+    fullyQualifiedTypePath: Boolean[0..1];
+    includeObjectReference: Boolean[0..1];
+}
+
+Enum meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReferenceType
+{
+   Relational   
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReference
+{
+   type                    : meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReferenceType[1];
+   pathToMapping           : String[1];
+   setId                   : String[1];
+   operationResolvedSetsId : String[*];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::Store extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+   includedStores:String[*];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::Mapping extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+   includedMappings:  meta::protocols::pure::v1_26_0::metamodel::mapping::MappingInclude[*];
+   classMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping[*];
+   associationMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::AssociationMapping[*];
+   enumerationMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::EnumerationMapping[*];
+   tests: meta::protocols::pure::v1_26_0::metamodel::mapping::MappingTest[0..*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::MappingTest
+{
+   name: String[1];
+   query: meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   inputData: meta::protocols::pure::v1_26_0::metamodel::mapping::InputData[*];
+   assert: meta::protocols::pure::v1_26_0::metamodel::mapping::MappingTestAssert[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::InputData
+{
+   _type: String[1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::ObjectInputData extends meta::protocols::pure::v1_26_0::metamodel::mapping::InputData
+{
+   sourceClass: String[1];
+   data: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::MappingTestAssert
+{
+   _type: String[1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::ExpectedOutputMappingTestAssert extends meta::protocols::pure::v1_26_0::metamodel::mapping::MappingTestAssert
+{
+   expectedOutput: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::MappingInclude
+{
+   includedMapping: String[1];
+   sourceDatabasePath: String[0..1];
+   targetDatabasePath: String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping
+{
+   id : String[1];
+   _type : String[1];
+   class : String[1];
+   root : Boolean[1];
+   extendsClassMappingId : String[0..1];
+   mappingClass: meta::protocols::pure::v1_26_0::metamodel::domain::MappingClass[0..1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::AssociationMapping
+{
+   id : String[1];
+   _type : String[1];
+   association : String[1];
+   stores : String[*];
+}
+
+Enum meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation
+{
+   STORE_UNION, ROUTER_UNION, INHERITANCE, MERGE
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::OperationClassMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping
+{
+   parameters : String[*];
+   operation : meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::MergeOperationClassMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::OperationClassMapping
+{
+   
+   validationFunction : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::AggregationAwareClassMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping
+{
+   mainSetImplementation:meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping[1];
+   propertyMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping[*];
+   aggregateSetImplementations: meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSetImplementationContainer[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSetImplementationContainer
+{
+   index : Integer[1];
+   setImplementation: meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping[1];
+   aggregateSpecification: meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSpecification[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSpecification
+{
+   canAggregate: Boolean[1];
+   groupByFunctions: meta::protocols::pure::v1_26_0::metamodel::mapping::GroupByFunctions[*];
+   aggregateValues: meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateFunctions[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::GroupByFunctions
+{
+   groupByFn: 	meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateFunctions
+{
+    mapFn: 	meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+    aggregateFn: 	meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping
+{
+   _type : String[1];
+   property : PropertyPtr[1];
+   source : String[0..1];
+   target : String[1];
+   localMappingProperty : meta::protocols::pure::v1_26_0::metamodel::mapping::LocalMappingPropertyInfo[0..1];
+   sourceInformation: SourceInformation[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::LocalMappingPropertyInfo
+{
+    type : String[1];
+    multiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::InlineEmbeddedPropertyMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping
+{
+   id : String[1];
+   setImplementationId : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::EnumerationMapping
+{
+   id : String[1];
+   sourceType: String[0..1];
+   enumeration : String[1];
+   enumValueMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMapping[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMapping
+{
+   enumValue : String[1];
+   sourceValues: meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingSourceValue[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingSourceValue
+{
+   _type: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingStringSourceValue extends meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingSourceValue
+{
+   value: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingIntegerSourceValue extends meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingSourceValue
+{
+   value: Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingEnumSourceValue extends meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingSourceValue
+{
+   enumeration: String[1];
+   value: String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::PureInstanceClassMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping
+{
+   srcClass : String[0..1];
+   propertyMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::PurePropertyMapping[*];
+   filter : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::PurePropertyMapping extends  meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping
+{
+   explodeProperty : Boolean[0..1];
+   enumMappingId : String[0..1];
+   transform : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStoreAssociationMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::AssociationMapping
+{
+   propertyMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStorePropertyMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping
+{
+   crossExpression : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::AggregationAwarePropertyMapping extends  meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping
+{
+}
+
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+   _type: String[1];
+   element: String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelConnection extends meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+   input : meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelInput[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::JsonModelConnection extends meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+   class : String[1];
+   url   : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::XmlModelConnection extends meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+   class : String[1];
+   url   : String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelChainConnection extends meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+     mappings : String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelInput
+{
+    _type: String[1];
+   class : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelStringInput extends meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelInput
+{
+   instances : String[*];
+}
+
+###Pure
+import meta::protocols::pure::v1_26_0::metamodel::executableMapping::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::ExecutableMapping extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement
+{
+   tests : Test[1..*];
+   mapping : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::Test
+{
+    data : TestData[*];
+    asserts : TestAssert[1..*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::TestAssert
+{
+   expected : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+   inputs : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+   comparisonKey : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[0..1];
+   comparisonType : ComparisonType[0..1];
+}
+
+Enum meta::protocols::pure::v1_26_0::metamodel::executableMapping::ComparisonType
+{
+   EQUALS,
+   SET_EQUALS
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::TestData
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::SetBasedStoreTestData extends TestData
+{
+   store : String[1];
+   data : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::ModelTestData extends TestData
+{
+   classTestData : ModelClassTestData[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::ModelClassTestData extends TestData
+{
+   class : String[1];
+   instances : String[*];
+}
+
+###Pure
+Class meta::protocols::pure::v1_26_0::metamodel::domain::Function extends meta::protocols::pure::v1_26_0::metamodel::PackageableElement, meta::protocols::pure::v1_26_0::metamodel::domain::AnnotatedElement
+{
+   preConstraints:meta::protocols::pure::v1_26_0::metamodel::domain::Constraint[*];
+   postConstraints:meta::protocols::pure::v1_26_0::metamodel::domain::Constraint[*];
+   returnType:String[1];
+   returnMultiplicity:meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+   parameters : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable[*];
+   body : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/results.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/results.pure
@@ -1,0 +1,107 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+//---------
+// Execute
+//---------
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ExecutionInput
+{
+    clientVersion:String[1];
+    function:meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+    mapping:String[0..1];
+    runtime:meta::protocols::pure::v1_26_0::metamodel::Runtime[0..1];
+    context:meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[0..1];
+    model:meta::protocols::pure::v1_26_0::metamodel::PureModelContext[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Result
+{
+   builder : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Builder[1];
+   activities : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ExecutionActivity[*];
+   generationInfo : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::GenerationInfo[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::GenerationInfo
+{
+   generationId : String[1];
+   activatedBy : String[1];
+   activatedTimestamp : Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ExecutionActivity
+{
+   _type : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::AggregationAwareActivity extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ExecutionActivity
+{
+   rewrittenQuery : String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Res
+{
+   columns : String[*];
+   rows : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Row[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Builder
+{
+   _type : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::TDSBuilder extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Builder
+{
+   columns : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::TDSColumn[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ClassBuilder extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Builder
+{
+   class : String[1];
+   mapping : String[1];
+   classMappings : 	meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ClassMappingInfo[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::DataTypeBuilder extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Builder
+{
+   type : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ClassMappingInfo
+{
+   class : String[1];
+   setImplementationId : String[1];
+   properties : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::PropertyInfo[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::PropertyInfo
+{
+   property : String[1];
+   type : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::TDSColumn
+{
+   name : String[1];
+   doc : String[0..1];
+   type : String[0..1];
+   relationalType : String[0..1];
+   enumMapping : Map<String, List<String>>[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Row
+{
+   values : Any[*];
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/scan/buildBasePureModel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/scan/buildBasePureModel.pure
@@ -1,0 +1,399 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::*;
+import meta::json::*;
+import meta::pure::store::*;
+import meta::pure::mapping::modelToModel::*;
+import meta::pure::milestoning::*;
+import meta::pure::mapping::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+
+Class <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::AllTypes
+{
+   classes : Class<Any>[*];
+   enumerations : Enumeration<Any>[*];
+   measures : Measure[*];
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildPureModelContextPointer(pointers:meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer[*], baseVersion:String[1], protocol:Protocol[1]):meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer
+   (
+      _type='pointer',
+      serializer = $protocol,
+      sdlcInfo= ^meta::protocols::pure::v1_26_0::metamodel::PureSDLC
+                (
+                   _type = 'pure',
+                   baseVersion = $baseVersion,
+                   version = 'none',
+                   packageableElementPointers = $pointers
+                )
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findInheritedTypes(classes:Class<Any>[*]):Type[*]
+{
+   let inherittedClasses    = $classes->map(class| $class->getAllClassGeneralisations())->filter(c|!$c->isWithinPackage(meta::pure::metamodel))->filter(c|!$c->in($classes))->remove(Any);
+   let typeUsedByInheritted = $inherittedClasses.properties->map(f|$f->functionReturnType().rawType);
+   $inherittedClasses->concatenate($typeUsedByInheritted)->removeDuplicates()->remove(Any);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::scan(v:ValueSpecification[1]):Type[*]
+{
+    $v->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::scan([])->distinct()
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::scan(v:Any[1], visited:FunctionDefinition<Any>[*]):Type[*]
+{
+   let matchClass = [c:Class<Any>[1]| $c,
+                     e:Enumeration<Any>[1]| $e,
+                     a:Any[*]| [] ];
+
+   $v->match(
+      [
+         {fe:FunctionExpression[1]|
+            let params = $fe.parametersValues->evaluateAndDeactivate()->map(p|$p->scan($visited));
+            let func = $fe.func->scan($visited);
+            $fe.genericType.rawType->concatenate($params)->concatenate($func);
+         },
+         i:InstanceValue[1]         | $i.values->map(v | $v->scan($visited)),
+         k:meta::pure::functions::lang::KeyExpression[1]         | $k.expression->scan($visited);,
+         lf :LambdaFunction<Any>[1] | $lf.expressionSequence->evaluateAndDeactivate()->map(e|$e->scan($visited)),
+         v:VariableExpression[1]    | [],
+         {cfd:ConcreteFunctionDefinition<Any>[1]|
+            if ($cfd->in($visited) || ($cfd->elementToPath()->startsWith('meta::') && not($cfd->meta::alloy::isMetaAlloyTestDependency())),
+                | [],
+                | let newVisited = $visited->concatenate($cfd);
+                  $cfd.expressionSequence->evaluateAndDeactivate()->map(e|$e->scan($newVisited));
+            );
+         },
+         a: Any[1] | $a
+
+      ]
+   )->map(a | $a->match($matchClass))->filter(c|$c->meta::alloy::isMetaAlloyTestDependency() || !$c->elementToPath()->startsWith('meta::'));
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::excludeTypes(types:Type[*], validPackages:String[*]):Type[*]
+{
+   $types->remove(Any)
+         ->removeDuplicates()
+         ->filter(c|let p = $c->elementToPath();
+                    !$c->instanceOf(MappingClass) && $validPackages->fold({a,b|$b || $p->startsWith($a)}, false);
+         );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::process(path:String[1], area:String[1]):String[*]
+{
+   let n = $area+'::';
+   let l = $n->length();
+   let index = $path->indexOf('::', $l);
+   let dms = if($index == -1,
+                |$path,
+                |let name = $path->substring($l, $index);
+                 ['apps','datamarts']->map(c|$c+'::'+$name);
+             );
+   $dms->concatenate(['apps::model', 'model']);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::navigateAssos(subset:Type[*], alreadyProcessed:Type[*], validPackages:String[*]):Type[*]
+{
+   let classes = $subset->filter(c|$c->instanceOf(Class) && !$c->instanceOf(MappingClass))->cast(@Class<Any>);
+   let res = $classes->map(c|$c.properties->concatenate($c.propertiesFromAssociations)->map(f|$f->functionReturnType().rawType)
+                              ->concatenate(
+                                 $c.qualifiedProperties->concatenate($c.qualifiedPropertiesFromAssociations)->evaluateAndDeactivate()
+                                 ->filter(p|!$p->hasGeneratedMilestoningPropertyStereotype())
+                                 ->map(q|let fType = $q->functionType();
+                                         let params = $fType.parameters->map(p|$p.genericType.rawType);
+                                         $params->concatenate($fType.returnType.rawType)->concatenate($q.expressionSequence->map(x|$x->scan()));
+                                 )
+                              )
+                               ->concatenate(
+                                  $c.constraints->map(c|$c.functionDefinition.expressionSequence->evaluateAndDeactivate()->map(e|$e->scan()))
+                               )
+
+                        );
+
+   let filteredClasses = $classes->excludeTypes($validPackages)->cast(@Class<Any>);
+
+   let newAll =  $filteredClasses
+                 ->concatenate($filteredClasses->map(c|$c->getAllClassGeneralisations()))
+                 ->concatenate($filteredClasses->map(c|$c->allSpecializations()))
+                 ->concatenate($res)
+                 ->excludeTypes($validPackages);
+
+   let set = $newAll->removeAllOptimized($alreadyProcessed);
+   if ($set->isEmpty(),
+       |$alreadyProcessed,
+       |$set->navigateAssos($alreadyProcessed->concatenate($set), $validPackages)
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllTypes(seedTypes:Type[*], validPackages:String[*]):AllTypes[1]
+{
+   let directTypes    = $seedTypes->navigateAssos($seedTypes, $validPackages)->removeDuplicates()->remove(Any);
+   let inheritedTypes = $directTypes->filter(t|$t->instanceOf(Class))->cast(@Class<Any>)->findInheritedTypes();
+   let allTypes       = $directTypes->concatenate($inheritedTypes)->removeDuplicates()->remove(Any)->filter(t|!$t->isWithinPackage(meta::pure::metamodel));
+   ^AllTypes(classes = $allTypes->filter(t|$t->instanceOf(Class))->cast(@Class<Any>),
+             enumerations = $allTypes->filter(t|$t->instanceOf(Enumeration))->cast(@Enumeration<Any>),
+             measures = $allTypes->filter(t|$t->instanceOf(Measure))->cast(@Measure));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllAssociations(classes:meta::pure::metamodel::type::Class<Any>[*]):Association[*]
+{
+    $classes->map(c|$c.propertiesFromAssociations).owner->removeDuplicates()->cast(@Association)
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllStoreIncludes(store:meta::pure::store::Store[1]):meta::pure::store::Store[*]
+{
+   $store->concatenate($store.includes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllStoreIncludes()))->removeDuplicates();
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllMappingIncludes(mapping:meta::pure::mapping::Mapping[1]):meta::pure::mapping::Mapping[*]
+{
+   $mapping->concatenate($mapping.includes->map(s|$s.included->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllMappingIncludes()))->removeDuplicates();
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findValidPathsFromPackage(p:PackageableElement[1]):String[*]
+{
+   let path = $p->elementToPath();
+   let sameArea = if ($path->startsWith('model'),
+       |['apps::model', 'model'],
+       |if($path->startsWith('datamarts'),
+           |process($path,'datamarts'),
+           |if($path->startsWith('apps'),
+              |process($path,'apps'),
+              |[]
+            )
+        )
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findValidPaths(p:Type[*], extensions:meta::pure::extension::Extension[*]):String[*]
+{
+    $p->cast(@PackageableElement)->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findValidPaths($extensions);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findValidPaths(p:PackageableElement[*], extensions:meta::pure::extension::Extension[*]):String[*]
+{
+   let validForTests = ['meta::java::generation::tests', 'meta::external', 'meta::pure::tests', 'apps::pure', 'apps::global']->concatenate($extensions.validTestPackages);
+   $validForTests->concatenate($p->map(op|$op->findValidPathsFromPackage()))->removeDuplicates();
+}
+
+function <<access.protected>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::enumerationMappings(m:Mapping[1]):EnumerationMapping<Any>[*]
+{
+   $m.enumerationMappings->concatenate($m.includes.included->map(i|$i->enumerationMappings()))
+}
+
+function  meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findTypesFromPureInstanceSetImplementation(p:PureInstanceSetImplementation[1]):Type[*]
+{
+   let srcClass = $p.srcClass->cast(@Class<Any>);
+   $p.class->concatenate($srcClass)
+      ->concatenate($srcClass.constraints->map(c|$c.functionDefinition.expressionSequence->evaluateAndDeactivate()->map(e|$e->scan())))
+      ->concatenate($srcClass.constraints->map(c|$c.messageFunction.expressionSequence->evaluateAndDeactivate()->map(e|$e->scan())))
+      ->concatenate($p.propertyMappings->filter(x | $x->instanceOf(PurePropertyMapping))->cast(@PurePropertyMapping).transform.expressionSequence->evaluateAndDeactivate()->map(e|$e->scan()));
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildDomain(found:AllTypes[1], associations:Association[*], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::PackageableElement[*]
+{
+   buildDomain($found, $associations, {p:Profile[1]|!$p->elementToPath()->startsWith('meta')}, $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildDomain(found:AllTypes[1], associations:Association[*], profileFilter:Function<{Profile[1]->Boolean[1]}>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::PackageableElement[*]
+{
+   let profiles = $found.classes->map(c | $c.stereotypes.profile->concatenate($c.taggedValues.tag.profile)
+                                                                ->concatenate($c.properties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile)))
+                                                                ->concatenate($c.qualifiedProperties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile))))
+                  ->concatenate($found.enumerations->cast(@AnnotatedElement)->map(e|$e.stereotypes.profile->concatenate($e.taggedValues.tag.profile)))
+                  ->concatenate($associations->map(a|$a.stereotypes.profile->concatenate($a.taggedValues.tag.profile)
+                                                                           ->concatenate($a.properties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile)))
+                                                                           ->concatenate($a.qualifiedProperties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile)))
+                                                  )
+                               )
+                  ->removeDuplicates()
+                  ->filter($profileFilter);
+   $found.classes->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformClass($extensions))
+     ->concatenate($associations->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformAssociation($extensions)))
+     ->concatenate($found.enumerations->map(e | $e->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformEnum()))
+     ->concatenate($profiles->map(p |$p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformProfile($extensions)
+                                   ))
+     ->concatenate($found.measures->map(m|$m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMeasure($extensions)));
+}
+
+function  meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllTypesFromMapping(m:Mapping[1], extensions:meta::pure::extension::Extension[*]):AllTypes[1]
+{
+   $m.classMappings()->map(c| $c->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildBasePureModel_findAllTypesFromMapping->concatenate(
+                                        [p:PureInstanceSetImplementation[1]| $p->findTypesFromPureInstanceSetImplementation(),
+                                         s:SetImplementation[1] |$s.class
+                                         ])->toOneMany()
+                                     )
+                       )
+   ->concatenate($m->enumerationMappings().enumeration)
+   ->concatenate($m->enumerationMappings()->map(e|$e.enumValueMappings.sourceValues->type()->filter(t|$t->instanceOf(Class) || $t->instanceOf(Enumeration))->remove(Nil)))
+   ->removeDuplicates()->remove(Any)
+   ->findAllTypes($m->findValidPaths($extensions));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::extractStores(si:SetImplementation[1], m:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::pure::store::Store[*]
+{
+   $si->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildBasePureModel_extractStores->map(e|$e->eval($m, $extensions))->concatenate([
+               ins: OperationSetImplementation[1] | [],
+               p: PureInstanceSetImplementation[1] | []
+            ])->toOneMany()
+      );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::processProperties(pmi:PropertyMappingsImplementation[1], m:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::pure::store::Store[*]
+{
+   $pmi.propertyMappings->map(pm|$pm->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildBasePureModel_processProperties->map(e|$e->eval($m, $extensions))->concatenate(
+                                          [
+                                             a:Any[*]|[]
+                                          ]
+                                          )->toOneMany()
+                                 )
+                             );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllTypesFromPackage(ps:Package[*], extensions:meta::pure::extension::Extension[*]):AllTypes[1]
+{
+   $ps->map(p|$p->getAllPackageElements(true))->removeDuplicates()->filter(c|$c->instanceOf(Type))->cast(@Type)->findAllTypes($ps->findValidPaths($extensions));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromMapping(gm:Mapping[*], toOrigin:Function<{Mapping[1], Protocol[1]->meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer[0..1]}>[1], extensions:meta::pure::extension::Extension[*]):meta::pure::functions::collection::Pair<meta::pure::functions::collection::List<Store>, meta::protocols::pure::v1_26_0::metamodel::PureModelContextData>[1]
+{
+   let allMappings = $gm->map(x | $x->findAllMappingIncludes())->removeDuplicates();
+
+   // Stores  ---------------
+   let classMappingStores = $allMappings->map(m|$m.classMappings->map(s|$s->extractStores($m, $extensions)));
+
+   let associationStores = $allMappings->map(m|$m.associationMappings).stores;
+
+   let storesFromInclude = $allMappings->map(m|let i = $m.includes.storeSubstitutions; $i->map(k|[$k.original, $k.substitute]););
+
+   let stores = $classMappingStores
+                ->concatenate($associationStores)
+                ->concatenate($storesFromInclude)
+                ->map(s|$s->concatenate($s->match(
+                                              $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildBasePureModel_buildPureModelFromMapping1->concatenate(
+                                              [
+                                                 a:Any[1]|[]
+                                              ])->toOneMany()
+                                             )
+                                       )
+                )->map(s|$s->findAllStoreIncludes())
+                ->removeDuplicatesBy(a|$a->elementToPath())
+                ->concatenate($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildBasePureModel_buildPureModelFromMapping2);
+
+   // Domain ----------------
+   let foundClasses = $gm->fold({x, y | let alltype = $x->findAllTypesFromMapping($extensions);
+                                        ^$y(classes = $y.classes->concatenate($alltype.classes)->removeDuplicates(),
+                                           enumerations = $y.enumerations->concatenate($alltype.enumerations)->removeDuplicates());}, ^AllTypes());
+
+   let associations = $foundClasses.classes->findAllAssociations();
+
+   let found = ^$foundClasses(classes = $foundClasses.classes->concatenate($associations.properties.genericType.rawType)->removeDuplicates()->cast(@Class<Any>));
+
+   //SecureViews Necessities
+
+   // Result ----------------
+   let protocol = ^Protocol(name='pure', version='v1_26_0');
+   pair(list($stores),
+        ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextData
+        (
+           _type = 'data',
+           serializer = $protocol,
+           origin = $toOrigin->eval($gm, $protocol),
+           elements = buildDomain($found, $associations, $extensions)
+                        ->concatenate($allMappings->map(m|$m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformMapping($extensions)))
+                        ->concatenate($stores->map(store|$store->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::transformStore($extensions)))
+        )
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromPackage(ps:Package[*], baseVersion:String[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::PureModelContextData[1]
+{
+   let found = findAllTypesFromPackage($ps, $extensions);
+   let associations = $found.classes->findAllAssociations();
+   let protocol = ^Protocol(name='pure', version='v1_26_0');
+   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextData
+   (
+      _type = 'data',
+      serializer = $protocol,
+      origin = buildPureModelContextPointer($ps->map(p|^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.PACKAGE, path=$p->elementToPath())), $baseVersion, $protocol),
+      elements = buildDomain($found, $associations, $extensions)
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromStore(store:meta::pure::store::Store[1], baseVersion:String[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::PureModelContextData[1]
+{
+   let stores = $store->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::transformStore($extensions));
+   let protocol = ^Protocol(name='pure', version='v1_26_0');
+   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextData
+   (
+      _type = 'data',
+      serializer = $protocol,
+      origin = buildPureModelContextPointer(^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.STORE, path=$store->elementToPath()), $baseVersion, $protocol),
+      elements = $stores
+   );
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromMapping(gm:Mapping[*], extensions:meta::pure::extension::Extension[*]):meta::pure::functions::collection::Pair<meta::pure::functions::collection::List<Store>, meta::protocols::pure::v1_26_0::metamodel::PureModelContextData>[1]
+{
+   let toOrigin = {m:Mapping[1], p:Protocol[1] | buildPureModelContextPointer(^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING, path=$m->elementToPath()), '-1', $p)};
+   buildBasePureModelFromMapping($gm, $toOrigin, $extensions);
+}
+
+
+//----------------------
+// Access using Strings
+//----------------------
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromMappingStr(mappingStr:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   let gm = $mappingStr->pathToElement()->cast(@Mapping);
+   let toOrigin = {m:Mapping[1], p:Protocol[1] | buildPureModelContextPointer(^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING, path=$gm->elementToPath()), '-1', $p)};
+   buildBasePureModelFromMapping($gm, $toOrigin, $extensions).second->toJsonBeta(^JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=true));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromPackageStr(packageStr:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   let gm = $packageStr->pathToElement()->cast(@Package);
+   buildBasePureModelFromPackage($gm, '-1', $extensions)->toJsonBeta(^JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=true));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromStoreStr(packageStr:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   let gm = $packageStr->pathToElement()->cast(@Store);
+   buildBasePureModelFromStore($gm, '-1', $extensions)->toJsonBeta(^JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=true));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildPureModelFromType(type:Type[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::PureModelContextData[1]
+{
+   let found = $type->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::findAllTypes($type->findValidPaths($extensions));
+   let associations = $found.classes->findAllAssociations();
+
+   let protocol = ^Protocol(name='pure', version='v1_26_0');
+   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextData
+   (
+      _type = 'data',
+      serializer = $protocol,
+      origin = buildPureModelContextPointer(^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.CLASS, path=$type->elementToPath()), '-1', $protocol),
+      elements = buildDomain($found, $associations, $extensions)
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildPureModelFromPackage(ps:Package[*], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::PureModelContextData[1]
+{
+   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromPackage($ps, '-1', $extensions);
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/scan/buildPureModelAsText.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/scan/buildPureModelAsText.pure
@@ -1,0 +1,206 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::functions::string::*;
+import meta::pure::extension::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::pure::mapping::*;
+import meta::pure::functions::io::*;
+import meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::*;
+
+Class <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::CodeSection {
+   name: String[1];
+   startLine: Integer[1];
+   noOfLines: Integer[1];
+   imports: String[*];
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildPureModelContextTextFromMapping(mapping: Mapping[*], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::PureModelContextText[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextText
+   (
+      _type = 'text',
+      code =  $mapping->getAllElementsFromMapping($extensions)->map(e|$e->getCorrectedElementSourceInformation($extensions)->getSourceTextForElement())->makeString('\n'),
+      serializer = ^meta::protocols::Protocol(name='pure', version='v1_26_0')
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildPureModelContextTextFromMappingAndQuery<T|m>(mapping: Mapping[*], query: FunctionDefinition<{->T[m]}>[1], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::PureModelContextText[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextText
+   (
+      _type = 'text',
+      code =  $mapping->getAllElementsFromMappingAndQuery($query, $extensions)->map(e|$e->getCorrectedElementSourceInformation($extensions)->getSourceTextForElement())->makeString('\n'),
+      serializer = ^meta::protocols::Protocol(name='pure', version='v1_26_0')
+   );
+}
+
+Class meta::protocols::pure::v1_26_0::transformation::fromPureGraph::SplitCodeResult {
+   codeLines: String[*];
+   index: Integer[1];
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::splitCodeIntoLines(code: String[1]):String[*]
+{
+    let result = range(0, $code->length(), 1)->fold({i, c |
+       if($i < $c.index || ($c.index > $code->length() - 1), | $c, |
+           let endColumn = if($code->indexOf('\n', $c.index) < 0, | $code->length(), | $code->indexOf('\n', $c.index));
+           let line = $code->substring(max($c.index - 1, 0), $endColumn->toOne())->replace('\n', '');
+           ^SplitCodeResult(codeLines=$c.codeLines->add($line), index=$endColumn->toOne() + 1););
+    }, ^SplitCodeResult(codeLines=[], index=0));
+
+    $result.codeLines;
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::getSourceTextForElement(sourceInformation: meta::pure::functions::meta::SourceInformation[1]): String[1]
+{
+   let content = $sourceInformation.source->readFile()->toOne();
+   let lines = $content->splitCodeIntoLines();
+   let count = 0;
+   let sections = $lines->size()->range()->zip($lines)->fold({pair, _sections |
+     if ($pair.second->trim()->startsWith('###'),
+         |$_sections->concatenate(^CodeSection(name = $pair.second, startLine = $pair.first + 1, noOfLines = 1, imports = [])),
+         |$_sections->slice(0, $_sections->size() - 1)->concatenate(^CodeSection(name = $_sections->last()->toOne().name, noOfLines = $_sections->last()->toOne().noOfLines + 1, startLine = $_sections->last()->toOne().startLine, imports = $_sections->last()->toOne().imports->concatenate(if($pair.second->trim()->startsWith('import '), |$pair.second, |[]))))
+     );
+   }, [^CodeSection(name='###Pure', startLine = 0, noOfLines = 0, imports = [])]);
+   let section = $sections->filter(section|$section.startLine <= max($sourceInformation.startLine - 1, 0))->last();
+   let startLine = $lines->at(max($sourceInformation.startLine - 1, 0));
+   let endLine = $lines->at(max($sourceInformation.endLine - 1, 0));
+   let sourceLines = if(max($sourceInformation.endLine, 0) > $sourceInformation.startLine, |
+                           $startLine->substring(max($sourceInformation.startColumn -1, 0), $startLine->length())
+                              ->concatenate($lines->slice($sourceInformation.startLine, max($sourceInformation.endLine - 1, 0)))
+                              ->concatenate($endLine->substring(0, $sourceInformation.endColumn)),
+                           |  $startLine->substring(max($sourceInformation.startColumn -1, 0), $sourceInformation.endColumn));
+
+   $section.name
+     ->concatenate($section.imports)
+     ->concatenate($sourceLines)
+     ->makeString('\n');
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::getSourceTextForElement(sourceInformation: meta::pure::functions::meta::SourceInformation[0..1]): String[1]
+{
+   if($sourceInformation->isEmpty(), |'', |$sourceInformation->toOne()->getSourceTextForElement());
+}
+
+function <<access.protected>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::getAllElementsFromMapping(gm:Mapping[*], extensions:meta::pure::extension::Extension[*]): meta::pure::metamodel::PackageableElement[*]
+{
+   // Mapping includes
+   let allMappings = $gm->map(x | $x->findAllMappingIncludes())->removeDuplicates();
+
+   // Stores
+   let classMappingStores = $allMappings->map(m|$m.classMappings->map(s|$s->extractStores($m, $extensions)));
+
+   let associationStores = $allMappings->map(m|$m.associationMappings).stores;
+
+   let storesFromInclude = $allMappings->map(m|let i = $m.includes.storeSubstitutions; $i->map(k|[$k.original, $k.substitute]););
+
+   let baseStores = $classMappingStores
+                ->concatenate($associationStores)
+                ->concatenate($storesFromInclude);
+ 
+   let stores = $extensions->map(e|$e.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildPureModelAsText_getAllElementsFromMapping->map(z|$z->eval($baseStores)))
+                ->map(s|$s->findAllStoreIncludes())
+                ->removeDuplicatesBy(a|$a->elementToPath());
+
+   // Domain
+   let foundClasses = $gm->fold({x, y | let alltype = $x->findAllTypesFromMapping($extensions);
+                                        ^$y(classes = $y.classes->concatenate($alltype.classes)->removeDuplicates(),
+                                           enumerations = $y.enumerations->concatenate($alltype.enumerations)->removeDuplicates());}, ^AllTypes());
+   let associations = $foundClasses.classes->findAllAssociations();
+   let found = ^$foundClasses(classes = $foundClasses.classes->concatenate($associations.properties.genericType.rawType)->removeDuplicates()->cast(@Class<Any>));
+   let profiles = $found.classes->map(c|$c.stereotypes.profile->concatenate($c.taggedValues.tag.profile)->concatenate(
+                                        $c.properties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile)))->concatenate(
+                                        $c.qualifiedProperties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile)))
+                                 )
+                  ->concatenate($found.enumerations->cast(@AnnotatedElement)->map(e|$e.stereotypes.profile->concatenate($e.taggedValues.tag.profile)))
+                  ->concatenate($associations->map(a|$a.stereotypes.profile->concatenate($a.taggedValues.tag.profile)->concatenate(
+                                           $a.properties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile)))->concatenate(
+                                           $a.qualifiedProperties->map(p|$p.stereotypes.profile->concatenate($p.taggedValues.tag.profile)))
+                                    )
+                  )->removeDuplicates()->filter(p|!$p->elementToPath()->startsWith('meta'));
+
+   // User defined functions
+   let userDefinedFunctions = $found->fold({x, y | let expr = $x.classes->map(c | $c.qualifiedProperties->map(q | $q.expressionSequence));
+                                                        let func = $expr->filter(e | $e->instanceOf(SimpleFunctionExpression))->map(s| $s->cast(@SimpleFunctionExpression)->evaluateAndDeactivate().func);
+                                                        $y->concatenate($func->filter(f | $f->instanceOf(ConcreteFunctionDefinition))->filter(f | !$f->elementToPath()->startsWith('meta::pure::functions::')));
+                                                }, [])->removeDuplicatesBy(a|$a->elementToPath());
+
+   // TODO? check have we included the measures mentioned in the mappings
+
+   $allMappings
+      ->concatenate($stores)
+      ->concatenate($extensions->map(e|$e.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildPureModelAsText_getAllElementsFromMapping2->map(z|$z->eval($stores))))
+      ->concatenate($profiles)
+      ->concatenate($userDefinedFunctions)
+      ->concatenate($found.classes)
+      ->concatenate($found.enumerations)
+      ->concatenate($found.measures)
+      ->concatenate($associations);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::getCorrectedElementSourceInformation(el: meta::pure::metamodel::PackageableElement[1], extensions:meta::pure::extension::Extension[*]): meta::pure::functions::meta::SourceInformation[0..1]
+{
+  let srcInfo = $extensions->map(e|$e.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).scan_buildPureModelAsText_getCorrectedElementSourceInformation->map(z|$z->eval($el)));
+  if ($srcInfo->isEmpty(),
+    |$el->sourceInformation(),
+    |$srcInfo->first();
+  );
+}
+
+function <<access.protected>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::getAllElementsFromMappingAndQuery<T|m>(gm:Mapping[*], query: FunctionDefinition<{->T[m]}>[1], extensions:meta::pure::extension::Extension[*]): meta::pure::metamodel::PackageableElement[*]
+{
+  // Stores
+  let queryDbs = meta::protocols::pure::v1_26_0::transformation::fromPureGraph::extractStoresFromTableReference($query);
+  let queryDbsFromInclude = $queryDbs->map(m|$m.includes);
+
+
+  let allElementsFromMapping = meta::protocols::pure::v1_26_0::transformation::fromPureGraph::getAllElementsFromMapping($gm, $extensions);
+
+  let allElements = $queryDbs
+    ->concatenate($queryDbsFromInclude)
+    ->concatenate($allElementsFromMapping)
+    ->removeDuplicatesBy(a|$a->elementToPath())
+    ->filter(a|!$a->isEmpty());
+
+  $allElements;  
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::extractStoresFromTableReference<T|m>(query: FunctionDefinition<{->T[m]}>[1]): meta::relational::metamodel::Database[*]
+{
+  let search = 'tableReference_Database_1__String_1__String_1__Table_1_';
+  let expressions = $query.expressionSequence->evaluateAndDeactivate();
+  let tableReference = $expressions->map(e| if($e->toOne()->meta::pure::functions::meta::instanceOf(SimpleFunctionExpression), 
+  | $e->toOne()->cast(@SimpleFunctionExpression)
+        ->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::searchQueryGraph($search),
+  | []));
+
+  $tableReference->map(ref| $ref->cast(@SimpleFunctionExpression).parametersValues->at(0)->cast(@InstanceValue).values->toOne()->cast(@meta::relational::metamodel::Database));
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::searchQueryGraph(func: SimpleFunctionExpression[1], text: String[1]): SimpleFunctionExpression[*]
+{
+  $func.parametersValues->map(x| $x->toOne()->match(
+      [
+         f:SimpleFunctionExpression[1]| if($f.func.name->toOne() == $text, | $f, | $f->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::searchQueryGraph($text)),
+         a:Any[1]|[]
+      ])
+  );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::tests::tst():Boolean[1]
+{
+  true;
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/scan/testBuildPureModel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/scan/testBuildPureModel.pure
@@ -1,0 +1,61 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::relational::mapping::*;
+
+function <<test.Test>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::tests::testGetAllElementsFromMapping():Boolean[1]
+{
+  let result = meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::dataToBookWithFunction->getAllElementsFromMapping(meta::pure::extension::defaultExtensions());
+   
+  let expected = ['meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::dataToBookWithFunction', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::printBook__String_1_', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::BookWithFunction', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::BookData', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::BookDataIdentifier', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::BookIdentifier', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::Book', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::BookIdentifierType', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::BookData_BookDataIdentifier', 
+                  'meta::pure::mapping::modelToModel::test::alloy::qualifiedProperties::Book_BookIdentifier'];
+
+  let actual = $result->map(x | $x->toRepresentation());
+  
+  //check if result contains all expeted elements
+  assertEquals($expected, $actual);
+}
+
+function <<test.Test>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::tests::testParsingOneLinerMapping():Boolean[1]
+{
+  let result = meta::protocols::pure::v1_26_0::transformation::fromPureGraph::tests::dummyMapping->buildPureModelContextTextFromMapping(meta::pure::extension::defaultExtensions());
+
+  let actual = $result.code->replace('\r\n', '\n');
+  let expected = '###Mapping\nMapping meta::protocols::pure::v1_26_0::transformation::fromPureGraph::tests::dummyMapping ()';
+
+  //check if prepared string contains all expected lines of pure code
+  assertEquals($expected, $actual);
+}
+
+function <<test.Test>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::tests::testSplitCodeIntoLines():Boolean[1]
+{
+  let string = 'Mapping meta::pure::mapping::modelToModel::test::filter::filterMapping\n(\nPerson : Pure\n{\n~src _Person\n\nlastName : $src.fullName\n}\n\nFirm : Puren\n{\n~src _Firm\nlegalName : $src.name,\nemployees : $src.employees\n}\n)';
+  let actual = splitCodeIntoLines($string);
+
+  //check if result contains all expected lines of pure code (empty lines included!)
+  assertEquals($string, $actual->makeString('\n'));
+}
+
+###Mapping
+Mapping meta::protocols::pure::v1_26_0::transformation::fromPureGraph::tests::dummyMapping ()

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/executionPlan.pure
@@ -1,0 +1,325 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::executionPlan::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::*;
+import meta::protocols::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformPlan(sourcePlan:meta::pure::executionPlan::ExecutionPlan[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionPlan[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionPlan
+   (
+      serializer = ^Protocol(name='pure', version='v1_26_0'),
+      templateFunctions = $sourcePlan.processingTemplateFunctions,
+      authDependent = $sourcePlan.authDependent,
+      kerberos = $sourcePlan.kerberos,
+      rootExecutionNode = $sourcePlan.rootExecutionNode->transformNode($sourcePlan.mapping, $extensions),
+      globalImplementationSupport = $sourcePlan.globalImplementationSupport->map(impl | $impl->transformPlatformGlobalImplementation())
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformNode(node:meta::pure::executionPlan::ExecutionNode[1], mapping:meta::pure::mapping::Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode[1]
+{
+   let n = $node->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_executionPlan_transformNode->map(f|$f->eval($mapping, $extensions))->concatenate(
+      [
+         
+         rel:meta::pure::mapping::modelToModel::ModelToModelExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::ModelToModelExecutionNode(
+               _type = 'm2m',
+               resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+               resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+               func = $rel.fd->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions),
+               jsonPropertyPaths = $rel.jsonPropertyPaths->map(j|$j->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)),
+               pathToMapping = $rel.mapping->elementToPath()->toOne(),
+               pathToClasses = $rel.classes->map(c|$c->elementToPath()),
+               connection = $rel.connection->cast(@meta::pure::mapping::modelToModel::ModelConnection)->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformModelConnection(),
+               pureModelContextData = $rel.mapping->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::buildBasePureModelFromMapping( {m:meta::pure::mapping::Mapping[1], p:	meta::protocols::Protocol[1] |[]}, $extensions).second
+         ),
+         platform:meta::pure::executionPlan::PureExpressionPlatformExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::PureExpressionPlatformExecutionNode(
+               _type='pureExp',
+               resultType=$platform.resultType->transformResultType($mapping, $extensions),
+               pure = $platform.expression->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification([], newMap([])->cast(@Map<String, List<Any>>), $extensions)
+            ),
+         platform:meta::pure::executionPlan::PlatformUnionExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformUnionExecutionNode(
+              _type='platformUnion',
+              resultType=$platform.resultType->transformResultType($mapping, $extensions)
+            ),
+         platform:meta::pure::executionPlan::PlatformMergeExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformMergeExecutionNode(
+              _type='platformMerge',
+              resultType=$platform.resultType->transformResultType($mapping, $extensions)
+            ),
+         cons:meta::pure::executionPlan::ConstantExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::ConstantExecutionNode(
+               _type='constant',
+               resultType=$cons.resultType->transformResultType($mapping, $extensions),
+               values=$cons.values->map(v | $v->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny([], newMap([]->cast(@Pair<String,List<Any>>)), PureOne, $extensions))
+            ),
+         seq:meta::pure::executionPlan::SequenceExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::SequenceExecutionNode(
+               _type = 'sequence',
+               resultType = $seq.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $seq.resultSizeRange->isEmpty()->if(|[],|$seq.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+            ),
+         seq:meta::pure::executionPlan::MultiResultSequenceExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::MultiResultSequenceExecutionNode(
+               _type = 'multiResultSequence',
+               resultType = $seq.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $seq.resultSizeRange->isEmpty()->if(|[],|$seq.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+            ),
+         agg:meta::pure::mapping::aggregationAware::AggregationAwareExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::AggregationAwareExecutionNode(
+               _type = 'aggregationAware',
+               resultType = $agg.resultType->transformResultType($mapping, $extensions),
+               aggregationAwareActivity = $agg.aggregationAwareActivity
+            ),
+         alloc:meta::pure::executionPlan::AllocationExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::AllocationExecutionNode(
+               _type = 'allocation',
+               resultType = $alloc.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $alloc.resultSizeRange->isEmpty()->if(|[],|$alloc.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+               varName = $alloc.varName
+            ),
+         exp:meta::pure::executionPlan::FunctionParametersValidationNode[1]|
+           ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::FunctionParametersValidationNode(
+              _type = 'function-parameters-validation',
+              resultType = $exp.resultType->transformResultType($mapping, $extensions),
+              functionParameters = $exp.functionParameters->map(p | ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable(_type='var', name=$p.name, supportsStream=$p.supportsStream, class=$p.type->elementToPath(), multiplicity=$p.multiplicity->isEmpty()->if(| [],| $p.multiplicity->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()))),
+              parameterValidationContext = $exp.parameterValidationContext->map(p | $p->match([
+                                                                              e:meta::pure::executionPlan::EnumValidationContext[1] | ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::EnumValidationContext(varName = $e.varName, validEnumValues = $e.validEnumValues, _type = 'enumValidationContext')
+                                                                            ]))
+
+            ),
+         g:meta::pure::graphFetch::executionPlan::GlobalGraphFetchExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::GlobalGraphFetchExecutionNode
+            (
+               _type = 'globalGraphFetchExecutionNode',
+               resultType = $g.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $g.resultSizeRange->isEmpty()->if(|[],|$g.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+               graphFetchTree = $g.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions),
+               store = $g.store->elementToPath(),
+               children = $g.children->map(s | $s->transformNode($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::GlobalGraphFetchExecutionNode),
+               localGraphFetchExecutionNode = $g.localGraphFetchExecutionNode->transformNode($mapping, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::LocalGraphFetchExecutionNode),
+               parentIndex = $g.parentIndex,
+               xStorePropertyMapping = $g.xStorePropertyMapping->map(x | $x->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::xStore::transformXStorePropertyMapping($mapping, $extensions)),
+               enableConstraints = $g.enableConstraints,
+               checked = $g.checked,
+               xStorePropertyFetchDetails = $g.xStorePropertyFetchDetails->map(x |
+                  ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::XStorePropertyFetchDetails
+                  (
+                     supportsCaching = $x.supportsCaching,
+                     propertyPath = $x.propertyPath,
+                     sourceMappingId = $x.sourceMappingId,
+                     sourceSetId = $x.sourceSetId,
+                     targetMappingId = $x.targetMappingId,
+                     targetSetId = $x.targetSetId,
+                     targetPropertiesOrdered = $x.targetPropertiesOrdered,
+                     subTree = $x.subTree
+                  )
+               )
+            ),
+         e:meta::pure::executionPlan::ErrorExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::ErrorExecutionNode
+            (
+               _type = 'error',
+               message = $e.message,
+               resultType = $e.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $e.resultSizeRange->isEmpty()->if(|[],|$e.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+            ),
+         f:meta::pure::executionPlan::FreeMarkerConditionalExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::FreeMarkerConditionalExecutionNode(
+               freeMarkerBooleanExpression = $f.freeMarkerBooleanExpression,
+               trueBlock = $f.trueBlock->transformNode($mapping, $extensions),
+               falseBlock = if($f.falseBlock->isEmpty(),|[],|$f.falseBlock->toOne()->transformNode($mapping, $extensions)),
+               _type = 'freeMarkerConditionalExecutionNode',
+               resultType = $f.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $f.resultSizeRange->isEmpty()->if(|[],|$f.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+            ),
+         v:meta::pure::executionPlan::VariableResolutionExecutionNode[1]|  
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::VariableResolutionExecutionNode(
+                _type      = 'varResolution',
+                resultType = $v.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                varName    = $v.varName
+            ),
+         f:meta::pure::mapping::modelToModel::graphFetch::executionPlan::StoreStreamReadingExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::StoreStreamReadingExecutionNode(
+               _type = 'storeStreamReading',
+               resultType = $f.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $f.resultSizeRange->isEmpty()->if(|[],|$f.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+               graphFetchTree = $f.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RootGraphFetchTree),
+               store = $f.store->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_executionPlan_transformNode_StoreStreamReadingExecutionNode->concatenate([
+                  any: Any[*] | []
+               ])->toOneMany()),
+               connection = $f.connection->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::transformConnection($extensions),
+               enableConstraints = $f.enableConstraints,
+               checked = $f.checked
+            ),
+         f:meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryCrossStoreGraphFetchExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryCrossStoreGraphFetchExecutionNode(
+               _type = 'inMemoryCrossStoreGraphFetch',
+               resultType = $f.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $f.resultSizeRange->isEmpty()->if(|[],|$f.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+               nodeIndex = $f.nodeIndex,
+               parentIndex = $f.parentIndex,
+               graphFetchTree = $f.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions),
+               batchSize = $f.batchSize,
+               checked = $f.checked,
+               xStorePropertyMapping = $f.xStorePropertyMapping->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::xStore::transformXStorePropertyMapping($mapping, $extensions),
+               supportsBatching = $f.supportsBatching,
+               children = $f.children->map(x | $x->transformNode($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryGraphFetchExecutionNode)
+            ),
+         f:meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryRootGraphFetchExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryRootGraphFetchExecutionNode(
+               _type = 'inMemoryRootGraphFetch',
+               resultType = $f.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $f.resultSizeRange->isEmpty()->if(|[],|$f.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+               nodeIndex = $f.nodeIndex,
+               parentIndex = $f.parentIndex,
+               graphFetchTree = $f.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions),
+               batchSize = $f.batchSize,
+               checked = $f.checked,
+               children = $f.children->map(x | $x->transformNode($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryGraphFetchExecutionNode)
+            ),
+         f:meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryPropertyGraphFetchExecutionNode[1]|
+            ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryPropertyGraphFetchExecutionNode(
+               _type = 'inMemoryPropertyGraphFetch',
+               resultType = $f.resultType->transformResultType($mapping, $extensions),
+               resultSizeRange = $f.resultSizeRange->isEmpty()->if(|[],|$f.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+               nodeIndex = $f.nodeIndex,
+               parentIndex = $f.parentIndex,
+               graphFetchTree = $f.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions),
+               children = $f.children->map(x | $x->transformNode($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::store::inMemory::InMemoryGraphFetchExecutionNode)
+            )
+      ])->toOneMany()
+   );
+
+   ^$n(
+      requiredVariableInputs = $node.requiredVariableInputs->map(s | $s->transformSource()),
+      executionNodes  = $node.executionNodes->map(s|$s->transformNode($mapping, $extensions)),
+      implementation  = $node.implementation->map(impl | $impl->transformPlatformNodeImplementation())
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformPlatformGlobalImplementation(impl: meta::pure::executionPlan::PlatformImplementation[1]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformImplementation[1]
+{
+   $impl->match([
+      javaImpl:JavaPlatformImplementation[1] | ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::JavaPlatformImplementation
+                                                (
+                                                   _type = 'java',
+                                                   classes = $javaImpl.classes->map({c |
+                                                      ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::JavaClass
+                                                       (
+                                                          package = $c.package,
+                                                          name = $c.name,
+                                                          source = $c.source,
+                                                          byteCode = $c.byteCode
+                                                       )
+                                                   })
+                                                )
+                                   ]
+                                )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformPlatformNodeImplementation(impl: meta::pure::executionPlan::PlatformImplementation[1]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::PlatformImplementation[1]
+{
+   $impl->match([
+      javaImpl:JavaPlatformImplementation[1] | ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::JavaPlatformImplementation
+                                                (
+                                                   _type = 'java',
+                                                   executionClassFullName = $javaImpl.executionClassFullName,
+                                                   executionMethodName    = $javaImpl.executionMethodName
+                                                )
+                                   ]
+                                )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformEnumMapping(e:meta::pure::mapping::EnumerationMapping<Any>[1]):Map<String,List<String>>[1]
+{
+   $e.enumValueMappings->map(e|pair($e.enum->id(), list($e.sourceValues->map(s|$s->toString()))))->newMap();
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformSetImplementation(setImplementation:meta::pure::mapping::SetImplementation[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::SetImplementationInfo[1]
+{
+   let propertyMappings = $setImplementation->cast(@meta::pure::mapping::InstanceSetImplementation).allPropertyMappings()
+                                    ->filter(pm|($pm.localMappingProperty->isEmpty() || $pm.localMappingProperty==false) &&
+                                                $pm.property->genericType().typeArguments->at(1).rawType->toOne()->instanceOf(meta::pure::metamodel::type::DataType)
+                                    );
+
+   ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::SetImplementationInfo
+   (
+      class = $setImplementation.class->elementToPath(),
+      mapping=$setImplementation.parent->elementToPath(),
+      id=$setImplementation.id,
+      propertyMappings = $propertyMappings->map(p|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::PropertyMapping
+                                                 (
+                                                    property = $p.property.name->toOne(),
+                                                    type = $p.property->genericType().typeArguments->at(1).rawType->toOne()->elementToPath(),
+                                                    enumMapping = $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_executionPlan_transformSetImplementation
+                                                                        ->filter(v|$v.first->eval($p))->map(x|$x.second->eval($p))->first()
+                                                 )
+                                                 
+                                            )
+   );
+
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType(rType:meta::pure::executionPlan::ResultType[1], mapping:meta::pure::mapping::Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::ResultType[1]
+{
+   $rType->match(
+      $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_executionPlan_transformResultType->map(f|$f->eval($mapping, $extensions))->concatenate([
+         partialClass:meta::pure::executionPlan::PartialClassResultType[1]|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::PartialClassResultType
+                                                                            (
+                                                                              _type = 'partialClass',
+                                                                               class = $partialClass.type->elementToPath(),
+                                                                               setImplementations=$partialClass.setImplementations->map(s|$s->transformSetImplementation($extensions)),
+                                                                               propertiesWithParameters = $partialClass.propertiesWithParameters->map(x | ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::PropertyWithParameters(property = $x.property.name->toOne(), parameters = $x.parameters->map(x | $x->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification([], ^Map<String,List<Any>>(), $extensions))))
+                                                                            ),
+         class:meta::pure::executionPlan::ClassResultType[1]|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::ClassResultType
+                                                             (
+                                                                _type='class',
+                                                                class = $class.type->elementToPath(),
+                                                                setImplementations=$class.setImplementations->map(s|$s->transformSetImplementation($extensions))
+                                                             ),
+         void:meta::pure::executionPlan::VoidResultType[1]|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::VoidResultType
+                                                             (
+                                                                _type='void'
+                                                             ),
+         rt:meta::pure::executionPlan::DataTypeResultType[1]|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::DataTypeResultType
+                                                              (
+                                                                 _type='dataType',
+                                                                 dataType=$rt.type->elementToPath()
+                                                              ),
+         rt:meta::pure::executionPlan::ResultType[1]|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::DataTypeResultType
+                                                      (
+                                                         _type='dataType',
+                                                         dataType=$rt.type->elementToPath()
+                                                      )
+      ])->toOneMany()
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformSource(source:meta::pure::executionPlan::VariableInput[1]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::VariableInput[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::VariableInput(
+     name = $source.name,
+     type = $source.type->elementToPath(),
+     multiplicity = $source.multiplicity->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()
+   )
+}
+

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/generation.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/generation.pure
@@ -1,0 +1,27 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+
+import meta::json::schema::generation::*;
+
+function meta::protocols::pure::v1_26_0::invocation::generation::json::transformJSONSchemaConfig(input:JSONSchemaConfig[1]):meta::protocols::pure::v1_26_0::metamodel::invocation::generation::json::JSONSchemaConfig[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::invocation::generation::json::JSONSchemaConfig(
+        package = $input.package,
+        class = $input.class,
+        includeAllRelatedTypes = $input.includeAllRelatedTypes,
+        useConstraints = $input.useConstraints
+   )
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/mapping.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/mapping.pure
@@ -1,0 +1,224 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::relational::tests::csv::mapping::*;
+import meta::flatten::metamodel::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::modelToModel::*;
+import meta::pure::mapping::xStore::*;
+import meta::pure::mapping::modelToModel::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::csv::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::*;
+import meta::pure::mapping::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformMapping(mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::Mapping[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::Mapping
+   (
+      _type = 'mapping',
+      includedMappings = $mapping.includes->map(m|let sourceDatabasePath = if($m.storeSubstitutions->isEmpty(),|[],|$m.storeSubstitutions.original->toOne()->elementToPath());
+                                                  let targetDatabasePath = if($m.storeSubstitutions->isEmpty(),|[],|$m.storeSubstitutions.substitute->toOne()->elementToPath());
+                                                  ^meta::protocols::pure::v1_26_0::metamodel::mapping::MappingInclude(includedMapping = if(!$m.included.package->isEmpty(), | $m.included.package->toOne()->elementToPath() + '::' + $m.included.name->toOne(), | $m.included.name->toOne()),
+                                                                                                                     sourceDatabasePath = $sourceDatabasePath,
+                                                                                                                     targetDatabasePath = $targetDatabasePath);),
+      name = $mapping.name->toOne(),
+      package = if($mapping.package->isEmpty(),|[],|$mapping.package->toOne()->elementToPath()),
+      classMappings = $mapping.classMappings->filter(x|$extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_mapping_transformMapping->fold({a,b|$a->eval($x) && $b}, true))
+                                            ->map(cm|$cm->transformSetImplementation($mapping, $extensions)),
+      associationMappings = $mapping.associationMappings->map(cm|$cm->transformAssociationImplementation($mapping, $extensions)),
+      enumerationMappings = $mapping.enumerationMappings->map(e|$e->transformEnumerationMapping())
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMappingClass(class:	meta::pure::mapping::MappingClass<Any>[1],mapping:meta::pure::mapping::Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::MappingClass[1]
+{
+   let properties = $class.properties->meta::pure::milestoning::reverseMilestoningTransforms()->cast(@Property<Nil,Any|*>);
+   let qualifiedProperties = $class.qualifiedProperties->meta::pure::milestoning::reverseMilestoningTransforms()->cast(@QualifiedProperty<Any>);
+
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::MappingClass
+   (
+      _type = 'mappingClass',
+      name = $class.name->toOne(),
+      package = if($class.package->isEmpty(),|[],|$class.package->toOne()->elementToPath()),
+      superTypes = $class.generalizations->map(g | $g.general.rawType->toOne()->elementToPath()),
+      properties = $properties->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformProperty($extensions)),
+      qualifiedProperties = $qualifiedProperties->map(q|$q->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformQualifiedProperty($extensions)),
+      stereotypes = $class.stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+      taggedValues = $class.taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue()),
+      setImplementation = $class.setImplementation->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformSetImplementation($mapping, $extensions)),
+      rootClass = $class.class->map(c|$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformClass($extensions)),
+      localProperties = $class.localProperties->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformProperty($extensions))
+   );
+}
+
+function <<access.public>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformSetImplementation(si:SetImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping[1]
+{
+   $si->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_mapping_transformSetImplementation->map(f|$f->eval($mapping))->concatenate(
+              $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_mapping_transformSetImplementation2->map(f|$f->eval($mapping, $extensions)))->concatenate([
+      o:OperationSetImplementation[1]| $o->transformOperationSetImplementation($mapping,$extensions),
+      p:PureInstanceSetImplementation[1]| $p->transformPureInstanceSetImplementation($mapping, $extensions)
+      ])->toOneMany()
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformAssociationImplementation(s:AssociationImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::AssociationMapping[1]
+{
+   $s->match(
+      $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_mapping_transformAssociationImplementation->map(f|$f->eval($mapping, $extensions))->concatenate([
+         x:XStoreAssociationImplementation[1]     | $x->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::xStore::transformXStoreAssociationImplementation($mapping, $extensions)
+      ])->toOneMany()
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformEnumerationMapping(em:EnumerationMapping<Any>[1]):meta::protocols::pure::v1_26_0::metamodel::mapping::EnumerationMapping[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::EnumerationMapping
+   (
+      id = $em.name,
+      enumeration = $em.enumeration->elementToPath(),
+      enumValueMappings = $em.enumValueMappings->map(e|
+                                                     ^meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMapping(
+                                                        enumValue=$e.enum.name,
+                                                        sourceValues=$e.sourceValues->map(s|$s->match([
+                                                           s: String[1] | ^meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingStringSourceValue(
+                                                              _type = 'stringSourceValue',
+                                                              value = $s
+                                                           ),
+                                                           i: Integer[1] | ^meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingIntegerSourceValue(
+                                                              _type = 'integerSourceValue',
+                                                              value = $i
+                                                           ),
+                                                           e: Enum[1] | ^meta::protocols::pure::v1_26_0::metamodel::mapping::EnumValueMappingEnumSourceValue(
+                                                              _type = 'enumSourceValue',
+                                                              enumeration = $e->type()->elementToPath(),
+                                                              value = $e->cast(@Enum)->id()
+                                                           )
+                                                        ]))
+                                                     ))
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformOperationSetImplementation(r:OperationSetImplementation[1], mapping:Mapping[1],extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::OperationClassMapping[1]
+{
+   let operation = if ($r.operation.name->startsWith('special_union'),
+       | meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation.ROUTER_UNION,
+       | if ($r.operation.name->startsWith('inheritance'),
+             |meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation.INHERITANCE,
+             |if($r.operation.name->startsWith('union'),
+                  | meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation.STORE_UNION,
+                  | if($r.operation.name->startsWith('merge'),
+                      |meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation.MERGE,
+                      | fail('Mapping operation not supported: '+$r.operation.name->toOne());
+                        meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation.ROUTER_UNION;
+                       )
+              )
+         )
+   );
+   
+   if($operation == meta::protocols::pure::v1_26_0::metamodel::mapping::MappingOperation.MERGE,
+        |   ^meta::protocols::pure::v1_26_0::metamodel::mapping::MergeOperationClassMapping
+               (
+                  id = $r.id,
+                  class = $r.class->elementToPath(),
+                  _type = 'mergeOperation',
+                  root = $r.root,
+                  parameters = $r.parameters.id,
+                  operation = $operation,
+                  validationFunction = $r->cast(@MergeOperationSetImplementation).validationFunction->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)
+               );,
+
+       | ^meta::protocols::pure::v1_26_0::metamodel::mapping::OperationClassMapping
+               (
+                  id = $r.id,
+                  class = $r.class->elementToPath(),
+                  _type = 'operation',
+                  root = $r.root,
+                  parameters = $r.parameters.id,
+                  operation = $operation
+               );
+      );
+
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::modelToModel::transformPureInstanceSetImplementation(p:PureInstanceSetImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::PureInstanceClassMapping[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::PureInstanceClassMapping
+   (
+      id = $p.id,
+      _type = 'pureInstance',
+      class = $p.class->elementToPath(),
+      root = $p.root,
+      propertyMappings = $p.propertyMappings->map(pm|$pm->transformPropertyMapping($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::PurePropertyMapping),
+      srcClass = if($p.srcClass->isEmpty(),|[],|$p.srcClass->toOne()->elementToPath()),
+      filter = $p.filter->map(f|$f->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions))
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::xStore::transformXStoreAssociationImplementation(r:meta::pure::mapping::xStore::XStoreAssociationImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStoreAssociationMapping[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStoreAssociationMapping
+   (
+      _type = 'xStore',
+      id = $r.id,
+      stores = $r.stores->map(s | $mapping.resolveStore($s)->elementToPath()),
+      association = $r.association->elementToPath(),
+      propertyMappings = $r.allPropertyMappings()->meta::pure::milestoning::excludeRangeMilestoningPropertyMapping()->map(pm | $pm->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::xStore::transformXStorePropertyMapping($mapping, $extensions))
+   );
+}
+
+function <<access.public>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::modelToModel::transformPropertyMapping(pm:PropertyMapping[1], mapping : Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping[1]
+{
+   $pm->match([p:PurePropertyMapping[1]| ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::PurePropertyMapping
+                                            (
+                                               _type = 'purePropertyMapping',
+                                               explodeProperty = $p.explodeProperty,
+                                               property = ^meta::protocols::pure::v1_26_0::metamodel::domain::PropertyPtr(class=$pm.property->genericType().typeArguments->at(0).rawType->toOne()->elementToPath(), property=$pm.property.name->toOne()),
+                                               source = $p.sourceSetImplementationId,
+                                               target = $p.targetSetImplementationId,
+                                               enumMappingId = $p.transformer->cast(@EnumerationMapping<Any>).name,
+                                               transform = meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($p.transform, true, $extensions),
+                                               localMappingProperty = if ($p.localMappingProperty->isNotEmpty() && $p.localMappingProperty->toOne(),
+                                                                          | ^meta::protocols::pure::v1_26_0::metamodel::mapping::LocalMappingPropertyInfo
+                                                                            (
+                                                                               type = $p.localMappingPropertyType->toOne()->elementToPath(),
+                                                                               multiplicity = $p.localMappingPropertyMultiplicity->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()
+                                                                            ),
+                                                                          | []
+                                                                      )
+                                             ),
+               a:meta::pure::mapping::aggregationAware::AggregationAwarePropertyMapping[1]| ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::AggregationAwarePropertyMapping
+                                                      (
+                                                         _type = 'AggregationAwarePropertyMapping',
+                                                         property = ^meta::protocols::pure::v1_26_0::metamodel::domain::PropertyPtr(class=$a.property->genericType().typeArguments->at(0).rawType->toOne()->elementToPath(), property=$a.property.name->toOne()),
+                                                         source = $a.sourceSetImplementationId,
+                                                         target = $a.targetSetImplementationId
+                                             )
+               ]);
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::xStore::transformXStorePropertyMapping(pm:PropertyMapping[1], mapping : Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStorePropertyMapping[1]
+{
+   $pm->match([p:meta::pure::mapping::xStore::XStorePropertyMapping[1]|
+      ^meta::protocols::pure::v1_26_0::metamodel::mapping::xStore::XStorePropertyMapping
+       (
+          _type = 'xStorePropertyMapping',
+          property = ^meta::protocols::pure::v1_26_0::metamodel::domain::PropertyPtr(class=$pm.property->genericType().typeArguments->filter(l| $l->isNotEmpty())->at(0).rawType->toOne()->elementToPath(), property=$pm.property.name->toOne()),
+          source = $p.sourceSetImplementationId,
+          target = $p.targetSetImplementationId,
+          crossExpression = meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($p.crossExpression, $extensions)
+       )
+   ]);
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/metamodel.pure
@@ -1,0 +1,262 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::metamodel::serialization::grammar::*;
+import meta::pure::runtime::*;
+import meta::pure::metamodel::constraint::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::model::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::*;
+import meta::protocols::alloy::model::*;
+import meta::protocols::alloy::function::*;
+import meta::pure::milestoning::*;
+import meta::json::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformPackageableElement(packageableElement:PackageableElement[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::PackageableElement[1]
+{
+   $packageableElement->match([
+     class:Class<Any>[1]             | transformClass($class, $extensions),
+     assoc:Association[1]            | transformAssociation($assoc, $extensions),
+     enum:Enumeration<Any>[1]        | transformEnum($enum),
+     meas:Measure[1]                 | transformMeasure($meas, $extensions),
+     unit:Unit[1]                    | transformUnit($unit, $extensions),
+     func:FunctionDefinition<Any>[1] | transformFunction($func, $extensions),
+     prof:Profile[1]                 | transformProfile($prof, $extensions)
+   ])
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformClass(class:Class<Any>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Class[1]
+{
+   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformClass($class, false, $extensions);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformClass(class:Class<Any>[1], useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Class[1]
+{
+   let properties = $class.properties->reverseMilestoningTransforms()->cast(@Property<Nil,Any|*>);
+   let qualifiedProperties = $class.qualifiedProperties->reverseMilestoningTransforms()->cast(@QualifiedProperty<Any>);
+   let originalMilestonedProperties = $class.originalMilestonedProperties->reverseMilestoningTransforms()->cast(@Property<Nil,Any|*>);
+
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Class
+   (
+      _type = 'class',
+      name = $class.name->toOne(),
+      constraints = $class.constraints->map(c|$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformConstraint($useAppliedFunction, $extensions)),
+      package = if($class.package->isEmpty(),|[],|$class.package->toOne()->elementToPath()),
+      superTypes = $class.generalizations->map(g | $g.general.rawType->toOne()->elementToPath()),
+      properties = $properties->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformProperty($extensions)),
+      qualifiedProperties = $qualifiedProperties->map(q|$q->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformQualifiedProperty($useAppliedFunction, $extensions)), 
+      originalMilestonedProperties = $originalMilestonedProperties->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformProperty($extensions)),
+      stereotypes = $class.stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+      taggedValues = $class.taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue())
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformConstraint(constraint:Constraint[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Constraint[1]
+{
+    meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformConstraint($constraint,false, $extensions);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformConstraint(constraint:Constraint[1],useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Constraint[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Constraint
+   (
+      name               = $constraint.name->toOne(),
+      functionDefinition = $constraint.functionDefinition->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($useAppliedFunction, $extensions),
+      externalId         = $constraint.externalId,
+      enforcementLevel   = $constraint.enforcementLevel,
+      messageFunction    = $constraint.messageFunction->map(f | let updatedMessageFunc = meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::removeParameters($f);
+                                                            $updatedMessageFunc->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($useAppliedFunction, $extensions);)
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::removeParameters(messageFunction:FunctionDefinition<Any>[1]):FunctionDefinition<Any>[1]
+{
+    let classifierGenericType = $messageFunction.classifierGenericType->toOne();
+    let typeArgument = $classifierGenericType.typeArguments->at(0)->toOne();
+    let functionType = $typeArgument.rawType->cast(@FunctionType)->toOne();
+    let updatedFunctionType = ^$functionType(parameters = []);
+    let updatedTypeArgument = ^$typeArgument(rawType = $updatedFunctionType);
+    let updatedClassifierGenericType = ^$classifierGenericType(typeArguments = $updatedTypeArgument->concatenate($classifierGenericType.typeArguments->tail()));
+    let updatedMessageFunction = ^$messageFunction(classifierGenericType = $updatedClassifierGenericType);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformAssociation(association:Association[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Association[1]
+{
+   let properties = $association.properties->reverseMilestoningTransforms()->cast(@Property<Nil,Any|*>);
+   let qualifiedProperties = $association.qualifiedProperties->reverseMilestoningTransforms()->cast(@QualifiedProperty<Any>);
+   let originalMilestonedProperties = $association.originalMilestonedProperties->reverseMilestoningTransforms()->cast(@Property<Nil,Any|*>);
+
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Association
+   (
+      _type = 'association',
+      name = $association.name->toOne(),
+      package = if($association.package->isEmpty(),|[],|$association.package->toOne()->elementToPath()),
+      properties = $properties->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformProperty($extensions)),
+      qualifiedProperties = $qualifiedProperties->map(q|$q->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformQualifiedProperty($extensions)),
+      originalMilestonedProperties = $originalMilestonedProperties->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformProperty($extensions)),
+      stereotypes = $association.stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+      taggedValues = $association.taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue())
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMeasure(measure:Measure[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Measure[1]
+{
+   let canonicalUnit = $measure.canonicalUnit;
+   let nonCanonicalUnits = $measure.nonCanonicalUnits;
+
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Measure
+   (
+      _type = 'measure',
+      name = $measure.name->toOne(),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
+      canonicalUnit = $canonicalUnit->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformUnit($extensions),
+      nonCanonicalUnits = $nonCanonicalUnits->map(nc | $nc->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformUnit($extensions))
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformUnit(unit:Unit[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Unit[1]
+{
+   let measure = $unit.measure;
+   let conversionFunction = $unit.conversionFunction;
+
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Unit
+   (
+      _type = 'unit',
+      name = $unit.name->toOne(),
+      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      measure = $measure->toOne()->elementToPath(),
+      conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformProperty(property:Property<Nil,Any|*>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Property[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Property
+   (
+      defaultValue = if($property.defaultValue->isEmpty(),|[],|$property.defaultValue->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformDefaultValue($extensions)->toOne()),
+      name = $property.name->toOne(),
+      multiplicity = $property.multiplicity->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()->toOne(),
+      type = $property.genericType.rawType->toOne()->elementToPath(),
+      stereotypes = $property.stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+      taggedValues = $property.taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue())
+   )
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformQualifiedProperty(qualifiedProperty:QualifiedProperty<Any>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::QualifiedProperty[1]
+{
+   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformQualifiedProperty($qualifiedProperty,false, $extensions);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformQualifiedProperty(qualifiedProperty:QualifiedProperty<Any>[1], useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::QualifiedProperty[1]
+{
+   let fType = $qualifiedProperty->functionType();
+
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::QualifiedProperty
+   (
+      name = $qualifiedProperty.name->toOne(),
+      parameters = $fType.parameters->tail()->map(p|$p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification([], newMap([]->cast(@Pair<String, List<Any>>)), true, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable)),
+      returnType = $fType.returnType.rawType->toOne()->elementToPath(),
+      returnMultiplicity = $fType.returnMultiplicity->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()->toOne(),
+      body = $qualifiedProperty->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformFunctionBody($useAppliedFunction, $extensions), 
+      stereotypes = $qualifiedProperty.stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+      taggedValues = $qualifiedProperty.taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue())
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype(s:Stereotype[1]): meta::protocols::pure::v1_26_0::metamodel::domain::StereotypePtr[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::StereotypePtr(profile=$s.profile->elementToPath(), value=$s.value)
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue(t:TaggedValue[1]): meta::protocols::pure::v1_26_0::metamodel::domain::TaggedValue[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::TaggedValue(tag=^meta::protocols::pure::v1_26_0::metamodel::domain::TagPtr(profile=$t.tag.profile->elementToPath(), value=$t.tag.value), value=$t.value)
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(multiplicity:Multiplicity[1]): meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity(lowerBound=$multiplicity.lowerBound.value, upperBound=$multiplicity.upperBound.value)
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformDefaultValue(d:meta::pure::metamodel::function::property::DefaultValue[1], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::domain::DefaultValue[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::DefaultValue(
+       _type = 'defaultValue',
+       name = $d.name->toOne(),
+       value = $d.functionDefinition.expressionSequence->at(0)->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification([], newMap([]->cast(@Pair<String, List<Any>>)),true, $extensions)
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformEnum(enum:Enumeration<Any>[1]):meta::protocols::pure::v1_26_0::metamodel::domain::Enumeration[1]
+{
+   let pack = $enum->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::enumPackage();
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Enumeration
+   (
+      _type = 'Enumeration',
+      name = $enum->enumName(),
+      package = if($pack == '',|[], |$pack),
+      values = $enum->enumValues()->map(e|^	meta::protocols::pure::v1_26_0::metamodel::domain::EnumValue
+                                           (
+                                              value=$e->cast(@Enum).name,
+                                              stereotypes = $e->cast(@AnnotatedElement).stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+                                              taggedValues = $e->cast(@AnnotatedElement).taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue())
+                                           )
+                                    ),
+       stereotypes = $enum->cast(@AnnotatedElement).stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+       taggedValues = $enum->cast(@AnnotatedElement).taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue())
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::enumPackage(e:Enumeration<Any>[1]):String[1]{
+   let s = $e->elementToPath()->split('::');
+   let fullLengh = $s->size();
+   if($fullLengh < 2,
+      |'',
+      |$s->init()->joinStrings('::');
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformFunction(f:FunctionDefinition<Any>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Function[1]
+{
+
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::Function
+   (
+      _type = 'function',
+      name = $f.name->toOne(),
+      package=$f.package->toOne()->elementToPath(),
+      body = $f->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformFunctionBody(true, $extensions),
+      parameters = $f->functionType().parameters->map(p |
+         $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification([], ^Map<String, meta::pure::functions::collection::List<Any>>(), true, true, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable)
+      ),
+      returnType = $f->functionReturnType().rawType->toOne()->elementToPath(),
+      returnMultiplicity = $f->functionReturnMultiplicity()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()->toOne(),
+      preConstraints  = $f.preConstraints->map(c |$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformConstraint($extensions)),
+      postConstraints  = $f.postConstraints->map(c |$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformConstraint($extensions)),
+      stereotypes = $f.stereotypes->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformStereotype()),
+      taggedValues = $f.taggedValues->map(t|$t->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformTaggedValue())
+
+   )
+}
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformProfile(p:Profile[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::domain::Profile[1]
+
+{   ^meta::protocols::pure::v1_26_0::metamodel::domain::Profile(_type = 'profile',
+                                                               name = $p.name->toOne(),
+                                                               package = if($p.package->isEmpty(),|[],|$p.package->toOne()->elementToPath()),
+                                                               stereotypes = $p.p_stereotypes->map(s|$s.value),
+                                                               tags = $p.p_tags->map(t|$t.value)
+                                           
+                                                          )
+                                   
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/store.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/store.pure
@@ -1,0 +1,91 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::extension::*;
+import meta::json::*;
+import meta::pure::runtime::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::transformRuntime(pureRuntime:Runtime[1], extensions:Extension[*]):meta::protocols::pure::v1_26_0::metamodel::Runtime[1]
+{
+   $pureRuntime->match([
+      legacy:Runtime[1] | ^meta::protocols::pure::v1_26_0::metamodel::LegacyRuntime(
+                             _type = 'legacyRuntime',
+                             connections = $pureRuntime.connections->map(con|$con->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::transformConnection($extensions))
+                          );
+   ])
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::transformStore(store:meta::pure::store::Store[1], extensions:Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::Store[1]
+{
+   let handlers = $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_store_transformStore
+                  ->concatenate($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_store_transformStore2->map(f | $f->eval($extensions)));
+   assert($handlers->isNotEmpty(), |'Error, trying to process Stores with no handlers');
+   $store->match($handlers->toOneMany());
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::transformConnection(connection:Connection[1], extensions:Extension[*]):meta::protocols::pure::v1_26_0::metamodel::runtime::Connection[1]
+{
+   $connection->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_store_transformConnection->concatenate(
+                      $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_store_transformConnection2->map(f | $f->eval($extensions)))->concatenate(
+      [
+         
+         model:meta::pure::mapping::modelToModel::ModelConnection[1]     | $model->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformModelConnection(),
+         j:meta::pure::mapping::modelToModel::JsonModelConnection[1]     | $j->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformJsonModelConnection(),
+         x:meta::pure::mapping::modelToModel::XmlModelConnection[1]      | $x->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformXmlModelConnection(),
+         c:meta::pure::mapping::modelToModel::ModelChainConnection[1]    | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformChainConnection(),
+
+         
+         other: meta::pure::runtime::Connection[1]                       | let failureClass = $other->class()->toString();
+                                                                           fail('' + $failureClass + ' Connection type not supported Yet!');
+                                                                           @meta::protocols::pure::v1_26_0::metamodel::runtime::Connection;
+      ])->toOneMany()
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformModelConnection(modelConnection: meta::pure::mapping::modelToModel::ModelConnection[1]):meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelConnection[1]
+{
+   let instances =  $modelConnection.instances->keyValues();
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelConnection( element = 'ModelStore',
+                                                                                      _type='ModelConnection',
+                                                                                      input = ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelStringInput(_type='ModelStringInput', class=$instances->at(0).first->elementToPath(), instances=$instances.second.values->map(i| $i->toJsonBeta())));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformJsonModelConnection(jsonModelConnection: meta::pure::mapping::modelToModel::JsonModelConnection[1]):meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::JsonModelConnection[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::JsonModelConnection(
+      element = 'ModelStore',
+      _type   = 'JsonModelConnection',
+      class   = $jsonModelConnection.class->elementToPath(),
+      url     = $jsonModelConnection.url
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformXmlModelConnection(xmlModelConnection: meta::pure::mapping::modelToModel::XmlModelConnection[1]):meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::XmlModelConnection[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::XmlModelConnection(
+      element = 'ModelStore',
+      _type   = 'XmlModelConnection',
+      class   = $xmlModelConnection.class->elementToPath(),
+      url     = $xmlModelConnection.url
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformChainConnection(modelChainConnection: meta::pure::mapping::modelToModel::ModelChainConnection[1]):meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelChainConnection[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::modelToModel::ModelChainConnection(
+      element  = 'ModelStore',
+      _type    = 'ModelChainConnection',
+      mappings = $modelChainConnection.mappings->map(m | $m->elementToPath())
+   )
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/valueSpecification.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/valueSpecification.pure
@@ -1,0 +1,599 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::milestoning::*;
+import meta::pure::graphFetch::execution::*;
+import meta::json::*;
+import meta::pure::graphFetch::routing::*;
+import meta::pure::router::clustering::*;
+import meta::pure::graphFetch::*;
+import meta::pure::metamodel::path::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformFunctionBody(f:FunctionDefinition<Any>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*]
+{
+    meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformFunctionBody($f,false, $extensions);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformFunctionBody(f:FunctionDefinition<Any>[1],useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*]
+{
+   $f.expressionSequence->map(e|$e->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($f->functionType().parameters->evaluateAndDeactivate().name, $f->openVariableValues(),false,$useAppliedFunction, $extensions));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification(v:ValueSpecification[1], inScope:String[*], open:Map<String,List<Any>>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]
+{
+    meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($v, $inScope, $open,false, $extensions);
+}
+
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification(v:ValueSpecification[1], inScope:String[*], open:Map<String,List<Any>>[1],isParameter:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]
+{
+   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($v, $inScope, $open,$isParameter,false, $extensions);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification(v:ValueSpecification[1], inScope:String[*], open:Map<String,List<Any>>[1],isParameter:Boolean[1],useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]
+{
+   $v->evaluateAndDeactivate()->match(
+      [
+         f:FunctionRoutedValueSpecification[1]|$f.value->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, false, $extensions),
+         e:ExtendedRoutedValueSpecification[1]|$e.value->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, false, $extensions),
+         e:ClusteredValueSpecification[1]|$e.val->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, false, $extensions),
+         funcExp:FunctionExpression[1]|
+                  let fe = meta::pure::milestoning::reverseMilestoningTransforms($funcExp);
+                  let spec = $fe.func->match(
+                                          [
+                                             p:Property<Nil,Any|*>[1]|
+                                                ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedProperty
+                                                (
+                                                   _type = 'property',
+                                                   property = $fe.func.name->toOne()->cast(@String),
+                                                   parameters = $fe.parametersValues->evaluateAndDeactivate()->map(pm|$pm->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open,false,$useAppliedFunction, $extensions))
+                                                ),
+                                             p:QualifiedProperty<Any>[1]|
+                                                ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedProperty
+                                                (
+                                                   _type = 'property',
+                                                   property = $fe.func.name->toOne()->cast(@String),
+                                                   parameters = $fe.parametersValues->evaluateAndDeactivate()->map(pm|$pm->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, false, $extensions))
+                                                ),
+                                             f:Function<Any>[1]|
+                                                let passToTransformAny =
+                                                   [
+                                                      agg_FunctionDefinition_1__FunctionDefinition_1__AggregateValue_1_,
+                                                      agg_String_1__FunctionDefinition_1__FunctionDefinition_1__AggregateValue_1_,
+                                                      func_String_1__FunctionDefinition_1__TdsOlapAggregation_1_,
+                                                      func_FunctionDefinition_1__TdsOlapRank_1_
+                                                   ];
+
+                                              let isExtractEnum = $fe->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::hasExtractEnumValue();
+                                                if($isExtractEnum,
+                                                 |^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedProperty
+                                                      (
+                                                         _type = 'property',
+                                                        property = $fe.parametersValues->at(1)->cast(@InstanceValue).values->toOne()->cast(@String),
+                                                        parameters =   $fe.parametersValues->at(0)->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open,false, $extensions)
+                                                      );,
+                                                    | let isAutoMap =   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::hasAutoMapProperty($fe);
+                                                      if($isAutoMap,
+                                                       |  let xs = $fe.parametersValues
+                                                                                       ->filter(f|$f->instanceOf(InstanceValue))->cast(@InstanceValue).values
+                                                                                        ->filter(f|$f->instanceOf(LambdaFunction))->cast(@LambdaFunction<Any>).expressionSequence;
+                                                           let newProp = $xs->at(0) ->cast(@SimpleFunctionExpression);
+                                                           let newProperty = meta::pure::milestoning::reverseMilestoningTransforms($newProp);
+                                                           let newParameter =    $fe.parametersValues->at(0);
+                                                           let additionalParameters =   $xs->cast(@SimpleFunctionExpression).parametersValues->tail();
+                                                           let updatedProperty = ^$newProperty(parametersValues = $newParameter ->concatenate(  $additionalParameters ));
+                                                           $updatedProperty->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope,$open,false,$useAppliedFunction, $extensions);
+
+                                                       ,|   if($passToTransformAny->contains($fe.func) || (new_Class_1__String_1__KeyExpression_MANY__T_1_ == $fe.func && $fe.parametersValues->at(0).genericType.typeArguments.rawType->cast(@Class<Any>)->at(0)->isWithinPackage(meta::pure)),
+                                                                       |$fe->reactivate($fe->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::scan()->map(o|pair($o,^List<Any>()))->newMap())->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, 0, $fe, $extensions);,
+                                                                       |let package = $fe.func.package->toOne();
+                                                                        if($fe.func->instanceOf(FunctionDefinition) && $useAppliedFunction && (!$package->isWithinPackage(meta) && !$package->meta::alloy::isMetaAlloyTestDependency() || $package->meta::alloy::isMetaAlloyTestDependencyForGeneration() ),
+                                                                           |let functionName = $fe.functionName->toOne();
+                                                                            let packagePath = $package->elementToPath() + '::';
+                                                                            ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedFunction
+                                                                                  (
+                                                                                      _type = 'func',
+                                                                                     function = if($functionName->startsWith($packagePath),|$functionName,|$packagePath + $functionName),
+                                                                                     parameters = $fe.parametersValues->evaluateAndDeactivate()->map(pm|$pm->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open,false,$useAppliedFunction, $extensions))
+                                                                                  )
+                                                                            ;,|if ($fe.func->instanceOf(FunctionDefinition) && (!$package->isWithinPackage(meta) || $package->meta::alloy::isMetaAlloyTestDependency()),
+                                                                                 |
+                                                                                  if($fe.func->cast(@FunctionDefinition<Any>).expressionSequence->size() == 1,
+                                                                                     {|
+                                                                                        //in-line function
+                                                                                        let pNames = $fe.func->functionType().parameters->evaluateAndDeactivate().name;
+                                                                                        let pValues = $fe.parametersValues->evaluateAndDeactivate()->map(v|
+                                                                                             $v->match([
+                                                                                               ve:VariableExpression[1]|
+                                                                                                  if($open->get($ve.name).values->isNotEmpty(),| $open->get($ve.name), |list($ve));
+                                                                                               ,
+                                                                                               any:ValueSpecification[1]|list($any)
+                                                                                            ]));
+
+                                                                                        let newOpen = $open->putAll($pNames->zip($pValues)->newMap());
+
+                                                                                        $fe.func->cast(@FunctionDefinition<Any>).expressionSequence->at(0)->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $newOpen,false,$useAppliedFunction, $extensions);
+                                                                                     },
+                                                                                     {|
+                                                                                        ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::UnknownAppliedFunction
+                                                                                        (
+                                                                                            _type = 'unknownFunc',
+                                                                                           function = $fe.func.functionName->toOne(),
+                                                                                           returnType = $fe.func->functionReturnType().rawType->toOne()->elementToPath(),
+                                                                                           returnMultiplicity = $fe.func->functionReturnMultiplicity()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()
+                                                                                        )
+                                                                                     }
+                                                                                   ),
+                                                                                 |^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedFunction
+                                                                                  (
+                                                                                      _type = 'func',
+                                                                                     function = $fe.func.functionName->toOne(),
+                                                                                     fControl = $fe.func.name->toOne(),
+                                                                                     parameters = $fe.parametersValues->evaluateAndDeactivate()->map(pm|$pm->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open,false,$useAppliedFunction, $extensions))
+                                                                                  )
+                                                                                 );
+                                                                     );
+                                                             );
+                                                          );
+                                                   );
+
+                                          ]
+                                       );
+                  ,
+         i:InstanceValue[1]|
+                        if($i->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isClassFunctionParameter(true),
+                           |$i->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformHackedClass(),
+                           | if($i->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isClassFunctionParameter(false),
+                                |$i.genericType.typeArguments.rawType->toOne()->meta::protocols::pure::v1_26_0::transformation ::fromPureGraph::valueSpecification::transformAny($inScope, $open, $i.multiplicity, 0 , [],$useAppliedFunction, $extensions),
+                                |if($i->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isHackedUnit(),
+                                  |$i->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformHackedUnit(),
+                                  |if($i->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isUnitType(),
+                                      |$i->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformUnitInstance(),
+                                      |$i.values->meta::protocols::pure::v1_26_0::transformation ::fromPureGraph::valueSpecification::transformAny($inScope, $open, $i.multiplicity, 0 , [],$useAppliedFunction, $extensions)))));,
+         v:VariableExpression[1]|
+            if ($inScope->contains($v.name),
+                |meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformVar($v,$isParameter),
+                |let r = $open->get($v.name);
+                 let vals = $r.values->evaluateAndDeactivate();
+                 if ($r->isEmpty(),
+                     |meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformVar($v,$isParameter),
+                     |if ($vals->size() == 1 && $vals->toOne()->instanceOf(VariableExpression),
+                        |meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformVar($vals->toOne()->cast(@VariableExpression),$isParameter),
+                        |$r.values->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, if($vals->isEmpty(),|PureZero,|$v.multiplicity), $extensions);
+                      )
+                 );
+            );
+      ]
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isUnitType(v:InstanceValue[1]):Boolean[1]
+{
+    $v.genericType.rawType->toOne()->instanceOf(Unit)
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isHackedUnit(v:InstanceValue[1]):Boolean[1]
+{
+    $v.values->isEmpty() && $v.multiplicity == PureOne && $v->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isUnitType()
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::isClassFunctionParameter(v:InstanceValue[1], ishacked:Boolean[1]):Boolean[1]
+{
+    let rawType = $v.genericType.rawType->toOne();
+    $v.values->isEmpty() && $v.multiplicity == PureOne && (($rawType->instanceOf(DataType) && !$rawType->instanceOf(Unit)) || $rawType->instanceOf(Class) && (($ishacked && $rawType.name != 'Class') || (!$ishacked && $rawType.name == 'Class')));
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformHackedClass(v:InstanceValue[1]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::HackedClassValue[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::HackedClassValue
+   (
+      _type = 'hackedClass',
+      fullPath = $v.genericType.rawType->toOne()->match([
+         d:DataType[1]|$d->makeString(),
+         c:Class<Any>[1]|$c->elementToPath()
+         ])
+   )
+}
+
+//here
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformVar(v:VariableExpression[1], isParameter:Boolean[1]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable[1]
+{
+   //xStore generates 'that' but provides no context on what the class is so we need to leave the class in
+//   if(($isParameter  &&$v.name != 'this' ) || $v.name == 'v_automap' || $v.name == 'that' ,
+   if($isParameter && !$v.genericType->instanceOf(InferredGenericType) && $v.name != 'this',
+      |^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable
+             (
+                _type = 'var',
+                multiplicity = $v.multiplicity->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                name = $v.name,
+                class = $v.genericType.rawType->toOne()->elementToPath()
+            );
+    ,|^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable
+                (
+                   _type = 'var',
+                   name = $v.name
+                );
+    );
+
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformHackedUnit(v:ValueSpecification[1]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::HackedUnit[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::HackedUnit(_type='hackedUnit', unitType=$v.genericType.rawType->toOne()->elementToPath());
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformUnitInstance(v:ValueSpecification[1]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::UnitInstance[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::UnitInstance(_type='unitInstance', unitType=$v.genericType.rawType->toOne()->elementToPath(), unitValue=$v->cast(@InstanceValue).values->toOne()->cast(@Number));
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny(l:Any[*], inScope:String[*], open:Map<String,List<Any>>[1], m:Multiplicity[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]
+{
+   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($l, $inScope, $open, $m, 0 , [], $extensions)
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny(l:Any[*], inScope:String[*], open:Map<String,List<Any>>[1], m:Multiplicity[1], depth:Integer[1], fe:FunctionExpression[0..1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]
+{
+   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($l, $inScope, $open, $m, $depth,$fe, false, $extensions)
+
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny(l:Any[*], inScope:String[*], open:Map<String,List<Any>>[1], m:Multiplicity[1], depth:Integer[1], fe:FunctionExpression[0..1],useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]
+{
+   $l->match(
+               $extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_valueSpecification_transformAny->map(f|$f->eval($inScope, $open, $m, $fe, $useAppliedFunction, $extensions))->concatenate([
+                  n:Nil[0] |
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Collection
+                     (
+                        _type = 'collection',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()
+                     ),
+                  s:String[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CString
+                     (
+                        _type = 'string',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $s
+                     ),
+                  i:Integer[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CInteger
+                     (
+                        _type = 'integer',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $i
+                     ),
+                  d:Decimal[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDecimal
+                     (
+                        _type = 'decimal',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $d
+                     ),
+                  f:Float[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CFloat
+                     (
+                        _type = 'float',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $f
+                     ),
+                  b:Boolean[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CBoolean
+                     (
+                        _type = 'boolean',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $b
+                     ),
+                  d:StrictDate[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CStrictDate
+                     (
+                        _type = 'strictDate',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $d->map(st|$st->toString())
+                     ),
+                  d:DateTime[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDateTime
+                     (
+                        _type = 'dateTime',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $d->map(st|$st->toString())
+                     ),
+                  l:LatestDate[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CLatestDate
+                     (
+                        _type = 'latestDate',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()
+                     ),
+                  c:Class<Any>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr
+                     (
+                        _type = 'packageableElementPtr',
+                        fullPath = $c->at(0)->elementToPath()
+                     ),
+                  l:LambdaFunction<Any>[1]|
+                     let nInScope = $l->functionType().parameters->evaluateAndDeactivate().name;
+                     let nOpen = $open->putAll($l->openVariableValues()->keyValues()->filter(v|$v.second.values->isNotEmpty()));
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda
+                     (
+                        _type = 'lambda',
+                        parameters = $l->at(0)->functionType().parameters->evaluateAndDeactivate()->map(p|$p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($nInScope, $nOpen, true,$useAppliedFunction, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable)),
+                        body = $l.expressionSequence->map(e|$e->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($nInScope, $nOpen,false,$useAppliedFunction, $extensions))
+                     );,
+                  e:Enum[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::EnumValue
+                     (
+                        _type = 'enumValue',
+                        fullPath = $e->genericType().rawType->toOne()->elementToPath(),
+                        value = $e->id()
+                     ),
+                  e:Enumeration<Any>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr
+                     (
+                        _type = 'packageableElementPtr',
+                        fullPath = $e->elementToPath()
+                     ),
+                  u:Unit[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::UnitType
+                     (
+                        _type='unitType',
+                        unitType=$u->elementToPath()
+                     );,
+                  v:ValueSpecification[1]|$v->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open,false,$useAppliedFunction, $extensions),
+                  a:Path<Nil,Any|*>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Path
+                     (
+                        _type = 'path',
+                        name = if ($a.name->isEmpty(),|'',|$a.name->toOne()),
+                        startType = $a.start.rawType->toOne()->elementToPath(),
+                        path = $a.path->map(
+                                    p|$p->match(
+                                       [
+                                          p:PropertyPathElement[1]|^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PropertyPathElement(
+                                                                        _type='propertyPath',
+                                                                        property=$p.property.name->toOne(),
+                                                                        parameters = $p.parameters->map(pa|$pa->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, $extensions))
+                                                                   )
+                                       ]
+                                    )
+                               )
+                     );,
+                  a:meta::pure::functions::collection::AggregateValue<Any, Any, Any>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::AggregateValue
+                     (
+                        _type = 'aggregateValue',
+                        mapFn = $a.mapFn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda),
+                        aggregateFn= $a.aggregateFn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda)
+                     ),
+                  a:meta::pure::tds::AggregateValue<Any,Any>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TDSAggregateValue
+                     (
+                        _type = 'tdsAggregateValue',
+                        name = $a.name,
+                        mapFn = $a.mapFn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda),
+                        aggregateFn= $a.aggregateFn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda)
+                     ),
+                  oo:meta::pure::tds::OlapOperation<Any>[1]|
+                     $oo->match([
+                        oa : meta::pure::tds::TdsOlapAggregation<Any>[1]|
+                           ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TdsOlapAggregation
+                           (
+                              _type = 'tdsOlapAggregation',
+                              columnName = $oa.colName,
+                              function = $oa.func->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda)
+                           ),
+                        or :  meta::pure::tds::TdsOlapRank<Any>[1]|
+                           ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TdsOlapRank
+                           (
+                              _type = 'tdsOlapRank',
+                              function = $or.func->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda)
+                           )
+                        ]),
+                  si:meta::pure::tds::SortInformation[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TDSSortInformation
+                     (
+                        _type = 'tdsSortInformation',
+                        column = $si.column,
+                        direction = $si.direction->toString()
+                     ),
+                  co:meta::pure::tds::BasicColumnSpecification<Any>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::TDSColumnInformation
+                     (
+                        _type = 'tdsColumnInformation',
+                        name = $co.name,
+                        columnFn = $co.func->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda)
+                     );,
+                  pair:Pair<Any,Any>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Pair
+                     (
+                        _type = 'pair',
+                        first = $pair.first->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions),
+                        second = $pair.second->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions)
+                     );,
+                 m:meta::pure::mapping::Mapping[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr
+                     (
+                        _type = 'packageableElementPtr',
+                        fullPath = $m->elementToPath()->toOne()
+                     ),
+                 r:meta::pure::runtime::Runtime[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RuntimeInstance
+                     (
+                        _type = 'runtimeInstance',
+                        runtime = $r->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::transformRuntime($extensions)
+                     ),
+                 l:List<Any>[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::List
+                     (
+                        _type = 'listInstance',
+                        values = $l.values->map(la|$la->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne, $extensions))
+                     ),
+                  a:AlloySerializationConfig[1] | ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::AlloySerializationConfig
+                     (
+                        _type = 'alloySerializationConfig',
+                        typeKeyName = $a.typeKeyName,
+                        includeType = $a.includeType,
+                        includeEnumType = $a.includeEnumType,
+                        removePropertiesWithNullValues = $a.removePropertiesWithNullValues,
+                        removePropertiesWithEmptySets = $a.removePropertiesWithEmptySets,
+                        fullyQualifiedTypePath = $a.fullyQualifiedTypePath,
+                        includeObjectReference = $a.includeObjectReference
+                     ),
+                  g:GraphFetchTree[1]|
+                     $g->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree($inScope, $open, $extensions),
+                  k:KeyExpression[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::KeyExpression
+                     (
+                        _type = 'keyExpression',
+                        add =  $k.add,
+                        key =  $k.key->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, false, $extensions),
+                        expression = $k.expression->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, false, $extensions)
+                     );,
+                    p:PrimitiveType[1]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PrimitiveTypeRef
+                        ( _type = 'primitiveType',
+                          name= $p.name->toOne()
+                         ),
+
+                  a:Any[1]|
+                             meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::possiblyTransformNewFunction($a, $m, $fe,  $inScope, $open, $extensions);,
+                  a:Any[*]|
+                     ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Collection
+                     (
+                        _type = 'collection',
+                        multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+                        values = $a->map(la|$la->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, PureOne,0,[],$useAppliedFunction, $extensions))
+                     );
+                ])->toOneMany()
+              );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::possiblyTransformNewFunction(any:Any[1], m:Multiplicity[1],fe:FunctionExpression[0..1], inScope:String[*], open:Map<String,List<Any>>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[1]
+{
+   if($fe->isNotEmpty() && $fe.functionName== 'new',
+      |let serialized =   ^	meta::protocols::pure::v1_26_0::metamodel::valueSpecification::application::AppliedFunction(
+                                 _type = 'func',
+                                 function = $fe.func.functionName->toOne(),
+                                 fControl = $fe.func.name->toOne(),
+                                 parameters = $fe->toOne().parametersValues->head()->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformNewClass()
+                                             ->concatenate($fe->toOne().parametersValues->tail()->map(vs|$vs->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification( $inScope, $open, $extensions) ))
+                                 );,
+
+
+      | let class = $any->genericType().rawType->toOne()->cast(@PackageableElement);
+         ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Whatever
+         (
+            _type = 'whatever',
+            class = $class->elementToPath(),
+            multiplicity = $m->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity(),
+            values = [] // newMap([]->cast(@Pair<String,meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification>))//->genericType().rawType->toOne()->cast(@Class<Any>).properties->map(p|pair($p.name->toOne(), $p->eval($a)->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open , $m, $depth+1)))->newMap()
+         );
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformNewClass(v:ValueSpecification[1]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr
+   (
+      _type = 'packageableElementPtr',
+      fullPath = $v.genericType.typeArguments->at(0).rawType->toOne()->elementToPath()
+   );
+}
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree(tree: GraphFetchTree[1], inScope:String[*], open:Map<String,List<Any>>[1], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::GraphFetchTree[1]
+{
+   let base = $tree->match([
+      r: RootGraphFetchTree<Any>[1] | ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RootGraphFetchTree(
+                                         _type = 'rootGraphFetchTree',
+                                         class = $r.class->elementToPath()
+                                      ),
+      p: PropertyGraphFetchTree[1]  | ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PropertyGraphFetchTree(
+                                         _type = 'propertyGraphFetchTree',
+                                         property   = $p.property.name->toOne(),
+                                         parameters = $p.parameters->map(p| $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open, $extensions)),
+                                         alias      = $p.alias,
+                                         subType    = $p.subType->map(st| $st->elementToPath())
+                                      ),
+      c: ClusteredGraphFetchTree[1] | meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree($c.tree, $inScope, $open, $extensions)
+   ]);
+
+   let subtrees = $tree->match([
+      c: ClusteredGraphFetchTree[1] | $c.tree.subTrees->map(st|$st->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree($inScope, $open, $extensions)),
+      g: GraphFetchTree[1]          | $g.subTrees->map(st|$st->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree($inScope, $open, $extensions))
+   ]);
+
+   ^$base(subTrees=$subtrees);
+}
+
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::hasAutoMapProperty(fe:FunctionExpression[1]):Boolean[1]
+{
+
+   let instanceProps =  $fe.parametersValues->evaluateAndDeactivate()->filter(f|$f->instanceOf(InstanceValue));
+   if($instanceProps->isNotEmpty(),
+      |let lambda = $instanceProps->cast(@InstanceValue).values->filter(f|$f->instanceOf(LambdaFunction));
+       if($lambda->isNotEmpty(),
+            | let es = $lambda->cast(@LambdaFunction<Any>).expressionSequence->at(0)->filter(e|$e->instanceOf(SimpleFunctionExpression));
+              if($es->isNotEmpty(),
+                   |let ve = $es->cast(@SimpleFunctionExpression).parametersValues->first()->filter(f|$f->instanceOf(VariableExpression));
+                    if($ve->isNotEmpty(),
+                       | $ve->cast(@VariableExpression).name== 'v_automap';
+                       ,|false);
+                 ,|false);
+            ,|false);
+      ,|false);
+
+}
+
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::hasExtractEnumValue(fe:FunctionExpression[1]):Boolean[1]
+{
+
+   if($fe.func.name=='extractEnumValue_Enumeration_1__String_1__T_1_',
+       |  if($fe.parametersValues->at(0)->instanceOf(InstanceValue)   &&  $fe.parametersValues->at(1)->instanceOf(InstanceValue) ,
+               |true,|false),
+       |false);
+
+}
+
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::scan(v:Any[1]):String[*]
+{
+   $v->match(
+      [
+         i:InstanceValue[1]| $i.values->map(s|$s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::scan()),
+         l:LambdaFunction<Any>[1]|$l.openVariables,
+         f:FunctionExpression[1]|$f.parametersValues->map(p|$p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::scan()),
+         a:Any[1]|[]
+      ]
+   )
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda(f:FunctionDefinition<Any>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1]
+{
+   meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($f, false, $extensions);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda(f:FunctionDefinition<Any>[1],useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1]
+{
+
+   ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda
+   (
+      _type = 'lambda',
+      body = $f->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformFunctionBody($useAppliedFunction, $extensions),
+      parameters = $f->functionType().parameters->map(p |
+         $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformValueSpecification([], ^Map<String, meta::pure::functions::collection::List<Any>>(), true, $useAppliedFunction, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::Variable)
+      )
+   )
+}

--- a/legend-engine-xt-avro-pure/src/main/resources/core_external_format_avro/protocol/protocol_v1_26_0.pure
+++ b/legend-engine-xt-avro-pure/src/main/resources/core_external_format_avro/protocol/protocol_v1_26_0.pure
@@ -1,0 +1,63 @@
+###Pure
+
+import meta::pure::generation::metamodel::*;
+import meta::external::format::avro::generation::*;
+import meta::json::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::alloy::metadataServer::*;
+import meta::pure::functions::io::http::*;
+
+function <<access.private>> meta::protocols::pure::v1_26_0::invocation::generation::avro::legendGenerateAvro(input:AvroConfig[1], host:String[1], port:Integer[1]):AvroOutput[*]
+{
+   meta::protocols::pure::v1_26_0::invocation::generation::avro::legendGenerateAvro($input, $host, $port, 'v1');
+}
+
+function meta::protocols::pure::v1_26_0::invocation::generation::avro::legendGenerateAvro(avroConfig:AvroConfig[1], host:String[1], port:Integer[1], version:String[1]):AvroOutput[*]
+{
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/schemaGeneration/avro'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 '{ "clientVersion":"v1_26_0",'+
+                                 '  "config":'+$avroConfig->meta::protocols::pure::v1_26_0::invocation::generation::avro::transformAvroGenerationConfig()->alloyToJSON()+','+
+                                 '  "model":'+if ($avroConfig.package->isEmpty(),
+                                                  |$avroConfig.class->toOne()->pathToElement()->toOne()->cast(@Type)->buildPureModelFromType(meta::pure::extension::defaultExtensions())->alloyToJSON(),
+                                                  |$avroConfig.package->toOne()->pathToElement()->toOne()->cast(@Package)->buildPureModelFromPackage(meta::pure::extension::defaultExtensions())->alloyToJSON())+
+                                 '}'
+                                );
+   assertEq(200, $resp.statusCode, | $resp.entity);
+   $resp.entity->parseJSON()->fromJSON(AvroOutput, ^ExtendedJSONDeserializationConfig(nullReplacementInArray = ^TDSNull(), typeKeyName='__TYPE', failOnUnknownProperties=true))->cast(@AvroOutput);
+}
+
+###Pure
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::generation::avro::AvroConfig extends meta::protocols::pure::v1_26_0::metamodel::invocation::generation::GenerationConfiguration
+{
+
+   includeNamespace: Boolean[0..1];
+   includeSuperTypes: Boolean[0..1];
+   includeAssociations: Boolean[0..1];
+   includeGeneratedMilestoning: Boolean[0..1];
+   timestampLogicalType: String[0..1];
+   propertyProfile: Profile[*];
+   namespaceOverride: Map<String, String>[0..1];
+   generateLogicalTypes:Boolean[0..1];
+}
+
+###Pure
+
+import meta::external::format::avro::generation::*;
+
+function meta::protocols::pure::v1_26_0::invocation::generation::avro::transformAvroGenerationConfig(input:AvroConfig[1]):meta::protocols::pure::v1_26_0::metamodel::invocation::generation::avro::AvroConfig[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::invocation::generation::avro::AvroConfig(
+      package = $input.package,
+      class = $input.class,
+      includeNamespace=$input.includeNamespace ,
+      includeSuperTypes=$input.includeSuperTypes,
+      includeAssociations=$input.includeAssociations,
+      includeGeneratedMilestoning=$input.includeGeneratedMilestoning,
+      timestampLogicalType=$input.timestampLogicalType,
+      propertyProfile=$input.propertyProfile,
+      namespaceOverride=$input.namespaceOverride,
+      generateLogicalTypes = $input.generateLogicalTypes
+   )
+}

--- a/legend-engine-xt-protobuf-pure/src/main/resources/core_external_format_protobuf/protocol/protocol_v1_26_0.pure
+++ b/legend-engine-xt-protobuf-pure/src/main/resources/core_external_format_protobuf/protocol/protocol_v1_26_0.pure
@@ -1,0 +1,160 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+###Pure
+
+import meta::json::*;
+import meta::pure::generation::metamodel::*;
+import meta::external::format::protobuf::metamodel::*;
+import meta::external::format::protobuf::deprecated::generation::configuration::*;
+import meta::external::format::protobuf::transformation::fromPure::*;
+import meta::protocols::pure::v1_26_0::invocation::generation::protobuf::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::alloy::metadataServer::*;
+import meta::pure::functions::io::http::*;
+import meta::external::format::protobuf::deprecated::generation::*;
+import meta::protocols::pure::v1_26_0::invocation::externalFormat::protobuf::*;
+
+import meta::pure::model::unit::*;
+
+function meta::protocols::pure::v1_26_0::invocation::externalFormat::protobuf::legendGenerateProtobuf(modelUnit:ModelUnit[1], input:ModelToProtobufDataConfiguration[1], host:String[1], port:Integer[1], version:String[1]):meta::external::shared::format::metamodel::data::SchemaData[*]
+{
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/external/format/generateSchema'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 '{ "clientVersion":"v1_26_0",'+
+                                 '  "sourceModelUnit": {"packageableElementIncludes" : ' + $modelUnit->resolve().packageableElements->map(e | $e->elementToPath())->joinStrings('["', '","', '"]') + '},' +
+                                 '  "config":'+$input->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::format::protobuf::transformModelToProtobufDataConfiguration()->alloyToJSON()+','+
+                                 '  "model":'+$modelUnit.packageableElementIncludes->match(
+                                                    [
+                                                      p:Package[1]|$p->buildPureModelFromPackage(meta::pure::extension::defaultExtensions())->alloyToJSON(),
+                                                      c:Type[1]|$c->buildPureModelFromType(meta::pure::extension::defaultExtensions())->alloyToJSON()
+                                                    ]
+                                                  )+
+                                 '}'
+                                );
+   assertEq(200, $resp.statusCode, | $resp.entity);
+   let jsonRes = $resp.entity->parseJSON()->cast(@JSONObject);
+   let schemas = $jsonRes->navigateArray('elements').values->at(0)->cast(@JSONObject)->navigateArray('schemas').values;
+   $schemas->cast(@JSONObject)->map(s|
+      ^meta::external::shared::format::metamodel::data::SchemaData
+      (
+        location = $s->navigateString('location').value,
+        content = $s->navigateString('content').value
+      )
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::invocation::externalFormat::protobuf::navigateString( o:JSONObject[1], p:String[1]):JSONString[1]
+{
+  $o.keyValuePairs->filter(k|$k.key.value == $p).value->toOne()->cast(@JSONString);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::invocation::externalFormat::protobuf::navigateArray( o:JSONObject[1], p:String[1]):JSONArray[1]
+{
+  $o.keyValuePairs->filter(k|$k.key.value == $p).value->toOne()->cast(@JSONArray);
+}
+
+
+function meta::protocols::pure::v1_26_0::invocation::generation::protobuf::legendGenerateProtobuf(input:ProtobufConfig[1], host:String[1], port:Integer[1], version:String[1]):meta::external::format::protobuf::deprecated::generation::ProtobufOutput[*]
+{
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/schemaGeneration/protobuf'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 '{ "clientVersion":"v1_26_0",'+
+                                 '  "config":'+$input->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::format::protobuf::transformProtobufConfig()->alloyToJSON()+','+
+                                 '  "model":'+if ($input.package->isEmpty(),
+                                                  |if (!$input.class->isEmpty(),
+                                                      |$input.class->toOne()->pathToElement()->toOne()->cast(@Type)->buildPureModelFromType(meta::pure::extension::defaultExtensions())->alloyToJSON(),
+                                                      | if ($input.scopeElements->at(0)->instanceOf(Class),
+                                                          |$input.scopeElements->at(0)->cast(@Class<Any>)->buildPureModelFromType(meta::pure::extension::defaultExtensions())->alloyToJSON(),
+                                                          |$input.scopeElements->at(0)->cast(@Package)->buildPureModelFromPackage(meta::pure::extension::defaultExtensions())->alloyToJSON()
+                                                      )
+                                                   ),
+                                                  |$input.package->toOne()->pathToElement()->toOne()->cast(@Package)->buildPureModelFromPackage(meta::pure::extension::defaultExtensions())->alloyToJSON()
+                                              )+
+                                 '}'
+                                );
+   assertEq(200, $resp.statusCode, | $resp.entity);
+   $resp.entity->parseJSON()->fromJSON(meta::external::format::protobuf::deprecated::generation::ProtobufOutput, ^ExtendedJSONDeserializationConfig(nullReplacementInArray = ^TDSNull(), typeKeyName='__TYPE', failOnUnknownProperties=true))->cast(@ProtobufOutput);
+}
+
+###Pure
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::ProtobufConfig extends meta::protocols::pure::v1_26_0::metamodel::invocation::generation::GenerationConfiguration
+{
+   options : meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::Options[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::Options
+{
+  javaPackage:String[0..1];
+  javaOuterClassname:String[0..1];
+  javaMultipleFiles:Boolean[0..1];
+  optimizeFor:meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::OptimizeMode[0..1];
+  customOptions:Map<String,Any>[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::ModelToProtobufDataConfiguration
+{
+   format : String[1];
+   targetSchemaSet : String[1];
+   javaPackage : String[0..1];
+   javaOuterClassname:String[0..1];
+   javaMultipleFiles:Boolean[0..1];
+   optimizeFor:meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::OptimizeMode[0..1];
+   customOptions:Map<String,Any>[0..1];
+}
+
+Enum meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::OptimizeMode
+{
+  SPEED,
+  CODE_SIZE,
+  LITE_RUNTIME
+}
+
+
+###Pure
+import meta::external::format::protobuf::deprecated::generation::configuration::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::format::protobuf::transformProtobufConfig(input:ProtobufConfig[1]):meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::ProtobufConfig[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::ProtobufConfig(
+        package = $input.package,
+        class = $input.class,
+        scopeElements = $input.scopeElements->map(e|$e->elementToPath()),
+        options = ^meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::Options
+                  (
+                      javaPackage = $input.javaPackage,
+                      javaOuterClassname = $input.javaOuterClassname,
+                      javaMultipleFiles = $input.javaMultipleFiles,
+                      optimizeFor = if($input.optimizeFor->isEmpty(),|[],|extractEnumValue(meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::OptimizeMode, $input.optimizeFor->toOne()->id())),
+                      customOptions = $input.customOptions
+                  )
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::external::format::protobuf::transformModelToProtobufDataConfiguration(input:meta::external::format::protobuf::transformation::fromPure::ModelToProtobufDataConfiguration[1]):meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::ModelToProtobufDataConfiguration[1]
+{
+  ^meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::ModelToProtobufDataConfiguration
+  (
+    format = $input.format,
+    targetSchemaSet = $input.targetSchemaSet,
+    javaPackage = $input.javaPackage,
+    javaOuterClassname = $input.javaOuterClassname,
+    javaMultipleFiles = $input.javaMultipleFiles,
+    optimizeFor = if($input.optimizeFor->isEmpty(),|[],|extractEnumValue(meta::protocols::pure::v1_26_0::metamodel::invocation::generation::protobuf::OptimizeMode, $input.optimizeFor->toOne()->id())),
+    customOptions = $input.customOptions
+  );
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/extension/extension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/extension/extension.pure
@@ -1,0 +1,23 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Class meta::protocols::pure::v1_26_0::extension::RelationalModuleSerializerExtension extends meta::protocols::pure::v1_26_0::extension::ModuleSerializerExtension
+{
+   transfers_connection_transformDatabaseConnection : Function<{String[1], String[1], String[1], meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorWithParameter[*] -> Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection[1]}>[*]}>[0..1];
+   transfers_connection_transformPostProcessors : Function<{Nil[1] -> meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::PostProcessor[1]}>[*];
+   transfers_connection_transformAuthenticationStrategy : Function<{Nil[1] -> meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy[1]}>[*];
+   transfers_connection_transformDatasourceSpecification : Function<{Nil[1] -> meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification[1]}>[*];
+   transfers_connection_transformPostProcessorParameters : Function<{Nil[1] -> meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorParameter[1]}>[*];
+   transfers_milestoning_transformMilestoning : Function<{Nil[1]->meta::protocols::pure::v1_26_0::metamodel::store::relational::Milestoning[1]}>[*];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/extension/extension_relational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/extension/extension_relational.pure
@@ -1,0 +1,308 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::extension::*;
+import meta::json::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::csv::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::context::*;
+import meta::pure::runtime::*;
+import meta::protocols::pure::v1_26_0::invocation::execution::execute::*;
+import meta::relational::mapping::*;
+import meta::pure::mapping::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+
+function meta::protocols::pure::v1_26_0::extension::getRelationalExtension(type:String[1]):meta::pure::extension::SerializerExtension[1]
+{
+   let res = [
+      pair('relational', | getRelationalExtension())
+   ]->filter(f|$f.first == $type);
+   assert($res->isNotEmpty(), |'Can\'t find the type '+$type);
+   $res->at(0).second->eval();
+   
+}
+
+function meta::protocols::pure::v1_26_0::extension::getRelationalExtension():meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0[1]
+{
+   ^meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0
+   (
+       transfers_mapping_transformMapping = x:SetImplementation[1] | !$x->instanceOf(EmbeddedRelationalInstanceSetImplementation),
+       transfers_mapping_transformSetImplementation2 = {mapping:Mapping[1], extensions:meta::pure::extension::Extension[*] | [
+                  r:RootRelationalInstanceSetImplementation[1]| $r->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRootRelationalInstanceSetImplementation($mapping, $extensions),
+                  a:meta::pure::mapping::aggregationAware::AggregationAwareSetImplementation[1]| $a->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformAggregationAwareSetImplementation($mapping, $extensions);
+            ]},
+       transfers_mapping_transformAssociationImplementation = {mapping:Mapping[1], extensions:meta::pure::extension::Extension[*] | a:RelationalAssociationImplementation[1] | $a->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalAssociationImplementation($mapping, $extensions)},
+
+       transfers_valueSpecification_transformAny = {
+          inScope:String[*], open:Map<String,List<Any>>[1], m:Multiplicity[1], fe:FunctionExpression[0..1],useAppliedFunction:Boolean[1], extensions:meta::pure::extension::Extension[*] |
+          [
+                r:meta::pure::runtime::Runtime[1]|
+                 ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::RuntimeInstance
+                  (
+                     _type = 'runtimeInstance',
+                     runtime = $r->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::transformRuntime($extensions)
+                   ),
+                e:meta::pure::runtime::ExecutionContext[1]|
+                 ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::ExecutionContextInstance
+                  (
+                     _type = 'executionContextInstance',
+                     executionContext = $e->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::context::transformContext($extensions)
+                  ),
+                d:meta::relational::metamodel::Database[1]|
+                 ^meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::PackageableElementPtr
+                  (
+                     _type = 'packageableElementPtr',
+                     fullPath = $d->elementToPath()
+                  )
+          ]
+       },
+       transfers_executionPlan_transformNode = {mapping:Mapping[1], extensions:meta::pure::extension::Extension[*] |
+          [
+                     rb:meta::pure::executionPlan::RelationalBlockExecutionNode[1]|
+                               ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalBlockExecutionNode( _type = 'relationalBlock',
+                                                                                                                       resultType = $rb.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions)),
+                     rel:meta::relational::mapping::SQLExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::SQLExecutionNode(
+                           _type = 'sql',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+                           resultColumns = $rel.resultColumns->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultColumn()),
+                           sqlQuery = $rel.sqlQuery,
+                           onConnectionCloseCommitQuery = $rel.onConnectionCloseCommitQuery,
+                           onConnectionCloseRollbackQuery = $rel.onConnectionCloseRollbackQuery,
+                           connection = $rel.connection->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformDatabaseConnection($extensions)
+                        ),
+                     rel:meta::relational::mapping::RelationalTdsInstantiationExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalTdsInstantiationExecutionNode(
+                           _type = 'relationalTdsInstantiation',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+                        ),
+                     rel:meta::relational::mapping::RelationalClassInstantiationExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalClassInstantiationExecutionNode(
+                           _type = 'relationalClassInstantiation',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+                        ),
+                     rel:meta::relational::mapping::RelationalRelationDataInstantiationExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalRelationDataInstantiationExecutionNode(
+                           _type = 'relationalRelationDataInstantiation',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+                        ),
+                     rel:meta::relational::mapping::RelationalDataTypeInstantiationExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalDataTypeInstantiationExecutionNode(
+                           _type = 'relationalDataTypeInstantiation',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity())
+                        ),
+                     cpt:meta::relational::mapping::CreateAndPopulateTempTableExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::CreateAndPopulateTempTableExecutionNode
+                        (
+                           _type = 'createAndPopulateTempTable',
+                           inputVarNames = $cpt.inputVarNames,
+                           tempTableName = $cpt.tempTableName,
+                           resultType = $cpt.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $cpt.resultSizeRange->isEmpty()->if(|[],|$cpt.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+                           tempTableColumnMetaData = $cpt.tempTableColumnMetaData->map(col | $col->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformTempTableColumnMetaData()),
+                           connection = $cpt.connection->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformDatabaseConnection($extensions)
+                        ),
+                     rel:meta::relational::graphFetch::executionPlan::RelationalRootQueryTempTableGraphFetchExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalRootQueryTempTableGraphFetchExecutionNode(
+                           _type = 'relationalRootQueryTempTableGraphFetch',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+                           batchSize = $rel.batchSize,
+                           tempTableName = $rel.tempTableName,
+                           columns = $rel.columns->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultColumn()),
+                           children = $rel.children->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformNode($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalGraphFetchExecutionNode),
+                           nodeIndex = $rel.nodeIndex,
+                           parentIndex = $rel.parentIndex,
+                           graphFetchTree = $rel.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions),
+                           checked = $rel.checked
+                        ),
+                     rel:meta::relational::graphFetch::executionPlan::RelationalCrossRootQueryTempTableGraphFetchExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalCrossRootQueryTempTableGraphFetchExecutionNode(
+                           _type = 'relationalCrossRootQueryTempTableGraphFetch',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+                           tempTableName = $rel.tempTableName,
+                           columns = $rel.columns->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultColumn()),
+                           children = $rel.children->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformNode($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalGraphFetchExecutionNode),
+                           nodeIndex = $rel.nodeIndex,
+                           parentIndex = $rel.parentIndex,
+                           parentTempTableName = $rel.parentTempTableName,
+                           parentTempTableColumns = $rel.parentTempTableColumns->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultColumn()),
+                           graphFetchTree = $rel.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions)
+                        ),
+                     rel:meta::relational::graphFetch::executionPlan::RelationalClassQueryTempTableGraphFetchExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalClassQueryTempTableGraphFetchExecutionNode(
+                           _type = 'relationalClassQueryTempTableGraphFetch',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+                           tempTableName = $rel.tempTableName,
+                           columns = $rel.columns->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultColumn()),
+                           children = $rel.children->map(c | $c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformNode($mapping, $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalGraphFetchExecutionNode),
+                           nodeIndex = $rel.nodeIndex,
+                           parentIndex = $rel.parentIndex,
+                           graphFetchTree = $rel.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions)
+                        ),
+                     rel:meta::relational::graphFetch::executionPlan::RelationalPrimitiveQueryGraphFetchExecutionNode[1]|
+                        ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalPrimitiveQueryGraphFetchExecutionNode(
+                           _type = 'relationalPrimitiveQueryGraphFetch',
+                           resultType = $rel.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                           resultSizeRange = $rel.resultSizeRange->isEmpty()->if(|[],|$rel.resultSizeRange->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+                           nodeIndex = $rel.nodeIndex,
+                           parentIndex = $rel.parentIndex,
+                           graphFetchTree = $rel.graphFetchTree->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], newMap([]->cast(@Pair<String,List<Any>>)), $extensions)
+                        )
+          ]
+       },
+       transfers_executionPlan_transformResultType =  {mapping:Mapping[1], extensions:meta::pure::extension::Extension[*] |
+         [
+            tds:meta::pure::executionPlan::TDSResultType[1]|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::TDSResultType
+                                                            (
+                                                               _type='tds',
+                                                               tdsColumns=$tds.tdsColumns->map(c|^meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::TDSColumn
+                                                                                                 (
+                                                                                                    name = $c.name,
+                                                                                                    doc = $c.documentation,
+                                                                                                    type = $c.type->toOne()->elementToPath(),
+                                                                                                    enumMapping = if($c.enumMappingId->isEmpty(),|[],|meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformEnumMapping($mapping.enumerationMappingByName($c.enumMappingId->toOne())->toOne())),
+                                                                                                    relationalType = $c.sourceDataType->match(
+                                                                                                       [
+                                                                                                          d:meta::relational::metamodel::datatype::DataType[0]|[],
+                                                                                                          d:meta::relational::metamodel::datatype::DataType[1]|$d->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::alloyTypeToString()
+                                                                                                       ]
+                                                                                                    )
+                                                                                                 )
+                                                                                           )
+                                                            ),
+         rel:meta::pure::executionPlan::RelationResultType[1]|^meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationResultType
+                                                             (
+                                                                _type='relation',
+                                                                relationName = $rel.relationName,
+                                                                relationType = $rel.relationType->toString(),
+                                                                schemaName = $rel.schemaName,
+                                                                database = $rel.database,
+                                                                columns = $rel.columns->map(c|$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformColumn())
+                                                             )
+         ]
+     },
+     transfers_executionPlan_transformSetImplementation = pair(p:meta::pure::mapping::PropertyMapping[1]|$p->instanceOf(meta::relational::mapping::RelationalPropertyMapping) && !$p->cast(@meta::relational::mapping::RelationalPropertyMapping).transformer->isEmpty(), p:meta::pure::mapping::PropertyMapping[1]|$p->cast(@meta::relational::mapping::RelationalPropertyMapping).transformer->cast(@meta::pure::mapping::EnumerationMapping<Any>)->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformEnumMapping()),
+      scan_buildBasePureModel_extractStores = {m:Mapping[1], extensions:meta::pure::extension::Extension[*] |
+                                                [
+                                                   rsi: RootRelationalInstanceSetImplementation[1] |
+                                                                     // Main Store
+                                                                     let mainTableAlias = $rsi.mainTableAlias;
+                                                                     let mainStore = if ($mainTableAlias.database->isEmpty(), | $rsi.mainTable.schema.database, | $mainTableAlias.database->toOne());
+                                                                     // Filter
+                                                                     let filter = $rsi.resolveFilter();
+                                                                     let fromFilter = $filter.database;
+                                                                     let fromFilterOpertation = $filter.filter.operation->meta::relational::functions::pureToSqlQuery::extractStore();
+                                                                     let fromFilterJoins = $filter.joinTreeNode->map(x|$x->meta::relational::functions::pureToSqlQuery::flatten()).database;
+                                                                     // Properties
+                                                                     let fromProperties = $rsi->processProperties($m, $extensions);
+                                                                     // All
+                                                                     $mainStore->concatenate($fromFilter)->concatenate($fromFilterOpertation)->concatenate($fromFilterJoins)->concatenate($fromProperties);,
+                                                   x: EmbeddedRelationalInstanceSetImplementation[1]|$x->processProperties($m, $extensions),
+                                                   ag:	meta::pure::mapping::aggregationAware::AggregationAwareSetImplementation[1]| $ag.mainSetImplementation->extractStores($m, $extensions)->concatenate($ag.aggregateSetImplementations->map(a|$a.setImplementation->extractStores($m, $extensions)))
+                                                ]
+                                              },
+      scan_buildBasePureModel_processProperties ={m:Mapping[1], extensions:meta::pure::extension::Extension[*] |
+                                                  [
+                                                     r:RelationalPropertyMapping[1]|$r.relationalOperationElement->map(o|$o->meta::relational::functions::pureToSqlQuery::extractStore()),
+                                                     e:EmbeddedRelationalInstanceSetImplementation[1]|extractStores($e, $m, $extensions)
+                                                  ]
+                                                 },
+      scan_buildBasePureModel_buildPureModelFromMapping1 = {d:meta::relational::metamodel::Database[1]|$d.joins->map(j|$j.operation->meta::relational::functions::pureToSqlQuery::extractStore())},
+      invocation_execution_execute2_pre2 = {extensions:meta::pure::extension::Extension[*] | [
+               pair ( builderType:String[1]| $builderType->isNotEmpty() && $builderType->toOne()=='tdsBuilder',
+                      {resultJSON:String[1], result:JSONObject[1], m:Mapping[1], r:Runtime[1],extendedJSONDeserializationConfig:ExtendedJSONDeserializationConfig[1], context:ExecutionContext[0..1]|
+                            let rv = $resultJSON->fromJSON(meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalTDSResult, $extendedJSONDeserializationConfig);
+                            $rv->cast(@meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalTDSResult)->toOne()->processTDSResult($extensions);}
+                    ),
+      
+               pair (builderType:String[1]| $builderType->isNotEmpty() && $builderType->toOne()=='classBuilder',
+                     {resultJSON:String[1], result:JSONObject[1], m:Mapping[1], pureRuntime:Runtime[1],extendedJSONDeserializationConfig:ExtendedJSONDeserializationConfig[1], context:ExecutionContext[0..1]|
+                            let r = $resultJSON->fromJSON(meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalClassResult, $extendedJSONDeserializationConfig);
+                            processRelationalClassResult($r, $m, $pureRuntime, $context, $extensions);}
+                    )
+      ]},
+      invocation_execution_execute2_post2 = {extensions:meta::pure::extension::Extension[*] | [
+               pair(builderType:String[1]|true,
+                    {resultJSON:String[1], result:JSONObject[1], m:Mapping[1], runtime:Runtime[1],extendedJSONDeserializationConfig:ExtendedJSONDeserializationConfig[1], context:ExecutionContext[0..1]|
+                            let r = $resultJSON->fromJSON(meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalDataTypeResult, $extendedJSONDeserializationConfig); // Assume dataTypeBuilder is resultType
+                            processDataTypeResult($r, $extensions);}
+                    )
+      ]}
+
+   ,
+   invocation_execution_transformContext = 
+      [
+         r:meta::relational::runtime::RelationalExecutionContext[1]|
+            let importDataFlowFkCols = if($r.importDataFlowFksByTable->isEmpty(), |[],
+               |$r.importDataFlowFksByTable->toOne()->keyValues()->map(p| ^meta::protocols::pure::v1_26_0::metamodel::TableForeignColumns(
+                  table=$p.first->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::setRelationToTablePtr(),
+                  columns=$p.second.values->map(c| $c.name)))
+            );
+            ^meta::protocols::pure::v1_26_0::metamodel::RelationalExecutionContext
+             (
+                queryTimeOutInSeconds = $r.queryTimeOutInSeconds,
+                enableConstraints = $r.enableConstraints,
+                addDriverTablePkForProject = $r.addDriverTablePkForProject,
+                insertDriverTablePkInTempTable = $r.insertDriverTablePkInTempTable,
+                useTempTableAsDriver = $r.useTempTableAsDriver,
+                preserveJoinOrder = $r.preserveJoinOrder,
+                importDataFlow = $r.importDataFlow,
+                importDataFlowAddFks = $r.importDataFlowAddFks,
+                importDataFlowFkCols = $importDataFlowFkCols,
+                importDataFlowImplementationCount = $r.importDataFlowImplementationCount,
+                _type = 'RelationalExecutionContext'
+             );
+
+      ],
+      transfers_store_transformStore2 = {extensions:meta::pure::extension::Extension[*] |
+      [
+         d:meta::relational::metamodel::Database[1] | $d->transformDatabase($extensions)
+      ]},
+      transfers_store_transformConnection2 = {extensions:meta::pure::extension::Extension[*] |
+      [
+         db:meta::relational::runtime::DatabaseConnection[1] | $db->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformDatabaseConnection($extensions)
+      ]},
+      scan_buildPureModelAsText_getAllElementsFromMapping = {stores : meta::pure::store::Store[*] |
+                        $stores->map(s|$s->concatenate($s->match([d:meta::relational::metamodel::Database[1]|$d.joins->map(j|$j.operation->meta::relational::functions::pureToSqlQuery::extractStore()),a:Any[1]|[]])))      
+      }
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultColumn(c: meta::relational::mapping::SQLResultColumn[1]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::SQLResultColumn[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::SQLResultColumn
+   (
+      label = $c.label,
+      dataType = $c.dataType->isEmpty()->if(|'', |$c.dataType->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::alloyTypeToString())
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformTempTableColumnMetaData(c: meta::relational::mapping::TempTableColumnMetaData[1]):meta::protocols::pure::v1_26_0::metamodel::executionPlan::TempTableColumnMetaData[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::TempTableColumnMetaData
+   (
+      column = $c.column->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultColumn(),
+      identifierForGetter = $c.identifierForGetter,
+      parametersForGetter = $c.parametersForGetter
+   )
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relation_executeInRelationalDb.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relation_executeInRelationalDb.pure
@@ -1,0 +1,44 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::alloy::connections::*;
+import meta::alloy::metadataServer::*;
+import meta::pure::functions::io::http::*;
+import meta::protocols::pure::v1_26_0::invocation::execution::executeInRelationalDb::*;
+
+function meta::protocols::pure::v1_26_0::invocation::execution::executeInRelationalDb::executeInRelationalDb(sqls:String[*], conn:RelationalDatabaseConnection[1], host:String[1], port:Integer[1], extensions:meta::pure::extension::Extension[*]):Boolean[1]
+{
+  let conn1= $conn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformDatabaseConnection($extensions)
+                  ->cast(@meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::RelationalDatabaseConnection);
+  
+  let input= ^ExecuteInRelationalDbInput(sqls=$sqls, connection = $conn1)->alloyToJSON();
+  
+  let resp= executeHTTPRaw(^URL(host=$host, port=$port , path='/api/pure/v1/utilities/tests/executeInRelationalDb'),
+                             HTTPMethod.POST ,
+                             'application/json',
+                             $input
+                            );
+
+   if($resp.statusCode != 200,
+       | println($resp.statusCode->toString()+' \''+$resp.entity->replace('\\n', '\n')->replace('\\t', '')+'\''); false; ,
+       | println($resp.entity->toOne()->toString());true;
+      );
+}
+
+
+Class meta::protocols::pure::v1_26_0::invocation::execution::executeInRelationalDb::ExecuteInRelationalDbInput
+{
+  connection : meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::RelationalDatabaseConnection[1];
+  sqls : String[*];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relational_execute.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relational_execute.pure
@@ -1,0 +1,339 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::mapping::aggregationAware::*;
+import meta::json::*;
+import meta::pure::extension::*;
+import meta::relational::extension::*;
+import meta::protocols::*;
+import meta::pure::mapping::modelToModel::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::context::*;
+import meta::pure::router::routing::*;
+import meta::protocols::pure::v1_26_0::invocation::execution::execute::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::*;
+import meta::pure::functions::io::http::*;
+import meta::pure::runtime::*;
+import meta::pure::mapping::*;
+import meta::pure::milestoning::*;
+import meta::alloy::metadataServer::*;
+import meta::relational::milestoning::*;
+import meta::relational::mapping::*;
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::processTDSResult(r:meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalTDSResult[1], extensions:meta::pure::extension::Extension[*]) : Pair<List<Any>,List<Activity>>[1]
+{
+   let res = ^TabularDataSet
+             (
+                columns = $r.builder->cast(@meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::TDSBuilder).columns
+                            ->map({c |
+                                    ^TDSColumn
+                                    (
+                                       name = $c.name,
+                                       documentation = $c.doc,
+                                       type = $c.type->toOne()->stringToDataType(),
+                                       offset = $r.result.columns->indexOf($c.name)
+                                    )})
+             );
+
+   let trans = $r.builder->cast(@meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::TDSBuilder).columns.type->map(c|meta::protocols::pure::v1_26_0::invocation::execution::execute::dataTypeTransformer($c));
+
+   let ra = range($r.result.columns->size());
+
+   let newRows = $r.result.rows
+                  ->map({r |
+                            let vals = $r.values;
+                            ^TDSRow
+                            (
+                               parent = $res,
+                               values = $ra->map(i | let v = $vals->at($i);
+                                                    if($v->instanceOf(TDSNull),
+                                                       | $v,
+                                                       | $trans->at($i)->eval($v);
+                                                    );
+                                               )
+                            );
+                        });
+   $res->mutateAdd('rows', $newRows);
+   ^Pair<List<Any>, List<Activity>>(first=^List<Any>(values=$res), second=^List<Activity>(values=$r.activities->transformActivities($extensions)));
+}
+
+
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::processDataTypeResult(r:meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalDataTypeResult[1], extensions:meta::pure::extension::Extension[*]) : Pair<List<Any>,List<Activity>>[1]
+{
+   let type = $r.builder->cast(@meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::DataTypeBuilder).type;
+   let trans = meta::protocols::pure::v1_26_0::invocation::execution::execute::dataTypeTransformer($type);
+   ^Pair<List<Any>, List<Activity>>(first=^List<Any>(values=$r.result.rows.values->map(v|$trans->eval($v))), second=^List<Activity>(values=$r.activities->transformActivities($extensions)));
+
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::processRelationalClassResult(r:meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalClassResult[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], extensions:meta::pure::extension::Extension[*]) : Pair<List<Any>,List<Activity>>[1]
+{
+   let builder = $r.builder->cast(@ meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ClassBuilder);
+
+   let retClass = $builder.class->pathToElement()->cast(@Class<Any>);
+
+   let setImplementations = $r.builder->cast(@meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ClassBuilder).classMappings.setImplementationId->map(
+                                             s:String[1]|$m.classMappingById($s)
+                                          )->cast(@RootRelationalInstanceSetImplementation);
+
+   let setImplMap = $setImplementations->map(set | pair($set.id, pair($set, meta::pure::milestoning::getTemporalMilestoningStrategy($set.class)->isNotEmpty() && meta::pure::milestoning::getTemporalMilestoningStrategy($set.class)->toOne()->meta::pure::milestoning::expandToSingleTemporalStrategies()->forAll(s| $s->meta::relational::milestoning::relationalElementCanSupportStrategy($set.mainTable())))))->newMap();
+
+   let exeCtx = if($context->isEmpty(), | ^ExecutionContext(), | $context->toOne());
+   let precas =  $setImplementations->map(set | pair($set.id, precaForRelationalSetImpl($set, $m, $pureRuntime, $exeCtx, $extensions)))->newMap();
+   let objects = $r.objects->map({obj |
+   let reference = $obj->get('alloyStoreObjectReference$')->toOne()->cast(@String)->decodeAndParseAlloyObjectReference()->cast(@meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyRelationalStoreObjectReference);
+   let setId = $reference.setId;
+   let preca = $precas->get($setId)->toOne();
+
+   let pkMap = $reference.pkMap;
+   let pks = $preca.pks->size()->range()->map({pkId |
+      let key = $preca.pks->at($pkId);
+      let jsonKey = 'pk$_' + $pkId->toString() + if($reference.operationResolvedSetsId->size() == 1, | '', | '_' + $reference.operationResolvedSetsId->indexOf($setId)->toString());
+      if($key.type->isNotEmpty() && ($key.type->toOne()->instanceOf(meta::relational::metamodel::datatype::Timestamp) || $key.type->toOne()->instanceOf(meta::relational::metamodel::datatype::Date)),
+         | parseDate($pkMap->get($jsonKey)->toOne()->cast(@String)),
+         | $pkMap->get($jsonKey)->toOne()
+      );
+   });
+   let keyInformation = ^KeyInformation (
+                           static = $preca.staticMappingInstanceData,
+                           pk = $pks,
+                           sourceConnection = $preca.sourceConnection,
+                           buildMethod = BuildMethod.TypeQuery
+                        );
+
+   $preca.type->dynamicNew(
+                   $preca.propMap->map({precav|
+                      let v = $obj->get($precav.property.name->toOne());
+                      ^KeyValue(
+                         key = $precav.property.name->toOne(),
+                         value = if($v->isEmpty() || $v == 'NULL' || $v->toOne()->instanceOf(TDSNull),
+                                    | [],
+                                    | if($precav.property->functionReturnType().rawType == Date,
+                                         | parseDate($v->toOne()->toString()),
+                                         | $precav.transform->eval($v->toOne())
+                                      )
+                                 )->match([
+                                    l : List<Any>[*] | $l.values,
+                                    a : Any[*] | $a
+                                    ])
+                      );
+                      })->concatenate($preca.addMilestoningProperties->if(|$preca.type.rawType->toOne()->cast(@Class<Any>).properties->filter(p| $p->genericType().typeArguments->at(1).rawType->toOne()->instanceOf(meta::pure::metamodel::type::DataType) && $p->meta::pure::milestoning::hasGeneratedMilestoningPropertyStereotype())->map({prop |
+                            let v = $obj->get($prop.name->toOne());
+                            ^KeyValue(
+                               key = $prop.name->toOne(),
+                               value = if($v->isEmpty() || $v == 'NULL' || $v->toOne()->instanceOf(TDSNull),
+                                          | [],
+                                          | if($prop->functionReturnType().rawType == Date,
+                                               | parseDate($v->toOne()->toString()),
+                                               | $v->toOne()
+                                            )
+                                       )
+                            );
+                         }), |[])),
+                         meta::pure::mapping::xStore::crossGetterOverrideToOne_Any_1__Property_1__Any_$0_1$_,
+                         meta::pure::mapping::xStore::crossGetterOverrideToMany_Any_1__Property_1__Any_MANY_,
+                         $keyInformation,
+                         $exeCtx->getConstraintsManager()
+                     );
+                   });
+   ^Pair<List<Any>, List<Activity>>(first=^List<Any>(values=$objects), second=^List<Activity>(values=$r.activities->transformActivities($extensions)));
+}
+
+
+
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::generateAlloyObjectReference(mapping:Mapping[1], rootSetId:String[1], setId:String[1], runtime:Runtime[1], pkMap:Map<String, Any>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReference[1]
+{
+   let sets                 = $mapping.classMappingById($rootSetId)->resolveOperation($mapping);
+   assert($sets->size() >= 1, | 'No Set Implementation found for setId : ' + $rootSetId + ', in mapping : ' + $mapping->elementToPath());
+
+   let set                  = $sets->filter(s | $s.id == $setId)->toOne();
+
+   $set->match([
+      r: RelationalInstanceSetImplementation[1] | meta::protocols::pure::v1_26_0::invocation::execution::execute::generateAlloyRelationalStoreObjectReference($mapping, $r, $sets, $runtime, $pkMap, $extensions);,
+      s: SetImplementation[1]                   | fail('Not Supported Yet!!'); ^meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReference(type = meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReferenceType.Relational, pathToMapping='', setId='');
+   ]);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::generateAlloyRelationalStoreObjectReference(mapping:Mapping[1], set:RelationalInstanceSetImplementation[1], sets:SetImplementation[*], runtime:Runtime[1], pkMap:Map<String, Any>[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyRelationalStoreObjectReference[1]
+{
+   let store                = $set.stores->toOne();
+   let databaseConnection   = $runtime->connectionByElement($store->toOne())->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::transformConnection($extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection);
+
+   let setIdx               = if($sets->size() == 1, | '', | '_' + $sets->indexOf($set)->toString());
+   let transformedPkMap     = meta::relational::mapping::resolvePrimaryKeysNames($set->cast(@RelationalInstanceSetImplementation), $pkMap, $setIdx, true, $extensions);
+
+   ^meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyRelationalStoreObjectReference(
+      type = meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReferenceType.Relational,
+      pathToMapping = $mapping->elementToPath(),
+      setId = $set.id,
+      operationResolvedSetsId = $sets.id,
+      databaseConnection = $databaseConnection,
+      pkMap = $transformedPkMap);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::decodeAndParseAlloyObjectReference(ref : String[1]):meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReference[1]
+{
+   let parsedObjectRef = meta::alloy::objectReference::decodeAndParseAlloyObjectReference($ref);
+   let type            = $parsedObjectRef->get('type')->cast(@String)->toOne();
+   
+   if($type->toLower() == 'relational',
+      | meta::protocols::pure::v1_26_0::invocation::execution::execute::getAlloyRelationalStoreObjectReference($parsedObjectRef),
+      | fail('Not Supported Yet!!'); 
+        ^meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReference
+         (
+            type = meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReferenceType.Relational,
+            pathToMapping = '',
+            setId = ''
+         ););
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::getAlloyRelationalStoreObjectReference(parsedObjectRef : Map<String, Any>[1]):meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyRelationalStoreObjectReference[1]
+{
+   let databaseConnection = $parsedObjectRef->get('databaseConnection')->cast(@String)->toOne()
+                                            ->meta::json::parseJSON()->cast(@JSONObject)
+                                            ->map(o | ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection(_type = $o->getValue('_type')->cast(@JSONString).value->toOne(),
+                                                                                                                                                   element = $o->getValue('element')->cast(@JSONString).value->toOne(),
+                                                                                                                                                   type = $o->getValue('type')->cast(@JSONString).value->toOne()));
+   ^meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyRelationalStoreObjectReference
+   (
+      type = meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReferenceType.Relational,
+      pathToMapping = $parsedObjectRef->get('pathToMapping')->cast(@String)->toOne(),
+      operationResolvedSetsId = $parsedObjectRef->get('operationResolvedSetsId')->cast(@List<String>).values,
+      setId = $parsedObjectRef->get('setId')->cast(@String)->toOne(),
+      databaseConnection = $databaseConnection,
+      pkMap = $parsedObjectRef->get('pkMap')->cast(@Map<String, Any>)->toOne()
+   );
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::getAlloyObjectReferenceAsMap(ref : String[1]):Map<String, Any>[1]
+{
+   let objReference = meta::protocols::pure::v1_26_0::invocation::execution::execute::decodeAndParseAlloyObjectReference($ref);
+
+   $objReference->match([
+      r:meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyRelationalStoreObjectReference[1] |
+                                                                                                            [
+                                                                                                               pair('type', $r.type->toString()),
+                                                                                                               pair('pathToMapping', $r.pathToMapping),
+                                                                                                               pair('operationResolvedSetsId', $r.operationResolvedSetsId->list()),
+                                                                                                               pair('setId', $r.setId),
+                                                                                                               pair('databaseConnection', $r.databaseConnection),
+                                                                                                               pair('pkMap', $r.pkMap)
+                                                                                                            ]->newMap();,
+      o:meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReference[1] | fail('Not Supported Yet!!'); ^Map<String, Any>();
+   ]);
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::execute::transformActivities(activities:meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ExecutionActivity[*], extensions:meta::pure::extension::Extension[*]):meta::pure::mapping::Activity[*]
+{
+   $activities->map(activity|$activity->match([
+      a:meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::AggregationAwareActivity[1]    | ^AggregationAwareActivity(rewrittenQuery = $a.rewrittenQuery),
+      r:meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalExecutionActivity[1] | ^RelationalActivity(sql=$r.sql)
+   ]->concatenate($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).transfers_execute_transformActivity)->toOneMany()))
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::invocation::execution::execute::precaForRelationalSetImpl(setImplementation:RootRelationalInstanceSetImplementation[1], mapping: Mapping[1], runtime: Runtime[1], exeCtx: ExecutionContext[1], extensions:meta::pure::extension::Extension[*]):RelationalSetImplPrecalc[1]
+{
+   let propertyMappings = $setImplementation.allPropertyMappings()
+                                    ->filter(pm|$pm.localMappingProperty==false &&
+                                                $pm.property->genericType().typeArguments->at(1).rawType->toOne()->instanceOf(meta::pure::metamodel::type::DataType)
+                                    );
+
+   let ps = $propertyMappings->map(p|^meta::protocols::pure::v1_26_0::invocation::execution::execute::PropMapPrecalc(
+                                                                                                    property = $p.property,
+                                                                                                    transform = if ($p->cast(@RelationalPropertyMapping).transformer->isEmpty(),
+                                                                                                                    |let type = $p.property->functionReturnType().rawType->toOne();
+                                                                                                                         if ($type == DateTime,
+                                                                                                                            |{z:Any[1]|$z->cast(@String)->parseDate()},
+                                                                                                                            |if ($type == StrictDate,
+                                                                                                                               |{z:Any[1]|$z->cast(@String)->parseDate()->datePart()->cast(@StrictDate)},
+                                                                                                                               |{z:Any[1]|$z}
+                                                                                                                             )
+                                                                                                                        );,
+                                                                                                                    |{z:Any[1]|extractEnumValue(
+                                                                                                                                   $p.property->functionReturnType().rawType->toOne()->cast(@Enumeration<Any>),
+                                                                                                                                   $z->toString()
+                                                                                                                               )}
+                                                                                                                )
+                                                                                            )
+                       );
+   ^RelationalSetImplPrecalc
+   (
+      type = ^GenericType(rawType = $setImplementation.class),
+      staticMappingInstanceData = ^meta::pure::mapping::StaticMappingInstanceData
+                                   (
+                                      runtime = $runtime,
+                                      mapping = $mapping,
+                                      systemMapping = meta::relational::contract::relationalStoreContract(),
+                                      setImplementation = $setImplementation,
+                                      exeCtx = $exeCtx,
+                                      debug = noDebug(),
+                                      extensions = $extensions
+                                   ),
+      pks = if($setImplementation->meta::relational::functions::pureToSqlQuery::getGroupBy()->isEmpty() && ($setImplementation->meta::relational::functions::pureToSqlQuery::getDistinct()->isEmpty() || $setImplementation->meta::relational::functions::pureToSqlQuery::getDistinct()->toOne() == false),
+               | $setImplementation.resolvePrimaryKey()->map(pk | ^RelationalSetPrimaryKey(element = $pk, type = $pk->meta::relational::functions::typeInference::inferRelationalType())),
+               | []),
+      sourceConnection = $runtime->connectionByElement($setImplementation->meta::pure::router::clustering::getResolvedStore($mapping)->toOne())->toOne(),
+      propMap = $ps,
+      addMilestoningProperties = meta::pure::milestoning::getTemporalMilestoningStrategy($setImplementation.class)->isNotEmpty() && meta::pure::milestoning::getTemporalMilestoningStrategy($setImplementation.class)->toOne()->meta::pure::milestoning::expandToSingleTemporalStrategies()->forAll(s| $s->meta::relational::milestoning::relationalElementCanSupportStrategy($setImplementation.mainTable()))
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::invocation::execution::execute::dataTypeTransformer(c:String[1]):Function<{Any[1]->Any[1]}>[1]
+{
+   if($c == 'Float' || $c == 'Number',
+      |{a:Any[1]|$a->cast(@Number)*1.0},
+      |if ($c == 'Decimal',
+           |{a:Any[1]|let e = $a->cast(@Number)*1.0; $e->toDecimal();},
+           |if ($c == 'StrictDate',
+              |{a:Any[1]|$a->cast(@String)->parseDate()->datePart()->cast(@StrictDate)},
+              |if ($c == 'Date' || $c == 'DateTime',
+                   |{a:Any[1]|$a->cast(@String)->parseDate()},
+                   |if ($c == 'Boolean',
+                        |{a:Any[1]|if($a=='false'||$a==false,|false,|true);},
+                        |if ($c->contains('::'),
+                             |let t = $c->pathToElement()->cast(@Enumeration<Any>);
+                              {a:Any[1]|$t->extractEnumValue($a->toString())};,
+                             |{a:Any[1]|$a}
+                         )
+                    )
+               )
+           )
+       )
+   );
+}
+
+Class <<access.private>> meta::protocols::pure::v1_26_0::invocation::execution::execute::RelationalSetImplPrecalc
+{
+   type : GenericType[1];
+   staticMappingInstanceData: meta::pure::mapping::StaticMappingInstanceData[1];
+   propMap : PropMapPrecalc[*];
+   sourceConnection : Connection[1];
+   pks: meta::protocols::pure::v1_26_0::invocation::execution::execute::RelationalSetPrimaryKey[*];
+   addMilestoningProperties : Boolean[1];
+}
+
+Class meta::protocols::pure::v1_26_0::invocation::execution::execute::RelationalSetPrimaryKey
+{
+   element : meta::relational::metamodel::RelationalOperationElement[1];
+   type : meta::relational::metamodel::datatype::DataType[0..1];
+}
+
+Class <<access.private>> meta::protocols::pure::v1_26_0::invocation::execution::execute::PropMapPrecalc
+{
+   property : Property<Nil,Any|*>[1];
+   transform : Function<{Any[1]->Any[1]}>[1];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relational_testConnection.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relational_testConnection.pure
@@ -1,0 +1,258 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::alloy::connections::*;
+import meta::relational::runtime::*;
+import meta::protocols::pure::v1_26_0::invocation::execution::testConnection::*;
+import meta::json::*;
+import meta::pure::functions::io::http::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::domain::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::*;
+import meta::protocols::pure::v1_26_0::metamodel::runtime::*;
+import meta::relational::metamodel::*;
+import meta::pure::functions::meta::*;
+import meta::protocols::pure::v1_26_0::transformation::toPureGraph::store::relational::*;
+import meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::element::*;
+import meta::protocols::pure::v1_26_0::transformation::toPureGraph::model::*;
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testConnection::getTestConnection(dbType:DatabaseType[1], host:String[1], port:Integer[1], extensions:meta::pure::extension::Extension[*]):meta::pure::alloy::connections::RelationalDatabaseConnection[0..1]
+{
+   let resp= executeHTTPRaw(^URL(host=$host, port=$port , path='/api/pure/v1/utilities/tests/connections/'+ $dbType->toString()),
+                             HTTPMethod.GET ,
+                             'application/json',
+                             []
+                            );
+
+   if($resp.statusCode != 200,
+       | println($resp.statusCode->toString()+' \''+$resp.entity->replace('\\n', '\n')->replace('\\t', '')+'\''),
+       |   
+          let res = $resp.entity->toOne()->toString();
+          $res -> meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::buildRelationalDatabaseConnection($extensions);
+      );
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::buildRelationalDatabaseConnection(connectionJSON:String[1], extensions:meta::pure::extension::Extension[*]):meta::pure::alloy::connections::RelationalDatabaseConnection[0..1]
+{
+  let protocolConn = meta::json::fromJSON($connectionJSON, 
+                  meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::RelationalDatabaseConnection ,
+                 ^JSONDeserializationConfig( 
+                                            typeKeyName='_type',
+                                            failOnUnknownProperties=false ,
+                                            retainTypeField=true,
+                                            typeLookup = [
+                                                            pair('delegatedKerberos', 'DelegatedKerberosAuthenticationStrategy'),
+                                                            pair('middleTierUserNamePassword', 'MiddleTierUserNamePasswordAuthenticationStrategy'),
+                                                            pair('userNamePassword', 'UserNamePasswordAuthenticationStrategy'),
+                                                            pair('h2Default', 'DefaultH2AuthenticationStrategy'),
+                                                            pair('test', 'TestDatabaseAuthenticationStrategy'),
+                                                            pair('snowflakePublic', 'SnowflakePublicAuthenticationStrategy'),
+                                                            pair('gcpApplicationDefaultCredentials', 'GCPApplicationDefaultCredentialsAuthenticationStrategy'),
+                                                            pair('apiToken', 'ApiTokenAuthenticationStrategy'),
+                                                            pair('gcpWorkloadIdentityFederationWithAWS','GCPWorkloadIdentityFederationWithAWSAuthenticationStrategy'),
+
+                                                            pair('static', 'StaticDatasourceSpecification'),
+                                                            pair('h2Embedded', 'EmbeddedH2DatasourceSpecification'),
+                                                            pair('h2Local', 'LocalH2DatasourceSpecification('),
+                                                            pair('snowflake', 'SnowflakeDatasourceSpecification'),
+                                                            pair('bigQuery', 'BigQueryDatasourceSpecification'),
+                                                            pair('databricks', 'DatabricksDatasourceSpecification'),
+                                                            pair('redshift', 'RedshiftDatasourceSpecification')
+                                                          ]
+                                            )
+                );
+  let pureConn = $protocolConn->meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformRelationalDatabaseConnection($extensions);
+  $pureConn->cast(@meta::pure::alloy::connections::RelationalDatabaseConnection); 
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformRelationalDatabaseConnection(conn : meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::RelationalDatabaseConnection[1] , extensions:meta::pure::extension::Extension[*]):meta::pure::alloy::connections::RelationalDatabaseConnection[1]
+{
+  let element = if($conn.element=='',                       // legend test server sends '' as element for testConnections , as store is not known before hand
+                  | ^Database(name='dummyDB'),
+                  | $conn.element->pathToElement()
+                  );
+
+  let type =  extractEnumValue(meta::relational::runtime::DatabaseType, $conn.type);
+  
+  ^meta::pure::alloy::connections::RelationalDatabaseConnection(
+              timeZone = $conn.timeZone,
+              quoteIdentifiers = $conn.quoteIdentifiers,
+              element = $element,
+              type = $type,
+              datasourceSpecification = $conn.datasourceSpecification->meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformDatasourceSpecification($extensions),
+              authenticationStrategy = $conn.authenticationStrategy->meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformAuthenticationStrategy($extensions),
+              postProcessors = $conn.postProcessors->meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformPostProcessors($extensions)
+            );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformAuthenticationStrategy(a: meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy[1], extensions:meta::pure::extension::Extension[*]):meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy[1]
+{  
+  // TODO - deserializer extensions ?
+
+  $a->match([
+      d:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::DelegatedKerberosAuthenticationStrategy[1] |
+          ^meta::pure::alloy::connections::alloy::authentication::DelegatedKerberosAuthenticationStrategy(
+              // _type = 'delegatedKerberos',
+              serverPrincipal = $d.serverPrincipal
+          ),
+      mup:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::MiddleTierUserNamePasswordAuthenticationStrategy[1] |
+          ^meta::pure::alloy::connections::alloy::authentication::MiddleTierUserNamePasswordAuthenticationStrategy(
+              // _type = 'middleTierUsernamePassword',
+              vaultReference = $mup.vaultReference
+          ),
+      u:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::UserNamePasswordAuthenticationStrategy[1] |
+          ^meta::pure::alloy::connections::alloy::authentication::UserNamePasswordAuthenticationStrategy(
+              // _type = 'userNamePassword',
+              baseVaultReference = $u.baseVaultReference,
+              userNameVaultReference = $u.userNameVaultReference,
+              passwordVaultReference = $u.passwordVaultReference
+            ),
+      d:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::DefaultH2AuthenticationStrategy[1] |
+         ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy(
+            // _type = 'h2Default'
+         ),
+      t:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::TestDatabaseAuthenticationStrategy[1] |
+         ^meta::pure::alloy::connections::alloy::authentication::TestDatabaseAuthenticationStrategy(
+            // _type = 'test'
+         ),
+      s:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::SnowflakePublicAuthenticationStrategy[1] |
+        ^meta::pure::alloy::connections::alloy::authentication::SnowflakePublicAuthenticationStrategy(
+            // _type = 'snowflakePublic',
+            privateKeyVaultReference = $s.privateKeyVaultReference,
+            passPhraseVaultReference = $s.passPhraseVaultReference,
+            publicUserName = $s.publicUserName
+        ),
+      b:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::GCPApplicationDefaultCredentialsAuthenticationStrategy[1] |
+         ^meta::pure::alloy::connections::alloy::authentication::GCPApplicationDefaultCredentialsAuthenticationStrategy(
+            // _type = 'gcpApplicationDefaultCredentials'
+         ),
+      l:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::ApiTokenAuthenticationStrategy[1] |
+         ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(
+            // _type = 'apiToken',
+            apiToken = $l.apiToken
+         ),
+      b:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::GCPWorkloadIdentityFederationAuthenticationStrategy[1] |
+         ^meta::pure::alloy::connections::alloy::authentication::GCPWorkloadIdentityFederationAuthenticationStrategy(
+            // _type = 'gcpWorkloadIdentityFederationWithAWS',
+            serviceAccountEmail = $b.serviceAccountEmail,
+            additionalGcpScopes = $b.additionalGcpScopes
+         )
+   ]);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformDatasourceSpecification(ds: meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification[1], extensions:meta::pure::extension::Extension[*]):meta::pure::alloy::connections::alloy::specification::DatasourceSpecification[1]
+{
+   $ds->match([
+      s:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::StaticDatasourceSpecification[1] |
+         ^meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification(
+            // _type = 'static',
+            host = $s.host,
+            port = $s.port,
+            databaseName = $s.databaseName
+         ),
+      e:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::EmbeddedH2DatasourceSpecification[1] |
+         ^meta::pure::alloy::connections::alloy::specification::EmbeddedH2DatasourceSpecification(
+            // _type = 'h2Embedded',
+            databaseName = $e.databaseName,
+            directory = $e.directory,
+            autoServerMode = $e.autoServerMode
+         ),
+      l:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::LocalH2DatasourceSpecification[1] |
+         ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(
+            //  _type = 'h2Local',
+             testDataSetupCsv = $l.testDataSetupCsv,
+             testDataSetupSqls = $l.testDataSetupSqls
+         ),
+      s:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::SnowflakeDatasourceSpecification[1] |
+        ^meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceSpecification(
+            // _type = 'snowflake',
+            accountName = $s.accountName,
+            region = $s.region,
+            warehouseName = $s.warehouseName,
+            databaseName = $s.databaseName,
+            cloudType = $s.cloudType,
+            quotedIdentifiersIgnoreCase = $s.quotedIdentifiersIgnoreCase,
+            proxyHost = $s.proxyHost,
+            proxyPort = $s.proxyPort,
+            nonProxyHosts = $s.nonProxyHosts,
+            accountType = if($s.accountType->isEmpty(),|[],
+                             |extractEnumValue(meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType, $s.accountType->toOne())),
+            organization = $s.organization,
+            role = $s.role
+        ),
+      b:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::BigQueryDatasourceSpecification[1] |
+         ^meta::pure::alloy::connections::alloy::specification::BigQueryDatasourceSpecification(
+            //  _type = 'bigQuery',
+             projectId = $b.projectId,
+             defaultDataset = $b.defaultDataset
+         ),
+      d:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatabricksDatasourceSpecification[1] |
+          ^meta::pure::alloy::connections::alloy::specification::DatabricksDatasourceSpecification(
+              // _type = 'databricks',
+              hostname = $d.hostname,
+              port = $d.port,
+              protocol = $d.protocol,
+              httpPath = $d.httpPath
+         ),
+     r:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::legend::specification::RedshiftDatasourceSpecification[1] |
+          ^meta::pure::legend::connections::legend::specification::RedshiftDatasourceSpecification(
+              //  _type = 'redshift',
+                clusterID = $r.clusterID,
+                port =$r.port,
+                region = $r.region,
+                databaseName = $r.databaseName,
+                endpointURL = $r.endpointURL,
+                host = $r.host 
+         )   
+   ]);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformPostProcessors(processors:meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::PostProcessor[*], extensions:meta::pure::extension::Extension[*]):meta::pure::alloy::connections::PostProcessor[*]
+{
+   $processors->map(processor |
+      $processor->match([
+         m:meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::MapperPostProcessor[1] | ^meta::pure::alloy::connections::MapperPostProcessor(
+            // _type = 'mapper',
+            mappers = transformPostProcessorMappers($m.mappers))
+      ]
+      )
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::toPureGraph::connection::transformPostProcessorMappers(mappers:meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::Mapper[*]):meta::pure::alloy::connections::Mapper[*]
+{
+   $mappers->map(mapper |
+                   $mapper->match([
+                      t:meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::TableNameMapper[1] | ^meta::pure::alloy::connections::TableNameMapper(
+                        //  _type = 'table',
+                         schema = ^meta::pure::alloy::connections::SchemaNameMapper(
+                            // _type = 'schema',
+                            from = $t.schema.from,
+                            to = $t.schema.to
+                         ),
+                         from = $t.from,
+                         to = $t.to
+                      ),
+                      s:meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::SchemaNameMapper[1] | ^meta::pure::alloy::connections::SchemaNameMapper(
+                        //  _type = 'schema',
+                         from = $s.from,
+                         to = $s.to
+                      )
+                   ])
+                )
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relational_testData.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/invocations/execution_relational_testData.pure
@@ -1,0 +1,299 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::context::*;
+import meta::protocols::pure::v1_26_0::invocation::execution::execute::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::runtime::*;
+import meta::pure::functions::io::http::*;
+import meta::pure::runtime::*;
+import meta::pure::mapping::*;
+import meta::alloy::metadataServer::*;
+import meta::json::*;
+import meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::*;
+
+Class meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::SeedDataGenerationInput
+{
+   clientVersion : String[1];
+   function : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   mapping : String[1];
+   runtime : meta::protocols::pure::v1_26_0::metamodel::Runtime[1];
+   context : meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[0..1];
+   model : meta::protocols::pure::v1_26_0::metamodel::PureModelContext[1];
+   parameters : Any[*];
+}
+
+Class meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::TestDataGenerationWithSeedInput
+{
+   clientVersion : String[1];
+   function : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   mapping : String[1];
+   runtime : meta::protocols::pure::v1_26_0::metamodel::Runtime[1];
+   context : meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[0..1];
+   model : meta::protocols::pure::v1_26_0::metamodel::PureModelContext[1];
+   hashStrings : Boolean[0..1];
+   tableRowIdentifiers : meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::TableRowIdentfiiers[*];
+}
+
+Class meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::TestDataGenerationWithDefaultSeedInput
+{
+   clientVersion : String[1];
+   function : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[1];
+   mapping : String[1];
+   runtime : meta::protocols::pure::v1_26_0::metamodel::Runtime[1];
+   context : meta::protocols::pure::v1_26_0::metamodel::ExecutionContext[0..1];
+   model : meta::protocols::pure::v1_26_0::metamodel::PureModelContext[1];
+   parameters : Any[*];
+   hashStrings : Boolean[0..1];
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateSeedDataInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], parameters: Any[*], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateSeedData($f, $m, $pureRuntime, $context, $parameters, '-1', $host, $port, $version, ExecutionMode.INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateSeedDataSemiInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], parameters: Any[*], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateSeedData($f, $m, $pureRuntime, $context, $parameters, '-1', $host, $port, $version, ExecutionMode.SEMI_INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateSeedDataInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], parameters: Any[*], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateSeedData($f, $m, $pureRuntime, $context, $parameters, $baseVersion, $host, $port, $version, ExecutionMode.INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateSeedDataSemiInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], parameters: Any[*], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateSeedData($f, $m, $pureRuntime, $context, $parameters, $baseVersion, $host, $port, $version, ExecutionMode.SEMI_INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateSeedData(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], parameters: Any[*], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   let transformedContext = if($context->isNotEmpty(), | $context->toOne()->transformContext($extensions),| []);
+   let execMode = ExecutionMode->extractEnumValue($executionMode);
+
+   let toOrigin = {m:Mapping[1], p:meta::protocols::Protocol[1] | buildPureModelContextPointer(^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING, path=$m->elementToPath()), $baseVersion, $p)};
+
+   let resultJSON = ^meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::SeedDataGenerationInput
+   (
+      clientVersion = 'v1_26_0',
+      function = transformLambda($f, $extensions),
+      mapping = $m->elementToPath(),
+      runtime = transformRuntime($pureRuntime, $extensions),
+      context = $transformedContext,
+      model = if($execMode == ExecutionMode.SEMI_INTERACTIVE,
+                  |let stores =  $pureRuntime.connections.element->cast(@meta::pure::store::Store)
+                                    ->map(s|$s->findAllStoreIncludes())
+                                    ->removeDuplicates()
+                                    ->map(c|^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.STORE,path=$c->elementToPath()));
+                   let mapping = ^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING,path=$m->elementToPath());
+                   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer
+                   (
+                      _type='pointer',
+                      serializer = ^meta::protocols::Protocol
+                                   (
+                                      name='pure',
+                                      version = 'v1_26_0'
+                                   ),
+                      sdlcInfo = ^meta::protocols::pure::v1_26_0::metamodel::PureSDLC
+                                 (
+                                    _type = 'pure',
+                                    baseVersion = $baseVersion,
+                                    version = 'none',
+                                    packageableElementPointers = $stores->concatenate($mapping)
+                                 )
+                   );,
+                  |$m->buildBasePureModelFromMapping($toOrigin, $extensions).second
+               ),
+      parameters = $parameters
+   )->alloyToJSON();
+
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/execution/testDataGeneration/generateSeedData'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 $resultJSON
+         );
+   assertEq(200, $resp.statusCode, | $resp.statusCode->toString()+' \''+$resp.entity+'\'');
+   $resp.entity;
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithSeedInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], tableRowIdentifiers: meta::relational::testDataGeneration::TableRowIdentifiers[*], hashStrings: Boolean[0..1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithSeed($f, $m, $pureRuntime, $context, $tableRowIdentifiers, $hashStrings, '-1', $host, $port, $version, ExecutionMode.INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithSeedSemiInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], tableRowIdentifiers: meta::relational::testDataGeneration::TableRowIdentifiers[*],  hashStrings: Boolean[0..1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithSeed($f, $m, $pureRuntime, $context, $tableRowIdentifiers, $hashStrings, '-1', $host, $port, $version, ExecutionMode.SEMI_INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithSeedInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], tableRowIdentifiers: meta::relational::testDataGeneration::TableRowIdentifiers[*], hashStrings: Boolean[0..1], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithSeed($f, $m, $pureRuntime, $context, $tableRowIdentifiers, $hashStrings, $baseVersion, $host, $port, $version, ExecutionMode.INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithSeedSemiInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], tableRowIdentifiers: meta::relational::testDataGeneration::TableRowIdentifiers[*],  hashStrings: Boolean[0..1], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithSeed($f, $m, $pureRuntime, $context, $tableRowIdentifiers, $hashStrings, $baseVersion, $host, $port, $version, ExecutionMode.SEMI_INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithSeed(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], tableRowIdentifiers: meta::relational::testDataGeneration::TableRowIdentifiers[*], hashStrings: Boolean[0..1], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   let transformedContext = if($context->isNotEmpty(), | $context->toOne()->transformContext($extensions),| []);
+   let execMode = ExecutionMode->extractEnumValue($executionMode);
+
+   let toOrigin = {m:Mapping[1], p:meta::protocols::Protocol[1] | buildPureModelContextPointer(^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING, path=$m->elementToPath()), $baseVersion, $p)};
+
+   let resultJSON = ^meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::TestDataGenerationWithSeedInput
+   (
+      clientVersion = 'v1_26_0',
+      function = transformLambda($f, $extensions),
+      mapping = $m->elementToPath(),
+      runtime = transformRuntime($pureRuntime, $extensions),
+      context = $transformedContext,
+      model = if($execMode == ExecutionMode.SEMI_INTERACTIVE,
+                  |let stores =  $pureRuntime.connections.element->cast(@meta::pure::store::Store)
+                                    ->map(s|$s->findAllStoreIncludes())
+                                    ->removeDuplicates()
+                                    ->map(c|^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.STORE,path=$c->elementToPath()));
+                   let mapping = ^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING,path=$m->elementToPath());
+                   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer
+                   (
+                      _type='pointer',
+                      serializer = ^meta::protocols::Protocol
+                                   (
+                                      name='pure',
+                                      version = 'v1_26_0'
+                                   ),
+                      sdlcInfo = ^meta::protocols::pure::v1_26_0::metamodel::PureSDLC
+                                 (
+                                    _type = 'pure',
+                                    baseVersion = $baseVersion,
+                                    version = 'none',
+                                    packageableElementPointers = $stores->concatenate($mapping)
+                                 )
+                   );,
+                  |$m->buildBasePureModelFromMapping($toOrigin, $extensions).second
+               ),
+      tableRowIdentifiers = $tableRowIdentifiers->map(x | $x->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::testDataGeneration::transformTableRowIdentifiers()),
+      hashStrings = $hashStrings
+   )->alloyToJSON();
+
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/execution/testDataGeneration/generateTestData_WithSeed'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 $resultJSON
+         );
+   assertEq(200, $resp.statusCode, | $resp.statusCode->toString()+' \''+$resp.entity+'\'');
+   $resp.entity;
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithDefaultSeedInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], hashStrings: Boolean[0..1], parameters: Any[*], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithDefaultSeed($f, $m, $pureRuntime, $context, $hashStrings, $parameters, '-1', $host, $port, $version, ExecutionMode.INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithDefaultSeedSemiInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], hashStrings: Boolean[0..1], parameters: Any[*], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithDefaultSeed($f, $m, $pureRuntime, $context, $hashStrings, $parameters, '-1', $host, $port, $version, ExecutionMode.SEMI_INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithDefaultSeedInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], hashStrings: Boolean[0..1], parameters: Any[*], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithDefaultSeed($f, $m, $pureRuntime, $context, $hashStrings, $parameters, $baseVersion, $host, $port, $version, ExecutionMode.INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithDefaultSeedSemiInteractive(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], hashStrings: Boolean[0..1], parameters: Any[*], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   alloyGenerateTestDataWithDefaultSeed($f, $m, $pureRuntime, $context, $hashStrings, $parameters, $baseVersion, $host, $port, $version, ExecutionMode.SEMI_INTERACTIVE->toString(), $extensions)
+}
+
+function meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::alloyGenerateTestDataWithDefaultSeed(f:FunctionDefinition<Any>[1], m:Mapping[1], pureRuntime:Runtime[1], context:ExecutionContext[0..1], hashStrings: Boolean[0..1], parameters: Any[*], baseVersion:String[1], host:String[1], port:Integer[1], version:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
+{
+   let transformedContext = if($context->isNotEmpty(), | $context->toOne()->transformContext($extensions),| []);
+   let execMode = ExecutionMode->extractEnumValue($executionMode);
+
+   let toOrigin = {m:Mapping[1], p:meta::protocols::Protocol[1] | buildPureModelContextPointer(^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING, path=$m->elementToPath()), $baseVersion, $p)};
+
+   let resultJSON = ^meta::protocols::pure::v1_26_0::invocation::execution::testDataGeneration::TestDataGenerationWithDefaultSeedInput
+   (
+      clientVersion = 'v1_26_0',
+      function = transformLambda($f, $extensions),
+      mapping = $m->elementToPath(),
+      runtime = transformRuntime($pureRuntime, $extensions),
+      context = $transformedContext,
+      model = if($execMode == ExecutionMode.SEMI_INTERACTIVE,
+                  |let stores =  $pureRuntime.connections.element->map(element |
+                     $element->match([
+                        store:meta::pure::store::Store[1] | $store->map(s|$s->findAllStoreIncludes())
+                                    ->removeDuplicates()
+                                    ->map(c|^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.STORE,path=$c->elementToPath()));,
+                        a:Any[*] | []
+                     ]);
+                   );
+                   let mapping = ^meta::protocols::pure::v1_26_0::metamodel::PackageableElementPointer(type=meta::protocols::pure::v1_26_0::metamodel::PackageableElementType.MAPPING,path=$m->elementToPath());
+                   ^meta::protocols::pure::v1_26_0::metamodel::PureModelContextPointer
+                   (
+                      _type='pointer',
+                      serializer = ^meta::protocols::Protocol
+                                   (
+                                      name='pure',
+                                      version = 'v1_26_0'
+                                   ),
+                      sdlcInfo = ^meta::protocols::pure::v1_26_0::metamodel::PureSDLC
+                                 (
+                                    _type = 'pure',
+                                    baseVersion = $baseVersion,
+                                    version = 'none',
+                                    packageableElementPointers = $stores->concatenate($mapping)
+                                 )
+                   );,
+                  |$m->buildBasePureModelFromMapping($toOrigin, $extensions).second
+               ),
+      parameters = $parameters,
+      hashStrings = $hashStrings
+   )->alloyToJSON();
+
+   let resp = executeHTTPRaw(^URL(host = $host , port=$port, path = '/api/pure/'+$version+'/execution/testDataGeneration/generateTestData_WithDefaultSeed'),
+                                 HTTPMethod.POST,
+                                 'application/json',
+                                 $resultJSON
+         );
+   assertEq(200, $resp.statusCode, | $resp.statusCode->toString()+' \''+$resp.entity+'\'');
+   $resp.entity;
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::testDataGeneration::transformTableRowIdentifiers(t: meta::relational::testDataGeneration::TableRowIdentifiers[1]):meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::TableRowIdentfiiers[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::TableRowIdentfiiers
+   (
+      table = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr
+               (
+                  _type = 'table',
+                  table = $t.table.name,
+                  schema = $t.table.schema.name,
+                  database = $t.table.schema.database ->elementToPath(),
+                  mainTableDb = $t.table.schema.database ->elementToPath()
+               ),
+      rowIdentifiers = $t.rowIdentifiers->map({ri |
+         ^meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::RowIdentifier
+          (
+             columnValuePairs = $ri.columnValuePairs->map(x | ^meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::ColumnValuePair(name = $x.first, value = $x.second))
+          )
+      })
+   )
+}
+
+

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/executionPlan_relational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/executionPlan_relational.pure
@@ -1,0 +1,116 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::SQLExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode
+{
+   sqlQuery : String[1];
+   onConnectionCloseCommitQuery : String[0..1];
+   onConnectionCloseRollbackQuery : String[0..1];
+   resultColumns : meta::protocols::pure::v1_26_0::metamodel::executionPlan::SQLResultColumn[*];
+   connection : meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalInstantiationExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalTdsInstantiationExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalInstantiationExecutionNode
+[tdsResultType:$this.resultType->instanceOf(TDSResultType)]
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalClassInstantiationExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalInstantiationExecutionNode
+[classResultType:$this.resultType->instanceOf(ClassResultType)]
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalRelationDataInstantiationExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalInstantiationExecutionNode
+[relationResultType:$this.resultType->instanceOf(RelationResultType)]
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalDataTypeInstantiationExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalInstantiationExecutionNode
+[dataTypeResultType:$this.resultType->instanceOf(DataTypeResultType)]
+{
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::graphFetch::LocalGraphFetchExecutionNode
+{
+   children : RelationalGraphFetchExecutionNode[*];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalTempTableGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalGraphFetchExecutionNode
+{
+   tempTableName : String[1];
+   columns       : SQLResultColumn[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalClassQueryTempTableGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalTempTableGraphFetchExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalPrimitiveQueryGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalGraphFetchExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalRootQueryTempTableGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalClassQueryTempTableGraphFetchExecutionNode
+{
+   batchSize : Integer[0..1];
+   checked : Boolean[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalRootListTempTableGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalTempTableGraphFetchExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalCrossRootQueryTempTableGraphFetchExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalClassQueryTempTableGraphFetchExecutionNode
+{
+   parentTempTableName    : String[1];
+   parentTempTableColumns : SQLResultColumn[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationalBlockExecutionNode extends SequenceExecutionNode
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::CreateAndPopulateTempTableExecutionNode extends ExecutionNode
+{
+   inputVarNames               : String[*];
+   tempTableName               : String[1];
+   tempTableColumnMetaData     : meta::protocols::pure::v1_26_0::metamodel::executionPlan::TempTableColumnMetaData[*];
+   connection                  : meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection[1];
+}
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::SQLResultColumn
+{
+   label : String[1];
+   dataType : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::TempTableColumnMetaData
+{
+   column                    : meta::protocols::pure::v1_26_0::metamodel::executionPlan::SQLResultColumn[1];
+   identifierForGetter       : String[0..1];
+   parametersForGetter       : Map<String, Any>[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::RelationResultType extends ResultType
+{
+   relationName : String[1];
+   relationType : String[1];
+   schemaName : String[1];
+   database : String[1];
+   columns : meta::protocols::pure::v1_26_0::metamodel::store::relational::Column[*];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/metamodel_connection.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/metamodel_connection.pure
@@ -1,0 +1,183 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::element::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::domain::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::RelationalDatabaseConnection extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection
+{
+   datasourceSpecification:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification[1];
+   authenticationStrategy:meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy[1];
+   postProcessors: meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::PostProcessor[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::DelegatedKerberosAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+   serverPrincipal: String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::MiddleTierUserNamePasswordAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+   vaultReference: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::UserNamePasswordAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+   baseVaultReference: String[0..1];
+   userNameVaultReference: String[1];
+   passwordVaultReference: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::DefaultH2AuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::ApiTokenAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+    apiToken:String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::TestDatabaseAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::DefaultH2AuthenticationStrategy
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::SnowflakePublicAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+    privateKeyVaultReference : String[1];
+    passPhraseVaultReference : String[1];
+    publicUserName : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::GCPApplicationDefaultCredentialsAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::GCPWorkloadIdentityFederationAuthenticationStrategy extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+    serviceAccountEmail : String[1];
+    additionalGcpScopes: String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::LocalH2DatasourceSpecification extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+    testDataSetupCsv:String[0..1];
+    testDataSetupSqls:String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::EmbeddedH2DatasourceSpecification extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+    databaseName:String[1];
+    directory:String[1];
+    autoServerMode:Boolean[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::StaticDatasourceSpecification extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+   host: String[1];
+   port: Integer[1];
+   databaseName: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatabricksDatasourceSpecification extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+    hostname:String[1];
+    port:String[1];
+    protocol:String[1];
+    httpPath:String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::SnowflakeDatasourceSpecification extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+    accountName : String[1];
+    region : String[1];
+    warehouseName : String[1];
+    databaseName : String[1];
+    cloudType : String[0..1];
+    accountType: String[0..1];
+    organization: String[0..1];
+
+    quotedIdentifiersIgnoreCase : Boolean[0..1];
+
+    proxyHost: String[0..1];
+    proxyPort: String[0..1];
+    nonProxyHosts: String[0..1];
+   
+    role: String [0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::BigQueryDatasourceSpecification extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+    projectId:String[1];
+    defaultDataset:String[1];
+    proxyHost: String[0..1];
+    proxyPort: String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::TestDatabaseConnection extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection
+{
+   testDataSetupCsv : String[0..1];
+   testDataSetupSqls : String[*];
+
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection extends meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+   type : String[1];
+   timeZone : String[0..1];
+   quoteIdentifiers : Boolean[0..1];
+   postProcessorWithParameter:	meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorWithParameter[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorWithParameter
+{
+   pp:String[1];
+   parameters: meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorParameter[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorParameter
+{
+   _type:String[1];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::PostProcessor
+{
+   _type:String[1];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+   _type: String[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::legend::specification::RedshiftDatasourceSpecification extends meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+   
+   clusterID:String[1];
+   region:String[1];
+   host:String[1];
+   databaseName:String[1];
+   port:Integer[1];
+   endpointURL:String[0..1];
+}
+
+
+
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+   _type: String[1];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/metamodel_relational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/metamodel_relational.pure
@@ -1,0 +1,357 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::element::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::domain::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::RelationalExecutionContext extends meta::protocols::pure::v1_26_0::metamodel::ExecutionContext
+{
+   addDriverTablePkForProject : Boolean[0..1];
+   insertDriverTablePkInTempTable : String[0..1];
+   useTempTableAsDriver : String[0..1];
+   preserveJoinOrder:Boolean[0..1];
+   importDataFlow : Boolean[0..1];
+   importDataFlowAddFks:Boolean[0..1];
+   importDataFlowFkCols : meta::protocols::pure::v1_26_0::metamodel::TableForeignColumns[*];
+   importDataFlowImplementationCount : Integer[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::TableForeignColumns
+{
+   table: TablePtr[1];
+   columns: String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyRelationalStoreObjectReference extends meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReference
+[
+   typeCondition : $this.type == meta::protocols::pure::v1_26_0::metamodel::objectReference::AlloyObjectReferenceType.Relational
+]
+{
+   databaseConnection    : meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection[1];
+   pkMap                 : Map<String, Any>[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Database extends meta::protocols::pure::v1_26_0::metamodel::store::Store
+{
+   schemas : meta::protocols::pure::v1_26_0::metamodel::store::relational::Schema[*];
+   joins : meta::protocols::pure::v1_26_0::metamodel::store::relational::Join[*];
+   filters : meta::protocols::pure::v1_26_0::metamodel::store::relational::Filter[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Schema
+{
+   name : String[1];
+   tables : meta::protocols::pure::v1_26_0::metamodel::store::relational::Table[*];
+   views : meta::protocols::pure::v1_26_0::metamodel::store::relational::View[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Relation
+{
+   columns : meta::protocols::pure::v1_26_0::metamodel::store::relational::Column[*];
+   primaryKey : String[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Milestoning
+{
+    _type : String[1];
+   infinityDate : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDate[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Table extends meta::protocols::pure::v1_26_0::metamodel::store::relational::Relation
+{
+   name : String[1];
+   milestoning : meta::protocols::pure::v1_26_0::metamodel::store::relational::Milestoning[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::ProcessingMilestoning extends meta::protocols::pure::v1_26_0::metamodel::store::relational::Milestoning
+{
+   in : String[1];
+   out : String[1];
+   outIsInclusive : Boolean[1];
+
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::BusinessSnapshotMilestoning extends meta::protocols::pure::v1_26_0::metamodel::store::relational::Milestoning
+{
+   snapshotDate:String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::BusinessMilestoning extends meta::protocols::pure::v1_26_0::metamodel::store::relational::Milestoning
+{
+   from : String[1];
+   thru : String[1];
+   thruIsInclusive : Boolean[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::View extends meta::protocols::pure::v1_26_0::metamodel::store::relational::Relation, meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalEntityMapping
+{
+   name : String[1];
+   columnMappings : meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::ColumnMapping[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalEntityMapping
+{
+   mainTable : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr[1];
+   distinct : Boolean[1];
+   groupBy : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[*];
+   filter : meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::FilterWithJoins[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalClassMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping
+{
+   primaryKey : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[*];
+   propertyMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalAssociationMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::AssociationMapping
+{
+    propertyMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RootRelationalClassMapping extends meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalClassMapping, meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalEntityMapping
+{
+   primaryKey : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[*];
+   propertyMappings : meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping[*];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalPropertyMapping extends  meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping
+{
+   enumMappingId : String[0..1];
+   relationalOperation : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::EmbeddedRelationalPropertyMapping extends  meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping
+{
+   id : String[1];
+   classMapping : meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalClassMapping[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::OtherwiseEmbeddedRelationalPropertyMapping extends meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::EmbeddedRelationalPropertyMapping
+{
+   otherwisePropertyMapping: RelationalPropertyMapping[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::ColumnMapping
+{
+   name : String[1];
+   operation : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::FilterWithJoins
+{
+   filter : FilterPtr[1];
+   joins : JoinPtr[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::FilterPtr
+{
+   db : String[1];
+   name : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::JoinPtr
+{
+   db : String[1];
+   name : String[1];
+   joinType : String[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Column
+{
+   name : String[1];
+   type : meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType[1];
+   nullable : Boolean[1];
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+   _type: String[1];
+
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::BigInt extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::SmallInt extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::TinyInt extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Integer extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Float extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Real extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Double extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Varchar extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+    size: Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Char extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+    size: Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Varbinary extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+    size: Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Decimal extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+    precision : Integer[1];
+    scale     : Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Numeric extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+    precision : Integer[1];
+    scale     : Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Timestamp extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Date extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Bit extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Binary extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+   size:Integer[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Other extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Array extends meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType
+{
+}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Join
+{
+   name : String[1];
+   target : String[0..1];
+   operation : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::Filter
+{
+   _type : String[1];
+   name : String[1];
+   operation : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement
+{
+   _type : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::element::ColumnPtr extends meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement
+{
+   tableAlias : String[1];
+   table: meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr[1];
+   column : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::element::ElementWithJoins extends meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement
+{
+   joins : meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::JoinPtr[*];
+   relationalElement : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::element::DynamicFunction extends meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement
+{
+   funcName : String[1];
+   parameters : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::element::Literal extends meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement
+{
+   value : Any[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::element::LiteralList extends meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement
+{
+   values : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::Literal[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr extends meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement
+{
+   database : String[1];
+   schema : String[1];
+   table : String[1];
+   mainTableDb: String[1];
+
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::Mapper
+{
+   _type: String[1];
+   from: String[1];
+   to: String[1];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::MapperPostProcessor extends meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::PostProcessor
+{
+   mappers: meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::Mapper[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::TableNameMapper extends meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::Mapper {
+   schema: meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::SchemaNameMapper[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::SchemaNameMapper extends meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::Mapper {}
+
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::TableNameMapper extends meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorParameter
+{
+   in:String[1];
+   out:String[1];
+   schemaMapperIn: String[1];
+   schemaMapperOut: String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::relational::SchemaNameMapper extends meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorParameter
+{
+   in:String[1];
+   out:String[1];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/results_relational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/results_relational.pure
@@ -1,0 +1,33 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalClassResult extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Result
+{
+   objects : Map<String, Any>[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalTDSResult extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Result
+{
+   result : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Res[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalDataTypeResult extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Result
+{
+   result : meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::Res[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::RelationalExecutionActivity extends meta::protocols::pure::v1_26_0::metamodel::invocation::execution::execute::ExecutionActivity
+{
+   sql : String[1];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/testData_relational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/models/testData_relational.pure
@@ -1,0 +1,32 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::protocols::*;
+Class meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::TableRowIdentfiiers
+{
+   table : meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr[1];
+   rowIdentifiers : meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::RowIdentifier[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::RowIdentifier
+{
+   columnValuePairs : meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::ColumnValuePair[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::testDataGeneration::ColumnValuePair
+{
+   name : String[1];
+   value : Any[1];
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/transfers/connection_relational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/transfers/connection_relational.pure
@@ -1,0 +1,262 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::json::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::domain::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::*;
+import meta::protocols::pure::v1_26_0::metamodel::runtime::*;
+import meta::relational::metamodel::*;
+import meta::pure::functions::meta::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::element::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::model::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformDatabaseConnection(otherConnection: meta::relational::runtime::DatabaseConnection[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection[1]
+{
+   let _type = $otherConnection->class()->toString();
+   let element = $otherConnection.element->match([d:meta::pure::store::Store[1]|$d->elementToPath(),s:String[1]|$s]);
+   let type = $otherConnection.type->toString();
+   let postProcessorsWithParams = if ($otherConnection->instanceOf(meta::pure::alloy::connections::RelationalDatabaseConnection),
+                                      | [],
+                                      | $otherConnection.queryPostProcessorsWithParameter->transformPostProcessors($extensions));
+
+
+   let alloyConnection = $otherConnection->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).moduleSerializerExtension('relational')->cast(@meta::protocols::pure::v1_26_0::extension::RelationalModuleSerializerExtension).transfers_connection_transformDatabaseConnection->map(f | $f->eval($_type, $element, $type, $postProcessorsWithParams))->concatenate([
+      test:meta::relational::runtime::TestDatabaseConnection[1]|
+          ^RelationalDatabaseConnection(
+            _type = 'RelationalDatabaseConnection',
+            type = $type,
+            timeZone = $test.timeZone,
+            quoteIdentifiers = $test.quoteIdentifiers,
+            element = $element,
+            datasourceSpecification = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::LocalH2DatasourceSpecification(
+              _type = 'h2Local',
+               testDataSetupCsv = $test.testDataSetupCsv,
+               testDataSetupSqls = $test.testDataSetupSqls
+            ),
+            authenticationStrategy = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::TestDatabaseAuthenticationStrategy(
+              _type = 'test'
+            ),
+            postProcessorWithParameter = $postProcessorsWithParams
+         ),
+      relational:meta::pure::alloy::connections::RelationalDatabaseConnection[1] |
+         let processors = transformPostProcessors($relational.postProcessors, $extensions);
+         relational($type, $element, $relational.timeZone, $relational.quoteIdentifiers, $processors, $relational.datasourceSpecification, $relational.authenticationStrategy, $extensions);,
+      dbCon:meta::relational::runtime::DatabaseConnection[1]|
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::DatabaseConnection(
+                  _type = $_type,
+                  timeZone = $dbCon.timeZone,
+                  quoteIdentifiers = $dbCon.quoteIdentifiers,
+                  element = $element,
+                  postProcessorWithParameter = $postProcessorsWithParams,
+                  type = $type)
+    ])->toOneMany());
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformPostProcessors(processors:meta::pure::alloy::connections::PostProcessor[*], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::PostProcessor[*]
+{
+   $processors->map(processor |
+      $processor->match([
+         m:meta::pure::alloy::connections::MapperPostProcessor[1] | ^meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::MapperPostProcessor(
+            _type = 'mapper',
+            mappers = transformPostProcessorMappers($m.mappers))
+      ]->concatenate($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).moduleSerializerExtension('relational')->cast(@meta::protocols::pure::v1_26_0::extension::RelationalModuleSerializerExtension).transfers_connection_transformPostProcessors)->toOneMany())
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformPostProcessorMappers(mappers:meta::pure::alloy::connections::Mapper[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::Mapper[*]
+{
+   $mappers->map(mapper |
+                   $mapper->match([
+                      t:meta::pure::alloy::connections::TableNameMapper[1] | ^meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::TableNameMapper(
+                         _type = 'table',
+                         schema = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::SchemaNameMapper(
+                            _type = 'schema',
+                            from = $t.schema.from,
+                            to = $t.schema.to
+                         ),
+                         from = $t.from,
+                         to = $t.to
+                      ),
+                      s:meta::pure::alloy::connections::SchemaNameMapper[1] | ^meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::SchemaNameMapper(
+                         _type = 'schema',
+                         from = $s.from,
+                         to = $s.to
+                      )
+                   ])
+                )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::relational(type:String[1], element:String[1], timeZone:String[0..1], quoteIdentifiers:Boolean[0..1],
+                                                                                              processors:meta::protocols::pure::v1_26_0::metamodel::store::relational::postProcessor::PostProcessor[*],
+                                                                                              spec:meta::pure::alloy::connections::alloy::specification::DatasourceSpecification[1],
+                                                                                              auth:meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy[1],
+                                                                                              extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::RelationalDatabaseConnection[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::RelationalDatabaseConnection(
+      _type = 'RelationalDatabaseConnection',
+      timeZone = $timeZone,
+      quoteIdentifiers = $quoteIdentifiers,
+      element = $element,
+      type = $type,
+      datasourceSpecification = $spec->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformDatasourceSpecification($extensions),
+      authenticationStrategy = $auth->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformAuthenticationStrategy($extensions),
+      postProcessors = $processors
+   );
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformAuthenticationStrategy(a:meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy[1]
+{
+   $a->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).moduleSerializerExtension('relational')->cast(@meta::protocols::pure::v1_26_0::extension::RelationalModuleSerializerExtension).transfers_connection_transformAuthenticationStrategy->concatenate([
+      d:meta::pure::alloy::connections::alloy::authentication::DelegatedKerberosAuthenticationStrategy[1] |
+      ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::DelegatedKerberosAuthenticationStrategy(
+         _type = 'delegatedKerberos',
+         serverPrincipal = $d.serverPrincipal
+      ),
+      mup:meta::pure::alloy::connections::alloy::authentication::MiddleTierUserNamePasswordAuthenticationStrategy[1] |
+      ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::MiddleTierUserNamePasswordAuthenticationStrategy(
+         _type = 'middleTierUserNamePassword',
+         vaultReference = $mup.vaultReference
+      ),
+      u:meta::pure::alloy::connections::alloy::authentication::UserNamePasswordAuthenticationStrategy[1] |
+      ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::UserNamePasswordAuthenticationStrategy(
+         _type = 'userNamePassword',
+         baseVaultReference = $u.baseVaultReference,
+         userNameVaultReference = $u.userNameVaultReference,
+         passwordVaultReference = $u.passwordVaultReference
+      ),
+      d:meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::DefaultH2AuthenticationStrategy(
+            _type = 'h2Default'
+         ),
+      l:meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::ApiTokenAuthenticationStrategy(
+            _type = 'apiToken',
+            apiToken = $l.apiToken
+         ),
+      t:meta::pure::alloy::connections::alloy::authentication::TestDatabaseAuthenticationStrategy[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::TestDatabaseAuthenticationStrategy(
+            _type = 'test'
+         ),
+      s:meta::pure::alloy::connections::alloy::authentication::SnowflakePublicAuthenticationStrategy[1] |
+        ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::SnowflakePublicAuthenticationStrategy(
+            _type = 'snowflakePublic',
+            privateKeyVaultReference = $s.privateKeyVaultReference,
+            passPhraseVaultReference = $s.passPhraseVaultReference,
+            publicUserName = $s.publicUserName
+        ),
+      b:meta::pure::alloy::connections::alloy::authentication::GCPApplicationDefaultCredentialsAuthenticationStrategy[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::GCPApplicationDefaultCredentialsAuthenticationStrategy(
+            _type = 'gcpApplicationDefaultCredentials'
+         ),
+      b:meta::pure::alloy::connections::alloy::authentication::GCPWorkloadIdentityFederationAuthenticationStrategy[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::authentication::GCPWorkloadIdentityFederationAuthenticationStrategy(
+            _type = 'gcpWorkloadIdentityFederation',
+            serviceAccountEmail = $b.serviceAccountEmail,
+            additionalGcpScopes = $b.additionalGcpScopes
+         )
+   ])->toOneMany())
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformDatasourceSpecification(ds: meta::pure::alloy::connections::alloy::specification::DatasourceSpecification[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification[1]
+{
+   $ds->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).moduleSerializerExtension('relational')->cast(@meta::protocols::pure::v1_26_0::extension::RelationalModuleSerializerExtension).transfers_connection_transformDatasourceSpecification->concatenate([
+      s:meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::StaticDatasourceSpecification(
+            _type = 'static',
+            host = $s.host,
+            port = $s.port,
+            databaseName = $s.databaseName
+         ),
+      e:meta::pure::alloy::connections::alloy::specification::EmbeddedH2DatasourceSpecification[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::EmbeddedH2DatasourceSpecification(
+            _type = 'h2Embedded',
+            databaseName = $e.databaseName,
+            directory = $e.directory,
+            autoServerMode = $e.autoServerMode
+         ),
+      l:meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::LocalH2DatasourceSpecification(
+             _type = 'h2Local',
+             testDataSetupCsv = $l.testDataSetupCsv,
+             testDataSetupSqls = $l.testDataSetupSqls
+         ),
+       d:meta::pure::alloy::connections::alloy::specification::DatabricksDatasourceSpecification[1] |
+          ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::DatabricksDatasourceSpecification(
+              _type = 'databricks',
+              hostname = $d.hostname,
+              port = $d.port,
+              protocol = $d.protocol,
+              httpPath = $d.httpPath
+         ),
+      s:meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceSpecification[1] |
+        ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::SnowflakeDatasourceSpecification(
+            _type = 'snowflake',
+            accountName = $s.accountName,
+            region = $s.region,
+            warehouseName = $s.warehouseName,
+            databaseName = $s.databaseName,
+            cloudType = $s.cloudType,
+            quotedIdentifiersIgnoreCase = $s.quotedIdentifiersIgnoreCase,
+            proxyHost = $s.proxyHost,
+            proxyPort = $s.proxyPort,
+            nonProxyHosts = $s.nonProxyHosts,
+            accountType = if($s.accountType->isEmpty(),|[],|$s.accountType->toOne()->toString()),
+            organization = $s.organization,
+            role = $s.role
+        ),
+      b:meta::pure::alloy::connections::alloy::specification::BigQueryDatasourceSpecification[1] |
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::alloy::specification::BigQueryDatasourceSpecification(
+             _type = 'bigQuery',
+             projectId = $b.projectId,
+             defaultDataset = $b.defaultDataset,
+             proxyHost = $b.proxyHost,
+             proxyPort = $b.proxyPort
+         ),
+     r:meta::pure::legend::connections::legend::specification::RedshiftDatasourceSpecification[1] |
+                                                  ^meta::protocols::pure::v1_26_0::metamodel::store::relational::connection::legend::specification::RedshiftDatasourceSpecification(
+                                                                   _type = 'redshift',
+                                                                   clusterID = $r.clusterID,
+                                                                   port =$r.port,
+                                                                   region = $r.region,
+                                                                   databaseName = $r.databaseName,
+                                                                   endpointURL = $r.endpointURL,
+                                                                   host = $r.host 
+                             )       
+
+         
+   ])->toOneMany())
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformPostProcessors(postP: meta::relational::runtime::PostProcessorWithParameter[*], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorWithParameter[*]
+{
+   $postP->map(postprocessor|
+            ^meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorWithParameter(pp = $postprocessor.postProcessor->elementToPath(), parameters = $postprocessor.parameters->transformPostProcessorParameters($extensions))
+               );
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::transformPostProcessorParameters(params: meta::relational::runtime::PostProcessorParameter[*], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::store::relational::PostProcessorParameter[*]
+{
+   $params->map(param|
+            $param->match([
+               t: meta::relational::postProcessor::TableNameMapper[1]| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::TableNameMapper(_type='tableMapper',in =$t.in, out = $t.out, schemaMapperIn = $t.schemaNameMapper.in, schemaMapperOut = $t.schemaNameMapper.out),
+               s: meta::relational::postProcessor::SchemaNameMapper[1]| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::SchemaNameMapper(_type='schemaMapper',in =$s.in, out = $s.out )
+            ]->concatenate($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).moduleSerializerExtension('relational')->cast(@meta::protocols::pure::v1_26_0::extension::RelationalModuleSerializerExtension).transfers_connection_transformPostProcessorParameters)->toOneMany()));
+}

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/transfers/metamodel_relational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/v1_26_0/transfers/metamodel_relational.pure
@@ -1,0 +1,461 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::extension::*;
+import meta::relational::extension::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::modelToModel::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::modelToModel::*;
+import meta::pure::mapping::modelToModel::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::csv::*;
+import meta::pure::mapping::*;
+import meta::relational::mapping::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::*;
+import meta::relational::metamodel::datatype::*;
+import meta::relational::functions::pureToSqlQuery::*;
+import meta::relational::metamodel::operation::*;
+import meta::relational::metamodel::relation::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::csv::*;
+import meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::*;
+import meta::relational::metamodel::*;
+import meta::pure::store::set::*;
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformDatabase(db:meta::relational::metamodel::Database[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::Database[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Database
+   (
+      _type = 'relational',
+      name = $db.name->toOne(),
+      package = if($db.package->isEmpty(), |[], |$db.package->toOne()->elementToPath()),
+      schemas = $db.schemas->map(s|$s->transformSchema($db, $extensions)),
+      joins = $db.joins->map(s|$s->transformJoin($db)),
+      filters = $db.filters->map(s|$s->transformFilter($db)),
+      includedStores = $db.includes->map(i|$i->elementToPath())
+   )
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRootRelationalInstanceSetImplementation(r:RootRelationalInstanceSetImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RootRelationalClassMapping[1]
+{
+   let table = $r.mainTableAlias.relationalElement->cast(@NamedRelation);
+   let schema = $table->match([t:Table[1]|$t.schema,v:View[1]|$v.schema]);
+   let db = $schema.database;
+   let storeFromTableAlias = $r.mainTableAlias.database;
+  ^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RootRelationalClassMapping
+   (
+      id = $r.id,
+      _type = 'relational',
+      class = $r.class->elementToPath(),
+      root = $r.root,
+      extendsClassMappingId = $r.superSetImplementationId,
+      mappingClass = $r.mappingClass->map(mc|$mc->transformMappingClass($mapping, $extensions)),
+      mainTable = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr(
+         _type = 'table',
+         table = $table.name,
+         mainTableDb = if($storeFromTableAlias->isNotEmpty(),|if($db->elementToPath() == $storeFromTableAlias->toOne()->elementToPath(),| $db ,| $storeFromTableAlias->toOne()), | $db)->elementToPath(),
+         database = $db->elementToPath(),
+         schema = $schema.name),
+      distinct = $r.distinct->isTrue(),
+      groupBy = $r.groupBy.columns->map(c|$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalOperationElement($db)),
+      filter = if($r.filter->isEmpty(), |[], | ^FilterWithJoins(filter = ^FilterPtr(db=$r.filter.filter.database->toOne()->elementToPath(), name=$r.filter->toOne().filterName), joins = if($r.filter->toOne().joinTreeNode->isEmpty(),|[],|$r.filter->toOne().joinTreeNode->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformJoinTreeNode()))),
+      primaryKey = $r.primaryKey->map(c|$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalOperationElement($db)),
+      propertyMappings = $r.propertyMappings->meta::pure::milestoning::excludeRangeMilestoningPropertyMapping()->map(pm|$pm->transformRelationalPropertyMapping($db, $mapping, $extensions))
+   );
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformAggregationAwareSetImplementation(a:	meta::pure::mapping::aggregationAware::AggregationAwareSetImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::AggregationAwareClassMapping[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::AggregationAwareClassMapping
+   (
+      id = $a.id,
+      _type = 'aggregationAware',
+      class = $a.class->elementToPath(),
+      root = $a.root,
+      mainSetImplementation = $a.mainSetImplementation->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformSetImplementation($mapping, $extensions),
+      propertyMappings = $a.propertyMappings->map(pm|$pm->transformPropertyMapping($mapping, $extensions)),
+       aggregateSetImplementations = $a.aggregateSetImplementations->map(s| $s->transformAggSetImplContainer($mapping, $extensions)),
+      mappingClass = $a.mappingClass->map(mc|$mc->transformMappingClass($mapping, $extensions))
+
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformAggSetImplContainer(a:	meta::pure::mapping::aggregationAware::AggregateSetImplementationContainer[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSetImplementationContainer[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSetImplementationContainer
+   (
+      index = $a.index,
+      setImplementation = $a.setImplementation->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::transformSetImplementation($mapping, $extensions),
+      aggregateSpecification = $a.aggregateSpecification->transformAggregateSpecification($extensions)
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformAggregateSpecification(a:	meta::pure::mapping::aggregationAware::AggregateSpecification[1], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSpecification[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateSpecification
+   (
+      canAggregate = $a.canAggregate,
+      groupByFunctions = $a.groupByFunctions->transformGroupByFunctionSpec($extensions),
+      aggregateValues = $a.aggregateValues->transformAggregationFunctionSpecification($extensions)
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformGroupByFunctionSpec(gb:meta::pure::mapping::aggregationAware::GroupByFunctionSpecification[*], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::mapping::GroupByFunctions[*]
+{
+  $gb->map(g| ^meta::protocols::pure::v1_26_0::metamodel::mapping::GroupByFunctions(groupByFn = $g.groupByFn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)))
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformAggregationFunctionSpecification(ag:meta::pure::mapping::aggregationAware::AggregationFunctionSpecification[*], extensions:meta::pure::extension::Extension[*]): meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateFunctions[*]
+{
+   $ag->map(a|^meta::protocols::pure::v1_26_0::metamodel::mapping::AggregateFunctions(mapFn = $a.mapFn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions), aggregateFn = $a.aggregateFn->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)))
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalAssociationImplementation(r:RelationalAssociationImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalAssociationMapping[1]
+{
+   let db = $r.stores->at(0)->cast(@meta::relational::metamodel::Database);
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalAssociationMapping
+   (
+      id = $r.id,
+      _type = 'relational',
+      stores = $db->elementToPath(),
+      association = $r.association->elementToPath(),
+      propertyMappings = $r.allPropertyMappings()->meta::pure::milestoning::excludeRangeMilestoningPropertyMapping()->map(pm|$pm->transformRelationalPropertyMapping($db, $mapping, $extensions))
+   );
+
+}
+
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformEmbeddedRelationalInstanceSetImplementation(r:EmbeddedRelationalInstanceSetImplementation[1], db: meta::relational::metamodel::Database[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalClassMapping[1]
+{
+   let mapping = $r.parent;
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalClassMapping
+   (
+      id = $r.id,
+      _type = 'embedded',
+      class = $r.class->elementToPath(),
+      root = false,
+      primaryKey = $r.primaryKey->map(c|$c->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalOperationElement($db->toOne())),
+      propertyMappings = $r.allPropertyMappings()->meta::pure::milestoning::excludeRangeMilestoningPropertyMapping()->map(pm|$pm->transformRelationalPropertyMapping($db->toOne(), $mapping, $extensions))
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalPropertyMapping(pm:PropertyMapping[1], topDatabase:meta::relational::metamodel::Database[1], mapping : Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::mapping::PropertyMapping[1]
+{
+   $pm->match([
+      r:meta::relational::mapping::RelationalPropertyMapping[1]|
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalPropertyMapping
+         (
+            _type = 'relationalPropertyMapping',
+            property = $pm.property->createPropertyPtr(),
+            enumMappingId = $r.transformer->cast(@EnumerationMapping<Any>).name,
+            source = if($pm.property.owner->instanceOf(Association),|$pm.sourceSetImplementationId,|[]),
+            target = $pm.targetSetImplementationId,
+            relationalOperation = $r.relationalOperationElement->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalOperationElement($topDatabase),
+            localMappingProperty = if ($pm.localMappingProperty->isNotEmpty() && $pm.localMappingProperty->toOne(),
+                                       |^meta::protocols::pure::v1_26_0::metamodel::mapping::LocalMappingPropertyInfo
+                                        (
+                                           type = $r.localMappingPropertyType->toOne()->elementToPath(),
+                                           multiplicity = $r.localMappingPropertyMultiplicity->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()
+                                        ),
+                                       |[]
+                                   )
+         ),
+      i:InlineEmbeddedSetImplementation[1]|
+         ^meta::protocols::pure::v1_26_0::metamodel::mapping::InlineEmbeddedPropertyMapping
+         (
+            _type = 'inlineEmbeddedPropertyMapping',
+            id = $i.id,
+            property = $pm.property->createPropertyPtr(),
+            target = $i.id,
+            setImplementationId = $i.inlineSetImplementationId
+         ),
+      o:OtherwiseEmbeddedRelationalInstanceSetImplementation[1]|
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::OtherwiseEmbeddedRelationalPropertyMapping
+         (
+            _type = 'otherwiseEmbeddedPropertyMapping',
+            id = $o.id,
+            property = $pm.property->createPropertyPtr(),
+            target = $o.id,
+            classMapping = $o->transformEmbeddedRelationalInstanceSetImplementation($topDatabase, $extensions)->cast(@RelationalClassMapping),
+            otherwisePropertyMapping = $o.otherwisePropertyMapping->transformRelationalPropertyMapping($topDatabase, $mapping, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::RelationalPropertyMapping)
+         ),
+      e:EmbeddedRelationalInstanceSetImplementation[1]|
+         ^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::EmbeddedRelationalPropertyMapping
+         (
+            _type = 'embeddedPropertyMapping',
+            id = $e.id,
+            property = $pm.property->createPropertyPtr(),
+            target = $e.id,
+            classMapping = $e->transformEmbeddedRelationalInstanceSetImplementation($topDatabase, $extensions)->cast(@RelationalClassMapping)
+         ),
+      x:meta::pure::mapping::xStore::XStorePropertyMapping[1] |
+         $x->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::mapping::xStore::transformXStorePropertyMapping($mapping, $extensions)
+   ]);
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::createPropertyPtr(p:AbstractProperty<Any>[1]): meta::protocols::pure::v1_26_0::metamodel::domain::PropertyPtr[1]
+{
+   let propertyName = $p->meta::pure::milestoning::reverseMilestoningTransforms()->orElse($p).name->toOne();
+   ^meta::protocols::pure::v1_26_0::metamodel::domain::PropertyPtr(class=$p->genericType().typeArguments->at(0).rawType->toOne()->elementToPath(), property=$propertyName);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformSchema(schema:meta::relational::metamodel::Schema[1], topDatabase: meta::relational::metamodel::Database[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::Schema[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Schema
+   (
+      name = $schema.name->toOne(),
+      tables = $schema.tables->map(t|$t->transformTable($extensions)),
+      views = $schema.views->map(t|$t->transformView($topDatabase))
+   )
+}
+
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformJoin(j:meta::relational::metamodel::join::Join[1], topDatabase:meta::relational::metamodel::Database[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::Join[1]
+{
+   let r = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Join
+   (
+      name = $j.name,
+      operation = $j.operation->transformRelationalOperationElement($topDatabase)
+   );
+   if ($j.target->isEmpty(),
+    |$r,
+    |^$r(target='{target}')
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformFilter(j:meta::relational::metamodel::Filter[1], topDatabase:meta::relational::metamodel::Database[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::Filter[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Filter
+   (
+      _type = $j->match([m:MultiGrainFilter[1]|'multigrain', f:Filter[1]|'filter']),
+      name = $j.name,
+      operation = $j.operation->transformRelationalOperationElement($topDatabase)
+   )
+}
+
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalOperationElement(re:meta::relational::metamodel::RelationalOperationElement[1], topDatabase:meta::relational::metamodel::Database[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::element::RelationalElement[1]
+{
+   $re->match(
+      [
+         t:TableAliasColumn[1]|let table = $t.alias.relationalElement->cast(@NamedRelation);
+                               let schema = $table->match([t:Table[1]|$t.schema,v:View[1]|$v.schema]);
+                               ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::ColumnPtr
+                               (
+                                  _type = 'column',
+                                  tableAlias = if($t.alias.name->equal('t_' + $table.name),|'{target}',|$t.alias.name),
+                                  table = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr(
+                                     _type = 'table',
+                                     database = $schema.database->elementToPath(),
+                                     mainTableDb = $schema.database->elementToPath(),
+                                     schema = $schema.name,
+                                     table = if($t.alias.name->equal('t_' + $table.name),|'{target}',|$table.name)),
+                                  column = $t.column.name
+                               );,
+         r:RelationalOperationElementWithJoin[1]| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::ElementWithJoins
+                                                 (
+                                                    _type = 'elemtWithJoins',
+                                                    joins = $r.joinTreeNode->toOne()->transformJoinTreeNode(),
+                                                    relationalElement = if ($r.relationalOperationElement->isEmpty(),|[],|$r.relationalOperationElement->toOne()->transformRelationalOperationElement(if($topDatabase==$r.joinTreeNode.database->toOne(),|$topDatabase,|$r.joinTreeNode.database->toOne())))
+                                                 );,
+         d:DynaFunction[1]| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::DynamicFunction
+                            (
+                               _type = 'dynaFunc',
+                               funcName = $d.name,
+                               parameters = $d.parameters->map(p|$p->transformRelationalOperationElement($topDatabase))
+                            ),
+         l:Literal[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::Literal
+                      (
+                         _type = 'literal',
+                         value = $l.value
+                      ),
+         l:LiteralList[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::LiteralList
+                      (
+                        _type = 'literalList',
+                        values = if ($l.values->isEmpty(),|[],|$l.values->map(x| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::Literal(_type='literal', value=$x.value)))
+                      ),
+         e:UnaryOperation[1]| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::DynamicFunction
+                               (
+                                  _type = 'dynaFunc',
+                                  funcName = $e->genericType().rawType.name->toOne(),
+                                  parameters = $e.nested->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalOperationElement($topDatabase)
+                               ),
+         e:BinaryOperation[1]| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::DynamicFunction
+                               (
+                                  _type = 'dynaFunc',
+                                  funcName = $e->genericType().rawType.name->toOne(),
+                                  parameters = $e.left->concatenate($e.right)->map(p|$p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformRelationalOperationElement($topDatabase))
+                               )
+      ]
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformJoinTreeNode(joinTreeNode: meta::relational::metamodel::join::JoinTreeNode[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::JoinPtr[*]
+{
+   $joinTreeNode->extractLine()->map(j|
+                                     ^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::JoinPtr(
+                                              db = $j.join.database->toOne()->elementToPath(),
+                                              name = $j.join.name,
+                                              joinType = if($j.joinType->isEmpty(),|[],|$j.joinType->toOne()->id())
+                                     )
+                                  )
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformView(view:View[1], topDatabase:Database[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::View[1]
+{
+   let table = $view.mainTableAlias.relationalElement->cast(@NamedRelation);
+   let schema = $table->match([t:Table[1]|$t.schema,v:View[1]|$v.schema]);
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::View
+   (
+      name = $view.name->toOne(),
+      mainTable = ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr(
+          _type = 'Table',
+          table = $table.name,
+          database = $schema.database->elementToPath(),
+         mainTableDb = $schema.database->elementToPath(),
+          schema = $schema.name),
+      primaryKey = $view.primaryKey->map(c|$c.name->toOne()),
+      distinct = $view.distinct->toOne(),
+      groupBy = $view.groupBy.columns->map(c|$c->transformRelationalOperationElement($topDatabase)),
+      filter = if($view.filter->isEmpty(), |[], | ^FilterWithJoins(filter = ^FilterPtr(db=$view.filter.filter.database->toOne()->elementToPath(), name=$view.filter->toOne().filterName), joins = if ($view.filter->toOne().joinTreeNode->isEmpty(),|[],|$view.filter->toOne().joinTreeNode->toOne()->transformJoinTreeNode()))),
+      columnMappings = $view.columnMappings->map(c|^meta::protocols::pure::v1_26_0::metamodel::store::relational::mapping::ColumnMapping(name=$c.columnName, operation=$c.relationalOperationElement->transformRelationalOperationElement($topDatabase)))
+   );
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformTable(table:meta::relational::metamodel::relation::Table[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::Table[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Table
+   (
+      name = $table.name->toOne(),
+      columns = $table.columns->map(c|$c->transformColumn()),
+      primaryKey = $table.primaryKey->map(c|$c.name->toOne()),
+      milestoning = $table.milestoning->map(m|$m->transformMilestoning($extensions))
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformColumn(c:meta::relational::metamodel::RelationalOperationElement[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::Column[1]
+{
+   $c->match([
+                c:Column[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Column
+                            (
+                               name = $c.name->toOne(),
+                               type = $c.type->pureDataTypeToAlloyDataType(),
+                               nullable = if($c.nullable == true,|true,|false)
+                            )
+             ])
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::pureDataTypeToAlloyDataType(c:meta::relational::metamodel::datatype::DataType[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::DataType[1]
+{
+   $c->match(
+               [
+                  r:Varchar[1]|  ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Varchar(_type='Varchar', size=$r.size),
+                  r:Char[1]|  ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Char(_type='Char', size=$r.size),
+                  d:meta::relational::metamodel::datatype::Decimal[1]|  ^meta::protocols::pure::v1_26_0::metamodel::store::relational::Decimal(_type='Decimal', precision=$d.precision, scale=$d.scale),
+                  r:Numeric[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Numeric(_type='Numeric', precision=$r.precision,scale=$r.scale),
+                  r:Double[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Double(_type='Double'),
+                  r:Bit[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Bit(_type='Bit' ),
+                  t:BigInt[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::BigInt(_type='BigInt'),
+                  t:TinyInt[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::TinyInt(_type='TinyInt'),
+                  s:SmallInt[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::SmallInt(_type='SmallInt'),
+                  v:Varbinary[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Varbinary(_type='Varbinary', size=$v.size),
+                  b:meta::relational::metamodel::datatype::Binary[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Binary(_type='Binary', size=$b.size),
+                  i:meta::relational::metamodel::datatype::Integer[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Integer(_type='Integer'),
+                  d:meta::relational::metamodel::datatype::Date[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Date(_type='Date'),
+                  d:meta::relational::metamodel::datatype::Timestamp[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Timestamp(_type='Timestamp'),
+                  d:meta::relational::metamodel::datatype::Float[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Float(_type='Float'),
+                  r:meta::relational::metamodel::datatype::Real[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Real(_type='Real'),
+                  o:meta::relational::metamodel::datatype::Other[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Other(_type='Other'),
+                  a:meta::relational::metamodel::datatype::Array[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::Array(_type='Array')
+
+                ]
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::alloyTypeToString(c:meta::relational::metamodel::datatype::DataType[1]):String[1]
+{
+   $c->match(
+               [
+                  r:Varchar[1]|'VARCHAR('+$r.size->toString()+')',
+                  r:Char[1]|'CHAR('+$r.size->toString()+')',
+                  d:meta::relational::metamodel::datatype::Decimal[1]|'DECIMAL('+$d.precision->toString()+','+$d.scale->toString()+')',
+                  r:Numeric[1]|'NUMERIC('+$r.precision->toString()+','+$r.scale->toString()+')',
+                  r:Double[1]|'DOUBLE',
+                  r:Bit[1]|'BIT',
+                  t:BigInt[1]|'BIGINT',
+                  t:TinyInt[1]|'TINYINT',
+                  s:SmallInt[1]|'SMALLINT',
+                  v:Varbinary[1]|'VARBINARY('+$v.size->toString()+')',
+                  b:meta::relational::metamodel::datatype::Binary[1]|'BINARY('+$b.size->toString()+')',
+                  i:meta::relational::metamodel::datatype::Integer[1]|'INTEGER',
+                  d:meta::relational::metamodel::datatype::Date[1]|'DATE',
+                  d:meta::relational::metamodel::datatype::Timestamp[1]|'TIMESTAMP',
+                  d:meta::relational::metamodel::datatype::Float[1]|'FLOAT',
+                  r:meta::relational::metamodel::datatype::Real[1]|'REAL',
+                  r:meta::relational::metamodel::datatype::Other[1]|'OTHER',
+                  r:meta::relational::metamodel::datatype::Array[1]|'ARRAY',
+                  d:meta::relational::metamodel::datatype::DbSpecificDataType[1]|$d.dbSpecificSql,
+                  d:meta::relational::metamodel::datatype::DataType[1]|'' //columns mapped to functions do not yet support specific DataTypes
+                ]
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::tableToTablePtr(table:meta::relational::metamodel::relation::Table[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr[1]
+{
+    ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr(
+       _type = 'table',
+       table = $table.name,
+       schema = $table.schema.name,
+       database = $table.schema.database ->elementToPath(),
+       mainTableDb = $table.schema.database ->elementToPath()
+    )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::setRelationToTablePtr(s:meta::pure::store::set::SetRelation[1]):meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr[1]
+{
+   $s->match([
+      t:meta::relational::metamodel::relation::Table[1]|
+          ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr(
+                                       _type = 'Table',
+                                       table = $t.name,
+                                       database = $t.schema.database->elementToPath(),
+                                       mainTableDb = $t.schema.database->elementToPath(),
+                                       schema = $t.schema.name);,
+      v:meta::relational::metamodel::relation::View[1]|
+          ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr(
+                                       _type = 'View',
+                                       table = $v.name,
+                                       database = $v.schema.database->elementToPath(),
+                                       mainTableDb = $v.schema.database->elementToPath(),
+                                       schema = $v.schema.name);,
+      s:meta::pure::store::set::SetRelation[1]| fail('not implemented');
+           ^meta::protocols::pure::v1_26_0::metamodel::store::relational::element::TablePtr(_type = 'Table',table = 'table',database = 'db',mainTableDb = 'db',schema = 'schema');
+   ])
+}
+
+function <<access.private>> meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::relational::transformMilestoning(m:meta::relational::metamodel::relation::Milestoning[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::relational::Milestoning[1]
+{
+   let open = newMap([]->cast(@Pair<String,List<Any>>));
+   let transformInfinityDate = {m:TemporalMilestoning[0..1]|if($m.infinityDate->isEmpty(),|[],|$m.infinityDate->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny([], $open, PureOne, $extensions)->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::CDate))};
+
+   $m->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).moduleSerializerExtension('relational')->cast(@meta::protocols::pure::v1_26_0::extension::RelationalModuleSerializerExtension).transfers_milestoning_transformMilestoning->concatenate([
+                b:BusinessMilestoning[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::BusinessMilestoning( _type = 'businessMilestoning', from = $b.from.name, thru = $b.thru.name, infinityDate=$transformInfinityDate->eval($b),thruIsInclusive = $b.thruIsInclusive),
+                s:BusinessSnapshotMilestoning[1]| ^meta::protocols::pure::v1_26_0::metamodel::store::relational::BusinessSnapshotMilestoning( _type = 'businessSnapshotMilestoning', snapshotDate =  $s.snapshotDate.name),
+                p:ProcessingMilestoning[1]|^meta::protocols::pure::v1_26_0::metamodel::store::relational::ProcessingMilestoning( _type = 'processingMilestoning', in = $p.in.name, out = $p.out.name, infinityDate=$transformInfinityDate->eval($p),outIsInclusive = $p.outIsInclusive)
+             ])->toOneMany());
+}

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/extension/extension.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/extension/extension.pure
@@ -1,0 +1,18 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Class meta::protocols::pure::v1_26_0::extension::store::service::ServiceStoreModuleSerializerExtension extends meta::protocols::pure::v1_26_0::extension::ModuleSerializerExtension
+{
+   transfers_securityScheme_transformSecurityScheme : Function<{Nil[1] -> meta::protocols::pure::v1_26_0::metamodel::store::service::SecurityScheme[1]}>[*];
+}

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/extension/extension_serviceStore.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/extension/extension_serviceStore.pure
@@ -1,0 +1,91 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::*;
+
+import meta::external::store::service::metamodel::*;
+import meta::external::store::service::metamodel::mapping::*;
+import meta::external::store::service::metamodel::runtime::*;
+
+function meta::protocols::pure::v1_26_0::extension::store::service::getServiceStoreExtension(type:String[1]):meta::pure::extension::SerializerExtension[1]
+{
+   let res = [
+      pair('serviceStore', | meta::protocols::pure::v1_26_0::extension::store::service::getServiceStoreExtension())
+   ]->filter(f|$f.first == $type);
+   assert($res->isNotEmpty(), |'Can\'t find the type '+$type);
+   $res->at(0).second->eval();
+}
+
+function meta::protocols::pure::v1_26_0::extension::store::service::getServiceStoreExtension():meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0[1]
+{
+   ^meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0
+   (
+      transfers_store_transformConnection = 
+          [
+             serviceStoreConnection:ServiceStoreConnection[1] | $serviceStoreConnection->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::store::service::transformServiceStoreConnection()
+          ],
+      transfers_executionPlan_transformNode = {mapping:Mapping[1], extensions:meta::pure::extension::Extension[*] |
+          [
+             ser:meta::external::store::service::executionPlan::nodes::RestServiceExecutionNode[1]|
+                ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::RestServiceExecutionNode(
+                   _type            = 'restService',
+                   resultType       = $ser.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                   url              = $ser.url,
+                   method           = $ser.method,
+                   mimeType         = $ser.mimeType,
+                   securitySchemes  = $ser.securitySchemes->map(s | $s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformSecurityScheme($extensions)),
+                   requestBodyDescription = if($ser.requestBodyDescription->isEmpty(),
+                                               |[],
+                                               |^meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::RequestBodyDescription(
+                                                    mimeType = $ser.requestBodyDescription.mimeType->toOne(),
+                                                    resultKey = $ser.requestBodyDescription.resultKey->toOne()
+                                                 )),
+                   params           = $ser.params->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStoreParameter())
+                ),
+             spr:meta::external::store::service::executionPlan::nodes::ServiceParametersResolutionExecutionNode[1]|
+                ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::ServiceParametersResolutionExecutionNode(
+                   _type                      = 'serviceParametersResolution',
+                   resultType                 = $spr.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                   requestParametersBuildInfo = $spr.requestParametersBuildInfo->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestParametersBuildInfo($extensions))
+                ),
+             limit:meta::external::store::service::executionPlan::nodes::LimitExecutionNode[1]|
+                ^meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::LimitExecutionNode(
+                   _type='limit',
+                   resultType=$limit.resultType->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                   limit = $limit.limit
+                )
+          ]},
+      transfers_mapping_transformSetImplementation2 = {mapping:Mapping[1], extensions:meta::pure::extension::Extension[*] | [
+            rsi:RootServiceInstanceSetImplementation[1]  | $rsi->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformRootServiceInstanceSetImplementation($mapping, $extensions),
+            esi:EmbeddedServiceStoreSetImplementation[1] | []
+          ]},
+      transfers_store_transformStore2 = {extensions:meta::pure::extension::Extension[*] |
+         [
+            s:ServiceStore[1] | $s->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStore($extensions)
+         ]},
+      scan_buildBasePureModel_extractStores = {m:Mapping[1], extensions:meta::pure::extension::Extension[*] |
+         [
+            rsi:RootServiceInstanceSetImplementation[1]  | $rsi->meta::protocols::pure::v1_26_0::extension::store::service::extractServiceStore(),
+            esi:EmbeddedServiceStoreSetImplementation[1] | $esi->meta::protocols::pure::v1_26_0::extension::store::service::extractServiceStore()
+         ]}
+   )
+}
+
+function meta::protocols::pure::v1_26_0::extension::store::service::extractServiceStore(set:SetImplementation[1]):ServiceStore[1]
+{
+   $set->match([
+      rsi:RootServiceInstanceSetImplementation[1]  | $rsi.serviceStore(),
+      esi:EmbeddedServiceStoreSetImplementation[1] | $esi.owner->cast(@SetImplementation)->toOne()->meta::protocols::pure::v1_26_0::extension::store::service::extractServiceStore()
+   ])
+}

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/models/executionPlan_serviceStore.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/models/executionPlan_serviceStore.pure
@@ -1,0 +1,46 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::*;
+import meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::*;
+
+import meta::protocols::pure::v1_26_0::metamodel::store::service::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::RestServiceExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode
+{
+   url             : String[1];
+   method          : meta::pure::functions::io::http::HTTPMethod[1];
+   mimeType        : String[1];
+   params          : ServiceParameter[*];
+   requestBodyDescription : RequestBodyDescription[0..1];
+   securitySchemes : SecurityScheme[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::RequestBodyDescription
+{
+   mimeType  : String[1];
+   resultKey : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::ServiceParametersResolutionExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode
+{
+   requestParametersBuildInfo : ServiceRequestParametersBuildInfo[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::executionPlan::store::service::LimitExecutionNode extends meta::protocols::pure::v1_26_0::metamodel::executionPlan::ExecutionNode
+{
+   limit : Integer[1];
+}
+

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/models/metamodel_connection.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/models/metamodel_connection.pure
@@ -1,0 +1,18 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Class meta::protocols::pure::v1_26_0::metamodel::connection::store::service::ServiceStoreConnection extends meta::protocols::pure::v1_26_0::metamodel::runtime::Connection
+{
+   baseUrl: String[1];
+}

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/models/metamodel_serviceStore.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/models/metamodel_serviceStore.pure
@@ -1,0 +1,158 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import meta::protocols::pure::v1_26_0::metamodel::store::service::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceStore extends meta::protocols::pure::v1_26_0::metamodel::store::Store
+{
+   description : String[0..1];
+   elements    : ServiceStoreElement[*];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceStoreElement
+{
+   _type    : String[1];
+   
+   id       : String[1];
+   path     : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceGroup extends ServiceStoreElement
+{
+   elements : ServiceStoreElement[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::Service extends ServiceStoreElement
+{  
+   requestBody : TypeReference[0..1];
+   method      : String[1];
+   parameters  : ServiceParameter[*];
+   response    : ComplexTypeReference[1];
+   security    : SecurityScheme[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceParameter
+{
+   name                 : String[1];
+   type                 : TypeReference[1];
+   location             : String[1];
+
+   allowReserved        : Boolean[0..1];
+   required             : Boolean[0..1];
+   _enum                : String[0..1];
+   serializationFormat  : SerializationFormat[0..1];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::store::service::TypeReference
+{
+   _type    : String[1];
+   
+   list     : Boolean[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::StringTypeReference extends meta::protocols::pure::v1_26_0::metamodel::store::service::TypeReference
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::BooleanTypeReference extends meta::protocols::pure::v1_26_0::metamodel::store::service::TypeReference
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::IntegerTypeReference extends meta::protocols::pure::v1_26_0::metamodel::store::service::TypeReference
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::FloatTypeReference extends meta::protocols::pure::v1_26_0::metamodel::store::service::TypeReference
+{
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::ComplexTypeReference extends meta::protocols::pure::v1_26_0::metamodel::store::service::TypeReference
+{
+   type    : String[1];
+   binding : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::SerializationFormat
+{
+   style   : String[0..1];
+   explode : Boolean[0..1];
+}
+
+Class <<typemodifiers.abstract>> meta::protocols::pure::v1_26_0::metamodel::store::service::SecurityScheme
+{
+   _type    : String[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceGroupPtr
+{
+   serviceStore : String[1];
+   serviceGroup : String[1];
+   parent       : ServiceGroupPtr[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::ServicePtr
+{
+   serviceStore : String[1];
+   service      : String[1];
+   parent       : ServiceGroupPtr[0..1];
+}
+
+
+// Mapping
+###Pure
+import meta::protocols::pure::v1_26_0::metamodel::store::service::*;
+import meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::*;
+
+import meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::*;
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::RootServiceClassMapping extends meta::protocols::pure::v1_26_0::metamodel::mapping::ClassMapping
+{
+   localMappingProperties : LocalMappingProperty[*];
+   servicesMapping        : ServiceMapping[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::LocalMappingProperty
+{
+   name         : String[1];
+   type         : String[1];
+   multiplicity : meta::protocols::pure::v1_26_0::metamodel::domain::Multiplicity[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceMapping
+{
+   service          : ServicePtr[1];
+   pathOffset       : Path[0..1];
+   requestBuildInfo : ServiceRequestBuildInfo[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestBuildInfo
+{
+   requestParametersBuildInfo : ServiceRequestParametersBuildInfo[0..1];
+   requestBodyBuildInfo       : ServiceRequestBodyBuildInfo[0..1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestParametersBuildInfo
+{
+   parameterBuildInfoList : ServiceRequestParameterBuildInfo[*];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestParameterBuildInfo
+{
+   serviceParameter : String[1];
+   transform        : Lambda[1];
+}
+
+Class meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestBodyBuildInfo
+{
+   transform        : Lambda[1];
+}

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/transfers/connection_serviceStore.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/transfers/connection_serviceStore.pure
@@ -1,0 +1,26 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::external::store::service::metamodel::*;
+import meta::external::store::service::metamodel::runtime::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::connection::store::service::transformServiceStoreConnection(connection: ServiceStoreConnection[1]):meta::protocols::pure::v1_26_0::metamodel::connection::store::service::ServiceStoreConnection[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::connection::store::service::ServiceStoreConnection(
+      _type   = 'serviceStore',
+      element = $connection.element->cast(@ServiceStore)->elementToPath(),
+      baseUrl = $connection.baseUrl
+   );
+}

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/transfers/metamodel_serviceStore.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/protocols/pure/v1_26_0/transfers/metamodel_serviceStore.pure
@@ -1,0 +1,169 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::extension::*;
+import meta::external::store::service::metamodel::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStore(s:ServiceStore[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceStore[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceStore(
+      _type       = 'serviceStore',
+      description = $s.description,
+      name        = $s.name->toOne(),
+      package     = if($s.package->isEmpty(), |[], |$s.package->toOne()->elementToPath()),
+      elements    = $s.elements->map(e | $e->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStoreElement($extensions))
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStoreElement(s:ServiceStoreElement[1], extensions:Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceStoreElement[1]
+{
+   $s->match([
+      sg: ServiceGroup[1] | ^meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceGroup(
+                                 _type    = 'serviceGroup',
+                                 id       = $sg.id,
+                                 path     = $sg.path,
+                                 elements = $sg.elements->map(e | $e->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStoreElement($extensions))
+                             ),
+      s: Service[1]       | ^meta::protocols::pure::v1_26_0::metamodel::store::service::Service(
+                                 _type      = 'service',
+                                 id         = $s.id,
+                                 path       = $s.path,
+                                 requestBody= $s.requestBody->map(b | $b->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformTypeReference()),
+                                 method     = $s.method->toString(),
+                                 parameters = $s.parameters->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStoreParameter()),
+                                 response   = $s.response->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformTypeReference()->cast(@meta::protocols::pure::v1_26_0::metamodel::store::service::ComplexTypeReference),
+                                 security   = $s.security->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformSecurityScheme($extensions))
+                             )
+   ])
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformServiceStoreParameter(s:ServiceParameter[1]):meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceParameter[1]
+{
+   let type = $s.type->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformTypeReference();
+   
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceParameter(
+      name                = $s.name,
+      type                = $type,
+      allowReserved       = $s.allowReserved,
+      required            = $s.required,
+      location            = $s.location->toString(),
+      _enum               = if($s.enum->isEmpty(), | [], | $s.enum->toOne()->elementToPath()),
+      serializationFormat = ^meta::protocols::pure::v1_26_0::metamodel::store::service::SerializationFormat(style = $s.serializationFormat.style, explode = $s.serializationFormat.explode)
+   );
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformTypeReference(t:TypeReference[1]):meta::protocols::pure::v1_26_0::metamodel::store::service::TypeReference[1]
+{
+   $t->match([
+      st: StringTypeReference[1]  | ^meta::protocols::pure::v1_26_0::metamodel::store::service::StringTypeReference(_type = 'string', list = $st.list),
+      bt: BooleanTypeReference[1] | ^meta::protocols::pure::v1_26_0::metamodel::store::service::BooleanTypeReference(_type = 'boolean', list = $bt.list),
+      it: IntegerTypeReference[1] | ^meta::protocols::pure::v1_26_0::metamodel::store::service::IntegerTypeReference(_type = 'integer', list = $it.list),
+      ft: FloatTypeReference[1]   | ^meta::protocols::pure::v1_26_0::metamodel::store::service::FloatTypeReference(_type = 'float', list = $ft.list),
+      ct: ComplexTypeReference[1] | ^meta::protocols::pure::v1_26_0::metamodel::store::service::ComplexTypeReference(_type = 'complex', list = $ct.list, type = $ct.type->elementToPath(), binding = $ct.binding->elementToPath())
+   ]);
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::transformSecurityScheme(a:SecurityScheme[1], extensions:Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::SecurityScheme[1]
+{
+   $a->match($extensions.serializerExtension('v1_26_0')->cast(@meta::protocols::pure::v1_26_0::extension::SerializerExtension_v1_26_0).moduleSerializerExtension('serviceStore')->cast(@meta::protocols::pure::v1_26_0::extension::store::service::ServiceStoreModuleSerializerExtension).transfers_securityScheme_transformSecurityScheme->concatenate([
+      a:SecurityScheme[1]      | fail('Unsupported Authentication Strategy'); ^meta::protocols::pure::v1_26_0::metamodel::store::service::SecurityScheme(_type = 'unknown');
+   ])->toOneMany())
+}
+
+// Mapping
+###Pure
+import meta::pure::mapping::*;
+
+import meta::external::store::service::metamodel::mapping::*;
+import meta::external::store::service::metamodel::*;
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformRootServiceInstanceSetImplementation(s:RootServiceInstanceSetImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::RootServiceClassMapping[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::RootServiceClassMapping(
+      id                     = $s.id,
+      _type                  = 'serviceStore',
+      class                  = $s.class->elementToPath(),
+      root                   = $s.root,
+      mappingClass           = $s.mappingClass->map(mc|$mc->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMappingClass($mapping, $extensions)),
+      localMappingProperties = $s.localProperties->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformLocalMappingProperties()),
+      servicesMapping        = $s.servicesMapping->map(sm | $sm->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceMapping($extensions))
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformLocalMappingProperties(p:Property<Nil,Any|*>[1]):meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::LocalMappingProperty[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::LocalMappingProperty(
+      name         = $p.name->toOne(),
+      type         = $p->functionReturnType().rawType->toOne()->elementToPath(),
+      multiplicity = $p.multiplicity->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::transformMultiplicity()
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceMapping(sm:ServiceMapping[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceMapping[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceMapping(
+      service          = $sm.service->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceToServicePtr(),
+      pathOffset       = $sm.pathOffset->map(p | $p->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::valueSpecification::transformAny([], newMap([])->cast(@Map<String,List<Any>>), $p->functionReturnMultiplicity(), $extensions))->cast(@meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Path),
+      requestBuildInfo = $sm.requestBuildInfo->map(r | $r->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestBuildInfo($extensions))
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceToServiceGroupPtr(s:ServiceGroup[1]):meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceGroupPtr[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::ServiceGroupPtr(
+      serviceGroup = $s.id,
+      serviceStore = $s.owner->elementToPath(),
+      parent       = if($s.parent->isEmpty(), | [], |$s.parent->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceToServiceGroupPtr())
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceToServicePtr(s:Service[1]):meta::protocols::pure::v1_26_0::metamodel::store::service::ServicePtr[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::ServicePtr(
+      service      = $s.id,
+      serviceStore = $s.owner->elementToPath(),
+      parent       = if($s.parent->isEmpty(), | [], |$s.parent->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceToServiceGroupPtr())
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestBuildInfo(s:ServiceRequestBuildInfo[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestBuildInfo[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestBuildInfo(
+      requestParametersBuildInfo = $s.requestParametersBuildInfo->map(param | $param->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestParametersBuildInfo($extensions)),
+      requestBodyBuildInfo       = $s.requestBodyBuildInfo->map(body | $body->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestBodyBuildInfo($extensions))
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestParametersBuildInfo(s:ServiceRequestParametersBuildInfo[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestParametersBuildInfo[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestParametersBuildInfo(
+      parameterBuildInfoList = $s.parameterBuildInfoList->map(param | $param->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestParameterBuildInfo($extensions))
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestParameterBuildInfo(s:ServiceRequestParameterBuildInfo[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestParameterBuildInfo[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestParameterBuildInfo(
+      serviceParameter = $s.serviceParameter.name,
+      transform        = $s.transform->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)
+   )
+}
+
+function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::store::service::mapping::transformServiceRequestBodyBuildInfo(s:ServiceRequestBodyBuildInfo[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestBodyBuildInfo[1]
+{
+   ^meta::protocols::pure::v1_26_0::metamodel::store::service::mapping::ServiceRequestBodyBuildInfo(
+      transform = $s.transform->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)
+   )
+}


### PR DESCRIPTION
#### What type of PR is this?

Enhancement

<!--
Add one/more labels.
-->

#### What does this PR do / why is it needed ?

This introduce a new client pure protocol version, 1_26_0.

Per instructions, copied all the X_X_X directories/files into newly created 1_26_0, and replaced vX_X_X on the code with v1_26_0.  This froze all changes develop on vX_X_X, and make them ready for production usage.

This change also set the production version as 1_26_0.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

Yes, this will enable new functionality under the X_X_X version.  Two that I'm aware: enum parameters on services, and url scheme when executing rest calls from execution plans.

<!--
-->
