### PR TITLE
Split deploy task into two commands to workaround maven-jar-plugin bug.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,9 @@ jobs:
           DOCKER_USERNAME: finos
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           MAVEN_OPTS: -Xmx4g
-        run: mvn install javadoc:javadoc deploy -P docker-snapshot
+        run: |
+          mvn install -DskipTests=true
+          mvn javadoc:javadoc deploy -P docker-snapshot
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
#### What type of PR is this?
Bug fix

#### What does this PR do / why is it needed ?
This PR splits our deployment action into two separate maven commands.
- The first does an install on the project, solely to kick-off APT code generation.
- The second generates javadoc (which would fail without APT code generation) and performs deploy

These commands were previously smushed into a single command, but this triggered a bug in maven-jar-plugin which fails when executing JAR twice in a build for a module with no source files.

#### Which issue(s) this PR fixes:
None

#### Other notes for reviewers:
None

#### Does this PR introduce a user-facing change?
No