### PR TITLE
Add source data type info for constant columns

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -2281,7 +2281,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testModelConnectionAgg(
    let expected =
       'Relational\n'+
       '(\n'+
-      '  type = TDS[(FirstName, String, "", ""), (PersonCount, Integer, INT, "")]\n'+
+      '  type = TDS[(FirstName, String, VARCHAR(200), ""), (PersonCount, Integer, INT, "")]\n'+
       '  resultColumns = [("FirstName", ""), ("PersonCount", "")]\n'+
       '  sql = select substring("root".fullname, 0, LOCATE(\' \', "root".fullname)) as "FirstName", count(substring("root".fullname, (LOCATE(\' \', "root".fullname) + 1), char_length("root".fullname))) as "PersonCount" from SPerson as "root" group by "FirstName"\n'+
       '  connection = TestDatabaseConnection(type = "H2")\n'+
@@ -2838,4 +2838,19 @@ function <<test.Test>> meta::pure::executionPlan::tests::testSupportGraphFetchWi
   assertSameElements([], $employeesTree.constraintsExclusions);
   assertSameElements(['duplicateEmployee'], $innerFirmTree.constraintsExclusions);
 
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::testGroupByWithGroupingOnConstantColumn():Boolean[1]
+{
+   let generatedPlan = executionPlan({|Address.all()->groupBy([x | 'constant'], [agg(x | $x.name, y | $y->count())], ['Constant', 'Constant Count'])}, simpleRelationalMapping, meta::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let result = $generatedPlan->planToString(meta::relational::extension::relationalExtensions());
+   let expected = 'Relational\n' +
+            '(\n' +
+            '  type = TDS[(Constant, String, VARCHAR(8), \"\"), (Constant Count, Integer, INT, \"\")]\n' +
+            '  resultColumns = [(\"Constant\", \"\"), (\"Constant Count\", \"\")]\n' +
+            '  sql = select \'constant\' as \"Constant\", count(\"root\".NAME) as \"Constant Count\" from addressTable as \"root\" group by \"Constant\"\n' +
+            '  connection = TestDatabaseConnection(type = \"H2\")\n' +
+            ')\n';
+   assertEquals($expected, $result);
+   assertSameElements(templateFunctionsList(),$generatedPlan.processingTemplateFunctions);
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -677,7 +677,7 @@ function  meta::relational::functions::pureToSqlQuery::processObjectGroupBy(f:Fu
    let funcPathInformation = $functions->map(f|let index = $functions->indexOf($f);
                                                let p = $preProcessedFuncs->at($index);
                                                let pureType = $f->functionReturnType().rawType->toOne();
-                                               let relationalType = $p.element->cast(@SelectWithCursor).select.groupBy->map(c | $c->meta::relational::functions::typeInference::inferRelationalType())->first();
+                                               let relationalType = $p.element->cast(@SelectWithCursor).select.groupBy->map(c | $c->meta::relational::functions::typeInference::inferRelationalType(false))->first();
                                                ^PathInformation(propertyMapping = if($p.currentPropertyMapping->isEmpty(),|[],|$p.currentPropertyMapping->at(0)),
                                                                 type = $pureType,
                                                                 relationalType = $relationalType);

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -676,8 +676,11 @@ function  meta::relational::functions::pureToSqlQuery::processObjectGroupBy(f:Fu
    //Functions
    let funcPathInformation = $functions->map(f|let index = $functions->indexOf($f);
                                                let p = $preProcessedFuncs->at($index);
+                                               let pureType = $f->functionReturnType().rawType->toOne();
+                                               let relationalType = $p.element->cast(@SelectWithCursor).select.groupBy->map(c | $c->meta::relational::functions::typeInference::inferRelationalType())->first();
                                                ^PathInformation(propertyMapping = if($p.currentPropertyMapping->isEmpty(),|[],|$p.currentPropertyMapping->at(0)),
-                                                                type = $f->functionReturnType().rawType->toOne());
+                                                                type = $pureType,
+                                                                relationalType = $relationalType);
                                                        );
 
    //Add types for Aggregations

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -139,7 +139,7 @@ function meta::relational::functions::typeInference::inferRelationalType(rop: Re
                                    | ^meta::relational::metamodel::datatype::Timestamp(),
                                    | if($d.type == StrictDate,
                                         | ^meta::relational::metamodel::datatype::Date(),
-                                        | fail('Not supported yet!'); ^meta::relational::metamodel::datatype::DataType();
+                                        | if($failOnMatchFailure, | fail('Not supported yet!'); ^meta::relational::metamodel::datatype::DataType();, |[]);
                                      )
                                 )
                            )
@@ -808,7 +808,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'minus',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == $params->at(1)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)},
+               {params: RelationalOperationElement[*] | ($params->size() == 1) || ($params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == $params->at(1)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>))},
                {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
             )
          ])


### PR DESCRIPTION
#### What type of PR is this?
This fixes gap in relational type inference for a column. It is a bug fix

#### What does this PR do / why is it needed ?
This fixes gap in relational type inference for a column.  This is needed because this information is used when a tds join is created on top of such query, In its absence query fails to generate sql

#### Which issue(s) this PR fixes:
No issue raised, ad-hoc fix

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes, this will fix join queries written on top of queries similar to one attached below. This will also populate additional info in execution plan, which should not have any negative impact 

```
{|Address.all()->groupBy([x | 'constant'], [agg(x | $x.name, y | $y->count())], ['Constant', 'Constant Count'])}
```
