### PR TITLE
Make sure role on Snowflake DB spec is properly propagated to pure

### DIFF
--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DatasourceSpecificationBuilder.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DatasourceSpecificationBuilder.java
@@ -104,7 +104,7 @@ public class DatasourceSpecificationBuilder implements DatasourceSpecificationVi
                 _snowflake._accountType(this.context.pureModel.getEnumValue("meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType", snowflakeDatasourceSpecification.accountType));
             }
             _snowflake._organization(snowflakeDatasourceSpecification.organization);
-
+            _snowflake._role(snowflakeDatasourceSpecification.role);
 
             return _snowflake;
         }

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalConnectionCompilationRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalConnectionCompilationRoundtrip.java
@@ -21,6 +21,8 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextDa
 import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_RelationalDatabaseConnection;
 import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_authentication_DelegatedKerberosAuthenticationStrategy_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_authentication_MiddleTierUserNamePasswordAuthenticationStrategy_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy;
+import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,30 +32,88 @@ import static org.junit.Assert.assertEquals;
 public class TestRelationalConnectionCompilationRoundtrip
 {
     @Test
-    public void testConnectionPropertiesPropagatedToCompiledGraph()
+    public void testSnowflakeConnectionPropertiesPropagatedToCompiledGraph()
     {
-        Pair<PureModelContextData, PureModel> compiledGraph = test(TestRelationalCompilationFromGrammar.DB_INC +
+        Pair<PureModelContextData, PureModel> result = test(TestRelationalCompilationFromGrammar.DB_INC +
                 "###Connection\n" +
-                "RelationalDatabaseConnection simple::H2Connection\n" +
+                "RelationalDatabaseConnection simple::StaticConnection\n" +
                 "{\n" +
-                "  store: model::relational::tests::dbInc;\n" +
-                "  type: H2;\n" +
-                "  quoteIdentifiers: true;\n" +
-                "  specification: LocalH2\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: Snowflake;\n" +
+                "  specification: Snowflake\n" +
                 "  {\n" +
+                "    name: 'test';\n" +
+                "    account: 'account';\n" +
+                "    warehouse: 'warehouseName';\n" +
+                "    region: 'us-east2';\n" +
+                "    proxyHost: 'sampleHost';\n" +
+                "    proxyPort: 'samplePort';\n" +
+                "    nonProxyHosts: 'sample';\n" +
+                "    accountType: MultiTenant;\n" +
+                "    organization: 'sampleOrganization';\n" +
+                "    role: 'DB_ROLE_123';\n" +
                 "  };\n" +
-                "  auth: DelegatedKerberos\n" +
-                "  {\n" +
-                "    serverPrincipal: 'dummyPrincipal';" +
+                "  auth: SnowflakePublic\n" +
+                "  {" +
+                "       publicUserName: 'name';\n" +
+                "       privateKeyVaultReference: 'privateKey';\n" +
+                "       passPhraseVaultReference: 'passPhrase';\n" +
                 "  };\n" +
                 "}\n");
-        Root_meta_pure_alloy_connections_RelationalDatabaseConnection connection = (Root_meta_pure_alloy_connections_RelationalDatabaseConnection) compiledGraph.getTwo().getConnection("simple::H2Connection", SourceInformation.getUnknownSourceInformation());
-        String serverPrincipal = ((Root_meta_pure_alloy_connections_alloy_authentication_DelegatedKerberosAuthenticationStrategy_Impl) connection._authenticationStrategy())._serverPrincipal();
-        Boolean quoteIdentifiers = connection._quoteIdentifiers();
 
-        Assert.assertTrue(quoteIdentifiers);
-        Assert.assertEquals("dummyPrincipal", serverPrincipal);
 
+        Root_meta_pure_alloy_connections_RelationalDatabaseConnection connection = (Root_meta_pure_alloy_connections_RelationalDatabaseConnection) result.getTwo().getConnection("simple::StaticConnection", SourceInformation.getUnknownSourceInformation());
+
+        Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification specification = (Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification) connection._datasourceSpecification();
+
+        Assert.assertEquals("test", specification._databaseName());
+        Assert.assertEquals("account", specification._accountName());
+        Assert.assertEquals("warehouseName", specification._warehouseName());
+        Assert.assertEquals("us-east2", specification._region());
+        Assert.assertEquals("sampleHost", specification._proxyHost());
+        Assert.assertEquals("samplePort", specification._proxyPort());
+        Assert.assertEquals("sample", specification._nonProxyHosts());
+        Assert.assertEquals(result.getTwo().getEnumValue("meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType", "MultiTenant"), specification._accountType());
+        Assert.assertEquals("sampleOrganization", specification._organization());
+        Assert.assertEquals("DB_ROLE_123", specification._role());
+
+        Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy authenticationStrategy = (Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy) connection._authenticationStrategy();
+
+        Assert.assertEquals("name", authenticationStrategy._publicUserName());
+        Assert.assertEquals("privateKey", authenticationStrategy._privateKeyVaultReference());
+        Assert.assertEquals("passPhrase", authenticationStrategy._passPhraseVaultReference());
+
+    }
+
+    @Test
+    public void testMemSqlConnectionPropertiesPropagatedToCompiledGraph()
+    {
+        Pair<PureModelContextData, PureModel> result = test(TestRelationalCompilationFromGrammar.DB_INC +
+                "###Connection\n" +
+                "RelationalDatabaseConnection simple::StaticConnection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: MemSQL;\n" +
+                "  specification: Static\n" +
+                "  {\n" +
+                "    name: 'name';\n" +
+                "    host: 'host';\n" +
+                "    port: 1234;\n" +
+                "  };\n" +
+                "  auth: MiddleTierUserNamePassword\n" +
+                "  {\n" +
+                "    vaultReference: 'value';\n" +
+                "  };\n" +
+                "}\n");
+
+        Root_meta_pure_alloy_connections_RelationalDatabaseConnection connection = (Root_meta_pure_alloy_connections_RelationalDatabaseConnection) result.getTwo().getConnection("simple::StaticConnection", SourceInformation.getUnknownSourceInformation());
+        String vaultReference = ((Root_meta_pure_alloy_connections_alloy_authentication_MiddleTierUserNamePasswordAuthenticationStrategy_Impl) connection._authenticationStrategy())._vaultReference();
+        assertEquals("value", vaultReference);
+    }
+
+    @Test
+    public void testSqlServerConnectionPropertiesPropagatedToCompiledGraph()
+    {
         test(TestRelationalCompilationFromGrammar.DB_INC +
                 "###Connection\n" +
                 "RelationalDatabaseConnection simple::StaticConnection\n" +
@@ -91,29 +151,32 @@ public class TestRelationalConnectionCompilationRoundtrip
                 "    passwordVaultReference: 'value';\n" +
                 "  };\n" +
                 "}\n");
-
-        Pair<PureModelContextData, PureModel> result = test(TestRelationalCompilationFromGrammar.DB_INC +
-                "###Connection\n" +
-                "RelationalDatabaseConnection simple::StaticConnection\n" +
-                "{\n" +
-                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
-                "  type: MemSQL;\n" +
-                "  specification: Static\n" +
-                "  {\n" +
-                "    name: 'name';\n" +
-                "    host: 'host';\n" +
-                "    port: 1234;\n" +
-                "  };\n" +
-                "  auth: MiddleTierUserNamePassword\n" +
-                "  {\n" +
-                "    vaultReference: 'value';\n" +
-                "  };\n" +
-                "}\n");
-
-        Root_meta_pure_alloy_connections_RelationalDatabaseConnection connection2 = (Root_meta_pure_alloy_connections_RelationalDatabaseConnection) result.getTwo().getConnection("simple::StaticConnection", SourceInformation.getUnknownSourceInformation());
-        String vaultReference = ((Root_meta_pure_alloy_connections_alloy_authentication_MiddleTierUserNamePasswordAuthenticationStrategy_Impl) connection2._authenticationStrategy())._vaultReference();
-        assertEquals("value", vaultReference);
     }
 
+    @Test
+    public void testH2ConnectionPropertiesPropagatedToCompiledGraph()
+    {
+        Pair<PureModelContextData, PureModel> compiledGraph = test(TestRelationalCompilationFromGrammar.DB_INC +
+                "###Connection\n" +
+                "RelationalDatabaseConnection simple::H2Connection\n" +
+                "{\n" +
+                "  store: model::relational::tests::dbInc;\n" +
+                "  type: H2;\n" +
+                "  quoteIdentifiers: true;\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "  };\n" +
+                "  auth: DelegatedKerberos\n" +
+                "  {\n" +
+                "    serverPrincipal: 'dummyPrincipal';" +
+                "  };\n" +
+                "}\n");
+        Root_meta_pure_alloy_connections_RelationalDatabaseConnection connection = (Root_meta_pure_alloy_connections_RelationalDatabaseConnection) compiledGraph.getTwo().getConnection("simple::H2Connection", SourceInformation.getUnknownSourceInformation());
+        String serverPrincipal = ((Root_meta_pure_alloy_connections_alloy_authentication_DelegatedKerberosAuthenticationStrategy_Impl) connection._authenticationStrategy())._serverPrincipal();
+        Boolean quoteIdentifiers = connection._quoteIdentifiers();
+
+        Assert.assertTrue(quoteIdentifiers);
+        Assert.assertEquals("dummyPrincipal", serverPrincipal);
+    }
 
 }


### PR DESCRIPTION
#### What type of PR is this?

Bugfix

<!--
Add one/more labels.
-->

#### What does this PR do / why is it needed ?

Currently, the Snowflake db spec model and grammar allow users to provide a role.  This role was not propagate to pure, ending not been use on the execution plans, and leading to confusion on user on why queries to Snowflake were failing.

This PR fixes this bug, and add test case to validate correct behavior.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
Not directly.  Users already can specify role on Snowflake DB spec.   This could yield to different execution behavior if they were indeed specifying this since this was previously ignored.