### PR TITLE
Support to override production pure client version

### DIFF
--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/DefaultPureClientVersionProvider.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/DefaultPureClientVersionProvider.java
@@ -1,0 +1,26 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure;
+
+class DefaultPureClientVersionProvider implements PureClientVersionProvider
+{
+    static final DefaultPureClientVersionProvider DEFAULT_PROVIDER = new DefaultPureClientVersionProvider();
+
+    @Override
+    public String getActiveVersion()
+    {
+        return "v1_26_0";
+    }
+}

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/PureClientVersionProvider.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/PureClientVersionProvider.java
@@ -1,0 +1,20 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure;
+
+public interface PureClientVersionProvider
+{
+    String getActiveVersion();
+}

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/PureClientVersions.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/PureClientVersions.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.protocol.pure;
 
+import java.util.Iterator;
+import java.util.ServiceLoader;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.impl.utility.ArrayIterate;
@@ -22,13 +24,33 @@ public class PureClientVersions
 {
     public static ImmutableList<String> versions = Lists.immutable.with("v1_0_0", "v1_1_0", "v1_2_0", "v1_3_0", "v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v1_8_0", "v1_9_0", "v1_10_0", "v1_11_0", "v1_12_0", "v1_13_0", "v1_14_0", "v1_15_0", "v1_16_0", "v1_17_0", "v1_18_0", "v1_19_0", "v1_20_0", "v1_21_0", "v1_22_0", "v1_23_0", "v1_24_0", "v1_25_0", "v1_26_0", "vX_X_X");
     public static ImmutableList<String> versionsSameCase = versions.collect(String::toLowerCase);
+    static PureClientVersionProvider pureClientVersionProvider = loadPureClientVersionProvider();
 
     static
     {
         assert !hasRepeatedVersions(versions) : "Repeated version id :" + versions.toBag().selectByOccurrences(i -> i > 1).toSet().makeString("[", ", ", "]");
     }
 
-    public static String production = "v1_26_0";
+    public static String production = pureClientVersionProvider.getActiveVersion();
+
+    private static PureClientVersionProvider loadPureClientVersionProvider()
+    {
+        PureClientVersionProvider provider;
+        Iterator<PureClientVersionProvider> providers = ServiceLoader.load(PureClientVersionProvider.class).iterator();
+        if (providers.hasNext())
+        {
+            provider = providers.next();
+            if (providers.hasNext())
+            {
+                throw new IllegalStateException("Found more than one PureClientVersionProvider in classpath");
+            }
+        }
+        else
+        {
+            provider = DefaultPureClientVersionProvider.DEFAULT_PROVIDER;
+        }
+        return provider;
+    }
 
     static boolean hasRepeatedVersions(ImmutableList<String> versions)
     {

--- a/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/pure/PureClientVersionProviderForTest.java
+++ b/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/pure/PureClientVersionProviderForTest.java
@@ -1,0 +1,24 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure;
+
+public class PureClientVersionProviderForTest implements PureClientVersionProvider
+{
+    @Override
+    public String getActiveVersion()
+    {
+        return DefaultPureClientVersionProvider.DEFAULT_PROVIDER.getActiveVersion();
+    }
+}

--- a/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/pure/TestPureClientVersions.java
+++ b/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/pure/TestPureClientVersions.java
@@ -1,0 +1,29 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestPureClientVersions
+{
+    @Test
+    public void loadVersionFromProvider()
+    {
+        PureClientVersionProvider pureClientVersionProvider = PureClientVersions.pureClientVersionProvider;
+        Assert.assertTrue(pureClientVersionProvider instanceof PureClientVersionProviderForTest);
+        Assert.assertSame(PureClientVersions.production, pureClientVersionProvider.getActiveVersion());
+    }
+}

--- a/legend-engine-protocol-pure/src/test/resources/META-INF/services/org.finos.legend.engine.protocol.pure.PureClientVersionProvider
+++ b/legend-engine-protocol-pure/src/test/resources/META-INF/services/org.finos.legend.engine.protocol.pure.PureClientVersionProvider
@@ -1,0 +1,1 @@
+org.finos.legend.engine.protocol.pure.PureClientVersionProviderForTest


### PR DESCRIPTION
#### What type of PR is this?

Enhancement
<!--
Add one/more labels.
-->

#### What does this PR do / why is it needed ?

Custom deployments might want to control what protocol is the default active one.  This PR proposed a mechanism where these use cases to inject the version they want using ServiceLoader.

If users don't provide an implementation of the provider, the status quo is kept.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
<!--
-->
