### PR TITLE
Adjust Parentheses for jsonToGrammar

### DIFF
--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperValueSpecificationGrammarComposer.java
@@ -137,50 +137,15 @@ public class HelperValueSpecificationGrammarComposer
 
     public static String possiblyAddParenthesis(String function, ValueSpecification param, DEPRECATED_PureGrammarComposerCore transformer)
     {
-        if ("and".equals(function) || "or".equals(function))
+        if ("and".equals(function) || "or".equals(function) || "plus".equals(function) || "minus".equals(function) || "times".equals(function) || "divide".equals(function))
         {
             if (param instanceof AppliedFunction && SPECIAL_INFIX.get(((AppliedFunction) param).function) != null)
             {
                 return "(" + param.accept(transformer) + ")";
             }
         }
-        else if ("plus".equals(function) || "minus".equals(function) || "times".equals(function) || "divide".equals(function))
-        {
-            if (isLowerPrecedenceFunction(param, function))
-            {
-                return "(" + param.accept(transformer) + ")";
-            }
-        }
-
         return param.accept(transformer);
     }
-
-    private static boolean isLowerPrecedenceFunction(ValueSpecification v, String function)
-    {
-        if (v instanceof AppliedFunction)
-        {
-            String compareTo = ((AppliedFunction) v).function;
-            return (isMultDiv(function) && !isMultDiv(compareTo)) || (isPlusMinus(function) && isRelational(compareTo));
-        }
-
-        return false;
-    }
-
-    private static boolean isMultDiv(String function)
-    {
-        return "times".equals(function) || "divide".equals(function);
-    }
-
-    private static boolean isPlusMinus(String function)
-    {
-        return "plus".equals(function) || "minus".equals(function);
-    }
-
-    private static boolean isRelational(String function)
-    {
-        return "lessThan".equals(function) || "lessThanEqual".equals(function) || "greaterThan".equals(function) || "greaterThanEqual".equals(function);
-    }
-
 
     public static String renderCollection(List<?> values, org.eclipse.collections.api.block.function.Function<Object, String> func, DEPRECATED_PureGrammarComposerCore transformer)
     {

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -490,7 +490,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     {
         test("function f(s: Integer[1], s2: Interger[2]): String[1]\n" +
                 "{\n" +
-                "   let a = (1 - 4 * (2 + 3)) * 4\n" +
+                "   let a = (1 - (4 * (2 + 3))) * 4\n" +
                 "}\n");
     }
 
@@ -499,7 +499,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     {
         test("function f(s: Integer[1], s2: Interger[2]): String[1]\n" +
                 "{\n" +
-                "   let a = 4 + 1 * (2 + 3) * 4 + (2 + 3) * 4\n" +
+                "   let a = (4 + (1 * (2 + 3) * 4)) + ((2 + 3) * 4)\n" +
                 "}\n");
     }
 
@@ -508,7 +508,35 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     {
         test("function f(s: Integer[1], s2: Interger[2]): String[1]\n" +
                 "{\n" +
-                "   let a = 4 + (1 - 2) / (2 + 3) * (1 - 4 - 5)\n" +
+                "   let a = 4 + (((1 - 2) / (2 + 3)) * (1 - 4 - 5))\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testMathParenthesis3()
+    {
+        test("function f(s: Integer[1], s2: Interger[2]): String[1]\n" +
+                "{\n" +
+                "   let a = 1 / (2 / 3);\n" +
+                "   let a = 1 * (2 * 3);\n" +
+                "   let a = 1 - (2 - 3);\n" +
+                "   let a = 1 + (2 + 3);\n" +
+                "   let a = (8 / 4) * 2;\n" +
+                "   let a = 8 / (4 * 2);\n" +
+                "   let a = (8 * 4) / 2;\n" +
+                "   let a = 8 * (4 / 2);\n" +
+                "   let a = (8 * 4) + 2;\n" +
+                "   let a = 8 * (4 + 2);\n" +
+                "   let a = (8 + 4) * 2;\n" +
+                "   let a = 8 + (4 * 2);\n" +
+                "   let a = (1 - (4 * (2 + 3))) * 4;\n" +
+                "   let a = ((1 - (4 * 2)) + 3) * 4;\n" +
+                "   let a = (1 - (4 * 2)) + (3 * 4);\n" +
+                "   let a = 1 + 4 + 2 + 3 + 4;\n" +
+                "   let a = (1 + 2) - (3 - 4);\n" +
+                "   let a = 1 + 2 <= 3 - 4;\n" +
+                "   let a = (8 <= 4) + 2;\n" +
+                "   let a = 8 + 4 <= 2;\n" +
                 "}\n");
     }
 


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
Studio automatically re-formats arithmetic operations expressed as a/(b/c) to a/b/c, which creates incorrect result equivalent to a/(b*c).
Change will properly preserve the user preferred precedence for execution.

#### Does this PR introduce a user-facing change?
No
