### PR TITLE
Tidy up persistence component and persistence test runner.

### DIFF
--- a/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-extensions-collection-generation/pom.xml
@@ -199,7 +199,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-test-runner</artifactId>
-            <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/test/TestBatch.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/test/TestBatch.java
@@ -22,7 +22,7 @@ import java.util.List;
 public abstract class TestBatch
 {
     public String id;
-    public Integer batchId;
+    public int batchId;
     public List<TestAssertion> assertions;
 
     public SourceInformation sourceInformation;

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/test/testable.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/test/testable.pure
@@ -31,7 +31,7 @@ Class <<typemodifiers.abstract>> meta::pure::test::AtomicTest extends Test
 Class <<typemodifiers.abstract>> meta::pure::test::TestBatch
 {
     id         : String[1];
-    batchId    : Integer[0..1];
+    batchId    : Integer[1];
     assertions : TestAssertion[*];
 }
 

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -146,7 +146,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-test-runner</artifactId>
-            <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/TestableRunner.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/TestableRunner.java
@@ -34,9 +34,6 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.test.Testable;
 import org.pac4j.core.profile.CommonProfile;
 
 import java.util.List;
-import java.util.Map;
-
-import static java.util.stream.Collectors.groupingBy;
 
 public class TestableRunner
 {
@@ -63,42 +60,39 @@ public class TestableRunner
             }
             Testable testable = (Testable) packageableElement;
             List<AtomicTestId> testIds = testableInput.unitTestIds;
-            List<String> atomicTestIds = ListIterate.collect(testIds, id -> id.atomicTestId);
+            List<String> testIdStrings = ListIterate.collect(testIds, id -> id.atomicTestId);
 
             TestRunner testRunner = TestableRunnerExtensionLoader.forTestable(testable);
             for (Test test : testable._tests())
             {
                 // We run all testIds if no `unitTestIds` are provided
-                if ((test instanceof Root_meta_pure_test_AtomicTest) && (testIds.isEmpty() || atomicTestIds.contains(test._id())))
+                if ((test instanceof Root_meta_pure_test_AtomicTest) && (testIds.isEmpty() || testIdStrings.contains(test._id())))
                 {
                     runTestsResult.results.add(testRunner.executeAtomicTest((Root_meta_pure_test_AtomicTest) test, pureModel, data));
                 }
+
                 if (test instanceof Root_meta_pure_test_TestSuite)
                 {
-                    Map<String, List<AtomicTestId>> testIdsBySuiteId = testIds.stream().collect(groupingBy(testId -> testId.testSuiteId));
-                    if (testIds.isEmpty() || testIdsBySuiteId.get(test._id()) != null)
+                    List<AtomicTestId> testIdsForSuite = ListIterate.select(testIds, testId -> test._id().equals(testId.testSuiteId));
+                    if (testIds.isEmpty() || !testIdsForSuite.isEmpty())
                     {
                         Root_meta_pure_test_TestSuite testSuite = (Root_meta_pure_test_TestSuite) test;
-                        List<AtomicTestId> updatedTestIds;
-                        if (testIds.isEmpty())
-                        {
-                            updatedTestIds = testSuite._tests().collect(pureTest ->
-                            {
-                                AtomicTestId id = new AtomicTestId();
-                                id.testSuiteId = testSuite._id();
-                                id.atomicTestId = pureTest._id();
-                                return id;
-                            }).toList();
-                        }
-                        else
-                        {
-                            updatedTestIds = testIdsBySuiteId.get(test._id());
-                        }
+                        List<AtomicTestId> updatedTestIds = testIds.isEmpty()
+                            ? testSuite._tests().collect(pureTest -> atomicTestId(testSuite, pureTest)).toList()
+                            : testIdsForSuite;
                         runTestsResult.results.addAll(testRunner.executeTestSuite(testSuite, updatedTestIds, pureModel, data));
                     }
                 }
             }
         }
         return runTestsResult;
+    }
+
+    private static AtomicTestId atomicTestId(Root_meta_pure_test_TestSuite testSuite, Root_meta_pure_test_AtomicTest atomicTest)
+    {
+        AtomicTestId id = new AtomicTestId();
+        id.testSuiteId = testSuite._id();
+        id.atomicTestId = atomicTest._id();
+        return id;
     }
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/pom.xml
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- IMMUTABLES -->

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/pom.xml
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/pom.xml
@@ -27,17 +27,14 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-physical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- IMMUTABLES -->

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/pom.xml
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/pom.xml
@@ -30,12 +30,10 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-physical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- IMMUTABLES -->

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/pom.xml
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/pom.xml
@@ -30,22 +30,18 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-physical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-ansi</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- H2 -->

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/pom.xml
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/pom.xml
@@ -30,22 +30,18 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-physical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-ansi</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- MARIADB -->

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
@@ -30,22 +30,18 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-physical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-ansi</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- SNOWFLAKE -->

--- a/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
+++ b/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
@@ -114,7 +114,12 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
             else if (trigger instanceof CronTrigger)
             {
                 CronTrigger cronTrigger = (CronTrigger) trigger;
-                return new Root_meta_pure_persistence_metamodel_trigger_CronTrigger_Impl("", null, compileContext.pureModel.getClass("meta::pure::persistence::metamodel::trigger::CronTrigger"))._minutes(cronTrigger.minutes)._hours(cronTrigger.hours)._dayOfMonth(cronTrigger.dayOfMonth)._month(cronTrigger.month)._dayOfWeek(cronTrigger.dayOfWeek);
+                return new Root_meta_pure_persistence_metamodel_trigger_CronTrigger_Impl("", null, compileContext.pureModel.getClass("meta::pure::persistence::metamodel::trigger::CronTrigger"))
+                    ._minutes(cronTrigger.minutes)
+                    ._hours(cronTrigger.hours)
+                    ._dayOfMonth(cronTrigger.dayOfMonth)
+                    ._month(cronTrigger.month)
+                    ._dayOfWeek(cronTrigger.dayOfWeek);
             }
             return null;
         });

--- a/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
+++ b/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
@@ -75,7 +75,7 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                             purePersistence._service(HelperPersistenceBuilder.buildService(persistence, context));
                             purePersistence._persister(HelperPersistenceBuilder.buildPersister(persistence.persister, context));
                             purePersistence._notifier(HelperPersistenceBuilder.buildNotifier(persistence.notifier, context));
-                            purePersistence._tests(HelperPersistenceBuilder.buildTest(persistence, context));
+                            purePersistence._tests(HelperPersistenceBuilder.buildTests(persistence, context));
                         }
                 ),
                 Processor.newProcessor(

--- a/legend-engine-xt-persistence-test-runner/pom.xml
+++ b/legend-engine-xt-persistence-test-runner/pom.xml
@@ -26,10 +26,6 @@
     <artifactId>legend-engine-xt-persistence-test-runner</artifactId>
     <name>Legend Engine - XT - Persistence - Test Runner</name>
 
-    <properties>
-        <milestoning.version>1.0-SNAPSHOT</milestoning.version>
-    </properties>
-
     <dependencies>
         <!-- PURE -->
         <dependency>
@@ -107,17 +103,14 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-persistence-component-relational-h2</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <!-- ENGINE -->
 

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/extension/PersistenceTestH2Connection.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/extension/PersistenceTestH2Connection.java
@@ -39,7 +39,7 @@ public class PersistenceTestH2Connection
 
     Connection getConnection()
     {
-        // Close connection to close any left over open connections
+        // Close connection to close any leftover open connections
         closeConnection();
         Properties properties = new Properties();
         properties.put("DATABASE_TO_UPPER", false);
@@ -88,5 +88,4 @@ public class PersistenceTestH2Connection
             }
         }
     }
-
 }

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/TestPersistenceBase.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/TestPersistenceBase.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package org.finos.legend.engine.testable.persistence.ingestmode;
 
 import org.apache.commons.io.FileUtils;
@@ -20,7 +19,6 @@ import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
-import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.engine.testable.model.RunTestsResult;
 import org.finos.legend.engine.testable.persistence.extension.PersistenceTestableRunnerExtension;
@@ -30,14 +28,13 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElem
 import java.io.File;
 import java.io.IOException;
 
-public class TestPersistenceBase
+public abstract class TestPersistenceBase
 {
 
     protected String readPureCode(String path) throws IOException
     {
         File file = new File(path);
-        String content = FileUtils.readFileToString(file, "UTF-8");
-        return content;
+        return FileUtils.readFileToString(file, "UTF-8");
     }
 
     protected RunTestsResult testPersistence(String persistenceSpec)
@@ -48,7 +45,6 @@ public class TestPersistenceBase
         Root_meta_pure_persistence_metamodel_Persistence purePersistence = (Root_meta_pure_persistence_metamodel_Persistence) packageableElement;
         // Invoke
         PersistenceTestableRunnerExtension extension = new PersistenceTestableRunnerExtension();
-        RunTestsResult result = extension.executePersistenceTest(purePersistence, model, contextData);
-        return result;
+        return extension.executePersistenceTest(purePersistence, model, contextData);
     }
 }

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/appendonly/TestAppendOnlyWithAllowDuplicates.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/appendonly/TestAppendOnlyWithAllowDuplicates.java
@@ -26,10 +26,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
-
 public class TestAppendOnlyWithAllowDuplicates extends TestPersistenceBase
 {
-
     @Test
     public void testAppendOnlyWithNoAuditing() throws Exception
     {

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/appendonly/TestAppendOnlyWithFilterDuplicates.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/appendonly/TestAppendOnlyWithFilterDuplicates.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
-
 public class TestAppendOnlyWithFilterDuplicates extends TestPersistenceBase
 {
     @Test
@@ -46,6 +45,4 @@ public class TestAppendOnlyWithFilterDuplicates extends TestPersistenceBase
         assertTrue(result instanceof TestPassed);
         Assert.assertEquals("test::TestPersistence", ((TestPassed) result).testable);
     }
-
-
 }

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/delta/bitemporal/TestPersistenceBitemporalDelta.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/delta/bitemporal/TestPersistenceBitemporalDelta.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 
 public class TestPersistenceBitemporalDelta extends TestPersistenceBase
 {
-
     @Test
     public void testBatchIdBasedNoDeleteIndicatorUserSpecifiesFromAndThru() throws Exception
     {

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/delta/unitemporal/TestPersistenceUnitemporalDelta.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/delta/unitemporal/TestPersistenceUnitemporalDelta.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 public class TestPersistenceUnitemporalDelta extends TestPersistenceBase
 {
-
     @Test
     public void testBatchIdBasedNoDeleteIndicator() throws Exception
     {

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/snapshot/nontemporal/TestNonTemporalSnapshot.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/snapshot/nontemporal/TestNonTemporalSnapshot.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 
 public class TestNonTemporalSnapshot extends TestPersistenceBase
 {
-
     @Test
     public void testSnapshotWithNoAuditing() throws Exception
     {

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/snapshot/unitemporal/TestPersistenceUnitemporalSnapshot.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/ingestmode/snapshot/unitemporal/TestPersistenceUnitemporalSnapshot.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 
 public class TestPersistenceUnitemporalSnapshot extends TestPersistenceBase
 {
-
     @Test
     public void testBatchIdBased() throws Exception
     {

--- a/pom.xml
+++ b/pom.xml
@@ -800,6 +800,48 @@
 
             <dependency>
                 <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-component-physical-plan</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-component-relational-ansi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-component-relational-h2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-component-relational-memsql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-component-relational-snowflake</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-persistence-test-runner</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
                 <artifactId>legend-engine-xt-mastery-protocol</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
#### What type of PR is this?
Cleanup.

#### What does this PR do / why is it needed ?
Make persistence component and persistence test runner more consistent with other Legend modules and related cleanup. Specifically:
- Fix multiplicity of TestBatch.batchId in pure model
- Use dependency management for version and scope control
- Fix newlines and line breaks
- Remove vestigial maven properties

#### Which issue(s) this PR fixes:
None.

#### Other notes for reviewers:
Cleanup for https://github.com/finos/legend-engine/pull/963.

#### Does this PR introduce a user-facing change?
No.
