### PR TITLE
fix ID instantiation of some element to make `getUserPathForPackageableElement()` works properly

### DIFF
--- a/legend-engine-language-pure-dsl-generation/src/main/java/org/finos/legend/engine/language/pure/dsl/generation/compiler/toPureGraph/GenerationCompilerExtensionImpl.java
+++ b/legend-engine-language-pure-dsl-generation/src/main/java/org/finos/legend/engine/language/pure/dsl/generation/compiler/toPureGraph/GenerationCompilerExtensionImpl.java
@@ -43,7 +43,7 @@ public class GenerationCompilerExtensionImpl implements GenerationCompilerExtens
                         (fileGeneration, context) ->
                         {
                             // NOTE: we stub out since this element doesn't have an equivalent packageable element form in PURE metamodel
-                            PackageableElement stub = new Root_meta_pure_metamodel_PackageableElement_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::PackageableElement"));
+                            PackageableElement stub = new Root_meta_pure_metamodel_PackageableElement_Impl(fileGeneration.name, null, context.pureModel.getClass("meta::pure::metamodel::PackageableElement"))._name(fileGeneration.name);
                             Root_meta_pure_generation_metamodel_GenerationConfiguration configuration = HelperFileGenerationBuilder.processFileGeneration(fileGeneration, context);
                             this.fileConfigurationsIndex.put(context.pureModel.buildPackageString(fileGeneration._package, fileGeneration.name), configuration);
                             return stub;
@@ -53,7 +53,7 @@ public class GenerationCompilerExtensionImpl implements GenerationCompilerExtens
                         Collections.singletonList(AbstractGenerationSpecification.class),
                         (generationSpecification, context) ->
                         {
-                            Root_meta_pure_generation_metamodel_GenerationSpecification genTree = new Root_meta_pure_generation_metamodel_GenerationSpecification_Impl("", null, context.pureModel.getClass("meta::pure::generation::metamodel::GenerationSpecification"));
+                            Root_meta_pure_generation_metamodel_GenerationSpecification genTree = new Root_meta_pure_generation_metamodel_GenerationSpecification_Impl(generationSpecification.name, null, context.pureModel.getClass("meta::pure::generation::metamodel::GenerationSpecification"))._name(generationSpecification.name);
                             HelperGenerationSpecificationBuilder.processGenerationSpecification(generationSpecification, context);
                             this.generationSpecificationsIndex.put(context.pureModel.buildPackageString(generationSpecification._package, generationSpecification.name), genTree);
                             return genTree;

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
@@ -57,7 +57,7 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
         return Collections.singletonList(Processor.newProcessor(
                 Service.class,
                 Lists.fixedSize.with(PackageableConnection.class, PackageableRuntime.class, DataElement.class),
-                (service, context) -> new Root_meta_legend_service_metamodel_Service_Impl("", null, context.pureModel.getClass("meta::legend::service::metamodel::Service"))
+                (service, context) -> new Root_meta_legend_service_metamodel_Service_Impl(service.name, null, context.pureModel.getClass("meta::legend::service::metamodel::Service"))
                         ._name(service.name)
                         ._stereotypes(ListIterate.collect(service.stereotypes, s -> context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
                         ._taggedValues(ListIterate.collect(service.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value)))

--- a/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
+++ b/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
@@ -51,7 +51,7 @@ public class DataSpaceCompilerExtension implements CompilerExtension
                 Lists.fixedSize.with(PackageableRuntime.class, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping.class, Diagram.class),
                 (dataSpace, context) ->
                 {
-                    Root_meta_pure_metamodel_dataSpace_DataSpace metamodel = new Root_meta_pure_metamodel_dataSpace_DataSpace_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::dataSpace::DataSpace"))._name(dataSpace.name);
+                    Root_meta_pure_metamodel_dataSpace_DataSpace metamodel = new Root_meta_pure_metamodel_dataSpace_DataSpace_Impl(dataSpace.name, null, context.pureModel.getClass("meta::pure::metamodel::dataSpace::DataSpace"))._name(dataSpace.name);
                     this.dataSpacesIndex.put(context.pureModel.buildPackageString(dataSpace._package, dataSpace.name), metamodel);
                     return metamodel;
                 },

--- a/legend-engine-xt-diagram-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DiagramCompilerExtension.java
+++ b/legend-engine-xt-diagram-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DiagramCompilerExtension.java
@@ -35,7 +35,7 @@ public class DiagramCompilerExtension implements CompilerExtension
         return Collections.singletonList(Processor.newProcessor(Diagram.class,
                 (diagram, context) ->
                 {
-                    Root_meta_pure_metamodel_diagram_Diagram metamodel = new Root_meta_pure_metamodel_diagram_Diagram_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::diagram::Diagram"))._name(diagram.name);
+                    Root_meta_pure_metamodel_diagram_Diagram metamodel = new Root_meta_pure_metamodel_diagram_Diagram_Impl(diagram.name, null, context.pureModel.getClass("meta::pure::metamodel::diagram::Diagram"))._name(diagram.name);
                     this.diagramsIndex.put(context.pureModel.buildPackageString(diagram._package, diagram.name), metamodel);
                     return metamodel;
                 },

--- a/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/MasteryCompilerExtension.java
+++ b/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/MasteryCompilerExtension.java
@@ -36,7 +36,8 @@ public class MasteryCompilerExtension implements CompilerExtension
                 MasterRecordDefinition.class,
                 Lists.fixedSize.with(Service.class, Mapping.class, Binding.class, PackageableConnection.class),
                 //First Pass instantiate - does not include Pure class properties on classes
-                (masterRecordDefinition, context) -> new Root_meta_pure_mastery_metamodel_MasterRecordDefinition_Impl("")
+                (masterRecordDefinition, context) -> new Root_meta_pure_mastery_metamodel_MasterRecordDefinition_Impl(masterRecordDefinition.name)
+                        ._name(masterRecordDefinition.name)
                         ._modelClass(HelperMasterRecordDefinitionBuilder.buildModelClass(masterRecordDefinition, context)),
                 //Second Pass stitched together - can access Pure class properties now.
                 (masterRecordDefinition, context) ->

--- a/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
+++ b/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
@@ -66,7 +66,8 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                 Processor.newProcessor(
                         Persistence.class,
                         Lists.fixedSize.of(Service.class, Mapping.class, Binding.class, PackageableConnection.class, Database.class),
-                        (persistence, context) -> new Root_meta_pure_persistence_metamodel_Persistence_Impl("", null, context.pureModel.getClass("meta::pure::persistence::metamodel::Persistence"))
+                        (persistence, context) -> new Root_meta_pure_persistence_metamodel_Persistence_Impl(persistence.name, null, context.pureModel.getClass("meta::pure::persistence::metamodel::Persistence"))
+                                ._name(persistence.name)
                                 ._documentation(persistence.documentation),
                         (persistence, context) ->
                         {
@@ -81,7 +82,7 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                 Processor.newProcessor(
                         PersistenceContext.class,
                         Lists.fixedSize.of(Persistence.class, PackageableConnection.class),
-                        (persistenceContext, context) -> new Root_meta_pure_persistence_metamodel_PersistenceContext_Impl("", null, context.pureModel.getClass("meta::pure::persistence::metamodel::PersistenceContext")),
+                        (persistenceContext, context) -> new Root_meta_pure_persistence_metamodel_PersistenceContext_Impl(persistenceContext.name, null, context.pureModel.getClass("meta::pure::persistence::metamodel::PersistenceContext"))._name(persistenceContext.name),
                         (persistenceContext, context) ->
                         {
                             Root_meta_pure_persistence_metamodel_PersistenceContext purePersistenceContext = (Root_meta_pure_persistence_metamodel_PersistenceContext) context.pureModel.getOrCreatePackage(persistenceContext._package)._children().detect(c -> persistenceContext.name.equals(c._name()));

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
@@ -115,7 +115,7 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
                 Database.class,
                 (Database srcDatabase, CompileContext context) ->
                 {
-                    org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database database = new Root_meta_relational_metamodel_Database_Impl(srcDatabase.name);
+                    org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database database = new Root_meta_relational_metamodel_Database_Impl(srcDatabase.name)._name(srcDatabase.name);
 
                     database._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
                             ._rawType(context.pureModel.getType("meta::relational::metamodel::Database")));

--- a/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ServiceStoreCompilerExtension.java
+++ b/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ServiceStoreCompilerExtension.java
@@ -57,7 +57,7 @@ public class ServiceStoreCompilerExtension implements IServiceStoreCompilerExten
                         // First pass - add serviceStores to compile context
                         (ServiceStore serviceStore, CompileContext context) ->
                         {
-                            Root_meta_external_store_service_metamodel_ServiceStore pureServiceStore = new Root_meta_external_store_service_metamodel_ServiceStore_Impl(serviceStore.name);
+                            Root_meta_external_store_service_metamodel_ServiceStore pureServiceStore = new Root_meta_external_store_service_metamodel_ServiceStore_Impl(serviceStore.name)._name(serviceStore.name);
 
                             pureServiceStore._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
                                     ._rawType(context.pureModel.getType("meta::external::store::service::metamodel::ServiceStore")));

--- a/legend-engine-xt-text-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TextCompilerExtension.java
+++ b/legend-engine-xt-text-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TextCompilerExtension.java
@@ -27,6 +27,6 @@ public class TextCompilerExtension implements CompilerExtension
     public Iterable<? extends Processor<?>> getExtraProcessors()
     {
         return Collections.singletonList(Processor.newProcessor(Text.class,
-                (text, context) -> new Root_meta_pure_metamodel_text_Text_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::text::Text"))._name(text.name)._type(text.type)._content(text.content)));
+                (text, context) -> new Root_meta_pure_metamodel_text_Text_Impl(text.name, null, context.pureModel.getClass("meta::pure::metamodel::text::Text"))._name(text.name)._type(text.type)._content(text.content)));
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What does this PR do / why is it needed ?

This is a fix needed so that function `getUserPathForPackageableElement` could work properly for the elements fixed.
`getUserPathForPackageableElement()` calls `getName()` which actually call `CoreInstance.id` instead of `CoreInstance.name` so when we build the elements, we must set both their name using `._name(...)` and their `id` using the constructor. This results in unfortunately bugs like:

```java

getUserPathForPackageableElement(<some element with path something::Weird>);
// returns "something"
```

This will mess up logic in many places, especially impact the artifact generation mechanism introduced in https://github.com/finos/legend-sdlc/pull/481

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
