### PR TITLE
Porting remaining Changes from Write component Library into Persistence component

### DIFF
--- a/legend-engine-xt-persistence-component/README.md
+++ b/legend-engine-xt-persistence-component/README.md
@@ -1,0 +1,350 @@
+# Legend Write Component
+
+Component library for persisting data to a target.
+
+[[_TOC_]]
+
+## Getting started
+
+### Prerequisites
+
+1. Install Java 8+
+2. Install maven 3.8.1
+
+### Development Setup
+
+1. Open *legend-engine-xt-persistence-component/pom.xml* as a project
+2. Configure the project as a Maven project
+3. Configure SDK - File > Project Structure > Project Settings > Project
+
+## Test suite
+
+The following tests are available for verifying the logic :
+
+* Tests to verify the SQL's generated in ANSI format (module : *legend-engine-xt-persistence-component-relational-ansi*)
+* Tests to verify the execution of the generated SQL's in an H2 executor (module : *legend-engine-xt-persistence-component-relational-h2*)
+* Tests to verify the SQL's generated for Snowflake (module : *legend-engine-xt-persistence-component-relational-snowflake*)
+* Tests to verify the SQL's generated for Memsql (module : *legend-engine-xt-persistence-component-relational-memsql*)
+
+## Using it as a library
+
+**Step 1:** Add the appropriate maven dependency.
+Please [pick](https://mvnrepository.com/search?q=legend-engine-xt-persistence-component-)
+the latest version from Maven Central.
+
+#### Using the snowflake executor
+
+    <dependency>
+      <groupId>org.finos.legend.engine</groupId>
+      <artifactId>legend-engine-xt-persistence-component-relational-snowflake</artifactId>
+      <version>[PICK THE LATEST VERSION FROM MAVEN CENTRAL]</version>
+    </dependency>
+
+#### Using the H2 executor
+
+    <dependency>
+      <groupId>org.finos.legend.engine</groupId>
+      <artifactId>legend-engine-xt-persistence-component-relational-h2</artifactId>
+      <version>[PICK THE LATEST VERSION FROM MAVEN CENTRAL]</version>
+    </dependency>
+
+#### Using the Memsql executor
+
+    <dependency>
+      <groupId>org.finos.legend.engine</groupId>
+      <artifactId>legend-engine-xt-persistence-component-relational-memsql</artifactId>
+      <version>[PICK THE LATEST VERSION FROM MAVEN CENTRAL]</version>
+    </dependency>
+
+**Step 2:** Create the Ingest mode object based on ingestion scheme (Details and examples for each scheme [below](#ingest-modes))
+
+    UnitemporalDelta ingestMode = UnitemporalDelta.builder()
+       .digestField(digestField)
+       .transactionMilestoning(BatchIdAndDateTime.builder()
+            .batchIdInName(batchIdInField)
+            .batchIdOutName(batchIdOutField)
+            .dateTimeInName(batchTimeInField)
+            .dateTimeOutName(batchTimeOutField)
+            .build())
+        .build();
+
+**Step 3:** Provide the datasets to be used for ingestion
+
+    // Provide the main and staging dataset 
+    Datasets datasets = Datasets.of(mainTable, stagingTable);
+
+    // Or provide main, staging and metadata dataset
+    Datasets datasets = Datasets.of(mainTable, stagingTable).withMetadataDataset(metadataDataset);
+
+    // Or provide main, staging and temp dataset (used only for bitemporal delta ingest mode)
+    Datasets datasets = Datasets.of(mainTable, stagingTable).withTempDataset(tempDataset);
+
+    // Or provide main, staging, temp and tempWithDeleteIndicator dataset (used only for bitemporal delta ingest mode)
+    Datasets datasets = Datasets.of(mainTable, stagingTable).withTempDataset(tempDataset).withTempDatasetWithDeleteIndicator(tempDatasetWithDeleteIndicator);
+
+**Step 4:** To extract the SQLs needed for ingestion, follow steps 4.1 and 4.2. 
+If you do not need the SQL and want to use the executor to execute the SQLs for you, skip this step and jump to Step 5.
+
+**Step 4.1:** Define a RelationalGenerator
+
+    RelationalGenerator generator = RelationalGenerator.builder()
+        .ingestMode(ingestMode)
+        .relationalSink(SnowflakeSink.get())
+        .cleanupStagingData(true)
+        .build();
+
+Mandatory Params:
+
+| parameters          | Description                                                         |
+|--------------------|---------------------------------------------------------------------|
+| ingestMode | Ingest mode object defined in Step 2  |
+| relationalSink | Choose the appropriate Sink where the data will be written to  |
+
+Optional Params:
+
+| parameters          | Description                                                         | Default Value |
+|--------------------|---------------------------------------------------------------------|----------------|
+| cleanupStagingData | clean staging table after completion of ingestion  | true |
+| collectStatistics | Collect Statistics from ingestion  | false |
+| enableSchemaEvolution | Enable Schema Evolution to happen  | false |
+| caseConversion | Convert SQL objects like table, db, column names to upper or lower case.<br> Values supported - TO_UPPER, TO_LOWER, NONE  | NONE |
+| executionTimestampClock | Clock to use to derive the time  | Clock.systemUTC() |
+| batchStartTimestampPattern | Pattern for batchStartTimestamp. If this pattern is provided, it will replace the batchStartTimestamp values | None |
+| batchEndTimestampPattern | Pattern for batchEndTimestamp. If this pattern is provided, it will replace the batchEndTimestamp values  | None |
+| batchIdPattern | Pattern for batch id. If this pattern is provided, it will replace the next batch id | None |
+
+**Step 4.2:** Use the generator object to extract the queries
+
+    GeneratorResult operations = generator.generateOperations(datasets);
+    List<String> preActionsSql = operations.preActionsSql(); // Pre actions: create tables
+    Map<StatisticName, String> preIngestStatisticsSql = operations.preIngestStatisticsSql(); // Pre Ingest stats
+    List<String> ingestSql = operations.ingestSql(); // milestoning sql
+    Map<StatisticName, String> postIngestStatisticsSql = operations.postIngestStatisticsSql(); // post Ingest stats
+    List<String> metadataIngestSql = operations.metadataIngestSql(); // insert batch into metadata table
+    List<String> postActionsSql = operations.postActionsSql(); // post actions cleanup
+
+NOTE 1: These queries must be strictly run in the order shown below.
+1. preActionsSql - Creates tables
+2. preIngestStatisticsSql - Collects pre ingest stats
+3. ingestSql - Performs ingest/milestoning
+4. postIngestStatisticsSql - Collects post ingest stats
+5. metadataIngestSql - Inserts batch Id into metadata table
+6. postActionsSql - Does clean up
+
+NOTE 2: Statistics provided:     
+1) INCOMING_RECORD_COUNT
+2) ROWS_TERMINATED
+3) ROWS_INSERTED
+4) ROWS_UPDATED
+5) ROWS_DELETED
+
+
+**Step 5:** To use the executor to perform the ingestion for you, follow the steps in step 5. Skip this step if you just want the SQLs.
+
+**Step 5.1:** Define a RelationalIngestor
+
+    RelationalIngestor ingestor = RelationalIngestor.builder()
+            .ingestMode(ingestMode)
+            .relationalSink(H2Sink.get())
+            .cleanupStagingData(true)
+            .collectStatistics(true)
+            .enableSchemaEvolution(true)
+            .build();
+
+Mandatory Params:
+
+| parameters          | Description                                                         |
+|--------------------|---------------------------------------------------------------------|
+| ingestMode | Ingest mode object defined in Step 2  |
+| relationalSink | Choose the appropriate Sink where the data will be written to  |
+
+Optional Params:
+
+| parameters          | Description                                                         | Default Value |
+|--------------------|---------------------------------------------------------------------|----------------|
+| cleanupStagingData | clean staging table after completion of ingestion  | true |
+| collectStatistics | Collect Statistics from ingestion  | true |
+| enableSchemaEvolution | Enable Schema Evolution to happen  | false |
+| caseConversion | Convert SQL objects like table, db, column names to upper or lower case.<br> Values supported - TO_UPPER, TO_LOWER, NONE  | NONE |
+| executionTimestampClock | Clock to use to derive the time  | Clock.systemUTC() |
+
+**Step 5.2:** Invoke the ingestion and get the stats
+
+    IngestorResult result = ingestor.ingest(h2Sink.connection(), datasets);
+    Map<StatisticName, Object> stats = result.statisticByName();
+
+## Ingest Modes
+
+### Non-temporal Snapshot
+
+This is used to load data that is a complete refresh with each load. All rows from older batches are removed.
+
+#### Object creation
+
+    NontemporalSnapshot ingestMode = NontemporalSnapshot.builder()
+            .auditing(NoAuditing.builder().build())
+            .build();
+
+#### Parameter information
+
+| Field Name     | Description                                            | Mandatory? |
+|----------------|--------------------------------------------------------|------------|
+| auditing | Choose either one of these two: <br> 1. NoAuditing: no auditing <br> 2. DateTimeAuditing: A dateTimeField will be added to each row     | Yes        |
+
+### Append-only
+
+This is used to load data incrementally. No rows are invalidated, new rows are simply appended.
+
+#### Object creation
+
+    AppendOnly ingestMode = AppendOnly.builder()
+            .digestField(digestName)
+            .deduplicationStrategy(FilterDuplicates.builder().build())
+            .auditing(NoAuditing.builder().build())
+            .build();
+
+
+#### Parameter information
+
+| Field Name     | Description                                                              | Mandatory?                          |
+|----------------|--------------------------------------------------------------------------|-------------------------------------|
+| digestField | Name of the digest field                                                    | No. Mandatory if deduplicationStrategy =  FilterDuplicates                                 | 
+| dataSplitField | Name of the field which contains the data split number                                                    | No                               |
+| deduplicationStrategy | Choose either one of these three: <br> 1. AllowDuplicates: allows duplicates to be appended <br> 2. FailOnDuplicates: pipeline to fail on duplicates <br> 3. FilterDuplicates: Filter out duplicates   | Yes                                  | 
+| auditing | Choose either one of these two: <br> 1. NoAuditing: no auditing <br> 2. DateTimeAuditing: A dateTimeField will be added to each row     | Yes        |
+
+### Nontemporal Delta
+
+This is used to load data incrementally. New rows are simply appended, where-as the updated rows overwritten.
+
+#### Object creation
+
+    NontemporalDelta ingestMode = NontemporalDelta.builder()
+            .digestField(digestName)
+            .auditing(NoAuditing.builder().build())
+            .build();
+
+#### Parameter information
+
+| Field Name     | Description                                                              | Mandatory?                          |
+|----------------|--------------------------------------------------------------------------|-------------------------------------|
+| digestField | Name of the digest field                                                    | Yes                                 | 
+| auditing | Choose either one of these two: <br> 1. NoAuditing: no auditing <br> 2. DateTimeAuditing: A dateTimeField will be added to each row     | Yes        |
+
+### Unitemporal Snapshot
+
+This is used to load data that is a complete refresh with each load. It does not repeat data that does not change from
+batch to batch, but it will repeat data that appears, disappears and then reappears between batches. No rows are ever
+removed, but rows become invalid if they no longer exist in the loaded data.
+
+There are two variants of this scheme:
+
+- With Partition: With this option, only the rows in the main dataset matching the values of the partition columns in
+  the incoming batch is affected by the milestoning. To use this option, you need to pass partitionFields.
+- Without Partition: This is the default mode.
+
+#### Object creation
+
+        UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
+            .digestField(digestName)
+            .transactionMilestoning(BatchIdAndDateTime.builder()
+                .batchIdInName(batchIdInName)
+                .batchIdOutName(batchIdOutName)
+                .dateTimeInName(batchTimeInName)
+                .dateTimeOutName(batchTimeOutName)
+                .build())
+            .build();
+
+
+#### Parameter information
+
+| Field Name     | Description                                                              | Mandatory?                          |
+|----------------|--------------------------------------------------------------------------|-------------------------------------|
+| digestField | Name of the digest field                                                    | Yes                                 | 
+| transactionMilestoning | Choose either one of these three: <br>1. BatchId : Batch id based milestoning. It will populate batch_id_in and batch_id_out fields <br>2. TransactionDateTime: Transaction time based milestoning. It will populate batch_time_in and batch_time_out fields <br>3. BatchIdAndDateTime:  Batch id and time based milestoning. It will populate batch_id_in, batch_id_out, batch_time_in and batch_time_out fields | Yes |
+| partitionFields | List of data partitioning columns. If provided, only the rows in the main dataset matching the values of the partitionFields in the incoming batch is affected by the milestoning                              | No                                                          |
+| partitionValuesByField | This is an optional parameter the can be used for boosting performance. If the end user knows the values of the partition keys, they can provide a map of partition key and their values. This map will be used to efficiently filter in only necessary records while milestoning                                                | No                             |
+
+### Unitemporal Delta
+
+This scheme is used to load data incrementally. Each batch can append new data to the dataset. No rows are ever removed,
+but rows that reappear in newer batches will invalidate those brought in by older batches.
+
+There are two variants of this scheme:
+
+- Without delete indicator: This mode does not support the concept of row deletion. This is the default mode.
+- With delete indicator: This mode enables a row to be marked as deleted based on a "delete indicator flag". To use this mode, set the mergeStrategy as DeleteIndicatorMergeStrategy.
+  A deleted row is identified by a delete indicator flag. 
+  To use this flag, you need to provide deleteField (field name containing delete indicator flag) and deleteValues (delete indicator flag values) parameters
+  
+#### Object creation
+
+        UnitemporalDelta ingestMode = UnitemporalDelta.builder()
+            .digestField(digestName)
+            .transactionMilestoning(BatchIdAndDateTime.builder()
+                .batchIdInName(batchIdInName)
+                .batchIdOutName(batchIdOutName)
+                .dateTimeInName(batchTimeInName)
+                .dateTimeOutName(batchTimeOutName)
+                .build())
+            .build();
+
+
+#### Parameter information
+
+| Field Name     | Description                                                              | Mandatory?                          |
+|----------------|--------------------------------------------------------------------------|-------------------------------------|
+| digestField | Name of the digest field                                                    | Yes                                 | 
+| dataSplitField | Name of the field which contains the data split number                                                    | No                               |
+| transactionMilestoning | Choose either one of these three: <br>1. BatchId : Batch id based milestoning. It will populate batch_id_in and batch_id_out fields <br>2. TransactionDateTime: Transaction time based milestoning. It will populate batch_time_in and batch_time_out fields <br>3. BatchIdAndDateTime:  Batch id and time based milestoning. It will populate batch_id_in, batch_id_out, batch_time_in and batch_time_out fields | Yes |
+| mergeStrategy | Choose either one of these two: <br>1. NoDeletesMergeStrategy: Default mode, this is without delete indicator mode. <br>2 DeleteIndicatorMergeStrategy: This is the delete indicator mode. User must provide deleteField and deleteValues in this case. | No                                                          |
+
+### Bitemporal Snapshot
+
+    WIP
+
+#### Object creation
+
+    WIP
+
+### Bitemporal Delta
+
+This scheme is used to load data incrementally, where the source data contains a validity time dimension. A validity time dimension consist of valid_from and valid_through fields.
+The source can either contain both these fields or only contain valid_from field. In case source only provides valid_from field, the milestoning process will derive the valid_through field.
+Each batch can append new data to the dataset. No rows are ever removed, but rows that reappear in newer batches will invalidate those brought in by older batches.
+
+There are two variants of this scheme:
+- Without delete indicator: This mode does not support the concept of row deletion. This is the default mode.
+- With delete indicator: This mode enables a row to be marked as deleted based on a "delete indicator flag". To use this mode, set the mergeStrategy as DeleteIndicatorMergeStrategy.
+  A deleted row is identified by a delete indicator flag. 
+  To use this flag, you need to provide deleteField (field name containing delete indicator flag) and deleteValues (delete indicator flag values) parameters
+
+#### Object creation
+
+    BitemporalDelta ingestMode = BitemporalDelta.builder()
+                .digestField(digestField)
+                .transactionMilestoning(BatchId.builder()
+                        .batchIdInName(batchIdInField)
+                        .batchIdOutName(batchIdOutField)
+                        .build())
+                .validityMilestoning(ValidDateTime.builder()
+                        .dateTimeFromName(validityFromTargetField)
+                        .dateTimeThruName(validityThroughTargetField)
+                        .validityDerivation(SourceSpecifiesFromAndThruDateTime.builder()
+                                .sourceDateTimeFromField(validityFromReferenceField)
+                                .sourceDateTimeThruField(validityThroughReferenceField)
+                                .build())
+                        .build())
+                .build();
+
+#### Parameter information
+
+| Field Name     | Description                                                              | Mandatory?                          |
+|----------------|--------------------------------------------------------------------------|-------------------------------------|
+| digestField | Name of the digest field                                                    | Yes                                 | 
+| dataSplitField | Name of the field which contains the data split number                                                    | No                               |
+| transactionMilestoning | Choose either one of these three: <br>1. BatchId : Batch id based milestoning. It will populate batch_id_in and batch_id_out fields <br>2. TransactionDateTime: Transaction time based milestoning. It will populate batch_time_in and batch_time_out fields <br>3. BatchIdAndDateTime:  Batch id and time based milestoning. It will populate batch_id_in, batch_id_out, batch_time_in and batch_time_out fields | Yes |
+| validityMilestoning | For the ValidityDerivation object, choose either one of these two: <br>1. SourceSpecifiesFromAndThruDateTime : choose this when source data contains both validity from field and validity through field. <br>2. SourceSpecifiesFromDateTime: choose this when source data contains only validity from field. The dateTimeFromName species the column in the main dataset which will be populated with the validity from time; the dateTimeThruName species the column in the main dataset which will be populated with the validity through time.   | Yes |
+| mergeStrategy | Choose either one of these two: <br>1. NoDeletesMergeStrategy: Default mode, this is without delete indicator mode. <br>2 DeleteIndicatorMergeStrategy: This is the delete indicator mode. User must provide deleteField and deleteValues in this case. | No                                                          |
+
+

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/common/ResourcesAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/common/ResourcesAbstract.java
@@ -29,18 +29,6 @@ import org.immutables.value.Value.Style;
 public interface ResourcesAbstract
 {
     @Default
-    default boolean mainDataSetExists()
-    {
-        return true;
-    }
-
-    @Default
-    default boolean stagingDatasetExists()
-    {
-        return true;
-    }
-
-    @Default
     default boolean stagingDataSetEmpty()
     {
         return false;

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyAbstract.java
@@ -18,7 +18,6 @@ import org.finos.legend.engine.persistence.components.ingestmode.audit.Auditing;
 import org.finos.legend.engine.persistence.components.ingestmode.deduplication.DeduplicationStrategy;
 import org.finos.legend.engine.persistence.components.ingestmode.deduplication.DeduplicationStrategyVisitors;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.immutables.value.Value.Check;
@@ -37,8 +36,6 @@ public interface AppendOnlyAbstract extends IngestMode
 {
     Optional<String> digestField();
 
-    List<String> keyFields();
-
     Optional<String> dataSplitField();
 
     Auditing auditing();
@@ -48,34 +45,12 @@ public interface AppendOnlyAbstract extends IngestMode
     @Check
     default void validate()
     {
-        if (deduplicationStrategy().accept(DeduplicationStrategyVisitors.IS_ALLOW_DUPLICATES))
-        {
-            if (!keyFields().isEmpty())
-            {
-                throw new IllegalStateException("Cannot build AppendOnly, [keyFields] must be empty since [deduplicationStrategy] is set to allow duplicates");
-            }
-        }
-        else if (deduplicationStrategy().accept(DeduplicationStrategyVisitors.IS_FILTER_DUPLICATES))
+        if (deduplicationStrategy().accept(DeduplicationStrategyVisitors.IS_FILTER_DUPLICATES))
         {
             if (!digestField().isPresent())
             {
                 throw new IllegalStateException("Cannot build AppendOnly, [digestField] must be specified since [deduplicationStrategy] is set to filter duplicates");
             }
-            if (keyFields().isEmpty())
-            {
-                throw new IllegalStateException("Cannot build AppendOnly, [keyFields] must contain at least one element since [deduplicationStrategy] is set to filter duplicates");
-            }
-        }
-        else if (deduplicationStrategy().accept(DeduplicationStrategyVisitors.IS_FAIL_ON_DUPLICATES))
-        {
-            if (keyFields().isEmpty())
-            {
-                throw new IllegalStateException("Cannot build AppendOnly, [keyFields] must contain at least one element since [deduplicationStrategy] is set to fail on duplicates");
-            }
-        }
-        else
-        {
-            throw new IllegalStateException("Unrecognized [deduplicationStrategy]: " + deduplicationStrategy().getClass());
         }
     }
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaAbstract.java
@@ -19,10 +19,8 @@ import org.finos.legend.engine.persistence.components.ingestmode.merge.NoDeletes
 import org.finos.legend.engine.persistence.components.ingestmode.transactionmilestoning.TransactionMilestoning;
 import org.finos.legend.engine.persistence.components.ingestmode.validitymilestoning.ValidityMilestoning;
 
-import java.util.List;
 import java.util.Optional;
 
-import static org.immutables.value.Value.Check;
 import static org.immutables.value.Value.Default;
 import static org.immutables.value.Value.Immutable;
 import static org.immutables.value.Value.Style;
@@ -39,8 +37,6 @@ public interface BitemporalDeltaAbstract extends IngestMode, BitemporalMilestone
 {
     String digestField();
 
-    List<String> keyFields();
-
     Optional<String> dataSplitField();
 
     @Override
@@ -53,15 +49,6 @@ public interface BitemporalDeltaAbstract extends IngestMode, BitemporalMilestone
     default MergeStrategy mergeStrategy()
     {
         return NoDeletesMergeStrategy.builder().build();
-    }
-
-    @Check
-    default void validate()
-    {
-        if (keyFields().isEmpty())
-        {
-            throw new IllegalStateException("Cannot build BitemporalDelta, [keyFields] must contain at least one element");
-        }
     }
 
     @Override

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalSnapshotAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalSnapshotAbstract.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.immutables.value.Value.Check;
 import static org.immutables.value.Value.Derived;
 import static org.immutables.value.Value.Immutable;
 import static org.immutables.value.Value.Style;
@@ -38,8 +37,6 @@ public interface BitemporalSnapshotAbstract extends IngestMode, BitemporalMilest
 {
     String digestField();
 
-    List<String> keyFields();
-
     @Override
     TransactionMilestoning transactionMilestoning();
 
@@ -54,15 +51,6 @@ public interface BitemporalSnapshotAbstract extends IngestMode, BitemporalMilest
     default boolean partitioned()
     {
         return !partitionFields().isEmpty();
-    }
-
-    @Check
-    default void validate()
-    {
-        if (keyFields().isEmpty())
-        {
-            throw new IllegalStateException("Cannot build BitemporalSnapshot, [keyFields] must contain at least one element");
-        }
     }
 
     @Override

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaAbstract.java
@@ -18,9 +18,6 @@ import org.finos.legend.engine.persistence.components.ingestmode.audit.Auditing;
 import org.finos.legend.engine.persistence.components.ingestmode.merge.MergeStrategy;
 import org.finos.legend.engine.persistence.components.ingestmode.merge.NoDeletesMergeStrategy;
 
-import java.util.List;
-
-import static org.immutables.value.Value.Check;
 import static org.immutables.value.Value.Default;
 import static org.immutables.value.Value.Immutable;
 import static org.immutables.value.Value.Style;
@@ -37,23 +34,12 @@ public interface NontemporalDeltaAbstract extends IngestMode
 {
     String digestField();
 
-    List<String> keyFields();
-
     Auditing auditing();
 
     @Default
     default MergeStrategy mergeStrategy()
     {
         return NoDeletesMergeStrategy.builder().build();
-    }
-
-    @Check
-    default void validate()
-    {
-        if (keyFields().isEmpty())
-        {
-            throw new IllegalStateException("Cannot build NontemporalDelta, [keyFields] must contain at least one element");
-        }
     }
 
     @Override

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaAbstract.java
@@ -19,10 +19,8 @@ import org.finos.legend.engine.persistence.components.ingestmode.merge.NoDeletes
 import org.finos.legend.engine.persistence.components.ingestmode.transactionmilestoning.TransactionMilestoned;
 import org.finos.legend.engine.persistence.components.ingestmode.transactionmilestoning.TransactionMilestoning;
 
-import java.util.List;
 import java.util.Optional;
 
-import static org.immutables.value.Value.Check;
 import static org.immutables.value.Value.Default;
 import static org.immutables.value.Value.Immutable;
 import static org.immutables.value.Value.Style;
@@ -39,8 +37,6 @@ public interface UnitemporalDeltaAbstract extends IngestMode, TransactionMilesto
 {
     String digestField();
 
-    List<String> keyFields();
-
     Optional<String> dataSplitField();
 
     @Override
@@ -50,15 +46,6 @@ public interface UnitemporalDeltaAbstract extends IngestMode, TransactionMilesto
     default MergeStrategy mergeStrategy()
     {
         return NoDeletesMergeStrategy.builder().build();
-    }
-
-    @Check
-    default void validate()
-    {
-        if (keyFields().isEmpty())
-        {
-            throw new IllegalStateException("Cannot build UnitemporalDelta, [keyFields] must contain at least one element");
-        }
     }
 
     @Override

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotAbstract.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.immutables.value.Value.Check;
 import static org.immutables.value.Value.Derived;
 import static org.immutables.value.Value.Immutable;
 import static org.immutables.value.Value.Style;
@@ -38,8 +37,6 @@ public interface UnitemporalSnapshotAbstract extends IngestMode, TransactionMile
 {
     String digestField();
 
-    List<String> keyFields();
-
     @Override
     TransactionMilestoning transactionMilestoning();
 
@@ -51,15 +48,6 @@ public interface UnitemporalSnapshotAbstract extends IngestMode, TransactionMile
     default boolean partitioned()
     {
         return !partitionFields().isEmpty();
-    }
-
-    @Check
-    default void validate()
-    {
-        if (keyFields().isEmpty())
-        {
-            throw new IllegalStateException("Cannot build UnitemporalSnapshot, [keyFields] must contain at least one element");
-        }
     }
 
     @Override

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/transactionmilestoning/TransactionMilestoned.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/transactionmilestoning/TransactionMilestoned.java
@@ -16,13 +16,9 @@ package org.finos.legend.engine.persistence.components.ingestmode.transactionmil
 
 import org.finos.legend.engine.persistence.components.ingestmode.IngestMode;
 
-import java.util.List;
-
 public interface TransactionMilestoned extends IngestMode
 {
     String digestField();
-
-    List<String> keyFields();
 
     TransactionMilestoning transactionMilestoning();
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/validitymilestoning/ValidityMilestoned.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/validitymilestoning/ValidityMilestoned.java
@@ -16,13 +16,9 @@ package org.finos.legend.engine.persistence.components.ingestmode.validitymilest
 
 import org.finos.legend.engine.persistence.components.ingestmode.IngestMode;
 
-import java.util.List;
-
 public interface ValidityMilestoned extends IngestMode
 {
     String digestField();
-
-    List<String> keyFields();
 
     ValidityMilestoning validityMilestoning();
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/operations/DeleteAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/operations/DeleteAbstract.java
@@ -17,6 +17,8 @@ package org.finos.legend.engine.persistence.components.logicalplan.operations;
 import org.finos.legend.engine.persistence.components.logicalplan.conditions.Condition;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Dataset;
 
+import java.util.Optional;
+
 import static org.immutables.value.Value.Immutable;
 import static org.immutables.value.Value.Parameter;
 import static org.immutables.value.Value.Style;
@@ -35,5 +37,5 @@ public interface DeleteAbstract extends Operation
     Dataset dataset();
 
     @Parameter(order = 1)
-    Condition condition();
+    Optional<Condition> condition();
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/BitemporalDeltaPlanner.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/BitemporalDeltaPlanner.java
@@ -34,7 +34,11 @@ import org.finos.legend.engine.persistence.components.logicalplan.conditions.Les
 import org.finos.legend.engine.persistence.components.logicalplan.conditions.Not;
 import org.finos.legend.engine.persistence.components.logicalplan.conditions.NotEquals;
 import org.finos.legend.engine.persistence.components.logicalplan.conditions.Or;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DataType;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Dataset;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetDefinition;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.Field;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.FieldType;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Join;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.JoinOperation;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Selection;
@@ -42,7 +46,7 @@ import org.finos.legend.engine.persistence.components.logicalplan.operations.Cre
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Drop;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Insert;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Operation;
-import org.finos.legend.engine.persistence.components.logicalplan.operations.Truncate;
+import org.finos.legend.engine.persistence.components.logicalplan.operations.Delete;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Update;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.UpdateAbstract;
 import org.finos.legend.engine.persistence.components.logicalplan.values.Case;
@@ -93,10 +97,12 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
     private List<FieldValue> primaryKeyFieldsAndFromField;
     private List<FieldValue> dataFields;
 
-    private final String startAlias = "start_date";
-    private final String endAlias = "end_date";
-    private final String xAlias = "x";
-    private final String yAlias = "y";
+    private static final String START_DATE = "start_date";
+    private static final String END_DATE = "end_date";
+    private static final String X_ALIAS = "x";
+    private static final String Y_ALIAS = "y";
+    private static final String TEMP = "temp";
+    private static final String TEMP_WITH_DELETE_INDICATOR = "tempWithDeleteIndicator";
 
     BitemporalDeltaPlanner(Datasets datasets, BitemporalDelta ingestMode, PlannerOptions plannerOptions)
     {
@@ -111,21 +117,24 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
 
         if (ingestMode().validityMilestoning().validityDerivation() instanceof SourceSpecifiesFromDateTime)
         {
-            this.tempDataset = datasets.tempDataset().orElseThrow(IllegalStateException::new);
-
-            this.dataFields = stagingDataset().schemaReference().fieldValues().stream().map(field -> FieldValue.builder().fieldName(field.fieldName()).build()).collect(Collectors.toList());
-            this.dataFields.removeIf(field -> field.fieldName().equals(ingestMode.digestField()));
-
-            this.primaryKeyFields = new ArrayList<>();
-            for (String pkName : ingestMode.keyFields())
-            {
-                this.primaryKeyFields.add(FieldValue.builder().fieldName(pkName).build());
-                this.dataFields.removeIf(field -> field.fieldName().equals(pkName));
-            }
+            this.tempDataset = getTempDataset(datasets);
 
             this.sourceValidDatetimeFrom = FieldValue.builder().fieldName(ingestMode.validityMilestoning().validityDerivation().accept(BitemporalPlanner.EXTRACT_SOURCE_VALID_DATE_TIME_FROM)).build();
             this.targetValidDatetimeFrom = FieldValue.builder().fieldName(ingestMode.validityMilestoning().accept(BitemporalPlanner.EXTRACT_TARGET_VALID_DATE_TIME_FROM)).build();
             this.targetValidDatetimeThru = FieldValue.builder().fieldName(ingestMode.validityMilestoning().accept(BitemporalPlanner.EXTRACT_TARGET_VALID_DATE_TIME_THRU)).build();
+
+            this.dataFields = stagingDataset().schemaReference().fieldValues().stream().map(field -> FieldValue.builder().fieldName(field.fieldName()).build()).collect(Collectors.toList());
+            this.dataFields.removeIf(field -> field.fieldName().equals(ingestMode.digestField()));
+
+            this.primaryKeys.removeIf(fieldName -> fieldName.equals(sourceValidDatetimeFrom.fieldName()));
+            this.primaryKeysMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(mainDataset(), stagingDataset(), primaryKeys.toArray(new String[0]));
+
+            this.primaryKeyFields = new ArrayList<>();
+            for (String pkName : primaryKeys)
+            {
+                this.primaryKeyFields.add(FieldValue.builder().fieldName(pkName).build());
+                this.dataFields.removeIf(field -> field.fieldName().equals(pkName));
+            }
 
             this.primaryKeyFieldsAndFromField = new ArrayList<>();
             this.primaryKeyFieldsAndFromField.addAll(primaryKeyFields);
@@ -135,7 +144,7 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
 
             if (deleteIndicatorField.isPresent())
             {
-                this.tempDatasetWithDeleteIndicator = datasets.tempDatasetWithDeleteIndicator().orElseThrow(IllegalStateException::new);
+                this.tempDatasetWithDeleteIndicator = getTempDatasetWithDeleteIndicator(datasets);
                 this.dataFields.removeIf(field -> field.fieldName().equals(deleteIndicatorField.get()));
             }
 
@@ -143,6 +152,38 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
             {
                 this.dataFields.removeIf(field -> field.fieldName().equals(ingestMode.dataSplitField().get()));
             }
+        }
+    }
+
+    private Dataset getTempDataset(Datasets datasets)
+    {
+        return datasets.tempDataset().orElse(DatasetDefinition.builder()
+            .schema(mainDataset().schema())
+            .database(mainDataset().datasetReference().database())
+            .group(mainDataset().datasetReference().group())
+            .name(LogicalPlanUtils.generateTableNameWithSuffix(mainDataset().datasetReference().name().orElseThrow((IllegalStateException::new)), TEMP))
+            .alias(TEMP)
+            .build());
+    }
+
+    private Dataset getTempDatasetWithDeleteIndicator(Datasets datasets)
+    {
+        if (datasets.tempDatasetWithDeleteIndicator().isPresent())
+        {
+            return datasets.tempDatasetWithDeleteIndicator().get();
+        }
+        else
+        {
+            Field deleteIndicator = Field.builder().name(deleteIndicatorField.orElseThrow((IllegalStateException::new))).type(FieldType.of(DataType.BOOLEAN, Optional.empty(), Optional.empty())).build();
+            List<Field> mainFieldsPlusDeleteIndicator = new ArrayList<>(mainDataset().schema().fields());
+            mainFieldsPlusDeleteIndicator.add(deleteIndicator);
+            return DatasetDefinition.builder()
+                .schema(mainDataset().schema().withFields(mainFieldsPlusDeleteIndicator))
+                .database(mainDataset().datasetReference().database())
+                .group(mainDataset().datasetReference().group())
+                .name(LogicalPlanUtils.generateTableNameWithSuffix(mainDataset().datasetReference().name().orElseThrow((IllegalStateException::new)), TEMP_WITH_DELETE_INDICATOR))
+                .alias(TEMP_WITH_DELETE_INDICATOR)
+                .build();
         }
     }
 
@@ -183,6 +224,12 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
                 // Op 7: Insert records from temp table to main table for deletion
                 operations.add(getTempToMainForDeletion());
             }
+            // Op 8: Cleanup temp tables
+            operations.add(Delete.builder().dataset(tempDataset).build());
+            if (deleteIndicatorField.isPresent())
+            {
+                operations.add(Delete.builder().dataset(tempDatasetWithDeleteIndicator).build());
+            }
         }
         return LogicalPlan.of(operations);
     }
@@ -219,18 +266,8 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         }
         else if (options().cleanupStagingData())
         {
-            operations.add(Truncate.of(stagingDataset()));
+            operations.add(Delete.builder().dataset(stagingDataset()).build());
         }
-
-        if (ingestMode().validityMilestoning().validityDerivation() instanceof SourceSpecifiesFromDateTime)
-        {
-            operations.add(Truncate.of(tempDataset));
-            if (deleteIndicatorField.isPresent())
-            {
-                operations.add(Truncate.of(tempDatasetWithDeleteIndicator));
-            }
-        }
-
         return LogicalPlan.of(operations);
     }
 
@@ -399,23 +436,23 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         Selection selectX1;
         if (deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(xAlias).build();
+            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(X_ALIAS).build();
         }
         else if (deleteIndicatorField.isPresent() && !ingestMode().dataSplitField().isPresent())
         {
-            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(deleteIndicatorIsNotSetCondition).alias(xAlias).build();
+            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(deleteIndicatorIsNotSetCondition).alias(X_ALIAS).build();
         }
         else if (!deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(dataSplitInRangeCondition).alias(xAlias).build();
+            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(dataSplitInRangeCondition).alias(X_ALIAS).build();
         }
         else
         {
-            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).alias(xAlias).build();
+            selectX1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).alias(X_ALIAS).build();
         }
-        Selection selectY1 = Selection.builder().source(mainDataset()).condition(openRecordCondition).addAllFields(primaryKeyFieldsAndFromField).alias(yAlias).build();
+        Selection selectY1 = Selection.builder().source(mainDataset()).condition(openRecordCondition).addAllFields(primaryKeyFieldsAndFromField).alias(Y_ALIAS).build();
 
-        Condition x1AndY1PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX1, selectY1, ingestMode().keyFields().toArray(new String[0]));
+        Condition x1AndY1PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX1, selectY1, primaryKeys.toArray(new String[0]));
         Condition x1FromLessThanY1From = LessThan.of(sourceValidDatetimeFrom.withDatasetRef(selectX1.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(selectY1.datasetReference()));
         Condition joinXY1Condition = And.builder().addConditions(x1AndY1PkMatchCondition, x1FromLessThanY1From).build();
         Join joinXY1 = Join.of(selectX1, selectY1, joinXY1Condition, JoinOperation.LEFT_OUTER_JOIN);
@@ -426,35 +463,35 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         selectXY1Fields.add(FunctionImpl.builder()
             .functionName(FunctionName.COALESCE)
             .addValue(FunctionImpl.builder().functionName(FunctionName.MIN).addValue(sourceValidDatetimeFrom.withDatasetRef(selectY1.datasetReference())).build(), LogicalPlanUtils.INFINITE_BATCH_TIME())
-            .alias(endAlias)
+            .alias(END_DATE)
             .build());
 
         List<Value> selectXY1GroupByFields = primaryKeyFieldsAndFromField.stream().map(field -> field.withDatasetRef(selectX1.datasetReference())).collect(Collectors.toList());
         Selection selectXY1 = Selection.builder().source(joinXY1).addAllFields(selectXY1Fields).groupByFields(selectXY1GroupByFields).build();
 
         // SECOND JOIN between X and Y
-        Selection selectX2 = selectXY1.withAlias(xAlias);
+        Selection selectX2 = selectXY1.withAlias(X_ALIAS);
         Selection selectY2;
         if (deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(yAlias).build();
+            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(Y_ALIAS).build();
         }
         else if (deleteIndicatorField.isPresent() && !ingestMode().dataSplitField().isPresent())
         {
-            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(deleteIndicatorIsNotSetCondition).alias(yAlias).build();
+            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(deleteIndicatorIsNotSetCondition).alias(Y_ALIAS).build();
         }
         else if (!deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(dataSplitInRangeCondition).alias(yAlias).build();
+            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(dataSplitInRangeCondition).alias(Y_ALIAS).build();
         }
         else
         {
-            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).alias(yAlias).build();
+            selectY2 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).alias(Y_ALIAS).build();
         }
 
-        Condition x2AndY2PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX2, selectY2, ingestMode().keyFields().toArray(new String[0]));
+        Condition x2AndY2PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX2, selectY2, primaryKeys.toArray(new String[0]));
         Condition y2FromGreaterThanX2From = GreaterThan.of(sourceValidDatetimeFrom.withDatasetRef(selectY2.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(selectX2.datasetReference()));
-        Condition y2FromLessThanX2Through = LessThan.of(sourceValidDatetimeFrom.withDatasetRef(selectY2.datasetReference()), FieldValue.builder().datasetRef(selectX2.datasetReference()).fieldName(endAlias).build());
+        Condition y2FromLessThanX2Through = LessThan.of(sourceValidDatetimeFrom.withDatasetRef(selectY2.datasetReference()), FieldValue.builder().datasetRef(selectX2.datasetReference()).fieldName(END_DATE).build());
         Condition joinXY2Condition = And.builder().addConditions(x2AndY2PkMatchCondition, y2FromGreaterThanX2From, y2FromLessThanX2Through).build();
         Join joinXY2 = Join.of(selectX2, selectY2, joinXY2Condition, JoinOperation.LEFT_OUTER_JOIN);
 
@@ -465,8 +502,8 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
             .functionName(FunctionName.COALESCE)
             .addValue(
                 FunctionImpl.builder().functionName(FunctionName.MIN).addValue(sourceValidDatetimeFrom.withDatasetRef(selectY2.datasetReference())).build(),
-                FunctionImpl.builder().functionName(FunctionName.MIN).addValue(FieldValue.builder().datasetRef(selectX2.datasetReference()).fieldName(endAlias).build()).build())
-            .alias(endAlias)
+                FunctionImpl.builder().functionName(FunctionName.MIN).addValue(FieldValue.builder().datasetRef(selectX2.datasetReference()).fieldName(END_DATE).build()).build())
+            .alias(END_DATE)
             .build());
 
         List<Value> selectXY2GroupByFields = primaryKeyFieldsAndFromField.stream().map(field -> field.withDatasetRef(selectX2.datasetReference())).collect(Collectors.toList());
@@ -476,24 +513,24 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         Selection selectX3;
         if (deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(xAlias).build();
+            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(X_ALIAS).build();
         }
         else if (deleteIndicatorField.isPresent() && !ingestMode().dataSplitField().isPresent())
         {
-            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).condition(deleteIndicatorIsNotSetCondition).alias(xAlias).build();
+            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).condition(deleteIndicatorIsNotSetCondition).alias(X_ALIAS).build();
         }
         else if (!deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).condition(dataSplitInRangeCondition).alias(xAlias).build();
+            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).condition(dataSplitInRangeCondition).alias(X_ALIAS).build();
         }
         else
         {
-            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).alias(xAlias).build();
+            selectX3 = Selection.builder().source(stagingDataset()).addAllFields(stagingDataset().schemaReference().fieldValues()).alias(X_ALIAS).build();
         }
 
-        Selection selectY3 = selectXY2.withAlias(yAlias);
+        Selection selectY3 = selectXY2.withAlias(Y_ALIAS);
 
-        Condition x3AndY3PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX3, selectY3, ingestMode().keyFields().toArray(new String[0]));
+        Condition x3AndY3PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX3, selectY3, primaryKeys.toArray(new String[0]));
         Condition x3FromEqualsY3From = Equals.of(sourceValidDatetimeFrom.withDatasetRef(selectX3.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(selectY3.datasetReference()));
         Condition joinXY3Condition = And.builder().addConditions(x3AndY3PkMatchCondition, x3FromEqualsY3From).build();
         Join joinXY3 = Join.of(selectX3, selectY3, joinXY3Condition, JoinOperation.LEFT_OUTER_JOIN);
@@ -503,7 +540,7 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         selectXY3Fields.addAll(dataFields.stream().map(field -> field.withDatasetRef(selectX3.datasetReference())).collect(Collectors.toList()));
         selectXY3Fields.add(digest.withDatasetRef(selectX3.datasetReference()));
         selectXY3Fields.add(sourceValidDatetimeFrom.withDatasetRef(selectX3.datasetReference()));
-        selectXY3Fields.add(FieldValue.builder().datasetRef(selectY3.datasetReference()).fieldName(endAlias).build());
+        selectXY3Fields.add(FieldValue.builder().datasetRef(selectY3.datasetReference()).fieldName(END_DATE).build());
         selectXY3Fields.addAll(transactionMilestoningFieldValues());
 
         Selection selectXY3 = Selection.builder().source(joinXY3).addAllFields(selectXY3Fields).build();
@@ -555,46 +592,46 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         // FIRST JOIN between X and Y
         List<Value> selectX1Fields = new ArrayList<>();
         selectX1Fields.addAll(primaryKeyFieldsAndFromField);
-        selectX1Fields.add(targetValidDatetimeThru.withAlias(endAlias));
+        selectX1Fields.add(targetValidDatetimeThru.withAlias(END_DATE));
 
-        Selection selectX1 = Selection.builder().source(mainDataset()).addAllFields(selectX1Fields).condition(openRecordCondition).alias(xAlias).build();
+        Selection selectX1 = Selection.builder().source(mainDataset()).addAllFields(selectX1Fields).condition(openRecordCondition).alias(X_ALIAS).build();
         Selection selectY1;
         if (deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(yAlias).build();
+            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(And.builder().addConditions(deleteIndicatorIsNotSetCondition.orElseThrow(IllegalStateException::new), dataSplitInRangeCondition.orElseThrow(IllegalStateException::new)).build()).alias(Y_ALIAS).build();
         }
         else if (deleteIndicatorField.isPresent() && !ingestMode().dataSplitField().isPresent())
         {
-            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(deleteIndicatorIsNotSetCondition).alias(yAlias).build();
+            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(deleteIndicatorIsNotSetCondition).alias(Y_ALIAS).build();
         }
         else if (!deleteIndicatorField.isPresent() && ingestMode().dataSplitField().isPresent())
         {
-            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(dataSplitInRangeCondition).alias(yAlias).build();
+            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).condition(dataSplitInRangeCondition).alias(Y_ALIAS).build();
         }
         else
         {
-            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).alias(yAlias).build();
+            selectY1 = Selection.builder().source(stagingDataset()).addAllFields(primaryKeyFieldsAndFromField).alias(Y_ALIAS).build();
         }
 
-        Condition x1AndY1PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX1, selectY1, ingestMode().keyFields().toArray(new String[0]));
+        Condition x1AndY1PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX1, selectY1, primaryKeys.toArray(new String[0]));
         Condition y1FromGreaterThanX1From = GreaterThan.of(sourceValidDatetimeFrom.withDatasetRef(selectY1.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(selectX1.datasetReference()));
-        Condition y1FromLessThanX1Through = LessThan.of(sourceValidDatetimeFrom.withDatasetRef(selectY1.datasetReference()), FieldValue.builder().datasetRef(selectX1.datasetReference()).fieldName(endAlias).build());
+        Condition y1FromLessThanX1Through = LessThan.of(sourceValidDatetimeFrom.withDatasetRef(selectY1.datasetReference()), FieldValue.builder().datasetRef(selectX1.datasetReference()).fieldName(END_DATE).build());
         Condition joinXY1Condition = And.builder().addConditions(x1AndY1PkMatchCondition, y1FromGreaterThanX1From, y1FromLessThanX1Through).build();
         Join joinXY1 = Join.of(selectX1, selectY1, joinXY1Condition, JoinOperation.INNER_JOIN);
 
         List<Value> selectXY1Fields = new ArrayList<>();
         selectXY1Fields.addAll(primaryKeyFields.stream().map(field -> field.withDatasetRef(selectX1.datasetReference())).collect(Collectors.toList()));
         selectXY1Fields.add(sourceValidDatetimeFrom.withDatasetRef(selectX1.datasetReference()));
-        selectXY1Fields.add(FunctionImpl.builder().functionName(FunctionName.MIN).addValue(sourceValidDatetimeFrom.withDatasetRef(selectY1.datasetReference())).alias(endAlias).build());
+        selectXY1Fields.add(FunctionImpl.builder().functionName(FunctionName.MIN).addValue(sourceValidDatetimeFrom.withDatasetRef(selectY1.datasetReference())).alias(END_DATE).build());
 
         List<Value> selectXY1GroupByFields = primaryKeyFieldsAndFromField.stream().map(field -> field.withDatasetRef(selectX1.datasetReference())).collect(Collectors.toList());
 
         Selection selectXY1 = Selection.builder().source(joinXY1).addAllFields(selectXY1Fields).groupByFields(selectXY1GroupByFields).build();
 
         // SECOND JOIN between X and Y
-        Selection selectX2 = selectXY1.withAlias(xAlias);
+        Selection selectX2 = selectXY1.withAlias(X_ALIAS);
 
-        Condition x2AndStagePkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX2, stagingDataset(), ingestMode().keyFields().toArray(new String[0]));
+        Condition x2AndStagePkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX2, stagingDataset(), primaryKeys.toArray(new String[0]));
         Condition x2FromEqualsStageFrom = Equals.of(sourceValidDatetimeFrom.withDatasetRef(selectX2.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(stagingDataset().datasetReference()));
         Condition selectFromStageCondition = And.builder().addConditions(x2AndStagePkMatchCondition, x2FromEqualsStageFrom).build();
         if (deleteIndicatorField.isPresent())
@@ -610,15 +647,15 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         List<Value> selectXY2Fields = new ArrayList<>();
         selectXY2Fields.addAll(primaryKeyFields.stream().map(field -> field.withDatasetRef(selectX2.datasetReference())).collect(Collectors.toList()));
         selectXY2Fields.add(sourceValidDatetimeFrom.withDatasetRef(selectX2.datasetReference()));
-        selectXY2Fields.add(FieldValue.builder().datasetRef(selectX2.datasetReference()).fieldName(endAlias).alias(endAlias).build());
+        selectXY2Fields.add(FieldValue.builder().datasetRef(selectX2.datasetReference()).fieldName(END_DATE).alias(END_DATE).build());
 
         Selection selectXY2 = Selection.builder().source(selectX2).addAllFields(selectXY2Fields).condition(whereNotExists).build();
 
         // THIRD JOIN between X and Y
-        Selection selectX3 = Selection.builder().source(mainDataset()).addAllFields(mainDataset().schemaReference().fieldValues()).condition(openRecordCondition).alias(xAlias).build();
-        Selection selectY3 = selectXY2.withAlias(yAlias);
+        Selection selectX3 = Selection.builder().source(mainDataset()).addAllFields(mainDataset().schemaReference().fieldValues()).condition(openRecordCondition).alias(X_ALIAS).build();
+        Selection selectY3 = selectXY2.withAlias(Y_ALIAS);
 
-        Condition x3AndY3PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX3, selectY3, ingestMode().keyFields().toArray(new String[0]));
+        Condition x3AndY3PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX3, selectY3, primaryKeys.toArray(new String[0]));
         Condition x3FromEqualsY3From = Equals.of(sourceValidDatetimeFrom.withDatasetRef(selectX3.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(selectY3.datasetReference()));
         Condition joinXY3Condition = And.builder().addConditions(x3AndY3PkMatchCondition, x3FromEqualsY3From).build();
         Join joinXY3 = Join.of(selectX3, selectY3, joinXY3Condition, JoinOperation.INNER_JOIN);
@@ -628,7 +665,7 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         selectXY3Fields.addAll(dataFields.stream().map(field -> field.withDatasetRef(selectX3.datasetReference())).collect(Collectors.toList()));
         selectXY3Fields.add(digest.withDatasetRef(selectX3.datasetReference()));
         selectXY3Fields.add(sourceValidDatetimeFrom.withDatasetRef(selectX3.datasetReference()));
-        selectXY3Fields.add(FieldValue.builder().datasetRef(selectY3.datasetReference()).fieldName(endAlias).build());
+        selectXY3Fields.add(FieldValue.builder().datasetRef(selectY3.datasetReference()).fieldName(END_DATE).build());
         selectXY3Fields.addAll(transactionMilestoningFieldValues());
 
         Selection selectXY3 = Selection.builder().source(joinXY3).addAllFields(selectXY3Fields).build();
@@ -657,7 +694,7 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
     */
     private Update getUpdateMain(Dataset tempDataset)
     {
-        Condition pKMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(mainDataset(), tempDataset, ingestMode().keyFields().toArray(new String[0]));
+        Condition pKMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(mainDataset(), tempDataset, primaryKeys.toArray(new String[0]));
         Condition fromMatchCondition = Equals.of(sourceValidDatetimeFrom.withDatasetRef(mainDataset().datasetReference()), sourceValidDatetimeFrom.withDatasetRef(tempDataset.datasetReference()));
         Condition selectionCondition = And.builder().addConditions(pKMatchCondition, fromMatchCondition).build();
 
@@ -714,19 +751,19 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         }
 
         Condition selectXCondition = And.builder().addConditions(openRecordCondition, Exists.of(innerSelect)).build();
-        Selection selectX = Selection.builder().source(mainDataset()).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).condition(selectXCondition).alias(xAlias).build();
+        Selection selectX = Selection.builder().source(mainDataset()).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).condition(selectXCondition).alias(X_ALIAS).build();
 
         Selection selectY;
         if (ingestMode().dataSplitField().isPresent())
         {
-            selectY = Selection.builder().source(stagingDataset()).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).condition(dataSplitInRangeCondition).alias(yAlias).build();
+            selectY = Selection.builder().source(stagingDataset()).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).condition(dataSplitInRangeCondition).alias(Y_ALIAS).build();
         }
         else
         {
-            selectY = Selection.builder().source(stagingDataset()).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).alias(yAlias).build();
+            selectY = Selection.builder().source(stagingDataset()).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).alias(Y_ALIAS).build();
         }
 
-        Condition xAndYPkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX, selectY, ingestMode().keyFields().toArray(new String[0]));
+        Condition xAndYPkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX, selectY, primaryKeys.toArray(new String[0]));
         Condition xFromEqualsYFrom = Equals.of(sourceValidDatetimeFrom.withDatasetRef(selectX.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(selectY.datasetReference()));
         Condition joinXYCondition = And.builder().addConditions(xAndYPkMatchCondition, xFromEqualsYFrom).build();
 
@@ -788,10 +825,10 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
     private Insert getTempToMainForDeletion()
     {
         // FIRST JOIN between X and Y
-        Dataset tempX1 = tempDatasetWithDeleteIndicator.datasetReference().withAlias(xAlias);
-        Dataset tempY1 = tempDatasetWithDeleteIndicator.datasetReference().withAlias(yAlias);
+        Dataset tempX1 = tempDatasetWithDeleteIndicator.datasetReference().withAlias(X_ALIAS);
+        Dataset tempY1 = tempDatasetWithDeleteIndicator.datasetReference().withAlias(Y_ALIAS);
 
-        Condition x1AndY1PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(tempX1, tempY1, ingestMode().keyFields().toArray(new String[0]));
+        Condition x1AndY1PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(tempX1, tempY1, primaryKeys.toArray(new String[0]));
         Condition y1FromGreaterThanX1From = GreaterThan.of(sourceValidDatetimeFrom.withDatasetRef(tempY1.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(tempX1.datasetReference()));
         Condition y1DeleteIndicatorIsZero = Equals.of(FieldValue.builder().fieldName(deleteIndicatorField.orElseThrow(IllegalStateException::new)).datasetRef(tempY1.datasetReference()).build(), NumericalValue.of(0L));
         Condition joinXY1Condition = And.builder().addConditions(x1AndY1PkMatchCondition, y1FromGreaterThanX1From, y1DeleteIndicatorIsZero).build();
@@ -801,8 +838,8 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         selectXY1Fields.addAll(primaryKeyFields.stream().map(field -> field.withDatasetRef(tempX1.datasetReference())).collect(Collectors.toList()));
         selectXY1Fields.addAll(dataFields.stream().map(field -> field.withDatasetRef(tempX1.datasetReference())).collect(Collectors.toList()));
         selectXY1Fields.add(digest.withDatasetRef(tempX1.datasetReference()));
-        selectXY1Fields.add(sourceValidDatetimeFrom.withDatasetRef(tempX1.datasetReference()).withAlias(startAlias));
-        selectXY1Fields.add(FunctionImpl.builder().functionName(FunctionName.COALESCE).addValue(FunctionImpl.builder().functionName(FunctionName.MIN).addValue(sourceValidDatetimeFrom.withDatasetRef(tempY1.datasetReference())).build(), LogicalPlanUtils.INFINITE_BATCH_TIME()).alias(endAlias).build());
+        selectXY1Fields.add(sourceValidDatetimeFrom.withDatasetRef(tempX1.datasetReference()).withAlias(START_DATE));
+        selectXY1Fields.add(FunctionImpl.builder().functionName(FunctionName.COALESCE).addValue(FunctionImpl.builder().functionName(FunctionName.MIN).addValue(sourceValidDatetimeFrom.withDatasetRef(tempY1.datasetReference())).build(), LogicalPlanUtils.INFINITE_BATCH_TIME()).alias(END_DATE).build());
         selectXY1Fields.addAll(transactionMilestoningFields().stream().map(field -> field.withDatasetRef(tempX1.datasetReference())).collect(Collectors.toList()));
 
         List<Value> selectXY1GroupByFields = new ArrayList<>();
@@ -814,15 +851,15 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
 
         Condition selectXY1Condition = Equals.of(FieldValue.builder().fieldName(deleteIndicatorField.orElseThrow(IllegalStateException::new)).datasetRef(tempX1.datasetReference()).build(), NumericalValue.of(0L));
 
-        Selection selectXY1 = Selection.builder().source(joinXY1).addAllFields(selectXY1Fields).condition(selectXY1Condition).groupByFields(selectXY1GroupByFields).alias(xAlias).build();
+        Selection selectXY1 = Selection.builder().source(joinXY1).addAllFields(selectXY1Fields).condition(selectXY1Condition).groupByFields(selectXY1GroupByFields).alias(X_ALIAS).build();
 
         // Second Left Join to extract the correct end_date
         Selection selectX2 = selectXY1;
-        Dataset tempY2 = tempDatasetWithDeleteIndicator.datasetReference().withAlias(yAlias);
+        Dataset tempY2 = tempDatasetWithDeleteIndicator.datasetReference().withAlias(Y_ALIAS);
 
-        Condition x2AndY2PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX2, tempY2, ingestMode().keyFields().toArray(new String[0]));
+        Condition x2AndY2PkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(selectX2, tempY2, primaryKeys.toArray(new String[0]));
         Condition y2ThroughGreaterThanX2From = GreaterThan.of(targetValidDatetimeThru.withDatasetRef(tempY2.datasetReference()), sourceValidDatetimeFrom.withDatasetRef(selectX2.datasetReference()));
-        Condition y2ThroughLessThanEqualsToX2Through = LessThanEqualTo.of(targetValidDatetimeThru.withDatasetRef(tempY2.datasetReference()), FieldValue.builder().fieldName(endAlias).datasetRef(selectX2.datasetReference()).build());
+        Condition y2ThroughLessThanEqualsToX2Through = LessThanEqualTo.of(targetValidDatetimeThru.withDatasetRef(tempY2.datasetReference()), FieldValue.builder().fieldName(END_DATE).datasetRef(selectX2.datasetReference()).build());
         Condition y2DeleteIndicatorIsNotZero = NotEquals.of(FieldValue.builder().fieldName(deleteIndicatorField.get()).datasetRef(tempY2.datasetReference()).build(), NumericalValue.of(0L));
         Condition joinXY2Condition = And.builder().addConditions(x2AndY2PkMatchCondition, y2ThroughGreaterThanX2From, y2ThroughLessThanEqualsToX2Through, y2DeleteIndicatorIsNotZero).build();
         Join joinXY2 = Join.of(selectX2, tempY2, joinXY2Condition, JoinOperation.LEFT_OUTER_JOIN);
@@ -831,8 +868,8 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         selectXY2Fields.addAll(primaryKeyFields.stream().map(field -> field.withDatasetRef(selectX2.datasetReference())).collect(Collectors.toList()));
         selectXY2Fields.addAll(dataFields.stream().map(field -> field.withDatasetRef(selectX2.datasetReference())).collect(Collectors.toList()));
         selectXY2Fields.add(digest.withDatasetRef(selectX2.datasetReference()));
-        selectXY2Fields.add(sourceValidDatetimeFrom.withDatasetRef(selectX2.datasetReference()).withAlias(startAlias));
-        selectXY2Fields.add(FunctionImpl.builder().functionName(FunctionName.MAX).addValue(targetValidDatetimeThru.withDatasetRef(tempY2.datasetReference())).alias(endAlias).build());
+        selectXY2Fields.add(sourceValidDatetimeFrom.withDatasetRef(selectX2.datasetReference()).withAlias(START_DATE));
+        selectXY2Fields.add(FunctionImpl.builder().functionName(FunctionName.MAX).addValue(targetValidDatetimeThru.withDatasetRef(tempY2.datasetReference())).alias(END_DATE).build());
         selectXY2Fields.addAll(transactionMilestoningFields().stream().map(field -> field.withDatasetRef(selectX2.datasetReference())).collect(Collectors.toList()));
 
         List<Value> selectXY2GroupByFields = new ArrayList<>();

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalDeltaPlanner.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalDeltaPlanner.java
@@ -66,6 +66,9 @@ class NontemporalDeltaPlanner extends Planner
     {
         super(datasets, ingestMode, plannerOptions);
 
+        // validate
+        validatePrimaryKeysNotEmpty(primaryKeys);
+
         this.deleteIndicatorField = ingestMode.mergeStrategy().accept(MergeStrategyVisitors.EXTRACT_DELETE_FIELD);
         this.deleteIndicatorValues = ingestMode.mergeStrategy().accept(MergeStrategyVisitors.EXTRACT_DELETE_VALUES);
 
@@ -81,7 +84,7 @@ class NontemporalDeltaPlanner extends Planner
     @Override
     public LogicalPlan buildLogicalPlanForIngest(Resources resources, Set<Capability> capabilities)
     {
-        Condition pkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(mainDataset(), stagingDataset(), ingestMode().keyFields().toArray(new String[0]));
+        Condition pkMatchCondition = LogicalPlanUtils.getPrimaryKeyMatchCondition(mainDataset(), stagingDataset(), primaryKeys.toArray(new String[0]));
         Condition digestDoesNotMatchCondition = LogicalPlanUtils.getDigestDoesNotMatchCondition(mainDataset(), stagingDataset(), ingestMode().digestField());
         Condition digestMatchCondition = LogicalPlanUtils.getDigestMatchCondition(mainDataset(), stagingDataset(), ingestMode().digestField());
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalSnapshotPlanner.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalSnapshotPlanner.java
@@ -25,7 +25,7 @@ import org.finos.legend.engine.persistence.components.logicalplan.datasets.Selec
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Create;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Insert;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Operation;
-import org.finos.legend.engine.persistence.components.logicalplan.operations.Truncate;
+import org.finos.legend.engine.persistence.components.logicalplan.operations.Delete;
 import org.finos.legend.engine.persistence.components.logicalplan.values.BatchStartTimestamp;
 import org.finos.legend.engine.persistence.components.logicalplan.values.FieldValue;
 import org.finos.legend.engine.persistence.components.logicalplan.values.Value;
@@ -79,7 +79,7 @@ class NontemporalSnapshotPlanner extends Planner
 
         List<Operation> operations = new ArrayList<>();
         // Step 1: Delete all rows from existing table
-        operations.add(Truncate.of(mainDataset()));
+        operations.add(Delete.builder().dataset(mainDataset()).build());
         // Step 2: Insert new dataset
         operations.add(Insert.of(mainDataset(), selectStaging, stagingFields));
 
@@ -96,7 +96,7 @@ class NontemporalSnapshotPlanner extends Planner
     public Map<StatisticName, LogicalPlan> buildLogicalPlanForPreRunStatistics(Resources resources)
     {
         Map<StatisticName, LogicalPlan> preRunStatisticsResult = new HashMap<>();
-        if (options().collectStatistics() && resources.mainDataSetExists())
+        if (options().collectStatistics())
         {
             //Rows Deleted = rows removed(hard-deleted) from sink table)
             preRunStatisticsResult.put(ROWS_DELETED,

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/util/LogicalPlanUtils.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/util/LogicalPlanUtils.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.persistence.components.util;
 
+import java.util.UUID;
 import org.finos.legend.engine.persistence.components.logicalplan.conditions.And;
 import org.finos.legend.engine.persistence.components.logicalplan.conditions.Condition;
 import org.finos.legend.engine.persistence.components.logicalplan.conditions.Equals;
@@ -56,8 +57,16 @@ public class LogicalPlanUtils
     public static final String DATA_SPLIT_LOWER_BOUND_PLACEHOLDER = "{DATA_SPLIT_LOWER_BOUND_PLACEHOLDER}";
     public static final String DATA_SPLIT_UPPER_BOUND_PLACEHOLDER = "{DATA_SPLIT_UPPER_BOUND_PLACEHOLDER}";
 
+    private static final String UNDERSCORE = "_";
+
     private LogicalPlanUtils()
     {
+    }
+
+    public static String generateTableNameWithSuffix(String tableName, String suffix)
+    {
+        UUID uuid = UUID.randomUUID();
+        return tableName + UNDERSCORE + suffix + UNDERSCORE + uuid;
     }
 
     public static NumericalValue INFINITE_BATCH_ID()

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/optimizer/LowerCaseOptimizer.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/optimizer/LowerCaseOptimizer.java
@@ -38,7 +38,6 @@ public class LowerCaseOptimizer implements CaseConversionOptimizer
         {
             Field field = (Field) component;
             field.setName(field.getName() != null ? field.getName().toLowerCase() : field.getName());
-            field.setAlias(field.getAlias() != null ? field.getAlias().toLowerCase() : field.getAlias());
             return field;
         }
         else if (component instanceof Column)
@@ -53,7 +52,6 @@ public class LowerCaseOptimizer implements CaseConversionOptimizer
             table.setDb(table.getDb() != null ? table.getDb().toLowerCase() : table.getDb());
             table.setSchema(table.getSchema() != null ? table.getSchema().toLowerCase() : table.getSchema());
             table.setTable(table.getTable() != null ? table.getTable().toLowerCase() : table.getTable());
-            table.setAlias(table.getAlias() != null ? table.getAlias().toLowerCase() : table.getAlias());
             return table;
         }
         else if (component instanceof TruncateTable)
@@ -65,7 +63,6 @@ public class LowerCaseOptimizer implements CaseConversionOptimizer
                 table.setDb(table.getDb() != null ? table.getDb().toLowerCase() : table.getDb());
                 table.setSchema(table.getSchema() != null ? table.getSchema().toLowerCase() : table.getSchema());
                 table.setTable(table.getTable() != null ? table.getTable().toLowerCase() : table.getTable());
-                table.setAlias(table.getAlias() != null ? table.getAlias().toLowerCase() : table.getAlias());
             }
             return truncateTable;
         }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/optimizer/UpperCaseOptimizer.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/optimizer/UpperCaseOptimizer.java
@@ -38,7 +38,6 @@ public class UpperCaseOptimizer implements CaseConversionOptimizer
         {
             Field field = (Field) component;
             field.setName(field.getName() != null ? field.getName().toUpperCase() : field.getName());
-            field.setAlias(field.getAlias() != null ? field.getAlias().toUpperCase() : field.getAlias());
             return field;
         }
         else if (component instanceof Column)
@@ -53,7 +52,6 @@ public class UpperCaseOptimizer implements CaseConversionOptimizer
             table.setDb(table.getDb() != null ? table.getDb().toUpperCase() : table.getDb());
             table.setSchema(table.getSchema() != null ? table.getSchema().toUpperCase() : table.getSchema());
             table.setTable(table.getTable() != null ? table.getTable().toUpperCase() : table.getTable());
-            table.setAlias(table.getAlias() != null ? table.getAlias().toUpperCase() : table.getAlias());
             return table;
         }
         else if (component instanceof TruncateTable)
@@ -65,7 +63,6 @@ public class UpperCaseOptimizer implements CaseConversionOptimizer
                 table.setDb(table.getDb() != null ? table.getDb().toUpperCase() : table.getDb());
                 table.setSchema(table.getSchema() != null ? table.getSchema().toUpperCase() : table.getSchema());
                 table.setTable(table.getTable() != null ? table.getTable().toUpperCase() : table.getTable());
-                table.setAlias(table.getAlias() != null ? table.getAlias().toUpperCase() : table.getAlias());
             }
             return truncateTable;
         }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/AllQuantifierVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/AllQuantifierVisitor.java
@@ -23,7 +23,7 @@ public class AllQuantifierVisitor implements LogicalPlanVisitor<org.finos.legend
 {
 
     @Override
-    public LogicalPlanVisitor.VisitorResult visit(PhysicalPlanNode prev, org.finos.legend.engine.persistence.components.logicalplan.quantifiers.AllQuantifier current, VisitorContext context)
+    public VisitorResult visit(PhysicalPlanNode prev, org.finos.legend.engine.persistence.components.logicalplan.quantifiers.AllQuantifier current, VisitorContext context)
     {
 
         AllQuantifier allQuantifier = new AllQuantifier();

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/DeleteVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/DeleteVisitor.java
@@ -35,9 +35,9 @@ public class DeleteVisitor implements LogicalPlanVisitor<Delete>
 
         List<LogicalPlanNode> logicalPlanNodeList = new ArrayList<>();
         logicalPlanNodeList.add(current.dataset());
-        if (current.condition() != null)
+        if (current.condition().isPresent())
         {
-            logicalPlanNodeList.add(current.condition());
+            logicalPlanNodeList.add(current.condition().get());
         }
 
         return new VisitorResult(deleteStatement, logicalPlanNodeList);

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/FieldValueVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/FieldValueVisitor.java
@@ -14,11 +14,9 @@
 
 package org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors;
 
-import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetReference;
 import org.finos.legend.engine.persistence.components.logicalplan.values.FieldValue;
 import org.finos.legend.engine.persistence.components.optimizer.Optimizer;
 import org.finos.legend.engine.persistence.components.physicalplan.PhysicalPlanNode;
-import org.finos.legend.engine.persistence.components.relational.sqldom.schemaops.expresssions.table.Table;
 import org.finos.legend.engine.persistence.components.relational.sqldom.schemaops.values.Field;
 import org.finos.legend.engine.persistence.components.transformer.LogicalPlanVisitor;
 import org.finos.legend.engine.persistence.components.transformer.VisitorContext;
@@ -29,10 +27,8 @@ public class FieldValueVisitor implements LogicalPlanVisitor<FieldValue>
     @Override
     public VisitorResult visit(PhysicalPlanNode prev, FieldValue current, VisitorContext context)
     {
-        Table table = determineTable(current, context);
-
         Field field = new Field(
-            table,
+            getDatasetReferenceAlias(current),
             current.fieldName(),
             context.quoteIdentifier(),
             current.alias().orElse(null));
@@ -47,27 +43,12 @@ public class FieldValueVisitor implements LogicalPlanVisitor<FieldValue>
         return new VisitorResult(null);
     }
 
-    private Table determineTable(FieldValue current, VisitorContext context)
+    private String getDatasetReferenceAlias(FieldValue current)
     {
         if (!current.datasetRef().isPresent())
         {
-            return new Table();
+            return null;
         }
-
-        DatasetReference datasetReference = current.datasetRef().get();
-
-        Table table = new Table(
-            datasetReference.database().orElse(null),
-            datasetReference.group().orElse(null),
-            datasetReference.name().orElse(null),
-            datasetReference.alias().orElse(null),
-            context.quoteIdentifier());
-
-        for (Optimizer optimizer : context.optimizers())
-        {
-            table = (Table) optimizer.optimize(table);
-        }
-
-        return table;
+        return current.datasetRef().get().alias().orElse(null);
     }
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/IngestModeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/IngestModeTest.java
@@ -71,17 +71,11 @@ public class IngestModeTest
     protected String validityFromTargetField = "validity_from_target";
     protected String validityThroughTargetField = "validity_through_target";
 
-    protected String[] primaryKeys = new String[]{"id", "name"};
-    protected List<String> primaryKeysList = Arrays.asList(primaryKeys);
     protected String[] partitionKeys = new String[]{"biz_date"};
     protected Map<String, Set<String>> partitionFilter = new HashMap<String, Set<String>>()
     {{
         put("biz_date", new HashSet<>(Arrays.asList("2000-01-01 00:00:00", "2000-01-02 00:00:00")));
     }};
-    protected String[] bitemporalFromAndThroughPrimaryKeys = new String[]{"id", "name", validityFromReferenceField};
-    protected List<String> bitemporalFromAndThroughPrimaryKeysList = Arrays.asList(bitemporalFromAndThroughPrimaryKeys);
-    protected String[] bitemporalFromOnlyPrimaryKeys = new String[]{"id", "name"};
-    protected List<String> bitemporalFromOnlyPrimaryKeysList = Arrays.asList(bitemporalFromOnlyPrimaryKeys);
     protected String[] bitemporalPartitionKeys = new String[]{validityFromReferenceField};
 
     // Base Columns: Primary keys : id, name
@@ -101,6 +95,8 @@ public class IngestModeTest
     protected Field validityThroughTarget = Field.builder().name(validityThroughTargetField).type(FieldType.of(DataType.DATETIME, Optional.empty(), Optional.empty())).build();
 
     // Problematic Columns
+    protected Field idNonPrimary = Field.builder().name("id").type(FieldType.of(DataType.INT, Optional.empty(), Optional.empty())).build();
+    protected Field nameNonPrimary = Field.builder().name("name").type(FieldType.of(DataType.VARCHAR, Optional.empty(), Optional.empty())).build();
     protected Field batchIdInNonPrimary = Field.builder().name(batchIdInField).type(FieldType.of(DataType.INT, Optional.empty(), Optional.empty())).build();
     protected Field batchTimeInNonPrimary = Field.builder().name(batchTimeInField).type(FieldType.of(DataType.DATETIME, Optional.empty(), Optional.empty())).build();
 
@@ -231,6 +227,14 @@ public class IngestModeTest
     protected SchemaDefinition baseTableSchemaWithDigest = SchemaDefinition.builder()
         .addFields(id)
         .addFields(name)
+        .addFields(amount)
+        .addFields(bizDate)
+        .addFields(digest)
+        .build();
+
+    protected SchemaDefinition baseTableSchemaWithNoPrimaryKeys = SchemaDefinition.builder()
+        .addFields(idNonPrimary)
+        .addFields(nameNonPrimary)
         .addFields(amount)
         .addFields(bizDate)
         .addFields(digest)
@@ -412,11 +416,11 @@ public class IngestModeTest
         " (SELECT 'main',(SELECT COALESCE(MAX(batch_metadata.\"table_batch_id\"),0)+1 FROM batch_metadata as batch_metadata WHERE batch_metadata.\"table_name\" = 'main'),'2000-01-01 00:00:00',CURRENT_TIMESTAMP(),'DONE')";
 
     protected String expectedMetadataTableIngestQueryWithUpperCase = "INSERT INTO BATCH_METADATA (\"TABLE_NAME\", \"TABLE_BATCH_ID\", \"BATCH_START_TS_UTC\", \"BATCH_END_TS_UTC\", \"BATCH_STATUS\")" +
-        " (SELECT 'main',(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),'2000-01-01 00:00:00',CURRENT_TIMESTAMP(),'DONE')";
+        " (SELECT 'main',(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),'2000-01-01 00:00:00',CURRENT_TIMESTAMP(),'DONE')";
 
     protected String expectedMetadataTableIngestQueryWithPlaceHolders = "INSERT INTO batch_metadata (\"table_name\", \"table_batch_id\", \"batch_start_ts_utc\", \"batch_end_ts_utc\", \"batch_status\") (SELECT 'main',{BATCH_ID_PATTERN},'{BATCH_START_TS_PATTERN}','{BATCH_END_TS_PATTERN}','DONE')";
 
-    protected String expectedTruncateTableQuery = "TRUNCATE TABLE \"mydb\".\"staging\"";
+    protected String expectedStagingCleanupQuery = "DELETE FROM \"mydb\".\"staging\" as stage";
 
     protected String expectedDropTableQuery = "DROP TABLE IF EXISTS \"mydb\".\"staging\"";
 
@@ -587,6 +591,11 @@ public class IngestModeTest
         "\"validity_through_target\" DATETIME," +
         "\"delete_indicator\" VARCHAR," +
         "PRIMARY KEY (\"id\", \"name\", \"validity_from_reference\", \"batch_id_in\", \"validity_from_target\"))";
+
+    protected String getExpectedCleanupSql(String fullName, String alias)
+    {
+        return String.format("DELETE FROM %s as %s", fullName, alias);
+    }
 
     public void assertIfListsAreSameIgnoringOrder(List<String> first, List<String> second)
     {

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaWithBatchIdTest.java
@@ -59,7 +59,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
     {
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromAndThroughPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -126,7 +125,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromAndThroughPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -193,7 +191,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromAndThroughPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -220,27 +217,27 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK " +
-            "SET SINK.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 " +
-            "FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')-1 " +
-            "WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE " +
-            "WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\") " +
-            "AND (SINK.\"VALIDITY_FROM_REFERENCE\" = STAGE.\"VALIDITY_FROM_REFERENCE\")) " +
-            "AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\")))";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink " +
+            "SET sink.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 " +
+            "FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')-1 " +
+            "WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage " +
+            "WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\") " +
+            "AND (sink.\"VALIDITY_FROM_REFERENCE\" = stage.\"VALIDITY_FROM_REFERENCE\")) " +
+            "AND (sink.\"DIGEST\" <> stage.\"DIGEST\")))";
 
         String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" " +
             "(\"ID\", \"NAME\", \"AMOUNT\", \"VALIDITY_FROM_REFERENCE\", \"VALIDITY_THROUGH_REFERENCE\", \"DIGEST\", \"BATCH_ID_IN\", " +
             "\"BATCH_ID_OUT\", \"VALIDITY_FROM_TARGET\", \"VALIDITY_THROUGH_TARGET\") " +
-            "(SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"VALIDITY_FROM_REFERENCE\",STAGE.\"VALIDITY_THROUGH_REFERENCE\"," +
-            "STAGE.\"DIGEST\",(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')" +
-            ",999999999,STAGE.\"VALIDITY_FROM_REFERENCE\",STAGE.\"VALIDITY_THROUGH_REFERENCE\" " +
-            "FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (EXISTS " +
-            "(SELECT * FROM \"MYDB\".\"MAIN\" as SINK " +
-            "WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) " +
-            "AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\") " +
-            "AND ((SINK.\"ID\" = STAGE.\"ID\") " +
-            "AND (SINK.\"NAME\" = STAGE.\"NAME\") " +
-            "AND (SINK.\"VALIDITY_FROM_REFERENCE\" = STAGE.\"VALIDITY_FROM_REFERENCE\")))))";
+            "(SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"VALIDITY_FROM_REFERENCE\",stage.\"VALIDITY_THROUGH_REFERENCE\"," +
+            "stage.\"DIGEST\",(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')" +
+            ",999999999,stage.\"VALIDITY_FROM_REFERENCE\",stage.\"VALIDITY_THROUGH_REFERENCE\" " +
+            "FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (EXISTS " +
+            "(SELECT * FROM \"MYDB\".\"MAIN\" as sink " +
+            "WHERE (sink.\"BATCH_ID_OUT\" = 999999999) " +
+            "AND (sink.\"DIGEST\" = stage.\"DIGEST\") " +
+            "AND ((sink.\"ID\" = stage.\"ID\") " +
+            "AND (sink.\"NAME\" = stage.\"NAME\") " +
+            "AND (sink.\"VALIDITY_FROM_REFERENCE\" = stage.\"VALIDITY_FROM_REFERENCE\")))))";
 
         Assertions.assertEquals(expectedBitemporalMainTableCreateQueryUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -276,7 +273,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -400,7 +396,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -530,6 +525,8 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
         Assertions.assertEquals(expectedMainToTempForDeletion, milestoningSql.get(4));
         Assertions.assertEquals(expectedUpdateMainForDeletion, milestoningSql.get(5));
         Assertions.assertEquals(expectedTempToMainForDeletion, milestoningSql.get(6));
+        Assertions.assertEquals(getExpectedCleanupSql("\"mydb\".\"temp\"", "temp"), milestoningSql.get(7));
+
         Assertions.assertEquals(expectedMetadataTableIngestQuery, metadataIngestSql.get(0));
     }
 
@@ -559,7 +556,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .dataSplitField(Optional.of(dataSplitField))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
@@ -645,10 +641,14 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
         Assertions.assertEquals(String.format(expectedMainToTemp, 2, 5, 2, 5), operations.get(0).ingestSql().get(1));
         Assertions.assertEquals(expectedUpdateMain, operations.get(0).ingestSql().get(2));
         Assertions.assertEquals(expectedTempToMain, operations.get(0).ingestSql().get(3));
+        Assertions.assertEquals(getExpectedCleanupSql("\"mydb\".\"temp\"", "temp"), operations.get(0).ingestSql().get(4));
+
         Assertions.assertEquals(String.format(expectedStageToTemp, 6, 7, 6, 7, 6, 7), operations.get(1).ingestSql().get(0));
         Assertions.assertEquals(String.format(expectedMainToTemp, 6, 7, 6, 7), operations.get(1).ingestSql().get(1));
         Assertions.assertEquals(expectedUpdateMain, operations.get(1).ingestSql().get(2));
         Assertions.assertEquals(expectedTempToMain, operations.get(1).ingestSql().get(3));
+        Assertions.assertEquals(getExpectedCleanupSql("\"mydb\".\"temp\"", "temp"), operations.get(1).ingestSql().get(4));
+
         Assertions.assertEquals(expectedMetadataTableIngestQuery, operations.get(0).metadataIngestSql().get(0));
         Assertions.assertEquals(expectedMetadataTableIngestQuery, operations.get(1).metadataIngestSql().get(0));
 
@@ -673,23 +673,8 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
             .schema(bitemporalFromOnlyStagingTableSchemaWithDeleteIndicatorWithDataSplit)
             .build();
 
-        DatasetDefinition tempTable = DatasetDefinition.builder()
-            .database(tempDbName)
-            .name(tempTableName)
-            .alias(tempTableAlias)
-            .schema(bitemporalFromOnlyTempTableSchema)
-            .build();
-
-        DatasetDefinition tempTableWithDeleteIndicator = DatasetDefinition.builder()
-            .database(tempWithDeleteIndicatorDbName)
-            .name(tempWithDeleteIndicatorTableName)
-            .alias(tempWithDeleteIndicatorTableAlias)
-            .schema(bitemporalFromOnlyTempTableWithDeleteIndicatorSchema)
-            .build();
-
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .dataSplitField(Optional.of(dataSplitField))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
@@ -708,7 +693,7 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
                 .build())
             .build();
 
-        Datasets datasets = Datasets.builder().mainDataset(mainTable).stagingDataset(stagingTable).tempDataset(tempTable).tempDatasetWithDeleteIndicator(tempTableWithDeleteIndicator).build();
+        Datasets datasets = Datasets.builder().mainDataset(mainTable).stagingDataset(stagingTable).build();
 
         RelationalGenerator generator = RelationalGenerator.builder()
             .ingestMode(ingestMode)
@@ -718,7 +703,35 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         List<GeneratorResult> operations = generator.generateOperationsWithDataSplits(datasets, dataSplitRanges);
 
-        String expectedStageToTemp = "INSERT INTO \"mydb\".\"temp\" " +
+        String tempName = operations.get(0).preActionsSql().get(2).split("CREATE TABLE IF NOT EXISTS ")[1].split("\\(")[0];
+        String tempWithDeleteIndicatorName = operations.get(0).preActionsSql().get(3).split("CREATE TABLE IF NOT EXISTS ")[1].split("\\(")[0];
+
+        String expectedBitemporalFromOnlyDefaultTempTableCreateQuery = "CREATE TABLE IF NOT EXISTS " + tempName +
+            "(\"id\" INTEGER," +
+            "\"name\" VARCHAR," +
+            "\"amount\" DOUBLE," +
+            "\"validity_from_reference\" DATETIME," +
+            "\"digest\" VARCHAR," +
+            "\"batch_id_in\" INTEGER," +
+            "\"batch_id_out\" INTEGER," +
+            "\"validity_from_target\" DATETIME," +
+            "\"validity_through_target\" DATETIME," +
+            "PRIMARY KEY (\"id\", \"name\", \"validity_from_reference\", \"batch_id_in\", \"validity_from_target\"))";
+
+        String expectedBitemporalFromOnlyDefaultTempTableWithDeleteIndicatorCreateQuery = "CREATE TABLE IF NOT EXISTS " + tempWithDeleteIndicatorName +
+            "(\"id\" INTEGER," +
+            "\"name\" VARCHAR," +
+            "\"amount\" DOUBLE," +
+            "\"validity_from_reference\" DATETIME," +
+            "\"digest\" VARCHAR," +
+            "\"batch_id_in\" INTEGER," +
+            "\"batch_id_out\" INTEGER," +
+            "\"validity_from_target\" DATETIME," +
+            "\"validity_through_target\" DATETIME," +
+            "\"delete_indicator\" BOOLEAN," +
+            "PRIMARY KEY (\"id\", \"name\", \"validity_from_reference\", \"batch_id_in\", \"validity_from_target\"))";
+
+        String expectedStageToTemp = "INSERT INTO " + tempName + " " +
             "(\"id\", \"name\", \"amount\", \"validity_from_reference\", \"digest\", \"validity_from_target\", \"validity_through_target\", \"batch_id_in\", \"batch_id_out\") " +
             "(SELECT x.\"id\",x.\"name\",x.\"amount\",x.\"validity_from_reference\",x.\"digest\",x.\"validity_from_reference\",y.\"end_date\",(SELECT COALESCE(MAX(batch_metadata.\"table_batch_id\"),0)+1 FROM batch_metadata as batch_metadata WHERE batch_metadata.\"table_name\" = 'main'),999999999 " +
             "FROM " +
@@ -739,7 +752,7 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
             "GROUP BY x.\"id\", x.\"name\", x.\"validity_from_reference\") as y " +
             "ON ((x.\"id\" = y.\"id\") AND (x.\"name\" = y.\"name\")) AND (x.\"validity_from_reference\" = y.\"validity_from_reference\"))";
 
-        String expectedMainToTemp = "INSERT INTO \"mydb\".\"temp\" " +
+        String expectedMainToTemp = "INSERT INTO " + tempName + " " +
             "(\"id\", \"name\", \"amount\", \"validity_from_reference\", \"digest\", \"validity_from_target\", \"validity_through_target\", \"batch_id_in\", \"batch_id_out\") " +
             "(SELECT x.\"id\",x.\"name\",x.\"amount\",x.\"validity_from_reference\",x.\"digest\",x.\"validity_from_reference\",y.\"end_date\",(SELECT COALESCE(MAX(batch_metadata.\"table_batch_id\"),0)+1 FROM batch_metadata as batch_metadata WHERE batch_metadata.\"table_name\" = 'main'),999999999 " +
             "FROM " +
@@ -763,15 +776,15 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
         String expectedUpdateMain = "UPDATE \"mydb\".\"main\" as sink " +
             "SET sink.\"batch_id_out\" = (SELECT COALESCE(MAX(batch_metadata.\"table_batch_id\"),0)+1 FROM batch_metadata as batch_metadata WHERE batch_metadata.\"table_name\" = 'main')-1 " +
             "WHERE (EXISTS " +
-            "(SELECT * FROM \"mydb\".\"temp\" as temp " +
+            "(SELECT * FROM " + tempName + " as temp " +
             "WHERE ((sink.\"id\" = temp.\"id\") AND (sink.\"name\" = temp.\"name\")) AND (sink.\"validity_from_reference\" = temp.\"validity_from_reference\"))) " +
             "AND (sink.\"batch_id_out\" = 999999999)";
 
         String expectedTempToMain = "INSERT INTO \"mydb\".\"main\" " +
             "(\"id\", \"name\", \"amount\", \"validity_from_reference\", \"digest\", \"batch_id_in\", \"batch_id_out\", \"validity_from_target\", \"validity_through_target\") " +
-            "(SELECT temp.\"id\",temp.\"name\",temp.\"amount\",temp.\"validity_from_reference\",temp.\"digest\",temp.\"batch_id_in\",temp.\"batch_id_out\",temp.\"validity_from_target\",temp.\"validity_through_target\" FROM \"mydb\".\"temp\" as temp)";
+            "(SELECT temp.\"id\",temp.\"name\",temp.\"amount\",temp.\"validity_from_reference\",temp.\"digest\",temp.\"batch_id_in\",temp.\"batch_id_out\",temp.\"validity_from_target\",temp.\"validity_through_target\" FROM " + tempName + " as temp)";
 
-        String expectedMainToTempForDeletion = "INSERT INTO \"mydb\".\"tempWithDeleteIndicator\" " +
+        String expectedMainToTempForDeletion = "INSERT INTO " + tempWithDeleteIndicatorName + " " +
             "(\"id\", \"name\", \"amount\", \"validity_from_reference\", \"digest\", \"validity_from_target\", \"validity_through_target\", \"batch_id_in\", \"batch_id_out\", \"delete_indicator\") " +
             "(SELECT x.\"id\",x.\"name\",x.\"amount\",x.\"validity_from_reference\",x.\"digest\",x.\"validity_from_reference\",x.\"validity_through_target\",(SELECT COALESCE(MAX(batch_metadata.\"table_batch_id\"),0)+1 FROM batch_metadata as batch_metadata WHERE batch_metadata.\"table_name\" = 'main'),999999999,(CASE WHEN y.\"delete_indicator\" IS NULL THEN 0 ELSE 1 END) " +
             "FROM " +
@@ -788,7 +801,7 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
         String expectedUpdateMainForDeletion = "UPDATE \"mydb\".\"main\" as sink " +
             "SET sink.\"batch_id_out\" = (SELECT COALESCE(MAX(batch_metadata.\"table_batch_id\"),0)+1 FROM batch_metadata as batch_metadata WHERE batch_metadata.\"table_name\" = 'main')-1 " +
             "WHERE (EXISTS " +
-            "(SELECT * FROM \"mydb\".\"tempWithDeleteIndicator\" as tempWithDeleteIndicator " +
+            "(SELECT * FROM " + tempWithDeleteIndicatorName + " as tempWithDeleteIndicator " +
             "WHERE ((sink.\"id\" = tempWithDeleteIndicator.\"id\") AND (sink.\"name\" = tempWithDeleteIndicator.\"name\")) AND (sink.\"validity_from_reference\" = tempWithDeleteIndicator.\"validity_from_reference\"))) " +
             "AND (sink.\"batch_id_out\" = 999999999)";
 
@@ -796,19 +809,19 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
             "(\"id\", \"name\", \"amount\", \"validity_from_reference\", \"digest\", \"validity_from_target\", \"validity_through_target\", \"batch_id_in\", \"batch_id_out\") " +
             "(SELECT x.\"id\",x.\"name\",x.\"amount\",x.\"validity_from_reference\",x.\"digest\",x.\"validity_from_reference\" as start_date,MAX(y.\"validity_through_target\") as end_date,x.\"batch_id_in\",x.\"batch_id_out\" FROM " +
             "(SELECT x.\"id\",x.\"name\",x.\"amount\",x.\"validity_from_reference\",x.\"digest\",x.\"validity_from_reference\" as start_date,COALESCE(MIN(y.\"validity_from_reference\"),'9999-12-31 23:59:59') as end_date,x.\"batch_id_in\",x.\"batch_id_out\" " +
-            "FROM \"mydb\".\"tempWithDeleteIndicator\" as x " +
-            "LEFT OUTER JOIN \"mydb\".\"tempWithDeleteIndicator\" as y " +
+            "FROM " + tempWithDeleteIndicatorName + " as x " +
+            "LEFT OUTER JOIN " + tempWithDeleteIndicatorName + " as y " +
             "ON ((x.\"id\" = y.\"id\") AND (x.\"name\" = y.\"name\")) AND (y.\"validity_from_reference\" > x.\"validity_from_reference\") AND (y.\"delete_indicator\" = 0) " +
             "WHERE x.\"delete_indicator\" = 0 " +
             "GROUP BY x.\"id\", x.\"name\", x.\"amount\", x.\"validity_from_reference\", x.\"digest\", x.\"validity_from_reference\", x.\"batch_id_in\", x.\"batch_id_out\") as x " +
-            "LEFT OUTER JOIN \"mydb\".\"tempWithDeleteIndicator\" as y " +
+            "LEFT OUTER JOIN " + tempWithDeleteIndicatorName + " as y " +
             "ON ((x.\"id\" = y.\"id\") AND (x.\"name\" = y.\"name\")) AND (y.\"validity_through_target\" > x.\"validity_from_reference\") AND (y.\"validity_through_target\" <= x.\"end_date\") AND (y.\"delete_indicator\" <> 0) " +
             "GROUP BY x.\"id\", x.\"name\", x.\"amount\", x.\"validity_from_reference\", x.\"digest\", x.\"validity_from_reference\", x.\"batch_id_in\", x.\"batch_id_out\")";
 
         Assertions.assertEquals(expectedBitemporalFromOnlyMainTableCreateQuery, operations.get(0).preActionsSql().get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQuery, operations.get(0).preActionsSql().get(1));
-        Assertions.assertEquals(expectedBitemporalFromOnlyTempTableCreateQuery, operations.get(0).preActionsSql().get(2));
-        Assertions.assertEquals(expectedBitemporalFromOnlyTempTableWithDeleteIndicatorCreateQuery, operations.get(0).preActionsSql().get(3));
+        Assertions.assertEquals(expectedBitemporalFromOnlyDefaultTempTableCreateQuery, operations.get(0).preActionsSql().get(2));
+        Assertions.assertEquals(expectedBitemporalFromOnlyDefaultTempTableWithDeleteIndicatorCreateQuery, operations.get(0).preActionsSql().get(3));
 
         Assertions.assertEquals(String.format(expectedStageToTemp, 2, 5, 2, 5, 2, 5), operations.get(0).ingestSql().get(0));
         Assertions.assertEquals(String.format(expectedMainToTemp, 2, 5, 2, 5), operations.get(0).ingestSql().get(1));
@@ -817,6 +830,9 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
         Assertions.assertEquals(String.format(expectedMainToTempForDeletion, 2, 5, 2, 5), operations.get(0).ingestSql().get(4));
         Assertions.assertEquals(expectedUpdateMainForDeletion, operations.get(0).ingestSql().get(5));
         Assertions.assertEquals(expectedTempToMainForDeletion, operations.get(0).ingestSql().get(6));
+        Assertions.assertEquals(getExpectedCleanupSql(tempName, "temp"), operations.get(0).ingestSql().get(7));
+        Assertions.assertEquals(getExpectedCleanupSql(tempWithDeleteIndicatorName, "tempWithDeleteIndicator"), operations.get(0).ingestSql().get(8));
+
         Assertions.assertEquals(String.format(expectedStageToTemp, 6, 7, 6, 7, 6, 7), operations.get(1).ingestSql().get(0));
         Assertions.assertEquals(String.format(expectedMainToTemp, 6, 7, 6, 7), operations.get(1).ingestSql().get(1));
         Assertions.assertEquals(expectedUpdateMain, operations.get(1).ingestSql().get(2));
@@ -824,6 +840,9 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
         Assertions.assertEquals(String.format(expectedMainToTempForDeletion, 6, 7, 6, 7), operations.get(1).ingestSql().get(4));
         Assertions.assertEquals(expectedUpdateMainForDeletion, operations.get(1).ingestSql().get(5));
         Assertions.assertEquals(expectedTempToMainForDeletion, operations.get(1).ingestSql().get(6));
+        Assertions.assertEquals(getExpectedCleanupSql(tempName, "temp"), operations.get(1).ingestSql().get(7));
+        Assertions.assertEquals(getExpectedCleanupSql(tempWithDeleteIndicatorName, "tempWithDeleteIndicator"), operations.get(1).ingestSql().get(8));
+
         Assertions.assertEquals(expectedMetadataTableIngestQuery, operations.get(0).metadataIngestSql().get(0));
         Assertions.assertEquals(expectedMetadataTableIngestQuery, operations.get(1).metadataIngestSql().get(0));
 
@@ -856,7 +875,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -971,7 +989,6 @@ public class BitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalSnapshotWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalSnapshotWithBatchIdTest.java
@@ -59,7 +59,6 @@ public class BitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromAndThroughPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -102,7 +101,6 @@ public class BitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromAndThroughPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -156,7 +154,6 @@ public class BitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromAndThroughPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -226,7 +223,6 @@ public class BitemporalSnapshotWithBatchIdTest extends IngestModeTest
 
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -295,7 +291,6 @@ public class BitemporalSnapshotWithBatchIdTest extends IngestModeTest
 
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -365,7 +360,6 @@ public class BitemporalSnapshotWithBatchIdTest extends IngestModeTest
 
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(bitemporalFromOnlyPrimaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaTest.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.persistence.components.ingestmode.nontemporal;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.finos.legend.engine.persistence.components.IngestModeTest;
 import org.finos.legend.engine.persistence.components.common.Datasets;
 import org.finos.legend.engine.persistence.components.common.StatisticName;
@@ -28,9 +30,6 @@ import org.finos.legend.engine.persistence.components.relational.api.GeneratorRe
 import org.finos.legend.engine.persistence.components.relational.api.RelationalGenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class NontemporalDeltaTest extends IngestModeTest
 {
@@ -50,7 +49,6 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -103,7 +101,6 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -117,22 +114,22 @@ public class NontemporalDeltaTest extends IngestModeTest
         List<String> preActionsSqlList = operations.preActionsSql();
         List<String> milestoningSqlList = operations.ingestSql();
 
-        String updateSql = "UPDATE \"MYDB\".\"MAIN\" as SINK " +
-            "SET SINK.\"ID\" = (SELECT STAGE.\"ID\" FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\"))," +
-            "SINK.\"NAME\" = (SELECT STAGE.\"NAME\" FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\"))," +
-            "SINK.\"AMOUNT\" = (SELECT STAGE.\"AMOUNT\" FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\"))," +
-            "SINK.\"BIZ_DATE\" = (SELECT STAGE.\"BIZ_DATE\" FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\"))," +
-            "SINK.\"DIGEST\" = (SELECT STAGE.\"DIGEST\" FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\")) " +
-            "WHERE EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE" +
-            " WHERE ((SINK.\"ID\" = STAGE.\"ID\") " +
-            "AND (SINK.\"NAME\" = STAGE.\"NAME\")) " +
-            "AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\"))";
+        String updateSql = "UPDATE \"MYDB\".\"MAIN\" as sink " +
+            "SET sink.\"ID\" = (SELECT stage.\"ID\" FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" <> stage.\"DIGEST\"))," +
+            "sink.\"NAME\" = (SELECT stage.\"NAME\" FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" <> stage.\"DIGEST\"))," +
+            "sink.\"AMOUNT\" = (SELECT stage.\"AMOUNT\" FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" <> stage.\"DIGEST\"))," +
+            "sink.\"BIZ_DATE\" = (SELECT stage.\"BIZ_DATE\" FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" <> stage.\"DIGEST\"))," +
+            "sink.\"DIGEST\" = (SELECT stage.\"DIGEST\" FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" <> stage.\"DIGEST\")) " +
+            "WHERE EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage" +
+            " WHERE ((sink.\"ID\" = stage.\"ID\") " +
+            "AND (sink.\"NAME\" = stage.\"NAME\")) " +
+            "AND (sink.\"DIGEST\" <> stage.\"DIGEST\"))";
 
         String insertSql = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\") " +
-            "(SELECT * FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as SINK " +
-            "WHERE ((SINK.\"ID\" = STAGE.\"ID\") " +
-            "AND (SINK.\"NAME\" = STAGE.\"NAME\")) " +
-            "AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\"))))";
+            "(SELECT * FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as sink " +
+            "WHERE ((sink.\"ID\" = stage.\"ID\") " +
+            "AND (sink.\"NAME\" = stage.\"NAME\")) " +
+            "AND (sink.\"DIGEST\" = stage.\"DIGEST\"))))";
 
         Assertions.assertEquals(expectedBaseTablePlusDigestCreateQueryWithUpperCase, preActionsSqlList.get(0));
         Assertions.assertEquals(updateSql, milestoningSqlList.get(0));
@@ -154,7 +151,6 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -204,7 +200,6 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(DateTimeAuditing.builder().dateTimeField(batchUpdateTimeField).build())
             .build();
 
@@ -247,26 +242,36 @@ public class NontemporalDeltaTest extends IngestModeTest
     {
         Dataset mainTable = DatasetDefinition.builder()
             .database(mainDbName).name(mainTableName).alias(mainTableAlias)
-            .schema(baseTableSchemaWithDigest)
+            .schema(baseTableSchemaWithNoPrimaryKeys)
             .build();
 
         Dataset stagingTable = DatasetDefinition.builder()
             .database(stagingDbName).name(stagingTableName).alias(stagingTableAlias)
-            .schema(baseTableSchemaWithDigest)
+            .schema(baseTableSchemaWithNoPrimaryKeys)
             .build();
+
+        NontemporalDelta ingestMode = NontemporalDelta.builder()
+            .digestField(digestField)
+            .auditing(NoAuditing.builder().build())
+            .build();
+
+        Datasets datasets = Datasets.of(mainTable, stagingTable);
 
         try
         {
-            NontemporalDelta ingestMode = NontemporalDelta.builder()
-                .digestField(digestField)
-                .auditing(NoAuditing.builder().build())
+            RelationalGenerator generator = RelationalGenerator.builder()
+                .ingestMode(ingestMode)
+                .relationalSink(AnsiSqlSink.get())
+                .executionTimestampClock(fixedClock_2000_01_01)
                 .build();
+
+            GeneratorResult operations = generator.generateOperations(datasets);
 
             Assertions.fail("Exception was not thrown");
         }
         catch (Exception e)
         {
-            Assertions.assertEquals("Cannot build NontemporalDelta, [keyFields] must contain at least one element", e.getMessage());
+            Assertions.assertEquals("Primary key list must not be empty", e.getMessage());
         }
     }
 
@@ -287,7 +292,6 @@ public class NontemporalDeltaTest extends IngestModeTest
         {
             NontemporalDelta ingestMode = NontemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .auditing(DateTimeAuditing.builder().build())
                 .build();
 
@@ -314,7 +318,6 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -346,7 +349,6 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(DateTimeAuditing.builder().dateTimeField(batchUpdateTimeField).build())
             .build();
 
@@ -385,7 +387,6 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(DateTimeAuditing.builder().dateTimeField(batchUpdateTimeField).build())
             .build();
 
@@ -409,7 +410,7 @@ public class NontemporalDeltaTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalSnapshotTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalSnapshotTest.java
@@ -43,8 +43,8 @@ import java.util.Map;
 
 public class NontemporalSnapshotTest extends IngestModeTest
 {
-    String truncateTableSql = "TRUNCATE TABLE \"mydb\".\"main\"";
-    String truncateTableSqlWithUpperCase = "TRUNCATE TABLE \"MYDB\".\"MAIN\"";
+    String cleanUpMainTableSql = "DELETE FROM \"mydb\".\"main\" as sink";
+    String cleanupMainTableSqlUpperCase = "DELETE FROM \"MYDB\".\"MAIN\" as sink";
 
     @Test
     void testSnapshotMilestoning()
@@ -78,7 +78,7 @@ public class NontemporalSnapshotTest extends IngestModeTest
             "(SELECT * FROM \"mydb\".\"staging\" as stage)";
 
         Assertions.assertEquals(expectedBaseTableCreateQuery, preActionsSqlList.get(0));
-        Assertions.assertEquals(truncateTableSql, milestoningSqlList.get(0));
+        Assertions.assertEquals(cleanUpMainTableSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
     }
 
@@ -111,10 +111,10 @@ public class NontemporalSnapshotTest extends IngestModeTest
 
         String insertSql = "INSERT INTO \"MYDB\".\"MAIN\" " +
             "(\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\") " +
-            "(SELECT * FROM \"MYDB\".\"STAGING\" as STAGE)";
+            "(SELECT * FROM \"MYDB\".\"STAGING\" as stage)";
 
         Assertions.assertEquals(expectedBaseTableCreateQueryWithUpperCase, preActionsSqlList.get(0));
-        Assertions.assertEquals(truncateTableSqlWithUpperCase, milestoningSqlList.get(0));
+        Assertions.assertEquals(cleanupMainTableSqlUpperCase, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
     }
 
@@ -150,7 +150,7 @@ public class NontemporalSnapshotTest extends IngestModeTest
             "(SELECT * FROM \"mydb\".\"staging\" as stage)";
 
         Assertions.assertEquals(expectedBaseTableCreateQuery, preActionsSqlList.get(0));
-        Assertions.assertEquals(truncateTableSql, milestoningSqlList.get(0));
+        Assertions.assertEquals(cleanUpMainTableSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
     }
 
@@ -190,7 +190,7 @@ public class NontemporalSnapshotTest extends IngestModeTest
             "FROM \"mydb\".\"staging\" as stage)";
 
         Assertions.assertEquals(expectedBaseTableCreateQuery, preActionsSqlList.get(0));
-        Assertions.assertEquals(truncateTableSql, milestoningSqlList.get(0));
+        Assertions.assertEquals(cleanUpMainTableSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
     }
 
@@ -312,7 +312,7 @@ public class NontemporalSnapshotTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }
@@ -370,48 +370,6 @@ public class NontemporalSnapshotTest extends IngestModeTest
         List<String> expectedSQL = new ArrayList<>();
         expectedSQL.add(expectedDropTableQuery);
         assertIfListsAreSameIgnoringOrder(expectedSQL, sqlsForPostActions);
-    }
-
-    @Test
-    public void testPreRunStatisticMainTableNotExist()
-    {
-        Dataset mainTable = DatasetDefinition.builder()
-            .database(mainDbName).name(mainTableName).alias(mainTableAlias)
-            .schema(baseTableSchema)
-            .build();
-
-        Dataset stagingTable = DatasetDefinition.builder()
-            .database(stagingDbName).name(stagingTableName).alias(stagingTableAlias)
-            .schema(baseTableShortenedSchema)
-            .build();
-
-        NontemporalSnapshot ingestMode = NontemporalSnapshot.builder().auditing(NoAuditing.builder().build()).build();
-
-        PlannerOptions options = PlannerOptions.builder().cleanupStagingData(true).collectStatistics(true).build();
-        Resources resources = Resources.builder().mainDataSetExists(false).build();
-        Datasets datasets = Datasets.of(mainTable, stagingTable);
-
-        Planner planner = Planners.get(datasets, ingestMode, options);
-        Map<StatisticName, LogicalPlan> preRunStatisticsLogicalPlan = planner.buildLogicalPlanForPreRunStatistics(resources);
-
-        RelationalTransformer transformer = new RelationalTransformer(AnsiSqlSink.get());
-
-        Map<StatisticName, SqlPlan> preRunStatisticsPhysicalPlan = new HashMap<>();
-        for (StatisticName statistic : preRunStatisticsLogicalPlan.keySet())
-        {
-            preRunStatisticsPhysicalPlan.put(statistic, transformer.generatePhysicalPlan(preRunStatisticsLogicalPlan.get(statistic)));
-        }
-
-        Map<StatisticName, String> preMilestoneStatistics = new HashMap<>();
-        for (StatisticName statistic : preRunStatisticsPhysicalPlan.keySet())
-        {
-            preMilestoneStatistics.put(statistic, preRunStatisticsPhysicalPlan.get(statistic).getSql());
-        }
-
-        List<String> preRunStatisticsSql = new ArrayList<>(preMilestoneStatistics.values());
-        List<String> expectedSQL = new ArrayList<>(); // Expected to be empty because main table does not exist yet
-
-        assertIfListsAreSameIgnoringOrder(expectedSQL, preRunStatisticsSql);
     }
 
     @Test

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaTest.java
@@ -61,7 +61,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -119,7 +118,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .dataSplitField(Optional.of(dataSplitField))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
@@ -185,7 +183,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -206,9 +203,9 @@ public class UnitemporalDeltaTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK SET SINK.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')-1,SINK.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\")))";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink SET sink.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')-1,sink.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" <> stage.\"DIGEST\")))";
 
-        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\", \"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"BIZ_DATE\",STAGE.\"DIGEST\",(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as SINK WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\") AND ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")))))";
+        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\", \"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"BIZ_DATE\",stage.\"DIGEST\",(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as sink WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (sink.\"DIGEST\" = stage.\"DIGEST\") AND ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")))))";
 
         Assertions.assertEquals(expectedMainTableCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -230,7 +227,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -296,7 +292,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -363,7 +358,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -416,7 +410,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         try
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -440,7 +433,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -467,7 +459,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -494,7 +485,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -528,7 +518,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -562,7 +551,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -643,7 +631,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -722,7 +709,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -787,7 +773,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -809,7 +794,7 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }
@@ -819,7 +804,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -859,7 +843,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -910,7 +893,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchIdTest.java
@@ -14,6 +14,10 @@
 
 package org.finos.legend.engine.persistence.components.ingestmode.unitemporal;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.finos.legend.engine.persistence.components.IngestModeTest;
 import org.finos.legend.engine.persistence.components.common.Datasets;
 import org.finos.legend.engine.persistence.components.common.StatisticName;
@@ -31,11 +35,6 @@ import org.finos.legend.engine.persistence.components.relational.api.RelationalG
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
 {
@@ -61,7 +60,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -118,7 +116,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .dataSplitField(Optional.of(dataSplitField))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
@@ -181,7 +178,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -200,22 +196,22 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK " +
-            "SET SINK.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 " +
-            "FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')-1 " +
-            "WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) " +
-            "AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE " +
-            "WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) " +
-            "AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\")))";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink " +
+            "SET sink.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 " +
+            "FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')-1 " +
+            "WHERE (sink.\"BATCH_ID_OUT\" = 999999999) " +
+            "AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage " +
+            "WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) " +
+            "AND (sink.\"DIGEST\" <> stage.\"DIGEST\")))";
 
         String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" " +
             "(\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\") " +
-            "(SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"BIZ_DATE\"," +
-            "STAGE.\"DIGEST\",(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')," +
-            "999999999 FROM \"MYDB\".\"STAGING\" as STAGE " +
-            "WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as SINK " +
-            "WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\") " +
-            "AND ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")))))";
+            "(SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"BIZ_DATE\"," +
+            "stage.\"DIGEST\",(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')," +
+            "999999999 FROM \"MYDB\".\"STAGING\" as stage " +
+            "WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as sink " +
+            "WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (sink.\"DIGEST\" = stage.\"DIGEST\") " +
+            "AND ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")))))";
 
         Assertions.assertEquals(expectedMainTableBatchIdBasedCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -237,7 +233,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -299,7 +294,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .dataSplitField(Optional.of(dataSplitField))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
@@ -365,7 +359,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchId.builder()
                     .batchIdInName(batchIdInField)
                     .build())
@@ -397,7 +390,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchId.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -423,7 +415,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -457,7 +448,6 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -488,7 +478,7 @@ public class UnitemporalDeltaWithBatchIdTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchTimeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchTimeTest.java
@@ -61,7 +61,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -117,7 +116,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .dataSplitField(Optional.of(dataSplitField))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
@@ -179,7 +177,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -198,9 +195,9 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK SET SINK.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' WHERE (SINK.\"BATCH_TIME_OUT\" = '9999-12-31 23:59:59') AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" <> STAGE.\"DIGEST\")))";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink SET sink.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' WHERE (sink.\"BATCH_TIME_OUT\" = '9999-12-31 23:59:59') AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" <> stage.\"DIGEST\")))";
 
-        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"BIZ_DATE\",STAGE.\"DIGEST\",'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as SINK WHERE (SINK.\"BATCH_TIME_OUT\" = '9999-12-31 23:59:59') AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\") AND ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")))))";
+        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"BIZ_DATE\",stage.\"DIGEST\",'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (EXISTS (SELECT * FROM \"MYDB\".\"MAIN\" as sink WHERE (sink.\"BATCH_TIME_OUT\" = '9999-12-31 23:59:59') AND (sink.\"DIGEST\" = stage.\"DIGEST\") AND ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")))))";
 
         Assertions.assertEquals(expectedMainTableTimeBasedCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -222,7 +219,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -284,7 +280,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .dataSplitField(Optional.of(dataSplitField))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
@@ -352,7 +347,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeOutName(batchTimeOutField)
                     .build())
@@ -380,7 +374,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeInName(batchTimeInField)
                     .dateTimeOutName(batchTimeOutField)
@@ -402,7 +395,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -439,7 +431,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -471,7 +462,7 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotTest.java
@@ -58,7 +58,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -96,7 +95,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -146,7 +144,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -167,8 +164,8 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK SET SINK.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')-1,SINK.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (NOT (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\"))))";
-        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\", \"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"BIZ_DATE\",STAGE.\"DIGEST\",(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (STAGE.\"DIGEST\" IN (SELECT SINK.\"DIGEST\" FROM \"MYDB\".\"MAIN\" as SINK WHERE SINK.\"BATCH_ID_OUT\" = 999999999)))";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink SET sink.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')-1,sink.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (NOT (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" = stage.\"DIGEST\"))))";
+        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\", \"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"BIZ_DATE\",stage.\"DIGEST\",(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (stage.\"DIGEST\" IN (SELECT sink.\"DIGEST\" FROM \"MYDB\".\"MAIN\" as sink WHERE sink.\"BATCH_ID_OUT\" = 999999999)))";
         Assertions.assertEquals(expectedMainTableCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
 
@@ -182,7 +179,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -232,7 +228,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -290,7 +285,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -355,7 +349,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdOutName(batchIdOutField)
                     .dateTimeInName(batchTimeInField)
@@ -385,7 +378,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -409,7 +401,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -431,7 +422,7 @@ public class UnitemporalSnapshotTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }
@@ -441,7 +432,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -481,7 +471,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -528,7 +517,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchIdTest.java
@@ -58,7 +58,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -94,7 +93,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -142,7 +140,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -161,9 +158,9 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK SET SINK.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')-1 WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (NOT (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\"))))";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink SET sink.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')-1 WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (NOT (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) AND (sink.\"DIGEST\" = stage.\"DIGEST\"))))";
 
-        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\") (SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"BIZ_DATE\",STAGE.\"DIGEST\",(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),999999999 FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (STAGE.\"DIGEST\" IN (SELECT SINK.\"DIGEST\" FROM \"MYDB\".\"MAIN\" as SINK WHERE SINK.\"BATCH_ID_OUT\" = 999999999)))";
+        String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\") (SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"BIZ_DATE\",stage.\"DIGEST\",(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),999999999 FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (stage.\"DIGEST\" IN (SELECT sink.\"DIGEST\" FROM \"MYDB\".\"MAIN\" as sink WHERE sink.\"BATCH_ID_OUT\" = 999999999)))";
 
         Assertions.assertEquals(expectedMainTableBatchIdBasedCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -178,7 +175,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -228,7 +224,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchId.builder()
                     .batchIdOutName(batchIdOutField)
                     .build())
@@ -256,7 +251,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchId.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -278,7 +272,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -313,7 +306,6 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -348,7 +340,7 @@ public class UnitemporalSnapshotWithBatchIdTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchTimeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchTimeTest.java
@@ -62,7 +62,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -81,9 +80,9 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK " +
-            "SET SINK.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' " +
-            "WHERE SINK.\"BATCH_TIME_OUT\" = '9999-12-31 23:59:59'";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink " +
+            "SET sink.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' " +
+            "WHERE sink.\"BATCH_TIME_OUT\" = '9999-12-31 23:59:59'";
 
         Assertions.assertEquals(expectedMainTableTimeBasedCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -97,7 +96,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -144,7 +142,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -194,7 +191,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeOutName(batchTimeOutField)
                     .build())
@@ -220,7 +216,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeInName(batchTimeInField)
                     .dateTimeOutName(batchTimeOutField)
@@ -242,7 +237,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -279,7 +273,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -313,7 +306,7 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/transformer/PlaceholderTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/transformer/PlaceholderTest.java
@@ -56,7 +56,7 @@ public class PlaceholderTest
         SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
         List<String> list = physicalPlan.getSqlList();
 
-        String expectedSql = "INSERT INTO BATCH_METADATA (\"TABLE_NAME\", \"TABLE_BATCH_ID\", \"BATCH_START_TS_UTC\", \"BATCH_END_TS_UTC\", \"BATCH_STATUS\") (SELECT 'main',(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),'{BATCH_START_TIMESTAMP_PLACEHOLDER}','{BATCH_END_TIMESTAMP_PLACEHOLDER}','DONE')";
+        String expectedSql = "INSERT INTO BATCH_METADATA (\"TABLE_NAME\", \"TABLE_BATCH_ID\", \"BATCH_START_TS_UTC\", \"BATCH_END_TS_UTC\", \"BATCH_STATUS\") (SELECT 'main',(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),'{BATCH_START_TIMESTAMP_PLACEHOLDER}','{BATCH_END_TIMESTAMP_PLACEHOLDER}','DONE')";
         Assertions.assertEquals(expectedSql, list.get(0));
     }
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/util/MetadataUtilsTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/util/MetadataUtilsTest.java
@@ -87,7 +87,7 @@ public abstract class MetadataUtilsTest
         RelationalTransformer transformer = new RelationalTransformer(AnsiSqlSink.get(), transformOptions.withOptimizers(new UpperCaseOptimizer()));
         SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
         List<String> list = physicalPlan.getSqlList();
-        String expectedSql = "SELECT COALESCE(MAX("  + upperCaseTableName() + ".\"TABLE_BATCH_ID\"),0)+1 FROM " + upperCaseTableName() + " as "  + upperCaseTableName() + " WHERE "  + upperCaseTableName() + ".\"TABLE_NAME\" = 'main'";
+        String expectedSql = "SELECT COALESCE(MAX("  + lowerCaseTableName() + ".\"TABLE_BATCH_ID\"),0)+1 FROM " + upperCaseTableName() + " as "  + lowerCaseTableName() + " WHERE "  + lowerCaseTableName() + ".\"TABLE_NAME\" = 'main'";
         Assertions.assertEquals(expectedSql, list.get(0));
     }
 
@@ -130,7 +130,7 @@ public abstract class MetadataUtilsTest
         RelationalTransformer transformer = new RelationalTransformer(AnsiSqlSink.get(), transformOptions.withOptimizers(new UpperCaseOptimizer()));
         SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
         List<String> list = physicalPlan.getSqlList();
-        String expectedSql = "SELECT (SELECT COALESCE(MAX(" + upperCaseTableName() + ".\"TABLE_BATCH_ID\"),0)+1 FROM " + upperCaseTableName() + " as "  + upperCaseTableName() + " WHERE "  + upperCaseTableName() + ".\"TABLE_NAME\" = 'main')-1";
+        String expectedSql = "SELECT (SELECT COALESCE(MAX(" + lowerCaseTableName() + ".\"TABLE_BATCH_ID\"),0)+1 FROM " + upperCaseTableName() + " as "  + lowerCaseTableName() + " WHERE "  + lowerCaseTableName() + ".\"TABLE_NAME\" = 'main')-1";
         Assertions.assertEquals(expectedSql, list.get(0));
     }
 
@@ -158,7 +158,7 @@ public abstract class MetadataUtilsTest
         SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
 
         List<String> list = physicalPlan.getSqlList();
-        String expectedSql = "INSERT INTO " + upperCaseTableName() + " (\"TABLE_NAME\", \"TABLE_BATCH_ID\", \"BATCH_START_TS_UTC\", \"BATCH_END_TS_UTC\", \"BATCH_STATUS\") (SELECT 'main',(SELECT COALESCE(MAX(" + upperCaseTableName() + ".\"TABLE_BATCH_ID\"),0)+1 FROM " + upperCaseTableName() + " as " + upperCaseTableName() + " WHERE " + upperCaseTableName() + ".\"TABLE_NAME\" = 'main'),'2000-01-01 00:00:00',CURRENT_TIMESTAMP(),'DONE')";
+        String expectedSql = "INSERT INTO " + upperCaseTableName() + " (\"TABLE_NAME\", \"TABLE_BATCH_ID\", \"BATCH_START_TS_UTC\", \"BATCH_END_TS_UTC\", \"BATCH_STATUS\") (SELECT 'main',(SELECT COALESCE(MAX(" + lowerCaseTableName() + ".\"TABLE_BATCH_ID\"),0)+1 FROM " + upperCaseTableName() + " as " + lowerCaseTableName() + " WHERE " + lowerCaseTableName() + ".\"TABLE_NAME\" = 'main'),'2000-01-01 00:00:00',CURRENT_TIMESTAMP(),'DONE')";
         Assertions.assertEquals(expectedSql, list.get(0));
     }
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/GeneratorResultAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/GeneratorResultAbstract.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 )
 public abstract class GeneratorResultAbstract
 {
-    private static final String SINGLE_QUOTE = "'";
+    public static final String SINGLE_QUOTE = "'";
 
     public abstract SqlPlan preActionsSqlPlan();
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/IngestorResultAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/IngestorResultAbstract.java
@@ -20,6 +20,7 @@ import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Immutable
 @Style(
@@ -31,6 +32,10 @@ import java.util.Map;
 )
 public abstract class IngestorResultAbstract
 {
+    public abstract Optional<Integer> batchId();
+
+    public abstract Optional<DataSplitRange> dataSplitRange();
+
     public abstract Map<StatisticName, Object> statisticByName();
 
     public abstract Datasets updatedDatasets();

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/values/Field.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/values/Field.java
@@ -15,14 +15,13 @@
 package org.finos.legend.engine.persistence.components.relational.sqldom.schemaops.values;
 
 import org.finos.legend.engine.persistence.components.relational.sqldom.SqlDomException;
-import org.finos.legend.engine.persistence.components.relational.sqldom.schemaops.expresssions.table.Table;
 import org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils;
 import org.finos.legend.engine.persistence.components.relational.sqldom.utils.StringUtils;
 
 public class Field extends Value
 {
-    private Table table;
     private String name;
+    private String datasetReferenceAlias;
     private String quoteIdentifier;
 
     public Field(String name, String quoteIdentifier)
@@ -31,10 +30,10 @@ public class Field extends Value
         this.quoteIdentifier = quoteIdentifier;
     }
 
-    public Field(Table table, String name, String quoteIdentifier, String alias)
+    public Field(String datasetReferenceAlias, String name, String quoteIdentifier, String alias)
     {
         super(alias);
-        this.table = table;
+        this.datasetReferenceAlias = datasetReferenceAlias;
         this.name = name;
         this.quoteIdentifier = quoteIdentifier;
     }
@@ -60,9 +59,9 @@ public class Field extends Value
     public void genSqlWithoutAlias(StringBuilder builder) throws SqlDomException
     {
         validate();
-        if (table != null && StringUtils.notEmpty(table.getAlias()))
+        if (datasetReferenceAlias != null)
         {
-            builder.append(table.getAlias()).append(".");
+            builder.append(datasetReferenceAlias).append(".");
         }
         builder.append(SqlGenUtils.getQuotedField(name, quoteIdentifier));
     }
@@ -76,14 +75,6 @@ public class Field extends Value
     @Override
     public void push(Object node)
     {
-        if (node instanceof Table)
-        {
-            table = (Table) node;
-        }
-        else if (node instanceof String)
-        {
-            name = (String) node;
-        }
     }
 
     void validate() throws SqlDomException

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/ConditionTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/ConditionTest.java
@@ -53,11 +53,11 @@ public class ConditionTest
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
         Table tableB = new Table("mydb", null, "mytable2", "stage", BaseTest.QUOTE_IDENTIFIER);
 
-        Value field1 = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field2 = new Field(tableB, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field2 = new Field(tableB.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
 
-        Value field3 = new Field(tableA, "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field4 = new Field(tableB, "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field3 = new Field(tableA.getAlias(), "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field4 = new Field(tableB.getAlias(), "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
         String expected = "(sink.\"column_varchar\" = stage.\"column_varchar\") AND (sink.\"column_timestamp\" <> stage.\"column_timestamp\")";
 
         Condition condition = new AndCondition(Arrays.asList(new EqualityCondition(field1, field2), new NotEqualCondition(field3, field4)));
@@ -71,10 +71,10 @@ public class ConditionTest
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
         Table tableB = new Table("mydb", null, "mytable2", "stage", BaseTest.QUOTE_IDENTIFIER);
 
-        Value field1 = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field2 = new Field(tableB, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field3 = new Field(tableA, "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field4 = new Field(tableB, "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field2 = new Field(tableB.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field3 = new Field(tableA.getAlias(), "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field4 = new Field(tableB.getAlias(), "column_timestamp", BaseTest.QUOTE_IDENTIFIER, null);
 
         String expected = "(sink.\"column_varchar\" < stage.\"column_varchar\") OR (sink.\"column_timestamp\" <= stage.\"column_timestamp\")";
 
@@ -89,8 +89,8 @@ public class ConditionTest
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
         Table tableB = new Table("mydb", null, "mytable2", "stage", BaseTest.QUOTE_IDENTIFIER);
 
-        Value field1 = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field2 = new Field(tableB, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field2 = new Field(tableB.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
 
         String expected = "NOT (sink.\"column_varchar\" > stage.\"column_varchar\")";
 
@@ -103,7 +103,7 @@ public class ConditionTest
     void testBetweenCondition()
     {
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
-        Value field1 = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
         ObjectValue value1 = new ObjectValue(1);
         ObjectValue value2 = new ObjectValue(10);
 
@@ -139,7 +139,7 @@ public class ConditionTest
     void testInArrayCondition()
     {
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
-        Value field1 = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
         ArrayExpression expression = new ArrayExpression(Arrays.asList(new Value[]{new StringValue("IN"), new StringValue("SG"), new StringValue("ID")}));
 
         String expected = "sink.\"column_varchar\" IN ('IN','SG','ID')";
@@ -154,8 +154,8 @@ public class ConditionTest
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
         Table tableB = new Table("mydb", null, "mytable2", "stage", BaseTest.QUOTE_IDENTIFIER);
 
-        Value field1 = new Field(tableA, "col1", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field2 = new Field(tableB, "col2", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "col1", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field2 = new Field(tableB.getAlias(), "col2", BaseTest.QUOTE_IDENTIFIER, null);
 
         SelectExpression selectExpression = new SelectStatement(
             null,
@@ -174,7 +174,7 @@ public class ConditionTest
     void testIsNullCondition()
     {
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
-        Value field1 = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
 
         String expected = "sink.\"column_varchar\" IS NULL";
         Condition condition = new IsNullCondition(field1);
@@ -186,7 +186,7 @@ public class ConditionTest
     void testIsNotNullCondition()
     {
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
-        Value field1 = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
 
         String expected = "sink.\"column_varchar\" IS NOT NULL";
         Condition condition = new IsNotNullCondition(field1);
@@ -198,7 +198,7 @@ public class ConditionTest
     void testLikeCondition()
     {
         Table tableA = new Table("mydb", null, "mytable1", "sink", BaseTest.QUOTE_IDENTIFIER);
-        Value field = new Field(tableA, "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field = new Field(tableA.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, null);
         StringValue value = new StringValue("%value");
 
         String expected = "sink.\"column_varchar\" LIKE '%value'";

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/InsertTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/InsertTest.java
@@ -79,18 +79,18 @@ class InsertTest
         Table tableToInsert = new Table("CONVOLVE_TEST_SCHEMA", null, "CONVOLVE_TEST_TABLE", null, BaseTest.QUOTE_IDENTIFIER);
         Table tableToSelect = new Table("CONVOLVE_TEST_SCHEMA", null, "CONVOLVE_TEST_TABLE__stage", "stage_left", BaseTest.QUOTE_IDENTIFIER);
 
-        Value item1 = new Field(tableToSelect, "convolve_digest", BaseTest.QUOTE_IDENTIFIER, "convolve_digest");
-        Value item2 = new Field(tableToSelect, "column_smallint", BaseTest.QUOTE_IDENTIFIER, "column_smallint");
-        Value item3 = new Field(tableToSelect, "column_tinyint", BaseTest.QUOTE_IDENTIFIER, "column_tinyint");
-        Value item4 = new Field(tableToSelect, "column_bigint", BaseTest.QUOTE_IDENTIFIER, "column_bigint");
-        Value item5 = new Field(tableToSelect, "column_varchar", BaseTest.QUOTE_IDENTIFIER, "column_varchar");
-        Value item6 = new Field(tableToSelect, "column_char", BaseTest.QUOTE_IDENTIFIER, "column_char");
-        Value item7 = new Field(tableToSelect, "column_timestamp", BaseTest.QUOTE_IDENTIFIER, "column_timestamp");
-        Value item8 = new Field(tableToSelect, "column_date", BaseTest.QUOTE_IDENTIFIER, "column_date");
-        Value item9 = new Field(tableToSelect, "column_float", BaseTest.QUOTE_IDENTIFIER, "column_float");
-        Value item10 = new Field(tableToSelect, "column_real", BaseTest.QUOTE_IDENTIFIER, "column_real");
-        Value item11 = new Field(tableToSelect, "column_decimal", BaseTest.QUOTE_IDENTIFIER, "column_decimal");
-        Value item12 = new Field(tableToSelect, "column_double", BaseTest.QUOTE_IDENTIFIER, "column_double");
+        Value item1 = new Field(tableToSelect.getAlias(), "convolve_digest", BaseTest.QUOTE_IDENTIFIER, "convolve_digest");
+        Value item2 = new Field(tableToSelect.getAlias(), "column_smallint", BaseTest.QUOTE_IDENTIFIER, "column_smallint");
+        Value item3 = new Field(tableToSelect.getAlias(), "column_tinyint", BaseTest.QUOTE_IDENTIFIER, "column_tinyint");
+        Value item4 = new Field(tableToSelect.getAlias(), "column_bigint", BaseTest.QUOTE_IDENTIFIER, "column_bigint");
+        Value item5 = new Field(tableToSelect.getAlias(), "column_varchar", BaseTest.QUOTE_IDENTIFIER, "column_varchar");
+        Value item6 = new Field(tableToSelect.getAlias(), "column_char", BaseTest.QUOTE_IDENTIFIER, "column_char");
+        Value item7 = new Field(tableToSelect.getAlias(), "column_timestamp", BaseTest.QUOTE_IDENTIFIER, "column_timestamp");
+        Value item8 = new Field(tableToSelect.getAlias(), "column_date", BaseTest.QUOTE_IDENTIFIER, "column_date");
+        Value item9 = new Field(tableToSelect.getAlias(), "column_float", BaseTest.QUOTE_IDENTIFIER, "column_float");
+        Value item10 = new Field(tableToSelect.getAlias(), "column_real", BaseTest.QUOTE_IDENTIFIER, "column_real");
+        Value item11 = new Field(tableToSelect.getAlias(), "column_decimal", BaseTest.QUOTE_IDENTIFIER, "column_decimal");
+        Value item12 = new Field(tableToSelect.getAlias(), "column_double", BaseTest.QUOTE_IDENTIFIER, "column_double");
 
         SelectExpression selectExpression = new SelectStatement(
             null,

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/SelectExpressionTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/SelectExpressionTest.java
@@ -112,14 +112,14 @@ class SelectExpressionTest
         Table leftTable = new Table("mydb", null, "left", "A", BaseTest.QUOTE_IDENTIFIER);
         Table rightTable = new Table("mydb", null, "right", "B", BaseTest.QUOTE_IDENTIFIER);
 
-        Value field1 = new Field(leftTable, "id", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field2 = new Field(rightTable, "id", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(leftTable.getAlias(), "id", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field2 = new Field(rightTable.getAlias(), "id", BaseTest.QUOTE_IDENTIFIER, null);
         Condition joinCondition = new EqualityCondition(field1, field2);
         TableLike table = new JoinOperation(leftTable, rightTable, Join.INNER_JOIN, joinCondition);
 
-        Value item1 = new Field(leftTable, "id", BaseTest.QUOTE_IDENTIFIER, null);
-        Value item2 = new Field(leftTable, "item2", BaseTest.QUOTE_IDENTIFIER, null);
-        Value item3 = new Field(rightTable, "item3", BaseTest.QUOTE_IDENTIFIER, "my_item");
+        Value item1 = new Field(leftTable.getAlias(), "id", BaseTest.QUOTE_IDENTIFIER, null);
+        Value item2 = new Field(leftTable.getAlias(), "item2", BaseTest.QUOTE_IDENTIFIER, null);
+        Value item3 = new Field(rightTable.getAlias(), "item3", BaseTest.QUOTE_IDENTIFIER, "my_item");
 
         SelectExpression selectExpression =
             new SelectStatement(

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/TableLikeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/TableLikeTest.java
@@ -52,8 +52,8 @@ class TableLikeTest
         Table leftTable = new Table("mydb", null, "left", "A", BaseTest.QUOTE_IDENTIFIER);
         Table rightTable = new Table("mydb", null, "right", "B", BaseTest.QUOTE_IDENTIFIER);
 
-        Value field1 = new Field(leftTable, "id", BaseTest.QUOTE_IDENTIFIER, null);
-        Value field2 = new Field(rightTable, "id", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field1 = new Field(leftTable.getAlias(), "id", BaseTest.QUOTE_IDENTIFIER, null);
+        Value field2 = new Field(rightTable.getAlias(), "id", BaseTest.QUOTE_IDENTIFIER, null);
 
         Condition joinCondition = new EqualityCondition(field1, field2);
         TableLike exp = new JoinOperation(leftTable, rightTable, Join.INNER_JOIN, joinCondition);

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/UpdateStatementTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/UpdateStatementTest.java
@@ -71,7 +71,7 @@ public class UpdateStatementTest
             new Pair<>(new Field("col4", BaseTest.QUOTE_IDENTIFIER), new ObjectValue(4L))
         );
         Condition condition = new EqualityCondition(
-            new Field(table, "id", BaseTest.QUOTE_IDENTIFIER, null),
+            new Field(table.getAlias(), "id", BaseTest.QUOTE_IDENTIFIER, null),
             new NumericalValue(1L));
 
         UpdateStatement query = new UpdateStatement(table, setPairs, condition);
@@ -93,21 +93,21 @@ public class UpdateStatementTest
         Table joinTable = new Table("my_db", null, "tableB", "B", BaseTest.QUOTE_IDENTIFIER);
 
         Condition pkMatchCondition = new EqualityCondition(
-            new Field(table, "id", BaseTest.QUOTE_IDENTIFIER, null),
-            new Field(joinTable, "a_id", BaseTest.QUOTE_IDENTIFIER, null));
+            new Field(table.getAlias(), "id", BaseTest.QUOTE_IDENTIFIER, null),
+            new Field(joinTable.getAlias(), "a_id", BaseTest.QUOTE_IDENTIFIER, null));
 
         List<Pair<Field, Value>> setPairs = Arrays.asList(
             new Pair<>(new Field("col1", BaseTest.QUOTE_IDENTIFIER), new SelectValue(
                 new SelectStatement(
                     null,
-                    Collections.singletonList(new Field(joinTable, "col1", BaseTest.QUOTE_IDENTIFIER, null)),
+                    Collections.singletonList(new Field(joinTable.getAlias(), "col1", BaseTest.QUOTE_IDENTIFIER, null)),
                     Collections.singletonList(joinTable),
                     pkMatchCondition,
                     Collections.emptyList()))),
             new Pair<>(new Field("col2", BaseTest.QUOTE_IDENTIFIER), new SelectValue(
                 new SelectStatement(
                     null,
-                    Collections.singletonList(new Field(joinTable, "col2", BaseTest.QUOTE_IDENTIFIER, null)),
+                    Collections.singletonList(new Field(joinTable.getAlias(), "col2", BaseTest.QUOTE_IDENTIFIER, null)),
                     Collections.singletonList(joinTable),
                     pkMatchCondition,
                     Collections.emptyList()))));

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/ValueTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/ValueTest.java
@@ -39,8 +39,8 @@ class ValueTest
         Table tableB = new Table(null, null, "mytable", "B", BaseTest.QUOTE_IDENTIFIER);
 
         Value item1 = new Field(null, "id", BaseTest.QUOTE_IDENTIFIER, null);
-        Value item2 = new Field(tableA, "item2", BaseTest.QUOTE_IDENTIFIER, "my_item");
-        Value item3 = new Field(tableB, "item3", BaseTest.QUOTE_IDENTIFIER, "my_item");
+        Value item2 = new Field(tableA.getAlias(), "item2", BaseTest.QUOTE_IDENTIFIER, "my_item");
+        Value item3 = new Field(tableB.getAlias(), "item3", BaseTest.QUOTE_IDENTIFIER, "my_item");
 
         String sql1 = BaseTest.genSqlIgnoringErrors(item1);
         String sql2 = BaseTest.genSqlIgnoringErrors(item2);

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/main/java/org/finos/legend/engine/persistence/components/relational/h2/sql/visitor/SchemaDefinitionVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/main/java/org/finos/legend/engine/persistence/components/relational/h2/sql/visitor/SchemaDefinitionVisitor.java
@@ -40,7 +40,7 @@ public class SchemaDefinitionVisitor implements LogicalPlanVisitor<SchemaDefinit
 {
 
     @Override
-    public LogicalPlanVisitor.VisitorResult visit(PhysicalPlanNode prev, SchemaDefinition current, VisitorContext context)
+    public VisitorResult visit(PhysicalPlanNode prev, SchemaDefinition current, VisitorContext context)
     {
 
         List<Field> pkFields = current.fields().stream().filter(Field::primaryKey).collect(Collectors.toList());

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaWithBatchIdTest.java
@@ -71,14 +71,13 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition mainTable = TestUtils.getBitemporalMainTable();
         DatasetDefinition stagingTable = TestUtils.getBitemporalStagingTable();
 
-        String[] schema = new String[]{key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
+        String[] schema = new String[] {key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
 
         // Create staging table
         createStagingTable(stagingTable);
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -135,14 +134,13 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition mainTable = TestUtils.getBitemporalMainTable();
         DatasetDefinition stagingTable = TestUtils.getBitemporalStagingTableWithDeleteIndicator();
 
-        String[] schema = new String[]{key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
+        String[] schema = new String[] {key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
 
         // Create staging table
         createStagingTable(stagingTable);
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -200,11 +198,10 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         String dataPass1 = basePathForInput + "source_specifies_from_and_through/less_columns_in_staging/staging_data_pass1.csv";
         Dataset stagingTable = TestUtils.getCsvDatasetRefWithLessColumnsThanMainForBitemp(dataPass1);
 
-        String[] schema = new String[]{key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
+        String[] schema = new String[] {key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -252,14 +249,13 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition mainTable = TestUtils.getBitemporalMainTable();
         DatasetDefinition stagingTable = TestUtils.getBitemporalStagingTableWithDeleteIndicator();
 
-        String[] schema = new String[]{key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
+        String[] schema = new String[] {key1Name, key2Name, valueName, dateInName, dateOutName, digestName, batchIdInName, batchIdOutName, lakeFromName, lakeThroughName};
 
         // Create staging table
         createStagingTable(stagingTable);
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -304,7 +300,7 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition stagingTable = TestUtils.getLoansStagingTableIdBased();
         DatasetDefinition tempTable = TestUtils.getLoansTempTableIdBased();
 
-        String[] schema = new String[]{loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
 
         // Create staging table
         createStagingTable(stagingTable);
@@ -313,7 +309,6 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(loanIdName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -387,7 +382,7 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition stagingTable = TestUtils.getLoansStagingTableIdBased();
         DatasetDefinition tempTable = TestUtils.getLoansTempTableIdBased();
 
-        String[] schema = new String[]{loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
 
         // Create staging table
         createStagingTable(stagingTable);
@@ -396,7 +391,6 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(loanIdName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -442,7 +436,7 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition stagingTable = TestUtils.getLoansStagingTableWithDataSplitIdBased();
         DatasetDefinition tempTable = TestUtils.getLoansTempTableIdBased();
 
-        String[] schema = new String[]{loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
 
         // Create staging table
         createStagingTable(stagingTable);
@@ -451,7 +445,6 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(loanIdName)
             .dataSplitField(dataSplitName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
@@ -477,11 +470,9 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         // 2. Execute Plan and Verify Results
         List<DataSplitRange> dataSplitRanges = new ArrayList<>();
         dataSplitRanges.add(DataSplitRange.of(1, 1));
-        List<String> expectedDataPasses = new ArrayList<>();
-        expectedDataPasses.add(expectedDataPass1);
         List<Map<String, Object>> expectedStats = new ArrayList<>();
         expectedStats.add(new HashMap<>());
-        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPasses, expectedStats, dataSplitRanges);
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, dataSplitRanges);
 
         // ------------ Perform Pass2 ------------------------
         String dataPass2 = basePathForInput + "source_specifies_from/without_delete_ind/set_3_with_data_split/staging_data_pass2.csv";
@@ -495,15 +486,92 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         dataSplitRanges.add(DataSplitRange.of(1, 1));
         dataSplitRanges.add(DataSplitRange.of(2, 3));
         dataSplitRanges.add(DataSplitRange.of(50, 100));
-        expectedDataPasses = new ArrayList<>();
-        expectedDataPasses.add(expectedDataPass2);
-        expectedDataPasses.add(expectedDataPass3);
-        expectedDataPasses.add(expectedDataPass4);
         expectedStats = new ArrayList<>();
         expectedStats.add(new HashMap<>());
         expectedStats.add(new HashMap<>());
         expectedStats.add(new HashMap<>());
-        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPasses, expectedStats, dataSplitRanges);
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass4, expectedStats, dataSplitRanges);
+    }
+
+
+    /*
+Scenario: Test milestoning Logic with only validity from time specified when staging table pre populated
+*/
+    @Test
+    void testMilestoningSourceSpecifiesFromSet3WithDataSplitMultiPasses() throws Exception
+    {
+        DatasetDefinition mainTable = TestUtils.getLoansMainTableIdBased();
+        DatasetDefinition stagingTable = TestUtils.getLoansStagingTableWithDataSplitIdBased();
+        DatasetDefinition tempTable = TestUtils.getLoansTempTableIdBased();
+
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+
+        // Create staging table
+        createStagingTable(stagingTable);
+        // Create temp table
+        createTempTable(tempTable);
+
+        BitemporalDelta ingestMode = BitemporalDelta.builder()
+            .digestField(digestName)
+            .dataSplitField(dataSplitName)
+            .transactionMilestoning(BatchId.builder()
+                .batchIdInName(batchIdInName)
+                .batchIdOutName(batchIdOutName)
+                .build())
+            .validityMilestoning(ValidDateTime.builder()
+                .dateTimeFromName(loanStartDateTimeName)
+                .dateTimeThruName(loanEndDateTimeName)
+                .validityDerivation(SourceSpecifiesFromDateTime.builder()
+                    .sourceDateTimeFromField(loanDateTimeName)
+                    .build())
+                .build())
+            .build();
+
+        PlannerOptions options = PlannerOptions.builder().cleanupStagingData(false).build();
+        Datasets datasets = Datasets.builder().mainDataset(mainTable).stagingDataset(stagingTable).tempDataset(tempTable).build();
+
+        // ------------ Perform Pass1 ------------------------
+        String dataPass1 = basePathForInput + "source_specifies_from/without_delete_ind/set_3_with_data_split/staging_data_pass1.csv";
+        String expectedDataPass1 = basePathForExpected + "source_specifies_from/without_delete_ind/set_3_with_data_split/expected_pass1.csv";
+        // 1. Load Staging table
+        loadStagingDataForLoansWithDataSplit(dataPass1);
+        // 2. Execute Plan and Verify Results
+        List<DataSplitRange> dataSplitRanges = new ArrayList<>();
+        dataSplitRanges.add(DataSplitRange.of(1, 1));
+        List<Map<String, Object>> expectedStats = new ArrayList<>();
+        expectedStats.add(new HashMap<>());
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, dataSplitRanges);
+
+        // ------------ Perform Pass2 ------------------------
+        String dataPass2 = basePathForInput + "source_specifies_from/without_delete_ind/set_3_with_data_split/staging_data_pass2.csv";
+        String expectedDataPass2 = basePathForExpected + "source_specifies_from/without_delete_ind/set_3_with_data_split/expected_pass2.csv";
+        // 1. Load Staging table
+        loadStagingDataForLoansWithDataSplit(dataPass2);
+        // 2. Execute Plan and Verify Results
+        dataSplitRanges = new ArrayList<>();
+        dataSplitRanges.add(DataSplitRange.of(1, 1));
+        expectedStats = new ArrayList<>();
+        expectedStats.add(new HashMap<>());
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, dataSplitRanges);
+
+        // ------------ Perform Pass3 ------------------------
+        String expectedDataPass3 = basePathForExpected + "source_specifies_from/without_delete_ind/set_3_with_data_split/expected_pass3.csv";
+        // 2. Execute Plan and Verify Results
+        dataSplitRanges = new ArrayList<>();
+        dataSplitRanges.add(DataSplitRange.of(2, 3));
+        expectedStats = new ArrayList<>();
+        expectedStats.add(new HashMap<>());
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, dataSplitRanges);
+
+
+        // ------------ Perform Pass4 ------------------------
+        String expectedDataPass4 = basePathForExpected + "source_specifies_from/without_delete_ind/set_3_with_data_split/expected_pass4.csv";
+        // 2. Execute Plan and Verify Results
+        dataSplitRanges = new ArrayList<>();
+        dataSplitRanges.add(DataSplitRange.of(50, 100));
+        expectedStats = new ArrayList<>();
+        expectedStats.add(new HashMap<>());
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass4, expectedStats, dataSplitRanges);
     }
 
     /*
@@ -517,7 +585,7 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition tempTable = TestUtils.getLoansTempTableIdBased();
         DatasetDefinition tempTableWithDeleteIndicator = TestUtils.getLoansTempTableWithDeleteIndicatorIdBased();
 
-        String[] schema = new String[]{loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
 
         // Create staging table
         createStagingTable(stagingTable);
@@ -527,7 +595,6 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(loanIdName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -605,7 +672,7 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         DatasetDefinition tempTable = TestUtils.getLoansTempTableIdBased();
         DatasetDefinition tempTableWithDeleteIndicator = TestUtils.getLoansTempTableWithDeleteIndicatorIdBased();
 
-        String[] schema = new String[]{loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
 
         // Create staging table
         createStagingTable(stagingTable);
@@ -615,7 +682,6 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(loanIdName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -663,20 +729,14 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
     {
         DatasetDefinition mainTable = TestUtils.getLoansMainTableIdBased();
         DatasetDefinition stagingTable = TestUtils.getLoansStagingTableWithDeleteIndicatorWithDataSplitIdBased();
-        DatasetDefinition tempTable = TestUtils.getLoansTempTableIdBased();
-        DatasetDefinition tempTableWithDeleteIndicator = TestUtils.getLoansTempTableWithDeleteIndicatorIdBased();
 
-        String[] schema = new String[]{loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
 
         // Create staging table
         createStagingTable(stagingTable);
-        // Create temp table
-        createTempTable(tempTable);
-        createTempTable(tempTableWithDeleteIndicator);
 
         BitemporalDelta ingestMode = BitemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(loanIdName)
             .dataSplitField(dataSplitName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
@@ -696,7 +756,7 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
             .build();
 
         PlannerOptions options = PlannerOptions.builder().cleanupStagingData(false).build();
-        Datasets datasets = Datasets.builder().mainDataset(mainTable).stagingDataset(stagingTable).tempDataset(tempTable).tempDatasetWithDeleteIndicator(tempTableWithDeleteIndicator).build();
+        Datasets datasets = Datasets.builder().mainDataset(mainTable).stagingDataset(stagingTable).build();
 
         // ------------ Perform Pass1 ------------------------
         String dataPass1 = basePathForInput + "source_specifies_from/with_delete_ind/set_3_with_data_split/staging_data_pass1.csv";
@@ -706,11 +766,9 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         // 2. Execute Plan and Verify Results
         List<DataSplitRange> dataSplitRanges = new ArrayList<>();
         dataSplitRanges.add(DataSplitRange.of(5, 5));
-        List<String> expectedDataPasses = new ArrayList<>();
-        expectedDataPasses.add(expectedDataPass1);
         List<Map<String, Object>> expectedStats = new ArrayList<>();
         expectedStats.add(new HashMap<>());
-        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPasses, expectedStats, dataSplitRanges);
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, dataSplitRanges);
 
         // ------------ Perform Pass2 ------------------------
         String dataPass2 = basePathForInput + "source_specifies_from/with_delete_ind/set_3_with_data_split/staging_data_pass2.csv";
@@ -722,12 +780,82 @@ class BitemporalDeltaWithBatchIdTest extends BaseTest
         dataSplitRanges = new ArrayList<>();
         dataSplitRanges.add(DataSplitRange.of(0, 1));
         dataSplitRanges.add(DataSplitRange.of(2, 2));
-        expectedDataPasses = new ArrayList<>();
-        expectedDataPasses.add(expectedDataPass2);
-        expectedDataPasses.add(expectedDataPass3);
         expectedStats = new ArrayList<>();
         expectedStats.add(new HashMap<>());
         expectedStats.add(new HashMap<>());
-        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPasses, expectedStats, dataSplitRanges);
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, dataSplitRanges);
     }
+
+    /*
+    Scenario: Test milestoning Logic with only validity from time specified when staging table pre populated
+    */
+    @Test
+    void testMilestoningSourceSpecifiesFromWithDeleteIndicatorSet3WithDataSplitWithMultiplePasses() throws Exception
+    {
+        DatasetDefinition mainTable = TestUtils.getLoansMainTableIdBased();
+        DatasetDefinition stagingTable = TestUtils.getLoansStagingTableWithDeleteIndicatorWithDataSplitIdBased();
+
+        String[] schema = new String[] {loanIdName, loanDateTimeName, loanBalanceName, digestName, loanStartDateTimeName, loanEndDateTimeName, batchIdInName, batchIdOutName};
+
+        // Create staging table
+        createStagingTable(stagingTable);
+
+        BitemporalDelta ingestMode = BitemporalDelta.builder()
+            .digestField(digestName)
+            .dataSplitField(dataSplitName)
+            .transactionMilestoning(BatchId.builder()
+                .batchIdInName(batchIdInName)
+                .batchIdOutName(batchIdOutName)
+                .build())
+            .validityMilestoning(ValidDateTime.builder()
+                .dateTimeFromName(loanStartDateTimeName)
+                .dateTimeThruName(loanEndDateTimeName)
+                .validityDerivation(SourceSpecifiesFromDateTime.builder()
+                    .sourceDateTimeFromField(loanDateTimeName)
+                    .build())
+                .build())
+            .mergeStrategy(DeleteIndicatorMergeStrategy.builder()
+                .deleteField(deleteIndicatorName)
+                .addAllDeleteValues(Arrays.asList(deleteIndicatorValuesEdgeCase))
+                .build())
+            .build();
+
+        PlannerOptions options = PlannerOptions.builder().cleanupStagingData(false).build();
+        Datasets datasets = Datasets.builder().mainDataset(mainTable).stagingDataset(stagingTable).build();
+
+        // ------------ Perform Pass1 ------------------------
+        String dataPass1 = basePathForInput + "source_specifies_from/with_delete_ind/set_3_with_data_split/staging_data_pass1.csv";
+        String expectedDataPass1 = basePathForExpected + "source_specifies_from/with_delete_ind/set_3_with_data_split/expected_pass1.csv";
+        // 1. Load Staging table
+        loadStagingDataForLoansWithDeleteIndWithDataSplit(dataPass1);
+        // 2. Execute Plan and Verify Results
+        List<DataSplitRange> dataSplitRanges = new ArrayList<>();
+        dataSplitRanges.add(DataSplitRange.of(5, 5));
+        List<Map<String, Object>> expectedStats = new ArrayList<>();
+        expectedStats.add(new HashMap<>());
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, dataSplitRanges);
+
+        // ------------ Perform Pass2 ------------------------
+        String dataPass2 = basePathForInput + "source_specifies_from/with_delete_ind/set_3_with_data_split/staging_data_pass2.csv";
+        String expectedDataPass2 = basePathForExpected + "source_specifies_from/with_delete_ind/set_3_with_data_split/expected_pass2.csv";
+        // 1. Load Staging table
+        loadStagingDataForLoansWithDeleteIndWithDataSplit(dataPass2);
+        // 2. Execute Plan and Verify Results
+        dataSplitRanges = new ArrayList<>();
+        dataSplitRanges.add(DataSplitRange.of(0, 1));
+        expectedStats = new ArrayList<>();
+        expectedStats.add(new HashMap<>());
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, dataSplitRanges);
+
+        // ------------ Perform Pass3 ------------------------
+        String expectedDataPass3 = basePathForExpected + "source_specifies_from/with_delete_ind/set_3_with_data_split/expected_pass3.csv";
+        // 2. Execute Plan and Verify Results
+        dataSplitRanges = new ArrayList<>();
+        dataSplitRanges.add(DataSplitRange.of(2, 2));
+        expectedStats = new ArrayList<>();
+        expectedStats.add(new HashMap<>());
+        executePlansAndVerifyResultsWithDataSplits(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, dataSplitRanges);
+    }
+
+
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalSnapshotWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalSnapshotWithBatchIdTest.java
@@ -67,7 +67,6 @@ class BitemporalSnapshotWithBatchIdTest extends BaseTest
         createStagingTable(stagingTable);
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -139,7 +138,6 @@ class BitemporalSnapshotWithBatchIdTest extends BaseTest
 
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -208,7 +206,6 @@ class BitemporalSnapshotWithBatchIdTest extends BaseTest
 
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -276,7 +273,6 @@ class BitemporalSnapshotWithBatchIdTest extends BaseTest
 
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -331,7 +327,6 @@ class BitemporalSnapshotWithBatchIdTest extends BaseTest
 
         BitemporalSnapshot ingestMode = BitemporalSnapshot.builder()
             .digestField(digestName)
-            .addKeyFields(key1Name, key2Name, dateInName)
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/AppendOnlyTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/AppendOnlyTest.java
@@ -60,7 +60,6 @@ class AppendOnlyTest extends BaseTest
         // Generate the milestoning object
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();
@@ -105,7 +104,6 @@ class AppendOnlyTest extends BaseTest
         // Generate the milestoning object
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();
@@ -144,7 +142,6 @@ class AppendOnlyTest extends BaseTest
         // Generate the milestoning object
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();
@@ -185,7 +182,6 @@ class AppendOnlyTest extends BaseTest
         // Generate the milestoning object
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();
@@ -223,7 +219,6 @@ class AppendOnlyTest extends BaseTest
         // Generate the milestoning object
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(DateTimeAuditing.builder().dateTimeField(batchUpdateTimeName).build())
             .build();
@@ -256,7 +251,6 @@ class AppendOnlyTest extends BaseTest
         // Generate the milestoning object
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();
@@ -304,7 +298,6 @@ class AppendOnlyTest extends BaseTest
         // Generate the milestoning object
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaMergeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaMergeTest.java
@@ -58,7 +58,6 @@ class NontemporalDeltaMergeTest extends BaseTest
         // Generate the milestoning object
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -102,7 +101,6 @@ class NontemporalDeltaMergeTest extends BaseTest
         // Generate the milestoning object
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -142,7 +140,6 @@ class NontemporalDeltaMergeTest extends BaseTest
         // Generate the milestoning object
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .auditing(DateTimeAuditing.builder().dateTimeField(batchUpdateTimeName).build())
             .build();
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaTest.java
@@ -58,7 +58,6 @@ class NontemporalDeltaTest extends BaseTest
         // Generate the milestoning object
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -101,7 +100,6 @@ class NontemporalDeltaTest extends BaseTest
         // Generate the milestoning object
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -141,7 +139,6 @@ class NontemporalDeltaTest extends BaseTest
         // Generate the milestoning object
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -180,7 +177,6 @@ class NontemporalDeltaTest extends BaseTest
         // Generate the milestoning object
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestName)
-            .addKeyFields(idName, startTimeName)
             .auditing(DateTimeAuditing.builder().dateTimeField(batchUpdateTimeName).build())
             .build();
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalSnapshotTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalSnapshotTest.java
@@ -69,11 +69,7 @@ class NontemporalSnapshotTest extends BaseTest
         loadBasicStagingData(dataPass1);
         // 2. Execute plans and verify results
 
-        Map<String, Object> expectedStats = new HashMap<>();
-        expectedStats.put(StatisticName.INCOMING_RECORD_COUNT.name(), 5);
-        expectedStats.put(StatisticName.ROWS_INSERTED.name(), 5);
-        expectedStats.put(StatisticName.ROWS_TERMINATED.name(), 0);
-        expectedStats.put(StatisticName.ROWS_UPDATED.name(), 0);
+        Map<String, Object> expectedStats = createExpectedStatsMap(5, 0, 5, 0, 0);
         executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats);
         // 3. Assert that the staging table is NOT truncated
         List<Map<String, Object>> stagingTableList = h2Sink.executeQuery("select * from \"TEST\".\"staging\"");
@@ -113,11 +109,7 @@ class NontemporalSnapshotTest extends BaseTest
         // ------------ Perform incremental (append) milestoning Pass1 ------------------------
         String expectedDataPass1 = basePath + "expected/with_update_timestamp_field/expected_pass1.csv";
         // Execute plans and verify results
-        Map<String, Object> expectedStats = new HashMap<>();
-        expectedStats.put(StatisticName.INCOMING_RECORD_COUNT.name(), 3);
-        expectedStats.put(StatisticName.ROWS_INSERTED.name(), 3);
-        expectedStats.put(StatisticName.ROWS_TERMINATED.name(), 0);
-        expectedStats.put(StatisticName.ROWS_UPDATED.name(), 0);
+        Map<String, Object> expectedStats = createExpectedStatsMap(3, 0, 3, 0, 0);
         executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
     }
 
@@ -140,11 +132,7 @@ class NontemporalSnapshotTest extends BaseTest
 
         // ------------ Perform snapshot milestoning Pass1 ------------------------
         String expectedDataPass1 = basePath + "expected/vanilla_case/expected_pass1.csv";
-        Map<String, Object> expectedStats = new HashMap<>();
-        expectedStats.put(StatisticName.INCOMING_RECORD_COUNT.name(), 5);
-        expectedStats.put(StatisticName.ROWS_INSERTED.name(), 5);
-        expectedStats.put(StatisticName.ROWS_TERMINATED.name(), 0);
-        expectedStats.put(StatisticName.ROWS_UPDATED.name(), 0);
+        Map<String, Object> expectedStats = createExpectedStatsMap(5, 0, 5, 0, 0);
         executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats);
 
         // ------------ Perform snapshot milestoning Pass2 ------------------------
@@ -176,11 +164,7 @@ class NontemporalSnapshotTest extends BaseTest
 
         // ------------ Perform snapshot milestoning Pass1 ------------------------
         String expectedDataPass1 = basePath + "expected/vanilla_case/expected_pass1.csv";
-        Map<String, Object> expectedStats = new HashMap<>();
-        expectedStats.put(StatisticName.INCOMING_RECORD_COUNT.name(), 5);
-        expectedStats.put(StatisticName.ROWS_INSERTED.name(), 5);
-        expectedStats.put(StatisticName.ROWS_TERMINATED.name(), 0);
-        expectedStats.put(StatisticName.ROWS_UPDATED.name(), 0);
+        Map<String, Object> expectedStats = createExpectedStatsMap(5, 0, 5, 0, 0);
         executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats);
 
         // ------------ Perform snapshot milestoning Pass2 ------------------------
@@ -213,11 +197,7 @@ class NontemporalSnapshotTest extends BaseTest
         // ------------ Perform snapshot milestoning Pass1 ------------------------
         String expectedDataPass1 = basePath + "expected/less_columns_in_staging/expected_pass1.csv";
         // Execute plans and verify results
-        Map<String, Object> expectedStats = new HashMap<>();
-        expectedStats.put(StatisticName.INCOMING_RECORD_COUNT.name(), 5);
-        expectedStats.put(StatisticName.ROWS_INSERTED.name(), 5);
-        expectedStats.put(StatisticName.ROWS_TERMINATED.name(), 0);
-        expectedStats.put(StatisticName.ROWS_UPDATED.name(), 0);
+        Map<String, Object> expectedStats = createExpectedStatsMap(5, 0, 5, 0, 0);
         executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats);
 
         // ------------ Perform snapshot milestoning Pass2 ------------------------
@@ -256,11 +236,7 @@ class NontemporalSnapshotTest extends BaseTest
         // 1. Load staging table
         loadBasicStagingData(dataPass1);
         // 2. Execute plans and verify results
-        Map<String, Object> expectedStats = new HashMap<>();
-        expectedStats.put(StatisticName.INCOMING_RECORD_COUNT.name(), 5);
-        expectedStats.put(StatisticName.ROWS_INSERTED.name(), 5);
-        expectedStats.put(StatisticName.ROWS_TERMINATED.name(), 0);
-        expectedStats.put(StatisticName.ROWS_UPDATED.name(), 0);
+        Map<String, Object> expectedStats = createExpectedStatsMap(5, 0, 5, 0, 0);
         executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats);
         // 3. Assert that the staging table is truncated
         List<Map<String, Object>> stagingTableList = h2Sink.executeQuery("select * from \"TEST\".\"staging\"");

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaDbAndSchemaMissingTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaDbAndSchemaMissingTest.java
@@ -24,7 +24,6 @@ import org.finos.legend.engine.persistence.components.planner.PlannerOptions;
 import org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -83,7 +82,6 @@ class UnitemporalDeltaDbAndSchemaMissingTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaTest.java
@@ -65,7 +65,6 @@ class UnitemporalDeltaTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -126,7 +125,6 @@ class UnitemporalDeltaTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -184,7 +182,6 @@ class UnitemporalDeltaTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -237,7 +234,6 @@ class UnitemporalDeltaTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -278,7 +274,6 @@ class UnitemporalDeltaTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchIdTest.java
@@ -62,7 +62,6 @@ class UnitemporalDeltaWithBatchIdTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -118,7 +117,6 @@ class UnitemporalDeltaWithBatchIdTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -164,7 +162,6 @@ class UnitemporalDeltaWithBatchIdTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -221,7 +218,6 @@ class UnitemporalDeltaWithBatchIdTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -273,7 +269,6 @@ class UnitemporalDeltaWithBatchIdTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchTimeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaWithBatchTimeTest.java
@@ -62,7 +62,6 @@ class UnitemporalDeltaWithBatchTimeTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)
@@ -119,7 +118,6 @@ class UnitemporalDeltaWithBatchTimeTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)
@@ -174,7 +172,6 @@ class UnitemporalDeltaWithBatchTimeTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)
@@ -226,7 +223,6 @@ class UnitemporalDeltaWithBatchTimeTest extends BaseTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotTest.java
@@ -27,7 +27,6 @@ import org.finos.legend.engine.persistence.components.util.MetadataDataset;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +71,6 @@ class UnitemporalSnapshotTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -138,7 +136,6 @@ class UnitemporalSnapshotTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -196,7 +193,6 @@ class UnitemporalSnapshotTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -242,7 +238,6 @@ class UnitemporalSnapshotTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -281,7 +276,6 @@ class UnitemporalSnapshotTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -323,7 +317,6 @@ class UnitemporalSnapshotTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchIdTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchIdTest.java
@@ -26,7 +26,6 @@ import org.finos.legend.engine.persistence.components.util.MetadataDataset;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +66,6 @@ class UnitemporalSnapshotWithBatchIdTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -127,7 +125,6 @@ class UnitemporalSnapshotWithBatchIdTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -183,7 +180,6 @@ class UnitemporalSnapshotWithBatchIdTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -238,7 +234,6 @@ class UnitemporalSnapshotWithBatchIdTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)
@@ -283,7 +278,6 @@ class UnitemporalSnapshotWithBatchIdTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(BatchId.builder()
                 .batchIdInName(batchIdInName)
                 .batchIdOutName(batchIdOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchTimeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotWithBatchTimeTest.java
@@ -26,7 +26,6 @@ import org.finos.legend.engine.persistence.components.util.MetadataDataset;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,6 @@ class UnitemporalSnapshotWithBatchTimeTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)
@@ -126,7 +124,6 @@ class UnitemporalSnapshotWithBatchTimeTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)
@@ -180,7 +177,6 @@ class UnitemporalSnapshotWithBatchTimeTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(idName, startTimeName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)
@@ -224,7 +220,6 @@ class UnitemporalSnapshotWithBatchTimeTest extends BaseTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestName)
-            .addAllKeyFields(Arrays.asList(dateName, tickerName))
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInName)
                 .dateTimeOutName(batchTimeOutName)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/main/java/org/finos/legend/engine/persistence/components/relational/memsql/MemSqlSink.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/main/java/org/finos/legend/engine/persistence/components/relational/memsql/MemSqlSink.java
@@ -165,7 +165,7 @@ public class MemSqlSink extends AnsiSqlSink
         }
     }
 
-    static final RelationalSink.ValidateMainDatasetSchema VALIDATE_MAIN_DATASET_SCHEMA = new RelationalSink.ValidateMainDatasetSchema()
+    static final ValidateMainDatasetSchema VALIDATE_MAIN_DATASET_SCHEMA = new ValidateMainDatasetSchema()
     {
         @Override
         public void execute(Executor<SqlGen, TabularData, SqlPlan> executor, JdbcHelper sink, Dataset dataset)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/main/java/org/finos/legend/engine/persistence/components/relational/memsql/sql/visitor/SchemaDefinitionVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/main/java/org/finos/legend/engine/persistence/components/relational/memsql/sql/visitor/SchemaDefinitionVisitor.java
@@ -41,7 +41,7 @@ public class SchemaDefinitionVisitor implements LogicalPlanVisitor<SchemaDefinit
 {
 
     @Override
-    public LogicalPlanVisitor.VisitorResult visit(PhysicalPlanNode prev, SchemaDefinition current, VisitorContext context)
+    public VisitorResult visit(PhysicalPlanNode prev, SchemaDefinition current, VisitorContext context)
     {
 
         List<Field> pkFields = current.fields().stream().filter(Field::primaryKey).collect(Collectors.toList());

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaTest.java
@@ -57,7 +57,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -112,7 +111,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -133,8 +131,8 @@ public class UnitemporalDeltaTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as SINK SET SINK.`BATCH_ID_OUT` = (SELECT COALESCE(MAX(BATCH_METADATA.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.`TABLE_NAME` = 'main')-1,SINK.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' WHERE (SINK.`BATCH_ID_OUT` = 999999999) AND (EXISTS (SELECT * FROM `MYDB`.`STAGING` as STAGE WHERE ((SINK.`ID` = STAGE.`ID`) AND (SINK.`NAME` = STAGE.`NAME`)) AND (SINK.`DIGEST` <> STAGE.`DIGEST`)))";
-        String expectedUpsertQuery = "INSERT INTO `MYDB`.`MAIN` (`ID`, `NAME`, `AMOUNT`, `BIZ_DATE`, `DIGEST`, `BATCH_ID_IN`, `BATCH_ID_OUT`, `BATCH_TIME_IN`, `BATCH_TIME_OUT`) (SELECT STAGE.`ID`,STAGE.`NAME`,STAGE.`AMOUNT`,STAGE.`BIZ_DATE`,STAGE.`DIGEST`,(SELECT COALESCE(MAX(BATCH_METADATA.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.`TABLE_NAME` = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM `MYDB`.`STAGING` as STAGE WHERE NOT (EXISTS (SELECT * FROM `MYDB`.`MAIN` as SINK WHERE (SINK.`BATCH_ID_OUT` = 999999999) AND (SINK.`DIGEST` = STAGE.`DIGEST`) AND ((SINK.`ID` = STAGE.`ID`) AND (SINK.`NAME` = STAGE.`NAME`)))))";
+        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as sink SET sink.`BATCH_ID_OUT` = (SELECT COALESCE(MAX(batch_metadata.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.`TABLE_NAME` = 'main')-1,sink.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' WHERE (sink.`BATCH_ID_OUT` = 999999999) AND (EXISTS (SELECT * FROM `MYDB`.`STAGING` as stage WHERE ((sink.`ID` = stage.`ID`) AND (sink.`NAME` = stage.`NAME`)) AND (sink.`DIGEST` <> stage.`DIGEST`)))";
+        String expectedUpsertQuery = "INSERT INTO `MYDB`.`MAIN` (`ID`, `NAME`, `AMOUNT`, `BIZ_DATE`, `DIGEST`, `BATCH_ID_IN`, `BATCH_ID_OUT`, `BATCH_TIME_IN`, `BATCH_TIME_OUT`) (SELECT stage.`ID`,stage.`NAME`,stage.`AMOUNT`,stage.`BIZ_DATE`,stage.`DIGEST`,(SELECT COALESCE(MAX(batch_metadata.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.`TABLE_NAME` = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM `MYDB`.`STAGING` as stage WHERE NOT (EXISTS (SELECT * FROM `MYDB`.`MAIN` as sink WHERE (sink.`BATCH_ID_OUT` = 999999999) AND (sink.`DIGEST` = stage.`DIGEST`) AND ((sink.`ID` = stage.`ID`) AND (sink.`NAME` = stage.`NAME`)))))";
 
         Assertions.assertEquals(expectedMainTableCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -154,7 +152,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -219,7 +216,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -272,7 +268,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         try
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -296,7 +291,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -319,7 +313,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -351,7 +344,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -385,7 +377,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -460,7 +451,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -535,7 +525,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -600,7 +589,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -622,7 +610,7 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }
@@ -632,7 +620,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaWithBatchTimeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaWithBatchTimeTest.java
@@ -57,7 +57,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -108,7 +107,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -127,9 +125,9 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as SINK SET SINK.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' WHERE (SINK.`BATCH_TIME_OUT` = '9999-12-31 23:59:59') AND (EXISTS (SELECT * FROM `MYDB`.`STAGING` as STAGE WHERE ((SINK.`ID` = STAGE.`ID`) AND (SINK.`NAME` = STAGE.`NAME`)) AND (SINK.`DIGEST` <> STAGE.`DIGEST`)))";
+        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as sink SET sink.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' WHERE (sink.`BATCH_TIME_OUT` = '9999-12-31 23:59:59') AND (EXISTS (SELECT * FROM `MYDB`.`STAGING` as stage WHERE ((sink.`ID` = stage.`ID`) AND (sink.`NAME` = stage.`NAME`)) AND (sink.`DIGEST` <> stage.`DIGEST`)))";
 
-        String expectedUpsertQuery = "INSERT INTO `MYDB`.`MAIN` (`ID`, `NAME`, `AMOUNT`, `BIZ_DATE`, `DIGEST`, `BATCH_TIME_IN`, `BATCH_TIME_OUT`) (SELECT STAGE.`ID`,STAGE.`NAME`,STAGE.`AMOUNT`,STAGE.`BIZ_DATE`,STAGE.`DIGEST`,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM `MYDB`.`STAGING` as STAGE WHERE NOT (EXISTS (SELECT * FROM `MYDB`.`MAIN` as SINK WHERE (SINK.`BATCH_TIME_OUT` = '9999-12-31 23:59:59') AND (SINK.`DIGEST` = STAGE.`DIGEST`) AND ((SINK.`ID` = STAGE.`ID`) AND (SINK.`NAME` = STAGE.`NAME`)))))";
+        String expectedUpsertQuery = "INSERT INTO `MYDB`.`MAIN` (`ID`, `NAME`, `AMOUNT`, `BIZ_DATE`, `DIGEST`, `BATCH_TIME_IN`, `BATCH_TIME_OUT`) (SELECT stage.`ID`,stage.`NAME`,stage.`AMOUNT`,stage.`BIZ_DATE`,stage.`DIGEST`,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM `MYDB`.`STAGING` as stage WHERE NOT (EXISTS (SELECT * FROM `MYDB`.`MAIN` as sink WHERE (sink.`BATCH_TIME_OUT` = '9999-12-31 23:59:59') AND (sink.`DIGEST` = stage.`DIGEST`) AND ((sink.`ID` = stage.`ID`) AND (sink.`NAME` = stage.`NAME`)))))";
 
         Assertions.assertEquals(expectedMainTableTimeBasedCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -149,7 +147,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -206,7 +203,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeInName(batchTimeInField)
                     .build())
@@ -232,7 +228,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalDelta ingestMode = UnitemporalDelta.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeInName(batchTimeInField)
                     .dateTimeOutName(batchTimeOutField)
@@ -254,7 +249,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -290,7 +284,6 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -324,7 +317,7 @@ public class UnitemporalDeltaWithBatchTimeTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotTest.java
@@ -56,7 +56,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -94,7 +93,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -144,7 +142,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -165,8 +162,8 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as SINK SET SINK.`BATCH_ID_OUT` = (SELECT COALESCE(MAX(BATCH_METADATA.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.`TABLE_NAME` = 'main')-1,SINK.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' WHERE (SINK.`BATCH_ID_OUT` = 999999999) AND (NOT (EXISTS (SELECT * FROM `MYDB`.`STAGING` as STAGE WHERE ((SINK.`ID` = STAGE.`ID`) AND (SINK.`NAME` = STAGE.`NAME`)) AND (SINK.`DIGEST` = STAGE.`DIGEST`))))";
-        String expectedUpsertQuery = "INSERT INTO `MYDB`.`MAIN` (`ID`, `NAME`, `AMOUNT`, `BIZ_DATE`, `DIGEST`, `BATCH_ID_IN`, `BATCH_ID_OUT`, `BATCH_TIME_IN`, `BATCH_TIME_OUT`) (SELECT STAGE.`ID`,STAGE.`NAME`,STAGE.`AMOUNT`,STAGE.`BIZ_DATE`,STAGE.`DIGEST`,(SELECT COALESCE(MAX(BATCH_METADATA.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.`TABLE_NAME` = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM `MYDB`.`STAGING` as STAGE WHERE NOT (STAGE.`DIGEST` IN (SELECT SINK.`DIGEST` FROM `MYDB`.`MAIN` as SINK WHERE SINK.`BATCH_ID_OUT` = 999999999)))";
+        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as sink SET sink.`BATCH_ID_OUT` = (SELECT COALESCE(MAX(batch_metadata.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.`TABLE_NAME` = 'main')-1,sink.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' WHERE (sink.`BATCH_ID_OUT` = 999999999) AND (NOT (EXISTS (SELECT * FROM `MYDB`.`STAGING` as stage WHERE ((sink.`ID` = stage.`ID`) AND (sink.`NAME` = stage.`NAME`)) AND (sink.`DIGEST` = stage.`DIGEST`))))";
+        String expectedUpsertQuery = "INSERT INTO `MYDB`.`MAIN` (`ID`, `NAME`, `AMOUNT`, `BIZ_DATE`, `DIGEST`, `BATCH_ID_IN`, `BATCH_ID_OUT`, `BATCH_TIME_IN`, `BATCH_TIME_OUT`) (SELECT stage.`ID`,stage.`NAME`,stage.`AMOUNT`,stage.`BIZ_DATE`,stage.`DIGEST`,(SELECT COALESCE(MAX(batch_metadata.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.`TABLE_NAME` = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' FROM `MYDB`.`STAGING` as stage WHERE NOT (stage.`DIGEST` IN (SELECT sink.`DIGEST` FROM `MYDB`.`MAIN` as sink WHERE sink.`BATCH_ID_OUT` = 999999999)))";
         Assertions.assertEquals(expectedMainTableCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
 
@@ -180,7 +177,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -231,7 +227,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -286,7 +281,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -336,7 +330,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -362,7 +355,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdOutName(batchIdOutField)
                     .dateTimeInName(batchTimeInField)
@@ -390,7 +382,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(BatchIdAndDateTime.builder()
                     .batchIdInName(batchIdInField)
                     .batchIdOutName(batchIdOutField)
@@ -414,7 +405,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -437,7 +427,7 @@ public class UnitemporalSnapshotTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         List<String> expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }
@@ -447,7 +437,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotWithBatchTimeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotWithBatchTimeTest.java
@@ -58,7 +58,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -79,9 +78,9 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
         List<String> milestoningSql = queries.ingestSql();
         List<String> metadataIngestSql = queries.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as SINK " +
-            "SET SINK.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' " +
-            "WHERE SINK.`BATCH_TIME_OUT` = '9999-12-31 23:59:59'";
+        String expectedMilestoneQuery = "UPDATE `MYDB`.`MAIN` as sink " +
+            "SET sink.`BATCH_TIME_OUT` = '2000-01-01 00:00:00' " +
+            "WHERE sink.`BATCH_TIME_OUT` = '9999-12-31 23:59:59'";
 
         Assertions.assertEquals(expectedMainTableTimeBasedCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
@@ -95,7 +94,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -142,7 +140,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -192,7 +189,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeOutName(batchTimeOutField)
                     .build())
@@ -218,7 +214,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
         {
             UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
                 .digestField(digestField)
-                .addAllKeyFields(primaryKeysList)
                 .transactionMilestoning(TransactionDateTime.builder()
                     .dateTimeInName(batchTimeInField)
                     .dateTimeOutName(batchTimeOutField)
@@ -240,7 +235,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -276,7 +270,6 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(TransactionDateTime.builder()
                 .dateTimeInName(batchTimeInField)
                 .dateTimeOutName(batchTimeOutField)
@@ -310,7 +303,7 @@ public class UnitemporalSnapshotWithBatchTimeTest extends IngestModeTest
 
         List<String> postActionsSql = operations.postActionsSql();
         expectedSQL = new ArrayList<>();
-        expectedSQL.add(expectedTruncateTableQuery);
+        expectedSQL.add(expectedStagingCleanupQuery);
 
         assertIfListsAreSameIgnoringOrder(expectedSQL, postActionsSql);
     }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/transformer/PlaceholderTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/transformer/PlaceholderTest.java
@@ -56,7 +56,7 @@ public class PlaceholderTest
         SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
         List<String> list = physicalPlan.getSqlList();
 
-        String expectedSql = "INSERT INTO BATCH_METADATA (`TABLE_NAME`, `TABLE_BATCH_ID`, `BATCH_START_TS_UTC`, `BATCH_END_TS_UTC`, `BATCH_STATUS`) (SELECT 'main',(SELECT COALESCE(MAX(BATCH_METADATA.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.`TABLE_NAME` = 'main'),'{BATCH_START_TIMESTAMP_PLACEHOLDER}','{BATCH_END_TIMESTAMP_PLACEHOLDER}','DONE')";
+        String expectedSql = "INSERT INTO BATCH_METADATA (`TABLE_NAME`, `TABLE_BATCH_ID`, `BATCH_START_TS_UTC`, `BATCH_END_TS_UTC`, `BATCH_STATUS`) (SELECT 'main',(SELECT COALESCE(MAX(batch_metadata.`TABLE_BATCH_ID`),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.`TABLE_NAME` = 'main'),'{BATCH_START_TIMESTAMP_PLACEHOLDER}','{BATCH_END_TIMESTAMP_PLACEHOLDER}','DONE')";
         Assertions.assertEquals(expectedSql, list.get(0));
     }
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
@@ -34,7 +34,6 @@ import org.finos.legend.engine.persistence.components.relational.snowflake.sql.v
 import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.BatchEndTimestampVisitor;
 import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.SchemaDefinitionVisitor;
 import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.ShowVisitor;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.TruncateVisitor;
 import org.finos.legend.engine.persistence.components.relational.sql.TabularData;
 import org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils;
 import org.finos.legend.engine.persistence.components.relational.transformer.RelationalTransformer;
@@ -71,7 +70,6 @@ public class SnowflakeSink extends AnsiSqlSink
         Map<Class<?>, LogicalPlanVisitor<?>> logicalPlanVisitorByClass = new HashMap<>();
         logicalPlanVisitorByClass.put(SchemaDefinition.class, new SchemaDefinitionVisitor());
         logicalPlanVisitorByClass.put(Alter.class, new AlterVisitor());
-        logicalPlanVisitorByClass.put(Truncate.class, new TruncateVisitor());
         logicalPlanVisitorByClass.put(Show.class, new ShowVisitor());
         logicalPlanVisitorByClass.put(BatchEndTimestamp.class, new BatchEndTimestampVisitor());
         LOGICAL_PLAN_VISITOR_BY_CLASS = Collections.unmodifiableMap(logicalPlanVisitorByClass);

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/AlterVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/AlterVisitor.java
@@ -28,7 +28,7 @@ public class AlterVisitor implements LogicalPlanVisitor<Alter>
 {
 
     @Override
-    public LogicalPlanVisitor.VisitorResult visit(PhysicalPlanNode prev, Alter current, VisitorContext context)
+    public VisitorResult visit(PhysicalPlanNode prev, Alter current, VisitorContext context)
     {
         AlterTable alterTable = new AlterTable(AlterOperation.valueOf(current.operation().name()));
         for (Optimizer optimizer : context.optimizers())

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/SchemaDefinitionVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/SchemaDefinitionVisitor.java
@@ -38,7 +38,7 @@ public class SchemaDefinitionVisitor implements LogicalPlanVisitor<SchemaDefinit
 {
 
     @Override
-    public LogicalPlanVisitor.VisitorResult visit(PhysicalPlanNode prev, SchemaDefinition current, VisitorContext context)
+    public VisitorResult visit(PhysicalPlanNode prev, SchemaDefinition current, VisitorContext context)
     {
 
         List<Field> pkFields = current.fields().stream().filter(Field::primaryKey).collect(Collectors.toList());

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyTest.java
@@ -46,7 +46,6 @@ public class AppendOnlyTest extends IngestModeTest
 
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();
@@ -90,7 +89,6 @@ public class AppendOnlyTest extends IngestModeTest
 
         AppendOnly ingestMode = AppendOnly.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .deduplicationStrategy(FilterDuplicates.builder().build())
             .auditing(NoAuditing.builder().build())
             .build();
@@ -107,10 +105,10 @@ public class AppendOnlyTest extends IngestModeTest
 
         String insertSql = "INSERT INTO \"MYDB\".\"MAIN\" " +
             "(\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\") " +
-            "(SELECT * FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (EXISTS " +
-            "(SELECT * FROM \"MYDB\".\"MAIN\" as SINK " +
-            "WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) " +
-            "AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\"))))";
+            "(SELECT * FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (EXISTS " +
+            "(SELECT * FROM \"MYDB\".\"MAIN\" as sink " +
+            "WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) " +
+            "AND (sink.\"DIGEST\" = stage.\"DIGEST\"))))";
 
         Assertions.assertEquals(expectedBaseTablePlusDigestCreateQueryWithUpperCase, preActionsSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(0));

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/IngestModeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/IngestModeTest.java
@@ -51,8 +51,6 @@ public class IngestModeTest
     String deleteIndicatorField = "delete_indicator";
     String[] deleteIndicatorValues = new String[]{"yes", "1", "true"};
 
-    String[] primaryKeys = new String[]{"id", "name"};
-    List<String> primaryKeysList = Arrays.asList(primaryKeys);
     String[] partitionKeys = new String[]{"biz_date"};
     HashMap<String, Set<String>> partitionFilter = new HashMap<String, Set<String>>()
     {{
@@ -134,7 +132,7 @@ public class IngestModeTest
         " (SELECT 'main',(SELECT COALESCE(MAX(batch_metadata.\"table_batch_id\"),0)+1 FROM batch_metadata as batch_metadata WHERE batch_metadata.\"table_name\" = 'main'),'2000-01-01 00:00:00',SYSDATE(),'DONE')";
 
     protected String expectedMetadataTableIngestQueryWithUpperCase = "INSERT INTO BATCH_METADATA (\"TABLE_NAME\", \"TABLE_BATCH_ID\", \"BATCH_START_TS_UTC\", \"BATCH_END_TS_UTC\", \"BATCH_STATUS\")" +
-        " (SELECT 'main',(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),'2000-01-01 00:00:00',SYSDATE(),'DONE')";
+        " (SELECT 'main',(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),'2000-01-01 00:00:00',SYSDATE(),'DONE')";
 
     String expectedCustomMetadataTableIngestQuery = "INSERT INTO \"mydb\".\"custom_metadata\" (\"table_name\", \"table_batch_id\", \"batch_start_ts_utc\", \"batch_end_ts_utc\", \"batch_status\")" +
         " (SELECT 'main',(SELECT COALESCE(MAX(custom_metadata.\"table_batch_id\"),0)+1 FROM \"mydb\".\"custom_metadata\" as custom_metadata WHERE custom_metadata.\"table_name\" = 'main'),'2000-01-01 00:00:00',SYSDATE(),'DONE')";

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaMergeTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaMergeTest.java
@@ -45,7 +45,6 @@ public class NontemporalDeltaMergeTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -95,7 +94,6 @@ public class NontemporalDeltaMergeTest extends IngestModeTest
 
         NontemporalDelta ingestMode = NontemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .auditing(NoAuditing.builder().build())
             .build();
 
@@ -109,13 +107,13 @@ public class NontemporalDeltaMergeTest extends IngestModeTest
         List<String> preActionsSqlList = operations.preActionsSql();
         List<String> milestoningSqlList = operations.ingestSql();
 
-        String mergeSql = "MERGE INTO \"MYDB\".\"MAIN\" as SINK USING \"MYDB\".\"STAGING\" as STAGE " +
-            "ON (SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\") WHEN MATCHED " +
-            "AND SINK.\"DIGEST\" <> STAGE.\"DIGEST\" THEN UPDATE SET SINK.\"ID\" = STAGE.\"ID\"," +
-            "SINK.\"NAME\" = STAGE.\"NAME\",SINK.\"AMOUNT\" = STAGE.\"AMOUNT\"," +
-            "SINK.\"BIZ_DATE\" = STAGE.\"BIZ_DATE\",SINK.\"DIGEST\" = STAGE.\"DIGEST\" " +
+        String mergeSql = "MERGE INTO \"MYDB\".\"MAIN\" as sink USING \"MYDB\".\"STAGING\" as stage " +
+            "ON (sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\") WHEN MATCHED " +
+            "AND sink.\"DIGEST\" <> stage.\"DIGEST\" THEN UPDATE SET sink.\"ID\" = stage.\"ID\"," +
+            "sink.\"NAME\" = stage.\"NAME\",sink.\"AMOUNT\" = stage.\"AMOUNT\"," +
+            "sink.\"BIZ_DATE\" = stage.\"BIZ_DATE\",sink.\"DIGEST\" = stage.\"DIGEST\" " +
             "WHEN NOT MATCHED THEN INSERT (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\") " +
-            "VALUES (STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"BIZ_DATE\",STAGE.\"DIGEST\")";
+            "VALUES (stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"BIZ_DATE\",stage.\"DIGEST\")";
 
         Assertions.assertEquals(expectedBaseTablePlusDigestCreateQueryWithUpperCase, preActionsSqlList.get(0));
         Assertions.assertEquals(mergeSql, milestoningSqlList.get(0));

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalSnapshotTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalSnapshotTest.java
@@ -138,8 +138,8 @@ public class NontemporalSnapshotTest extends IngestModeTest
         List<String> preActionsSqlList = oper.preActionsSql();
         List<String> milestoningSqlList = oper.ingestSql();
 
-        String deleteFromTableSql = "DELETE FROM \"MYDB\".\"MAIN\" as SINK";
-        String insertSql = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"BATCH_UPDATE_TIME\") (SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\",STAGE.\"BIZ_DATE\",'2000-01-01 00:00:00' FROM \"MYDB\".\"STAGING\" as STAGE)";
+        String deleteFromTableSql = "DELETE FROM \"MYDB\".\"MAIN\" as sink";
+        String insertSql = "INSERT INTO \"MYDB\".\"MAIN\" (\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"BATCH_UPDATE_TIME\") (SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\",stage.\"BIZ_DATE\",'2000-01-01 00:00:00' FROM \"MYDB\".\"STAGING\" as stage)";
 
         Assertions.assertEquals(expectedBaseTableCreateQueryWithUpperCase, preActionsSqlList.get(0));
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaTest.java
@@ -53,7 +53,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -120,7 +119,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -195,7 +193,6 @@ public class UnitemporalDeltaTest extends IngestModeTest
 
         UnitemporalDelta ingestMode = UnitemporalDelta.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -221,25 +218,25 @@ public class UnitemporalDeltaTest extends IngestModeTest
         List<String> metadataIngestSql = operations.metadataIngestSql();
         List<String> postActionsSql = operations.postActionsSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK " +
-            "SET SINK.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 " +
-            "FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')-1,SINK.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' " +
-            "WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE " +
-            "WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) " +
-            "AND ((SINK.\"DIGEST\" <> STAGE.\"DIGEST\") OR (STAGE.\"DELETE_INDICATOR\" IN ('yes','1','true')))))";
+
+        String expectedPostActionsSql = "DELETE FROM \"MYDB\".\"STAGING\" as stage";
+
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink " +
+            "SET sink.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 " +
+            "FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')-1,sink.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' " +
+            "WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage " +
+            "WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) " +
+            "AND ((sink.\"DIGEST\" <> stage.\"DIGEST\") OR (stage.\"DELETE_INDICATOR\" IN ('yes','1','true')))))";
 
         String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" " +
             "(\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\", " +
-            "\"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\"," +
-            "STAGE.\"BIZ_DATE\",STAGE.\"DIGEST\",(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 " +
-            "FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00'," +
-            "'9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as STAGE WHERE (NOT (EXISTS " +
-            "(SELECT * FROM \"MYDB\".\"MAIN\" as SINK WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND " +
-            "(SINK.\"DIGEST\" = STAGE.\"DIGEST\") AND ((SINK.\"ID\" = STAGE.\"ID\") AND " +
-            "(SINK.\"NAME\" = STAGE.\"NAME\"))))) AND (STAGE.\"DELETE_INDICATOR\" NOT IN ('yes','1','true')))";
-
-        String expectedPostActionsSql = "DELETE FROM \"MYDB\".\"STAGING\" as STAGE";
-
+            "\"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\"," +
+            "stage.\"BIZ_DATE\",stage.\"DIGEST\",(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 " +
+            "FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00'," +
+            "'9999-12-31 23:59:59' FROM \"MYDB\".\"STAGING\" as stage WHERE (NOT (EXISTS " +
+            "(SELECT * FROM \"MYDB\".\"MAIN\" as sink WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND " +
+            "(sink.\"DIGEST\" = stage.\"DIGEST\") AND ((sink.\"ID\" = stage.\"ID\") AND " +
+            "(sink.\"NAME\" = stage.\"NAME\"))))) AND (stage.\"DELETE_INDICATOR\" NOT IN ('yes','1','true')))";
         Assertions.assertEquals(expectedMainTableCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotTest.java
@@ -52,7 +52,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -89,7 +88,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -137,7 +135,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -187,7 +184,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
     {
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -240,7 +236,6 @@ public class UnitemporalSnapshotTest extends IngestModeTest
 
         UnitemporalSnapshot ingestMode = UnitemporalSnapshot.builder()
             .digestField(digestField)
-            .addAllKeyFields(primaryKeysList)
             .transactionMilestoning(BatchIdAndDateTime.builder()
                 .batchIdInName(batchIdInField)
                 .batchIdOutName(batchIdOutField)
@@ -263,21 +258,21 @@ public class UnitemporalSnapshotTest extends IngestModeTest
         List<String> milestoningSql = operations.ingestSql();
         List<String> metadataIngestSql = operations.metadataIngestSql();
 
-        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as SINK " +
-            "SET SINK.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 " +
-            "FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main')-1,SINK.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' " +
-            "WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (NOT (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as STAGE " +
-            "WHERE ((SINK.\"ID\" = STAGE.\"ID\") AND (SINK.\"NAME\" = STAGE.\"NAME\")) " +
-            "AND (SINK.\"DIGEST\" = STAGE.\"DIGEST\")))) " +
-            "AND (SINK.\"BIZ_DATE\" IN ('2000-01-01 00:00:00','2000-01-02 00:00:00'))";
+        String expectedMilestoneQuery = "UPDATE \"MYDB\".\"MAIN\" as sink " +
+            "SET sink.\"BATCH_ID_OUT\" = (SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 " +
+            "FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main')-1,sink.\"BATCH_TIME_OUT\" = '2000-01-01 00:00:00' " +
+            "WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (NOT (EXISTS (SELECT * FROM \"MYDB\".\"STAGING\" as stage " +
+            "WHERE ((sink.\"ID\" = stage.\"ID\") AND (sink.\"NAME\" = stage.\"NAME\")) " +
+            "AND (sink.\"DIGEST\" = stage.\"DIGEST\")))) " +
+            "AND (sink.\"BIZ_DATE\" IN ('2000-01-01 00:00:00','2000-01-02 00:00:00'))";
 
         String expectedUpsertQuery = "INSERT INTO \"MYDB\".\"MAIN\" " +
             "(\"ID\", \"NAME\", \"AMOUNT\", \"BIZ_DATE\", \"DIGEST\", \"BATCH_ID_IN\", \"BATCH_ID_OUT\", " +
-            "\"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT STAGE.\"ID\",STAGE.\"NAME\",STAGE.\"AMOUNT\"," +
-            "STAGE.\"BIZ_DATE\",STAGE.\"DIGEST\",(SELECT COALESCE(MAX(BATCH_METADATA.\"TABLE_BATCH_ID\"),0)+1 " +
-            "FROM BATCH_METADATA as BATCH_METADATA WHERE BATCH_METADATA.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' " +
-            "FROM \"MYDB\".\"STAGING\" as STAGE WHERE NOT (STAGE.\"DIGEST\" IN (SELECT SINK.\"DIGEST\" " +
-            "FROM \"MYDB\".\"MAIN\" as SINK WHERE (SINK.\"BATCH_ID_OUT\" = 999999999) AND (SINK.\"BIZ_DATE\" IN ('2000-01-01 00:00:00','2000-01-02 00:00:00')))))";
+            "\"BATCH_TIME_IN\", \"BATCH_TIME_OUT\") (SELECT stage.\"ID\",stage.\"NAME\",stage.\"AMOUNT\"," +
+            "stage.\"BIZ_DATE\",stage.\"DIGEST\",(SELECT COALESCE(MAX(batch_metadata.\"TABLE_BATCH_ID\"),0)+1 " +
+            "FROM BATCH_METADATA as batch_metadata WHERE batch_metadata.\"TABLE_NAME\" = 'main'),999999999,'2000-01-01 00:00:00','9999-12-31 23:59:59' " +
+            "FROM \"MYDB\".\"STAGING\" as stage WHERE NOT (stage.\"DIGEST\" IN (SELECT sink.\"DIGEST\" " +
+            "FROM \"MYDB\".\"MAIN\" as sink WHERE (sink.\"BATCH_ID_OUT\" = 999999999) AND (sink.\"BIZ_DATE\" IN ('2000-01-01 00:00:00','2000-01-02 00:00:00')))))";
 
         Assertions.assertEquals(expectedMainTableCreateQueryWithUpperCase, preActionsSql.get(0));
         Assertions.assertEquals(expectedMetadataTableCreateQueryWithUpperCase, preActionsSql.get(1));

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/logicalplan/operations/CreateTableTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/logicalplan/operations/CreateTableTest.java
@@ -30,6 +30,7 @@ import static org.finos.legend.engine.persistence.components.BaseTestUtils.schem
 
 public class CreateTableTest
 {
+
     @Test
     public void testCreateTable()
     {

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/AppendOnlyMapper.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/AppendOnlyMapper.java
@@ -25,14 +25,13 @@ import static org.finos.legend.engine.testable.persistence.mapper.IngestModeMapp
 
 public class AppendOnlyMapper
 {
-    public static org.finos.legend.engine.persistence.components.ingestmode.AppendOnly from(AppendOnly appendOnly, String[] pkFields)
+    public static org.finos.legend.engine.persistence.components.ingestmode.AppendOnly from(AppendOnly appendOnly)
     {
         DeduplicationStrategy deduplicationStrategy = appendOnly.filterDuplicates ?
                 FilterDuplicates.builder().build() : AllowDuplicates.builder().build();
 
         return org.finos.legend.engine.persistence.components.ingestmode.AppendOnly.builder()
                 .digestField(DIGEST_FIELD_DEFAULT)
-                .addAllKeyFields(Arrays.asList(pkFields))
                 .deduplicationStrategy(deduplicationStrategy)
                 .auditing(appendOnly.auditing.accept(MappingVisitors.MAP_TO_COMPONENT_AUDITING))
                 .build();

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/BitemporalDeltaMapper.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/BitemporalDeltaMapper.java
@@ -22,12 +22,11 @@ import static org.finos.legend.engine.testable.persistence.mapper.IngestModeMapp
 
 public class BitemporalDeltaMapper
 {
-    public static org.finos.legend.engine.persistence.components.ingestmode.BitemporalDelta from(BitemporalDelta bitemporalDelta, String[] pkFields)
+    public static org.finos.legend.engine.persistence.components.ingestmode.BitemporalDelta from(BitemporalDelta bitemporalDelta)
     {
         return org.finos.legend.engine.persistence.components.ingestmode.BitemporalDelta.builder()
                 .digestField(DIGEST_FIELD_DEFAULT)
                 .mergeStrategy(bitemporalDelta.mergeStrategy.accept(MappingVisitors.MAP_TO_COMPONENT_MERGE_STRATEGY))
-                .addAllKeyFields(Arrays.asList(pkFields))
                 .transactionMilestoning(bitemporalDelta.transactionMilestoning.accept(MappingVisitors.MAP_TO_COMPONENT_TRANSACTION_MILESTONING))
                 .validityMilestoning(bitemporalDelta.validityMilestoning.accept(MappingVisitors.MAP_TO_COMPONENT_VALIDITY_MILESTONING))
                 .build();

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/BitemporalSnapshotMapper.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/BitemporalSnapshotMapper.java
@@ -22,11 +22,10 @@ import static org.finos.legend.engine.testable.persistence.mapper.IngestModeMapp
 
 public class BitemporalSnapshotMapper
 {
-    public static org.finos.legend.engine.persistence.components.ingestmode.BitemporalSnapshot from(BitemporalSnapshot bitemporalSnapshot, String[] pkFields)
+    public static org.finos.legend.engine.persistence.components.ingestmode.BitemporalSnapshot from(BitemporalSnapshot bitemporalSnapshot)
     {
         return org.finos.legend.engine.persistence.components.ingestmode.BitemporalSnapshot.builder()
                 .digestField(DIGEST_FIELD_DEFAULT)
-                .addAllKeyFields(Arrays.asList(pkFields))
                 .transactionMilestoning(bitemporalSnapshot.transactionMilestoning.accept(MappingVisitors.MAP_TO_COMPONENT_TRANSACTION_MILESTONING))
                 .validityMilestoning(bitemporalSnapshot.validityMilestoning.accept(MappingVisitors.MAP_TO_COMPONENT_VALIDITY_MILESTONING))
                 .build();

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/NontemporalDeltaMapper.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/NontemporalDeltaMapper.java
@@ -22,11 +22,10 @@ import static org.finos.legend.engine.testable.persistence.mapper.IngestModeMapp
 
 public class NontemporalDeltaMapper
 {
-    public static org.finos.legend.engine.persistence.components.ingestmode.NontemporalDelta from(NontemporalDelta nontemporalDelta, String[] pkFields)
+    public static org.finos.legend.engine.persistence.components.ingestmode.NontemporalDelta from(NontemporalDelta nontemporalDelta)
     {
         return org.finos.legend.engine.persistence.components.ingestmode.NontemporalDelta.builder()
                 .digestField(DIGEST_FIELD_DEFAULT)
-                .addAllKeyFields(Arrays.asList(pkFields))
                 .auditing(nontemporalDelta.auditing.accept(MappingVisitors.MAP_TO_COMPONENT_AUDITING))
                 .mergeStrategy(nontemporalDelta.mergeStrategy.accept(MappingVisitors.MAP_TO_COMPONENT_MERGE_STRATEGY))
                 .build();

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/UnitemporalDeltaMapper.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/UnitemporalDeltaMapper.java
@@ -22,12 +22,11 @@ import static org.finos.legend.engine.testable.persistence.mapper.IngestModeMapp
 
 public class UnitemporalDeltaMapper
 {
-    public static org.finos.legend.engine.persistence.components.ingestmode.UnitemporalDelta from(UnitemporalDelta unitemporalDelta, String[] pkFields)
+    public static org.finos.legend.engine.persistence.components.ingestmode.UnitemporalDelta from(UnitemporalDelta unitemporalDelta)
     {
         return org.finos.legend.engine.persistence.components.ingestmode.UnitemporalDelta.builder()
                 .digestField(DIGEST_FIELD_DEFAULT)
                 .mergeStrategy(unitemporalDelta.mergeStrategy.accept(MappingVisitors.MAP_TO_COMPONENT_MERGE_STRATEGY))
-                .addAllKeyFields(Arrays.asList(pkFields))
                 .transactionMilestoning(unitemporalDelta.transactionMilestoning.accept(MappingVisitors.MAP_TO_COMPONENT_TRANSACTION_MILESTONING))
                 .build();
     }

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/UnitemporalSnapshotMapper.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/mapper/UnitemporalSnapshotMapper.java
@@ -22,11 +22,10 @@ import static org.finos.legend.engine.testable.persistence.mapper.IngestModeMapp
 
 public class UnitemporalSnapshotMapper
 {
-    public static org.finos.legend.engine.persistence.components.ingestmode.UnitemporalSnapshot from(UnitemporalSnapshot unitemporalSnapshot, String[] pkFields)
+    public static org.finos.legend.engine.persistence.components.ingestmode.UnitemporalSnapshot from(UnitemporalSnapshot unitemporalSnapshot)
     {
         return org.finos.legend.engine.persistence.components.ingestmode.UnitemporalSnapshot.builder()
                 .digestField(DIGEST_FIELD_DEFAULT)
-                .addAllKeyFields(Arrays.asList(pkFields))
                 .transactionMilestoning(unitemporalSnapshot.transactionMilestoning.accept(MappingVisitors.MAP_TO_COMPONENT_TRANSACTION_MILESTONING))
                 .build();
     }

--- a/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/mapper/IngestModeMapperTest.java
+++ b/legend-engine-xt-persistence-test-runner/src/test/java/org/finos/legend/engine/testable/persistence/mapper/IngestModeMapperTest.java
@@ -49,13 +49,6 @@ public class IngestModeMapperTest extends MapperBaseTest
     public static Field income = Field.builder().name("income").type(FieldType.of(DataType.BIGINT, Optional.empty(), Optional.empty())).fieldAlias("income").build();
 
     @Test
-    public void testCommonPrimaryKeys()
-    {
-        String[] commonPrimaryKeys = IngestModeMapper.getCommonPrimaryKeys(getMainDataset(), getStagingDataset(), null);
-        Assert.assertEquals("id", commonPrimaryKeys[0]);
-    }
-
-    @Test
     public void testMapperForNonTemporalSnapshot() throws Exception
     {
         IngestMode ingestMode = getNonTemporalSnapshotDateTimeAuditing();
@@ -91,7 +84,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", appendOnly.digestField().get());
         Assert.assertTrue(appendOnly.auditing() instanceof NoAuditing);
         Assert.assertTrue(appendOnly.deduplicationStrategy() instanceof AllowDuplicates);
-        Assert.assertEquals(0, appendOnly.keyFields().size());
 
         ingestMode = getAppendOnlyNoAuditingWithFilteringDuplicates();
         persistence = getPersistence(ingestMode);
@@ -103,8 +95,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", appendOnly.digestField().get());
         Assert.assertTrue(appendOnly.auditing() instanceof NoAuditing);
         Assert.assertTrue(appendOnly.deduplicationStrategy() instanceof FilterDuplicates);
-        Assert.assertEquals("id", appendOnly.keyFields().get(0));
-
 
         ingestMode = getAppendOnlyDatetimeAuditingNoFilteringDuplicates();
         persistence = getPersistence(ingestMode);
@@ -118,7 +108,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         DateTimeAuditing dateTimeAuditing = (DateTimeAuditing) appendOnly.auditing();
         Assert.assertEquals("AUDIT_TIME", dateTimeAuditing.dateTimeField());
         Assert.assertTrue(appendOnly.deduplicationStrategy() instanceof AllowDuplicates);
-        Assert.assertEquals(0, appendOnly.keyFields().size());
 
         ingestMode = getAppendOnlyDatetimeAuditingWithFilteringDuplicates();
         persistence = getPersistence(ingestMode);
@@ -132,7 +121,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         dateTimeAuditing = (DateTimeAuditing) appendOnly.auditing();
         Assert.assertEquals("AUDIT_TIME", dateTimeAuditing.dateTimeField());
         Assert.assertTrue(appendOnly.deduplicationStrategy() instanceof FilterDuplicates);
-        Assert.assertEquals("id", appendOnly.keyFields().get(0));
     }
 
     @Test
@@ -148,7 +136,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", nontemporalDelta.digestField());
         Assert.assertTrue(nontemporalDelta.auditing() instanceof NoAuditing);
         Assert.assertTrue(nontemporalDelta.mergeStrategy() instanceof NoDeletesMergeStrategy);
-        Assert.assertEquals("id", nontemporalDelta.keyFields().get(0));
 
         ingestMode = getNontemporalDeltaNoAuditingDeleteIndMergeStrategy();
         persistence = getPersistence(ingestMode);
@@ -159,7 +146,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", nontemporalDelta.digestField());
         Assert.assertTrue(nontemporalDelta.auditing() instanceof NoAuditing);
         Assert.assertTrue(nontemporalDelta.mergeStrategy() instanceof DeleteIndicatorMergeStrategy);
-        Assert.assertEquals("id", nontemporalDelta.keyFields().get(0));
 
         ingestMode = getNontemporalDeltaWithAuditingNoMergeStrategy();
         persistence = getPersistence(ingestMode);
@@ -170,7 +156,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", nontemporalDelta.digestField());
         Assert.assertTrue(nontemporalDelta.auditing() instanceof DateTimeAuditing);
         Assert.assertTrue(nontemporalDelta.mergeStrategy() instanceof NoDeletesMergeStrategy);
-        Assert.assertEquals("id", nontemporalDelta.keyFields().get(0));
 
         ingestMode = getNontemporalDeltaWithAuditingDeleteIndMergeStrategy();
         persistence = getPersistence(ingestMode);
@@ -181,7 +166,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", nontemporalDelta.digestField());
         Assert.assertTrue(nontemporalDelta.auditing() instanceof DateTimeAuditing);
         Assert.assertTrue(nontemporalDelta.mergeStrategy() instanceof DeleteIndicatorMergeStrategy);
-        Assert.assertEquals("id", nontemporalDelta.keyFields().get(0));
     }
 
     @Test
@@ -198,7 +182,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertTrue(unitemporalDelta.mergeStrategy() instanceof NoDeletesMergeStrategy);
         Assert.assertTrue(unitemporalDelta.transactionMilestoning() instanceof BatchId);
         Assert.assertFalse(unitemporalDelta.dataSplitField().isPresent());
-        Assert.assertEquals("id", unitemporalDelta.keyFields().get(0));
 
         ingestMode = getUnitempDeltaNoMergeBatchIdAndTimeBased();
         persistence = getPersistence(ingestMode);
@@ -210,7 +193,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertTrue(unitemporalDelta.mergeStrategy() instanceof NoDeletesMergeStrategy);
         Assert.assertTrue(unitemporalDelta.transactionMilestoning() instanceof BatchIdAndDateTime);
         Assert.assertFalse(unitemporalDelta.dataSplitField().isPresent());
-        Assert.assertEquals("id", unitemporalDelta.keyFields().get(0));
 
         ingestMode = getUnitempDeltaNoMergeTimeBased();
         persistence = getPersistence(ingestMode);
@@ -222,7 +204,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertTrue(unitemporalDelta.mergeStrategy() instanceof NoDeletesMergeStrategy);
         Assert.assertTrue(unitemporalDelta.transactionMilestoning() instanceof TransactionDateTime);
         Assert.assertFalse(unitemporalDelta.dataSplitField().isPresent());
-        Assert.assertEquals("id", unitemporalDelta.keyFields().get(0));
 
         ingestMode = getUnitempDeltaDelIndMergeBatchIdBased();
         persistence = getPersistence(ingestMode);
@@ -234,7 +215,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertTrue(unitemporalDelta.mergeStrategy() instanceof DeleteIndicatorMergeStrategy);
         Assert.assertTrue(unitemporalDelta.transactionMilestoning() instanceof BatchId);
         Assert.assertFalse(unitemporalDelta.dataSplitField().isPresent());
-        Assert.assertEquals("id", unitemporalDelta.keyFields().get(0));
 
         ingestMode = getUnitempDeltaDelIndMergeBatchIdAndTimeBased();
         persistence = getPersistence(ingestMode);
@@ -246,7 +226,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertTrue(unitemporalDelta.mergeStrategy() instanceof DeleteIndicatorMergeStrategy);
         Assert.assertTrue(unitemporalDelta.transactionMilestoning() instanceof BatchIdAndDateTime);
         Assert.assertFalse(unitemporalDelta.dataSplitField().isPresent());
-        Assert.assertEquals("id", unitemporalDelta.keyFields().get(0));
 
         ingestMode = getUnitempDeltaDelIndMergeTimeBased();
         persistence = getPersistence(ingestMode);
@@ -258,7 +237,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertTrue(unitemporalDelta.mergeStrategy() instanceof DeleteIndicatorMergeStrategy);
         Assert.assertTrue(unitemporalDelta.transactionMilestoning() instanceof TransactionDateTime);
         Assert.assertFalse(unitemporalDelta.dataSplitField().isPresent());
-        Assert.assertEquals("id", unitemporalDelta.keyFields().get(0));
     }
 
     @Test
@@ -274,7 +252,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", unitemporalSnapshot.digestField());
         Assert.assertFalse(unitemporalSnapshot.partitioned());
         Assert.assertTrue(unitemporalSnapshot.transactionMilestoning() instanceof BatchId);
-        Assert.assertEquals("id", unitemporalSnapshot.keyFields().get(0));
 
         ingestMode = getUnitemporalSnapshotBatchIdAndTimeBased();
         persistence = getPersistence(ingestMode);
@@ -285,7 +262,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", unitemporalSnapshot.digestField());
         Assert.assertFalse(unitemporalSnapshot.partitioned());
         Assert.assertTrue(unitemporalSnapshot.transactionMilestoning() instanceof BatchIdAndDateTime);
-        Assert.assertEquals("id", unitemporalSnapshot.keyFields().get(0));
 
         ingestMode = getUnitemporalSnapshotTimeBased();
         persistence = getPersistence(ingestMode);
@@ -296,7 +272,6 @@ public class IngestModeMapperTest extends MapperBaseTest
         Assert.assertEquals("DIGEST", unitemporalSnapshot.digestField());
         Assert.assertFalse(unitemporalSnapshot.partitioned());
         Assert.assertTrue(unitemporalSnapshot.transactionMilestoning() instanceof TransactionDateTime);
-        Assert.assertEquals("id", unitemporalSnapshot.keyFields().get(0));
     }
 
     private Persistence getPersistence(IngestMode ingestMode)


### PR DESCRIPTION
#### What type of PR is this?
Feature.

#### What does this PR do / why is it needed ?
We are introducing a common library to handle batch ingestion logic with an initial focus on batch milestoning into relational databases. This library consolidates the implementation across multiple backend persistence implementations. It also provides an in-memory implementation that will be of use for fast testing.
This PR is for porting the remaining Changes from Write component Library into Persistence component

#### Which issue(s) this PR fixes:

Fixes #
None. But this is the first of a series of PRs addressing https://github.com/finos/legend-engine/issues/920

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
