### PR TITLE
Upgrade legend-pure version to 3.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>3.6.1</legend.pure.version>
+        <legend.pure.version>3.6.2</legend.pure.version>
         <legend.shared.version>0.22.0</legend.shared.version>
 
         <!-- SONAR -->


### PR DESCRIPTION
#### What type of PR is this?

dependencies

#### What does this PR do / why is it needed ?

Upgrade legend-pure version to 3.6.2. This makes indexing of Pure repositories thread local so that builds can be safely parallelized.

#### Other notes for reviewers:

This is necessary for parallelizing the legend-engine build.

#### Does this PR introduce a user-facing change?
No