### PR TITLE
Upgrade legend-pure version to 3.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>3.6.2</legend.pure.version>
+        <legend.pure.version>3.7.0</legend.pure.version>
         <legend.shared.version>0.22.0</legend.shared.version>
 
         <!-- SONAR -->


### PR DESCRIPTION
#### What type of PR is this?

dependencies

#### What does this PR do / why is it needed ?

Upgrades legend-pure version to 3.7.0. This introduces an improvement in the compiler to reduce unnecessary re-processing during type inference. In some cases, such as chained filter expressions, this can speed up compilation by many orders of magnitude.

#### Does this PR introduce a user-facing change?

Functionally, no, but this introduces an improvement to the Pure compiler, which may improve Pure compilation time for some users. In some cases, the improvement may be substantial and quite noticeable.