### PR TITLE
fix issue with printing of database  names in join chains

### DIFF
--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -881,6 +881,12 @@ public class RelationalParseTreeWalker
         String database = ctx.databasePointer() != null ? this.visitDatabasePointer(ctx.databasePointer()) : (scopeInfo != null ? scopeInfo.database : null);
         ElementWithJoins operation = new ElementWithJoins();
         operation.sourceInformation = this.walkerSourceInformation.getSourceInformation(ctx);
+        operation.joins = this.visitJoinSequence(ctx.joinSequence(), database, scopeInfo);
+        if (!operation.joins.isEmpty())
+        {
+            String lastDB = operation.joins.get(operation.joins.size() - 1).db;
+            database = lastDB != null ? lastDB : database;
+        }
         if (ctx.booleanOperation() != null)
         {
             operation.relationalElement = this.visitBooleanOperation(ctx.booleanOperation(), ScopeInfo.Builder.newInstance(scopeInfo).withDatabase(database).build());
@@ -889,7 +895,6 @@ public class RelationalParseTreeWalker
         {
             operation.relationalElement = this.visitTableAliasColumnOperation(ctx.tableAliasColumnOperation(), database, scopeInfo);
         }
-        operation.joins = this.visitJoinSequence(ctx.joinSequence(), database, scopeInfo);
         return operation;
     }
 

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -1414,4 +1414,65 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
         // classMappingId
         Assert.assertEquals(rootRelationalInstanceSetImplementation._id(), "simple_Item");
     }
+
+    @Test
+    public void testNestedJoinFromIncludedDatabase()
+
+    {
+        test("###Relational\n" +
+                "Database example::database\n" +
+                "(\n" +
+                "  include example::databaseInc\n" +
+                "\n" +
+                "  Schema exampleRoot\n" +
+                "  (\n" +
+                "    Table TableC\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "\n" +
+                "    View dbView\n" +
+                "    (\n" +
+                "      nameL :exampleSub.TableASub.name,\n" +
+                "      rootTable: [example::databaseInc]@AtoB > [example::database] @BtoC |exampleRoot.TableC.name\n" +
+                "    )\n" +
+                "    View dbViewIncTable\n" +
+                "    (\n" +
+                "      nameL :exampleRoot.TableC.name,\n" +
+                "      incTable: [example::database]@BtoC > [example::databaseInc]@AtoB |exampleSub.TableASub.name\n" +
+                "    )\n" +
+                "  )\n" +
+                "\n" +
+                "  Join BtoC([example::databaseInc]exampleSub.TableBSub.id = exampleRoot.TableC.id)\n" +
+                ")\n" +
+                "\n" +
+                "Database example::databaseInc\n" +
+                "(\n" +
+                "  Schema exampleSub\n" +
+                "  (\n" +
+                "    Table TableASub\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "    Table TableBSub\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "\n" +
+                "  )\n" +
+                "\n" +
+                "  Join AtoB(exampleSub.TableASub.id = exampleSub.TableBSub.id)\n" +
+                ")\n");
+
+    }
+
+
+
+
+
+
+
 }

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
@@ -125,4 +125,58 @@ public class TestRelationalMappingGrammarRoundtrip extends TestGrammarRoundtrip.
                 "  }\n" +
                 ")\n");
     }
+
+
+    @Test
+    public void testNestedJoinFromIncludedDatabase()
+
+    {
+        test("###Relational\n" +
+                "Database example::database\n" +
+                "(\n" +
+                "  include example::databaseInc\n" +
+                "\n" +
+                "  Schema exampleRoot\n" +
+                "  (\n" +
+                "    Table TableC\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "\n" +
+                "    View dbView\n" +
+                "    (\n" +
+                "      nameL: exampleSub.TableASub.name,\n" +
+                "      rootTable: [example::databaseInc]@AtoB > [example::database]@BtoC | exampleRoot.TableC.name\n" +
+                "    )\n" +
+                "    View dbViewIncTable\n" +
+                "    (\n" +
+                "      nameL: exampleRoot.TableC.name,\n" +
+                "      incTable: [example::database]@BtoC > [example::database]@AtoB | [example::databaseInc]exampleSub.TableASub.name\n" +
+                "    )\n" +
+                "  )\n" +
+                "\n" +
+                "  Join BtoC([example::databaseInc]exampleSub.TableBSub.id = exampleRoot.TableC.id)\n" +
+                ")\n" +
+                "\n" +
+                "Database example::databaseInc\n" +
+                "(\n" +
+                "  Schema exampleSub\n" +
+                "  (\n" +
+                "    Table TableASub\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "    Table TableBSub\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "  )\n" +
+                "\n" +
+                "  Join AtoB(exampleSub.TableASub.id = exampleSub.TableBSub.id)\n" +
+                ")\n");
+
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

This fixes a compiler issue that led to an incorrect database name in the returned grammar after round trip


#### Does this PR introduce a user-facing change?
Yes , it will change grammar printing of join chains to be more specific in  certain scenarios 
