### PR TITLE
Streaming GCP build logs

### DIFF
--- a/.gcp/cloud-build/cloudbuild.yaml
+++ b/.gcp/cloud-build/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: 'maven:3.8-openjdk-11'
     args: ['bash', './.gcp/cloud-build/build.sh']
-timeout: 14400s
+timeout: 7200s
 logsBucket: 'gs://finos-legend-engine-logs'
 options:
   logging: GCS_ONLY

--- a/.github/workflows/trigger-gcp-build.yml
+++ b/.github/workflows/trigger-gcp-build.yml
@@ -47,9 +47,19 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Get last build ID
-        run: echo "GCP_BUILD_ID=$(gcloud builds list --sort-by CREATE_TIME --limit 1 --format='value(id)')" >> $GITHUB_ENV
+        run: echo "GCP_BUILD_ID=$(gcloud builds list --filter substitutions.TRIGGER_NAME='legend-engine-build-webhook' --sort-by create_time --limit 1 --format='value(id)')" >> $GITHUB_ENV
 
-      - name: Build logs
+      - name: Stream build logs
+        run: gcloud builds log --stream '${{ env.GCP_BUILD_ID }}'
+
+      - name: Report GCP build status
         run: |
-          echo "Build logs for the triggered job are available here: https://storage.googleapis.com/finos-legend-engine-logs/log-${{ env.GCP_BUILD_ID }}.txt"
-          echo "All GCP build log are available here: https://console.cloud.google.com/storage/browser/finos-legend-engine-logs"
+          buildStatus=$(gcloud builds list --filter id='${{ env.GCP_BUILD_ID }}' --format='value(status)')
+          
+          echo "Logs streaming ended with the build having a status of '${buildStatus}'"
+          echo "Check the full build logs at: https://storage.googleapis.com/finos-legend-engine-logs/log-${{ env.GCP_BUILD_ID }}.txt"
+          echo "All GCP build logs are available here: https://console.cloud.google.com/storage/browser/finos-legend-engine-logs"
+          
+          if [ $buildStatus != "SUCCESS" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
#### What type of PR is this?

This change improves the GCP build trigger.

#### What does this PR do / why is it needed ?

The GitHub action that triggers a GCP build will now stream the build's logs. This has the desired side effect that now the GitHub action will last as long as the GCP build and give an indicator on whether the GCP build succeeded or failed.

