### PR TITLE
Apply fix for false realizeInMemory calls during plan execution (edited)

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/ExecutionNodeExecutor.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/ExecutionNodeExecutor.java
@@ -196,12 +196,7 @@ public class ExecutionNodeExecutor implements ExecutionNodeVisitor<Result>
     public Result visit(AllocationExecutionNode allocationExecutionNode)
     {
         String varName = allocationExecutionNode.varName;
-        Result result = allocationExecutionNode.executionNodes().getFirst().accept(new ExecutionNodeExecutor(this.profiles, new ExecutionState(this.executionState).varName(varName)));
-//        if (!(r instanceof ConstantResult) && !(r instanceof RelationalResult) && !(r instanceof StreamingObjectResult))
-//        {
-//            r.close();
-//            throw new RuntimeException("Not supported yet! " + r.getClass().getName());
-//        }
+        Result result = allocationExecutionNode.executionNodes().getFirst().accept(new ExecutionNodeExecutor(this.profiles, new ExecutionState(this.executionState).varName(varName).setRealizeInMemory(allocationExecutionNode.realizeInMemory)));
         if (result instanceof ConstantResult && ((ConstantResult) result).getValue() instanceof Map && ((Map<?, ?>) ((ConstantResult) result).getValue()).get("values") != null)
         {
             result = new ConstantResult(((List<?>) ((Map<?, ?>) ((ConstantResult) result).getValue()).get("values")).get(0));

--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/state/ExecutionState.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/state/ExecutionState.java
@@ -45,7 +45,7 @@ public class ExecutionState
     public boolean inLake;
     public String allocationNodeName;
     public String authId;
-    public boolean transformAllocation;
+    public boolean realizeInMemory;
     public Span topSpan;
     public boolean realizeAllocationResults;
 
@@ -71,7 +71,7 @@ public class ExecutionState
         this.allocationNodeName = state.allocationNodeName;
         this.templateFunctions = state.templateFunctions;
         this.authId = state.authId;
-        this.transformAllocation = state.transformAllocation;
+        this.realizeInMemory = state.realizeInMemory;
         this.topSpan = state.topSpan;
         this.activities = state.activities;
         this.realizeAllocationResults = state.realizeAllocationResults;
@@ -114,7 +114,7 @@ public class ExecutionState
     public ExecutionState inLake(boolean inLake)
     {
         this.inLake = inLake;
-        this.transformAllocation = true;
+        this.realizeInMemory = true;
         return this;
     }
 
@@ -130,10 +130,10 @@ public class ExecutionState
         return setAuthUser(user, true);
     }
 
-    public ExecutionState setAuthUser(String user, boolean setTransformAllocation)
+    public ExecutionState setAuthUser(String user, boolean setRealizeInMemory)
     {
         this.authId = user;
-        this.transformAllocation = setTransformAllocation;
+        this.realizeInMemory = setRealizeInMemory;
         return this;
     }
 
@@ -187,6 +187,15 @@ public class ExecutionState
     public ExecutionState setGraphFetchCaches(List<GraphFetchCache> graphFetchCaches)
     {
         this.graphFetchCaches = graphFetchCaches;
+        return this;
+    }
+
+    public ExecutionState setRealizeInMemory(boolean realizeInMemory)
+    {
+        if (!this.realizeInMemory)
+        {
+            this.realizeInMemory = realizeInMemory;
+        }
         return this;
     }
 

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/AllocationExecutionNode.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/AllocationExecutionNode.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes;
 public class AllocationExecutionNode extends ExecutionNode
 {
     public String varName;
+    public boolean realizeInMemory;
 
     @Override
     public <T> T accept(ExecutionNodeVisitor<T> executionNodeVisitor)

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/ExecutionNode.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/ExecutionNode.java
@@ -64,6 +64,7 @@ public abstract class ExecutionNode
     public Multiplicity resultSizeRange;
     public List<VariableInput> requiredVariableInputs;
     public PlatformImplementation implementation;
+    public boolean authDependent;
 
     public abstract <T> T accept(ExecutionNodeVisitor<T> executionNodeVisitor);
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan.pure
@@ -65,6 +65,7 @@ Class meta::pure::executionPlan::ExecutionPlan
    runtime : Runtime[1];
    rootExecutionNode : ExecutionNode[1];
    processingTemplateFunctions :String[*];
+   <<doc.deprecated>>
    authDependent: Boolean[1];
    kerberos: String [0..1];
    globalImplementationSupport: PlatformImplementation[0..1];
@@ -160,6 +161,7 @@ Class meta::pure::executionPlan::CompiledClass
 Class meta::pure::executionPlan::AllocationExecutionNode extends meta::pure::executionPlan::ExecutionNode
 {
    varName : String[1];
+   realizeInMemory : Boolean[0..1];
 }
 
 Class meta::pure::executionPlan::ConstantExecutionNode extends meta::pure::executionPlan::ExecutionNode

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/executionPlan.pure
@@ -21,7 +21,6 @@ Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::ExecutionPlan
    serializer : Protocol[1];
    templateFunctions : String[*];
    rootExecutionNode : ExecutionNode[1];
-   authDependent: Boolean[1];
    kerberos: String [0..1];
    globalImplementationSupport : meta::protocols::pure::vX_X_X::metamodel::executionPlan::PlatformImplementation[0..1];
 }
@@ -35,6 +34,7 @@ Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::ExecutionNode
    isChildrenExecutionParallelizable: Boolean[0..1];
    executionNodes : ExecutionNode[*];
    implementation : meta::protocols::pure::vX_X_X::metamodel::executionPlan::PlatformImplementation[0..1];
+   authDependent: Boolean[0..1];
 }
 
 Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::VariableInput
@@ -47,6 +47,7 @@ Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::VariableInput
 Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::AllocationExecutionNode extends ExecutionNode
 {
    varName : String[1];
+   realizeInMemory : Boolean[0..1];
 }
 
 Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::PureExpressionPlatformExecutionNode extends ExecutionNode

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/executionPlan.pure
@@ -25,7 +25,6 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::execution
    (
       serializer = ^Protocol(name='pure', version='vX_X_X'),
       templateFunctions = $sourcePlan.processingTemplateFunctions,
-      authDependent = $sourcePlan.authDependent,
       kerberos = $sourcePlan.kerberos,
       rootExecutionNode = $sourcePlan.rootExecutionNode->transformNode($sourcePlan.mapping, $extensions),
       globalImplementationSupport = $sourcePlan.globalImplementationSupport->map(impl | $impl->transformPlatformGlobalImplementation())
@@ -94,7 +93,8 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::execution
                _type = 'allocation',
                resultType = $alloc.resultType->transformResultType($mapping, $extensions),
                resultSizeRange = $alloc.resultSizeRange->isEmpty()->if(|[],|$alloc.resultSizeRange->toOne()->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::domain::transformMultiplicity()),
-               varName = $alloc.varName
+               varName = $alloc.varName,
+               realizeInMemory = $alloc.realizeInMemory
             ),
          exp:meta::pure::executionPlan::FunctionParametersValidationNode[1]|
            ^meta::protocols::pure::vX_X_X::metamodel::executionPlan::FunctionParametersValidationNode(
@@ -212,7 +212,8 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::execution
    ^$n(
       requiredVariableInputs = $node.requiredVariableInputs->map(s | $s->transformSource()),
       executionNodes  = $node.executionNodes->map(s|$s->transformNode($mapping, $extensions)),
-      implementation  = $node.implementation->map(impl | $impl->transformPlatformNodeImplementation())
+      implementation  = $node.implementation->map(impl | $impl->transformPlatformNodeImplementation()),
+      authDependent = $node.authDependent
    );
 }
 

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/RelationalExecutor.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/RelationalExecutor.java
@@ -139,7 +139,7 @@ public class RelationalExecutor
 
         if (executionState.inAllocation)
         {
-            if ((ExecutionNodeTDSResultHelper.isResultTDS(node) || (ExecutionNodeResultHelper.isResultSizeRangeSet(node) && !ExecutionNodeResultHelper.isSingleRecordResult(node))) && !executionState.transformAllocation)
+            if ((ExecutionNodeTDSResultHelper.isResultTDS(node) || (ExecutionNodeResultHelper.isResultSizeRangeSet(node) && !ExecutionNodeResultHelper.isSingleRecordResult(node))) && !executionState.realizeInMemory)
             {
                 return new RelationalResult(executionState.activities, node, node.resultColumns, databaseTypeName, databaseTimeZone, connectionManagerConnection, profiles, tempTableList, executionState.topSpan);
             }

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -302,7 +302,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
 
                 if (this.executionState.inAllocation)
                 {
-                    if (!this.executionState.transformAllocation)
+                    if (!this.executionState.realizeInMemory)
                     {
                         return relationalTdsResult;
                     }
@@ -396,7 +396,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
 
                 if (this.executionState.inAllocation)
                 {
-                    if ((ExecutionNodeResultHelper.isResultSizeRangeSet(node) && !ExecutionNodeResultHelper.isSingleRecordResult(node)) && !this.executionState.transformAllocation)
+                    if ((ExecutionNodeResultHelper.isResultSizeRangeSet(node) && !ExecutionNodeResultHelper.isSingleRecordResult(node)) && !this.executionState.realizeInMemory)
                     {
                         return relationalPrimitiveResult;
                     }

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
@@ -52,14 +52,15 @@ public class RealizedRelationalResult extends StreamingResult
         this.transformedRows = Lists.mutable.empty();
         this.resultSetRows = Lists.mutable.empty();
         ResultSet resultSet = relationalResult.resultSet;
+        int SUPPORTED_RESULT_ROWS = getRowLimit();
         int rowCount = 0;
         try
         {
             while (resultSet.next())
             {
-                if (rowCount > getRowLimit())
+                if (rowCount > SUPPORTED_RESULT_ROWS )
                 {
-                    throw new RuntimeException("Too many rows returned. Realization of relational results currently supports results with up to " + getRowLimit() + " rows.");
+                    throw new RuntimeException("Too many rows returned. Realization of relational results currently supports results with up to " + SUPPORTED_RESULT_ROWS + " rows.");
                 }
 
                 List<Object> transformedRow = Lists.mutable.empty();

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
@@ -40,7 +40,7 @@ public class RealizedRelationalResult extends StreamingResult
     public List<List<Object>> transformedRows;
 
     private static final int DEFAULT_ROW_LIMIT = 1000;
-    private static final String ROW_LIMIT_PROPERTY_NAME = "DEFAULT_ROW_LIMIT";
+    public static final String ROW_LIMIT_PROPERTY_NAME = "org.finos.legend.engine.realizedRelationalResultRowLimit";
 
     public RealizedRelationalResult(RelationalResult relationalResult) throws SQLException
     {
@@ -85,11 +85,7 @@ public class RealizedRelationalResult extends StreamingResult
 
     public int getRowLimit()
     {
-        if (System.getProperty(ROW_LIMIT_PROPERTY_NAME) == null)
-        {
-            return DEFAULT_ROW_LIMIT;
-        }
-        return Integer.valueOf(System.getProperty(ROW_LIMIT_PROPERTY_NAME));
+        return Integer.getInteger(ROW_LIMIT_PROPERTY_NAME, DEFAULT_ROW_LIMIT);
     }
 
     private RealizedRelationalResult()

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
@@ -40,6 +40,7 @@ public class RealizedRelationalResult extends StreamingResult
     public List<List<Object>> transformedRows;
 
     private static final int DEFAULT_ROW_LIMIT = 1000;
+    private static final String ROW_LIMIT_PROPERTY_NAME = "DEFAULT_ROW_LIMIT";
 
     public RealizedRelationalResult(RelationalResult relationalResult) throws SQLException
     {
@@ -56,9 +57,9 @@ public class RealizedRelationalResult extends StreamingResult
         {
             while (resultSet.next())
             {
-                if (rowCount > 1000)
+                if (rowCount > getRowLimit())
                 {
-                    throw new RuntimeException("Too many rows returned. Realization of relational results currently supports results with up to " + DEFAULT_ROW_LIMIT + " rows.");
+                    throw new RuntimeException("Too many rows returned. Realization of relational results currently supports results with up to " + getRowLimit() + " rows.");
                 }
 
                 List<Object> transformedRow = Lists.mutable.empty();
@@ -80,6 +81,15 @@ public class RealizedRelationalResult extends StreamingResult
         {
             relationalResult.close();
         }
+    }
+
+    public int getRowLimit()
+    {
+        if (System.getProperty(ROW_LIMIT_PROPERTY_NAME) == null)
+        {
+            return DEFAULT_ROW_LIMIT;
+        }
+        return Integer.valueOf(System.getProperty(ROW_LIMIT_PROPERTY_NAME));
     }
 
     private RealizedRelationalResult()

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RealizedRelationalResult.java
@@ -58,7 +58,7 @@ public class RealizedRelationalResult extends StreamingResult
         {
             while (resultSet.next())
             {
-                if (rowCount > SUPPORTED_RESULT_ROWS )
+                if (rowCount > SUPPORTED_RESULT_ROWS)
                 {
                     throw new RuntimeException("Too many rows returned. Realization of relational results currently supports results with up to " + SUPPORTED_RESULT_ROWS + " rows.");
                 }

--- a/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/AlloyTestServer.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/AlloyTestServer.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.plan.execution.stores.relational.connection;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.collections.impl.factory.Maps;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperValueSpecificationBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -151,6 +152,11 @@ public abstract class AlloyTestServer
         return executePlan(singleExecutionPlan, Collections.emptyMap());
     }
 
+    protected String executePlan(SingleExecutionPlan plan,String user)
+    {
+        RelationalResult result = (RelationalResult) planExecutor.execute((SingleExecutionPlan) plan, Maps.mutable.empty(), user, null);
+        return result.flush(new RelationalResultToJsonDefaultSerializer(result));
+    }
 
     protected String executePlan(SingleExecutionPlan plan, Map<String, ?> params)
     {

--- a/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinRealizedResults.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinRealizedResults.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.plan.execution.stores.relational.test.full.tdsJo
 
 import org.apache.commons.io.IOUtils;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.AlloyTestServer;
+import org.finos.legend.engine.plan.execution.stores.relational.result.RealizedRelationalResult;
 import org.finos.legend.engine.plan.execution.stores.relational.test.full.functions.in.TestPlanExecutionForIn;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.junit.Assert;
@@ -85,7 +86,7 @@ public class TestTDSJoinRealizedResults extends AlloyTestServer
         {
             InputStream executionPlanJson = TestPlanExecutionForIn.class.getClassLoader().getResourceAsStream("org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinExpectedFail.json");
             String executionPlanJsonString = IOUtils.toString(executionPlanJson);
-            System.setProperty("DEFAULT_ROW_LIMIT", "2");
+            System.setProperty(RealizedRelationalResult.ROW_LIMIT_PROPERTY_NAME, "3");
             SingleExecutionPlan plan = objectMapper.readValue(executionPlanJsonString, SingleExecutionPlan.class);
 
             String expectedResult = "{\"builder\": {\"_type\":\"tdsBuilder\",\"columns\":[{\"name\":\"firstName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"},{\"name\":\"eID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"managerID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"fID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"legalName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"}]}, \"activities\": [{\"_type\":\"relational\",\"sql\":\"select \\\"root\\\".FIRSTNAME as \\\"firstName\\\", \\\"firmtable_0\\\".ID as \\\"eID\\\", case when \\\"root\\\".MANAGERID = 0 then 0 else \\\"root\\\".MANAGERID end as \\\"managerID\\\" from personTable as \\\"root\\\" left outer join firmTable as \\\"firmtable_0\\\" on (\\\"firmtable_0\\\".ID = \\\"root\\\".FIRMID)\"},{\"_type\":\"relational\",\"sql\":\"select \\\"tdsvar0_0_0\\\".firstName as \\\"firstName\\\", \\\"tdsvar0_0_0\\\".eID as \\\"eID\\\", \\\"tdsvar0_0_0\\\".managerID as \\\"managerID\\\", \\\"tdsvar0_0_0\\\".\\\"fID\\\" as \\\"fID\\\", \\\"tdsvar0_0_0\\\".\\\"legalName\\\" as \\\"legalName\\\" from (select * from tdsVar0_0 as \\\"tdsvar0_0_1\\\" inner join (select \\\"root\\\".ID as \\\"fID\\\", \\\"root\\\".LEGALNAME as \\\"legalName\\\" from firmTable as \\\"root\\\") as \\\"firmtable_0\\\" on (\\\"tdsvar0_0_1\\\".eID = \\\"firmtable_0\\\".\\\"fID\\\")) as \\\"tdsvar0_0_0\\\"\"}], \"result\" : {\"columns\" : [\"firstName\",\"eID\",\"managerID\",\"fID\",\"legalName\"], \"rows\" : [{\"values\": [\"Peter\",1,2,1,\"Firm X\"]},{\"values\": [\"John\",1,4,1,\"Firm X\"]},{\"values\": [\"John\",1,2,1,\"Firm X\"]},{\"values\": [\"Anthony\",1,null,1,\"Firm X\"]},{\"values\": [\"Fabrice\",2,null,2,\"Firm A\"]},{\"values\": [\"Oliver\",3,null,3,\"Firm B\"]},{\"values\": [\"David\",4,null,4,\"Firm C\"]}]}}";

--- a/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinRealizedResults.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinRealizedResults.java
@@ -1,0 +1,103 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.test.full.tdsJoin;
+
+import org.apache.commons.io.IOUtils;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.AlloyTestServer;
+import org.finos.legend.engine.plan.execution.stores.relational.test.full.functions.in.TestPlanExecutionForIn;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class TestTDSJoinRealizedResults extends AlloyTestServer
+{
+    @Override
+    protected void insertTestData(Statement statement) throws SQLException
+    {
+        statement.execute("Drop table if exists PERSON;");
+        statement.execute("Create Table PERSON(fullName VARCHAR(100) NOT NULL,firmName VARCHAR(100) NULL,addressName VARCHAR(100) NULL,birthTime TIMESTAMP NULL, PRIMARY KEY(fullName));");
+        statement.execute("insert into PERSON (fullName,firmName,addressName,birthTime) values ('P1','F1','A1','2020-12-12 20:00:00');");
+        statement.execute("insert into PERSON (fullName,firmName,addressName,birthTime) values ('P2','F2','A2','2020-12-13 20:00:00');");
+        statement.execute("insert into PERSON (fullName,firmName,addressName,birthTime) values ('P3',null,null,'2020-12-14 20:00:00');");
+        statement.execute("insert into PERSON (fullName,firmName,addressName,birthTime) values ('P4',null,'A3','2020-12-15 20:00:00');");
+        statement.execute("insert into PERSON (fullName,firmName,addressName,birthTime) values ('P5','F1','A1','2020-12-16 20:00:00');");
+        statement.execute("insert into PERSON (fullName,firmName,addressName,birthTime) values ('P10','F1','A1','2020-12-17 20:00:00');");
+
+        statement.execute("Drop table if exists PersonTable;");
+        statement.execute("Create Table PersonTable(id INT, firstName VARCHAR(200), lastName VARCHAR(200), age INT, addressId INT, firmId INT, managerId INT);");
+        statement.execute("insert into PersonTable (id, firstName, lastName, age, addressId, firmId, managerId) values (1, \'Peter\', \'Smith\',23, 1,1,2);");
+        statement.execute("insert into PersonTable (id, firstName, lastName, age, addressId, firmId, managerId) values (2, \'John\', \'Johnson\',22, 2,1,4);");
+        statement.execute("insert into PersonTable (id, firstName, lastName, age, addressId, firmId, managerId) values (3, \'John\', \'Hill\',12, 3,1,2);");
+        statement.execute("insert into PersonTable (id, firstName, lastName, age, addressId, firmId, managerId) values (4, \'Anthony\', \'Allen\',22, 4,1,null);");
+        statement.execute("insert into PersonTable (id, firstName, lastName, age, addressId, firmId, managerId) values (5, \'Fabrice\', \'Roberts\',34, 5,2,null);");
+        statement.execute("insert into PersonTable (id, firstName, lastName, age, addressId, firmId, managerId) values (6, \'Oliver\', \'Hill\',32, 6,3,null);");
+        statement.execute("insert into PersonTable (id, firstName, lastName, age, addressId, firmId, managerId) values (7, \'David\', \'Harris\',35, 7,4,null);");
+
+        statement.execute("Drop table if exists FirmTable");
+        statement.execute("Create Table FirmTable(id INT, legalName VARCHAR(200), addressId INT, ceoId INT);");
+        statement.execute("insert into FirmTable (id, legalName, addressId, ceoId) values (1, \'Firm X\', 8, 1);");
+        statement.execute("insert into FirmTable (id, legalName, addressId, ceoId) values (2, \'Firm A\', 9, 5);");
+        statement.execute("insert into FirmTable (id, legalName, addressId, ceoId) values (3, \'Firm B\', 10, 3);");
+        statement.execute("insert into FirmTable (id, legalName, addressId, ceoId) values (4, \'Firm C\', 11, 7);");
+
+    }
+
+    @Test
+    public void TDSJoin()
+    {
+        try
+        {
+            InputStream executionPlanJson = TestPlanExecutionForIn.class.getClassLoader().getResourceAsStream("org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoin.json");
+            String executionPlanJsonString = IOUtils.toString(executionPlanJson);
+            SingleExecutionPlan plan = objectMapper.readValue(executionPlanJsonString, SingleExecutionPlan.class);
+
+            String expectedResult = "{\"builder\": {\"_type\":\"tdsBuilder\",\"columns\":[{\"name\":\"firstName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"},{\"name\":\"eID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"managerID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"fID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"legalName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"}]}, \"activities\": [{\"_type\":\"relational\",\"sql\":\"select \\\"root\\\".FIRSTNAME as \\\"firstName\\\", \\\"firmtable_0\\\".ID as \\\"eID\\\", case when \\\"root\\\".MANAGERID = 0 then 0 else \\\"root\\\".MANAGERID end as \\\"managerID\\\" from personTable as \\\"root\\\" left outer join firmTable as \\\"firmtable_0\\\" on (\\\"firmtable_0\\\".ID = \\\"root\\\".FIRMID)\"},{\"_type\":\"relational\",\"sql\":\"select \\\"tdsvar0_0_0\\\".firstName as \\\"firstName\\\", \\\"tdsvar0_0_0\\\".eID as \\\"eID\\\", \\\"tdsvar0_0_0\\\".managerID as \\\"managerID\\\", \\\"tdsvar0_0_0\\\".\\\"fID\\\" as \\\"fID\\\", \\\"tdsvar0_0_0\\\".\\\"legalName\\\" as \\\"legalName\\\" from (select * from tdsVar0_0 as \\\"tdsvar0_0_1\\\" inner join (select \\\"root\\\".ID as \\\"fID\\\", \\\"root\\\".LEGALNAME as \\\"legalName\\\" from firmTable as \\\"root\\\") as \\\"firmtable_0\\\" on (\\\"tdsvar0_0_1\\\".eID = \\\"firmtable_0\\\".\\\"fID\\\")) as \\\"tdsvar0_0_0\\\"\"}], \"result\" : {\"columns\" : [\"firstName\",\"eID\",\"managerID\",\"fID\",\"legalName\"], \"rows\" : [{\"values\": [\"Peter\",1,2,1,\"Firm X\"]},{\"values\": [\"John\",1,4,1,\"Firm X\"]},{\"values\": [\"John\",1,2,1,\"Firm X\"]},{\"values\": [\"Anthony\",1,null,1,\"Firm X\"]},{\"values\": [\"Fabrice\",2,null,2,\"Firm A\"]},{\"values\": [\"Oliver\",3,null,3,\"Firm B\"]},{\"values\": [\"David\",4,null,4,\"Firm C\"]}]}}";
+            Assert.assertEquals(expectedResult, executePlan(plan, "user01"));
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // test will throw runtime exception due to realized relational result memory exceeding max default rows
+    @Test (expected = RuntimeException.class)
+    public void TDSJoinThrowsFailToRealizeInMemory() throws Exception
+    {
+        try
+        {
+            InputStream executionPlanJson = TestPlanExecutionForIn.class.getClassLoader().getResourceAsStream("org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinExpectedFail.json");
+            String executionPlanJsonString = IOUtils.toString(executionPlanJson);
+            System.setProperty("DEFAULT_ROW_LIMIT", "2");
+            SingleExecutionPlan plan = objectMapper.readValue(executionPlanJsonString, SingleExecutionPlan.class);
+
+            String expectedResult = "{\"builder\": {\"_type\":\"tdsBuilder\",\"columns\":[{\"name\":\"firstName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"},{\"name\":\"eID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"managerID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"fID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"legalName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"}]}, \"activities\": [{\"_type\":\"relational\",\"sql\":\"select \\\"root\\\".FIRSTNAME as \\\"firstName\\\", \\\"firmtable_0\\\".ID as \\\"eID\\\", case when \\\"root\\\".MANAGERID = 0 then 0 else \\\"root\\\".MANAGERID end as \\\"managerID\\\" from personTable as \\\"root\\\" left outer join firmTable as \\\"firmtable_0\\\" on (\\\"firmtable_0\\\".ID = \\\"root\\\".FIRMID)\"},{\"_type\":\"relational\",\"sql\":\"select \\\"tdsvar0_0_0\\\".firstName as \\\"firstName\\\", \\\"tdsvar0_0_0\\\".eID as \\\"eID\\\", \\\"tdsvar0_0_0\\\".managerID as \\\"managerID\\\", \\\"tdsvar0_0_0\\\".\\\"fID\\\" as \\\"fID\\\", \\\"tdsvar0_0_0\\\".\\\"legalName\\\" as \\\"legalName\\\" from (select * from tdsVar0_0 as \\\"tdsvar0_0_1\\\" inner join (select \\\"root\\\".ID as \\\"fID\\\", \\\"root\\\".LEGALNAME as \\\"legalName\\\" from firmTable as \\\"root\\\") as \\\"firmtable_0\\\" on (\\\"tdsvar0_0_1\\\".eID = \\\"firmtable_0\\\".\\\"fID\\\")) as \\\"tdsvar0_0_0\\\"\"}], \"result\" : {\"columns\" : [\"firstName\",\"eID\",\"managerID\",\"fID\",\"legalName\"], \"rows\" : [{\"values\": [\"Peter\",1,2,1,\"Firm X\"]},{\"values\": [\"John\",1,4,1,\"Firm X\"]},{\"values\": [\"John\",1,2,1,\"Firm X\"]},{\"values\": [\"Anthony\",1,null,1,\"Firm X\"]},{\"values\": [\"Fabrice\",2,null,2,\"Firm A\"]},{\"values\": [\"Oliver\",3,null,3,\"Firm B\"]},{\"values\": [\"David\",4,null,4,\"Firm C\"]}]}}";
+            Assert.assertEquals(expectedResult, executePlan(plan, "user01"));
+
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+
+}

--- a/legend-engine-xt-relationalStore-executionPlan/src/test/resources/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoin.json
+++ b/legend-engine-xt-relationalStore-executionPlan/src/test/resources/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoin.json
@@ -1,0 +1,210 @@
+{
+  "rootExecutionNode": {
+    "executionNodes": [
+      {
+        "_type": "allocation",
+        "authDependent":  false,
+        "realizeInMemory": false,
+        "executionNodes": [
+          {
+            "executionNodes": [
+              {
+                "sqlQuery": "select \"root\".FIRSTNAME as \"firstName\", \"firmtable_0\".ID as \"eID\", case when \"root\".MANAGERID = 0 then 0 else \"root\".MANAGERID end as \"managerID\" from personTable as \"root\" left outer join firmTable as \"firmtable_0\" on (\"firmtable_0\".ID = \"root\".FIRMID)",
+                "resultColumns": [
+                  {
+                    "dataType": "VARCHAR(200)",
+                    "label": "\"firstName\""
+                  },
+                  {
+                    "dataType": "INTEGER",
+                    "label": "\"eID\""
+                  },
+                  {
+                    "dataType": "",
+                    "label": "\"managerID\""
+                  }
+                ],
+                "_type": "sql",
+                "connection": {
+                  "_type": "RelationalDatabaseConnection",
+                  "authenticationStrategy": {
+                    "_type": "test"
+                  },
+                  "type": "H2",
+                  "datasourceSpecification": {
+                    "_type": "h2Local"
+                  },
+                  "element": "meta::relational::tests::dbInc"
+                },
+                "resultType": {
+                  "dataType": "meta::pure::metamodel::type::Any",
+                  "_type": "dataType"
+                }
+              }
+            ],
+            "_type": "relationalTdsInstantiation",
+            "resultType": {
+              "tdsColumns": [
+                {
+                  "relationalType": "VARCHAR(200)",
+                  "name": "firstName",
+                  "type": "String"
+                },
+                {
+                  "relationalType": "INTEGER",
+                  "name": "eID",
+                  "type": "Integer"
+                },
+                {
+                  "relationalType": "INTEGER",
+                  "name": "managerID",
+                  "type": "Integer"
+                }
+              ],
+              "_type": "tds"
+            }
+          }
+        ],
+        "varName": "tdsVar0_0",
+        "resultType": {
+          "tdsColumns": [
+            {
+              "relationalType": "VARCHAR(200)",
+              "name": "firstName",
+              "type": "String"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "eID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "managerID",
+              "type": "Integer"
+            }
+          ],
+          "_type": "tds"
+        }
+      },
+      {
+        "executionNodes": [
+          {
+            "sqlQuery": "select \"tdsvar0_0_0\".firstName as \"firstName\", \"tdsvar0_0_0\".eID as \"eID\", \"tdsvar0_0_0\".managerID as \"managerID\", \"tdsvar0_0_0\".\"fID\" as \"fID\", \"tdsvar0_0_0\".\"legalName\" as \"legalName\" from (select * from (${tdsVar0_0}) as \"tdsvar0_0_1\" inner join (select \"root\".ID as \"fID\", \"root\".LEGALNAME as \"legalName\" from firmTable as \"root\") as \"firmtable_0\" on (\"tdsvar0_0_1\".eID = \"firmtable_0\".\"fID\")) as \"tdsvar0_0_0\"",
+            "resultColumns": [
+              {
+                "dataType": "INTEGER",
+                "label": "\"firstName\""
+              },
+              {
+                "dataType": "INTEGER",
+                "label": "\"eID\""
+              },
+              {
+                "dataType": "INTEGER",
+                "label": "\"managerID\""
+              },
+              {
+                "dataType": "INTEGER",
+                "label": "\"fID\""
+              },
+              {
+                "dataType": "VARCHAR(200)",
+                "label": "\"legalName\""
+              }
+            ],
+            "_type": "sql",
+            "connection": {
+              "_type": "RelationalDatabaseConnection",
+              "authenticationStrategy": {
+                "_type": "test"
+              },
+              "type": "H2",
+              "datasourceSpecification": {
+                "_type": "h2Local"
+              },
+              "element": "meta::relational::tests::tds::tdsJoin::database2"
+            },
+            "resultType": {
+              "dataType": "meta::pure::metamodel::type::Any",
+              "_type": "dataType"
+            }
+          }
+        ],
+        "_type": "relationalTdsInstantiation",
+        "resultType": {
+          "tdsColumns": [
+            {
+              "relationalType": "VARCHAR(200)",
+              "name": "firstName",
+              "type": "String"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "eID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "managerID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "fID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "VARCHAR(200)",
+              "name": "legalName",
+              "type": "String"
+            }
+          ],
+          "_type": "tds"
+        }
+      }
+    ],
+    "_type": "sequence",
+    "resultType": {
+      "tdsColumns": [
+        {
+          "relationalType": "VARCHAR(200)",
+          "name": "firstName",
+          "type": "String"
+        },
+        {
+          "relationalType": "INTEGER",
+          "name": "eID",
+          "type": "Integer"
+        },
+        {
+          "relationalType": "INTEGER",
+          "name": "managerID",
+          "type": "Integer"
+        },
+        {
+          "relationalType": "INTEGER",
+          "name": "fID",
+          "type": "Integer"
+        },
+        {
+          "relationalType": "VARCHAR(200)",
+          "name": "legalName",
+          "type": "String"
+        }
+      ],
+      "_type": "tds"
+    }
+  },
+  "authDependent": false,
+  "serializer": {
+    "name": "pure",
+    "version": "vX_X_X"
+  },
+  "templateFunctions": [
+    "<#function renderCollection collection separator prefix suffix defaultValue><#if collection?size == 0><#return defaultValue><\/#if><#return prefix + collection?join(suffix + separator + prefix) + suffix><\/#function>",
+    "<#function collectionSize collection> <#return collection?size?c> <\/#function>",
+    "<#function optionalVarPlaceHolderOperationSelector optionalParameter trueClause falseClause><#if optionalParameter?has_content || optionalParameter?is_string><#return trueClause><#else><#return falseClause><\/#if><\/#function>",
+    "<#function varPlaceHolderToString optionalParameter prefix suffix defaultValue><#if optionalParameter?is_enumerable && !optionalParameter?has_content><#return defaultValue><#else><#return prefix + optionalParameter + suffix><\/#if><\/#function>"
+  ]
+}

--- a/legend-engine-xt-relationalStore-executionPlan/src/test/resources/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinExpectedFail.json
+++ b/legend-engine-xt-relationalStore-executionPlan/src/test/resources/org/finos/legend/engine/plan/execution/stores/relational/test/full/tdsJoin/TestTDSJoinExpectedFail.json
@@ -1,0 +1,210 @@
+{
+  "rootExecutionNode": {
+    "executionNodes": [
+      {
+        "_type": "allocation",
+        "authDependent":  false,
+        "realizeInMemory": true,
+        "executionNodes": [
+          {
+            "executionNodes": [
+              {
+                "sqlQuery": "select \"root\".FIRSTNAME as \"firstName\", \"firmtable_0\".ID as \"eID\", case when \"root\".MANAGERID = 0 then 0 else \"root\".MANAGERID end as \"managerID\" from personTable as \"root\" left outer join firmTable as \"firmtable_0\" on (\"firmtable_0\".ID = \"root\".FIRMID)",
+                "resultColumns": [
+                  {
+                    "dataType": "VARCHAR(200)",
+                    "label": "\"firstName\""
+                  },
+                  {
+                    "dataType": "INTEGER",
+                    "label": "\"eID\""
+                  },
+                  {
+                    "dataType": "",
+                    "label": "\"managerID\""
+                  }
+                ],
+                "_type": "sql",
+                "connection": {
+                  "_type": "RelationalDatabaseConnection",
+                  "authenticationStrategy": {
+                    "_type": "test"
+                  },
+                  "type": "H2",
+                  "datasourceSpecification": {
+                    "_type": "h2Local"
+                  },
+                  "element": "meta::relational::tests::dbInc"
+                },
+                "resultType": {
+                  "dataType": "meta::pure::metamodel::type::Any",
+                  "_type": "dataType"
+                }
+              }
+            ],
+            "_type": "relationalTdsInstantiation",
+            "resultType": {
+              "tdsColumns": [
+                {
+                  "relationalType": "VARCHAR(200)",
+                  "name": "firstName",
+                  "type": "String"
+                },
+                {
+                  "relationalType": "INTEGER",
+                  "name": "eID",
+                  "type": "Integer"
+                },
+                {
+                  "relationalType": "INTEGER",
+                  "name": "managerID",
+                  "type": "Integer"
+                }
+              ],
+              "_type": "tds"
+            }
+          }
+        ],
+        "varName": "tdsVar0_0",
+        "resultType": {
+          "tdsColumns": [
+            {
+              "relationalType": "VARCHAR(200)",
+              "name": "firstName",
+              "type": "String"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "eID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "managerID",
+              "type": "Integer"
+            }
+          ],
+          "_type": "tds"
+        }
+      },
+      {
+        "executionNodes": [
+          {
+            "sqlQuery": "select \"tdsvar0_0_0\".firstName as \"firstName\", \"tdsvar0_0_0\".eID as \"eID\", \"tdsvar0_0_0\".managerID as \"managerID\", \"tdsvar0_0_0\".\"fID\" as \"fID\", \"tdsvar0_0_0\".\"legalName\" as \"legalName\" from (select * from (${tdsVar0_0}) as \"tdsvar0_0_1\" inner join (select \"root\".ID as \"fID\", \"root\".LEGALNAME as \"legalName\" from firmTable as \"root\") as \"firmtable_0\" on (\"tdsvar0_0_1\".eID = \"firmtable_0\".\"fID\")) as \"tdsvar0_0_0\"",
+            "resultColumns": [
+              {
+                "dataType": "INTEGER",
+                "label": "\"firstName\""
+              },
+              {
+                "dataType": "INTEGER",
+                "label": "\"eID\""
+              },
+              {
+                "dataType": "INTEGER",
+                "label": "\"managerID\""
+              },
+              {
+                "dataType": "INTEGER",
+                "label": "\"fID\""
+              },
+              {
+                "dataType": "VARCHAR(200)",
+                "label": "\"legalName\""
+              }
+            ],
+            "_type": "sql",
+            "connection": {
+              "_type": "RelationalDatabaseConnection",
+              "authenticationStrategy": {
+                "_type": "test"
+              },
+              "type": "H2",
+              "datasourceSpecification": {
+                "_type": "h2Local"
+              },
+              "element": "meta::relational::tests::tds::tdsJoin::database2"
+            },
+            "resultType": {
+              "dataType": "meta::pure::metamodel::type::Any",
+              "_type": "dataType"
+            }
+          }
+        ],
+        "_type": "relationalTdsInstantiation",
+        "resultType": {
+          "tdsColumns": [
+            {
+              "relationalType": "VARCHAR(200)",
+              "name": "firstName",
+              "type": "String"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "eID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "managerID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "INTEGER",
+              "name": "fID",
+              "type": "Integer"
+            },
+            {
+              "relationalType": "VARCHAR(200)",
+              "name": "legalName",
+              "type": "String"
+            }
+          ],
+          "_type": "tds"
+        }
+      }
+    ],
+    "_type": "sequence",
+    "resultType": {
+      "tdsColumns": [
+        {
+          "relationalType": "VARCHAR(200)",
+          "name": "firstName",
+          "type": "String"
+        },
+        {
+          "relationalType": "INTEGER",
+          "name": "eID",
+          "type": "Integer"
+        },
+        {
+          "relationalType": "INTEGER",
+          "name": "managerID",
+          "type": "Integer"
+        },
+        {
+          "relationalType": "INTEGER",
+          "name": "fID",
+          "type": "Integer"
+        },
+        {
+          "relationalType": "VARCHAR(200)",
+          "name": "legalName",
+          "type": "String"
+        }
+      ],
+      "_type": "tds"
+    }
+  },
+  "authDependent": false,
+  "serializer": {
+    "name": "pure",
+    "version": "vX_X_X"
+  },
+  "templateFunctions": [
+    "<#function renderCollection collection separator prefix suffix defaultValue><#if collection?size == 0><#return defaultValue><\/#if><#return prefix + collection?join(suffix + separator + prefix) + suffix><\/#function>",
+    "<#function collectionSize collection> <#return collection?size?c> <\/#function>",
+    "<#function optionalVarPlaceHolderOperationSelector optionalParameter trueClause falseClause><#if optionalParameter?has_content || optionalParameter?is_string><#return trueClause><#else><#return falseClause><\/#if><\/#function>",
+    "<#function varPlaceHolderToString optionalParameter prefix suffix defaultValue><#if optionalParameter?is_enumerable && !optionalParameter?has_content><#return defaultValue><#else><#return prefix + optionalParameter + suffix><\/#if><\/#function>"
+  ]
+}


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix/ Feature Improvement
<!--
Add one/more labels.
-->

#### What does this PR do / why is it needed ?

<!--  
Describe change being introduced by this PR.
--> Modifies the way plan is generated by separating authDependency on the plan and transformAllocation, which helps resolve logical fallacy occurring with setting TA inside execution nodes, that later is used to determine if plan is realized in Memory.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
--> PR responds to a keystone raised by user where plan fails to execute because it is unexpectedly realizing in Memory for their TDS Join operation. 



