### PR TITLE
throw error instead of warning from pure when engine is enabled but test conn not found

### DIFF
--- a/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-extensions-collection-generation/pom.xml
@@ -286,6 +286,15 @@
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-bigquery-grammar</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-bigquery-protocol</artifactId>
+        </dependency>
+     
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-serviceStore-grammar</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-extensions-collection-generation/pom.xml
@@ -286,15 +286,6 @@
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-relationalStore-bigquery-grammar</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-relationalStore-bigquery-protocol</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-serviceStore-grammar</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
+++ b/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
@@ -210,6 +210,7 @@ public class TestExtensions
                 .with(org.finos.legend.engine.protocol.pure.v1.PersistenceCloudProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.MasteryProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.RelationalProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.pure.v1.BigQueryProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.ServiceProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.ServiceStoreProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.TextProtocolExtension.class)
@@ -261,6 +262,7 @@ public class TestExtensions
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.grammar.to.PersistenceComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.cloud.grammar.to.PersistenceCloudComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.grammar.to.RelationalGrammarComposerExtension.class)
+                .with(org.finos.legend.engine.language.pure.grammar.to.BigQueryGrammarComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.service.grammar.to.ServiceGrammarComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.grammar.to.ServiceStoreGrammarComposerExtension.class)
                 .with(TextGrammarComposerExtension.class);
@@ -282,6 +284,7 @@ public class TestExtensions
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.compiler.toPureGraph.PersistenceCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.cloud.compiler.toPureGraph.PersistenceCloudCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.RelationalCompilerExtension.class)
+                .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.BigQueryCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.ServiceStoreCompilerExtension.class);
     }
 
@@ -328,6 +331,7 @@ public class TestExtensions
                 .with("core_mastery")
                 .with("core_persistence_cloud")
                 .with("core_relational")
+                .with("core_relational_bigquery")
                 .with("core_servicestore")
                 .with("core_text");
     }

--- a/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
+++ b/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
@@ -210,7 +210,6 @@ public class TestExtensions
                 .with(org.finos.legend.engine.protocol.pure.v1.PersistenceCloudProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.MasteryProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.RelationalProtocolExtension.class)
-                .with(org.finos.legend.engine.protocol.pure.v1.BigQueryProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.ServiceProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.ServiceStoreProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.TextProtocolExtension.class)
@@ -262,7 +261,6 @@ public class TestExtensions
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.grammar.to.PersistenceComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.cloud.grammar.to.PersistenceCloudComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.grammar.to.RelationalGrammarComposerExtension.class)
-                .with(org.finos.legend.engine.language.pure.grammar.to.BigQueryGrammarComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.service.grammar.to.ServiceGrammarComposerExtension.class)
                 .with(org.finos.legend.engine.language.pure.grammar.to.ServiceStoreGrammarComposerExtension.class)
                 .with(TextGrammarComposerExtension.class);
@@ -284,7 +282,6 @@ public class TestExtensions
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.compiler.toPureGraph.PersistenceCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.cloud.compiler.toPureGraph.PersistenceCloudCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.RelationalCompilerExtension.class)
-                .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.BigQueryCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.ServiceStoreCompilerExtension.class);
     }
 
@@ -331,7 +328,6 @@ public class TestExtensions
                 .with("core_mastery")
                 .with("core_persistence_cloud")
                 .with("core_relational")
-                .with("core_relational_bigquery")
                 .with("core_servicestore")
                 .with("core_text");
     }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
@@ -35,7 +35,7 @@ function meta::relational::dbTestRunner::getTestConnection(dbType:DatabaseType[1
          let res= $xf->evaluate([$dbType, $host, $port]->map(v|list($v))->concatenate(list($extensions)));
          if($res->isNotEmpty(), 
            |$res->toOne()->cast(@RelationalDatabaseConnection),
-           | println('**** Warning **** : Test Connection for dbType: '+ $dbType->toString() + ' not available on Legend Engine Server, tests will only generate execution plans without asserting actual data');
+           | fail('**** Error **** : Test Connection for dbType: '+ $dbType->toString() + ' not available on Legend Engine Server');
              []->cast(@RelationalDatabaseConnection);
            );
          },


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What does this PR do / why is it needed ?

Pure gives warning currently, when engine is enabled, but no test connection for dbType exists. This causes the integration test to pass silently, even without actually executing against test db instance. Make that warning into an error, so that test stops in such cases and fails.

#### Which issue(s) this PR fixes:
None

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No. It is backward compatible. Tc is green.
