### PR TITLE
[Router clean up] Remove advanced routing

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
@@ -110,9 +110,9 @@ function meta::pure::executionPlan::executionPlan(clusters:ClusteredValueSpecifi
    let functionParameters = $f->stubFuncParameters();
    
    let node = if ($clusters->size() == 1,
-       | $clusters->at(0)->plan($runtime, $inScopeVars, $routed.advancedRouting, $context, $extensions, $debugContext),
+       | $clusters->at(0)->plan($runtime, $inScopeVars, $context, $extensions, $debugContext),
        | let allNodes = $clusters->fold({c,a|let x = $a.vars;
-                                             let node = $c->plan($runtime, $x, $routed.advancedRouting, $context, $extensions, $debugContext);
+                                             let node = $c->plan($runtime, $x, $context, $extensions, $debugContext);
                                              let nVars = $node->match([a:AllocationExecutionNode[1]|let varValues = if($a.resultType.type ==TabularDataSet,
                                                                                                                        |^PlanSetPlaceHolder(name=$a.varName,tdsColumns = $a.resultType->match([x:TDSResultType[1]|$x.tdsColumns, a:Any[1]|[]])),
                                                                                                                        |^PlanVarPlaceHolder(name=$a.varName,type = $a.resultType.type, multiplicity=$a.resultSizeRange));
@@ -207,7 +207,7 @@ function meta::pure::executionPlan::stubFuncParameters(f:FunctionDefinition<Any>
    $f->functionType().parameters->evaluateAndDeactivate()->map(p|^PlanVarPlaceHolder(name=$p.name, type = $p.genericType.rawType->toOne(), multiplicity=$p.multiplicity));
 }
 
-function meta::pure::executionPlan::plan(cluster:ClusteredValueSpecification[1], runtime:Runtime[0..1], inScopeVars:Map<String, List<Any>>[1], advancedRouting:Boolean[0..1], context:ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionNode[1]
+function meta::pure::executionPlan::plan(cluster:ClusteredValueSpecification[1], runtime:Runtime[0..1], inScopeVars:Map<String, List<Any>>[1], context:ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionNode[1]
 {
     let fe = $cluster.val->match([r:ExtendedRoutedValueSpecification[1]|$r.value,
                                   t:TDSRoutedValueSpecification[1] | $t.value,
@@ -218,7 +218,7 @@ function meta::pure::executionPlan::plan(cluster:ClusteredValueSpecification[1],
             let subPlan = $variables->at(1)->match(
                               [
                                  c:ClusteredValueSpecification[1]|
-                                    $c->plan($runtime, $inScopeVars, $advancedRouting, if ($c.exeCtx->isEmpty(), | $context, | $c.exeCtx->toOne()), $extensions, $debugContext);,
+                                    $c->plan($runtime, $inScopeVars, if ($c.exeCtx->isEmpty(), | $context, | $c.exeCtx->toOne()), $extensions, $debugContext);,
                                  i:InstanceValue[1]|^meta::pure::executionPlan::ConstantExecutionNode
                                                     (
                                                        resultType = ^ResultType(type = $i.genericType.rawType->toOne()),
@@ -253,7 +253,7 @@ function meta::pure::executionPlan::plan(cluster:ClusteredValueSpecification[1],
                r:Runtime[0..1] | $r
             ]);
 
-            let query = ^meta::pure::mapping::StoreQuery(store=$cluster.store, fe=$fe, inScopeVars=$inScopeVars, advancedRouting=$advancedRouting);
+            let query = ^meta::pure::mapping::StoreQuery(store=$cluster.store, fe=$fe, inScopeVars=$inScopeVars);
             let res = $cluster.s.planExecution->toOne()->eval($query, $cluster.val->match([r:RoutedValueSpecification[1]|$r, a:Any[*]|[]])->cast(@RoutedValueSpecification), $cluster.mapping, $rt, if ($cluster.exeCtx->isEmpty(), | $context, | $cluster.exeCtx->toOne()), $extensions, $debugContext);
             ^$res(fromCluster=$cluster);
     );

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphFetchExecutionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphFetchExecutionPlan.pure
@@ -137,7 +137,7 @@ function meta::pure::graphFetch::executionPlan::planRouterUnionGraphFetchExecuti
 
    let subClusters  = $fe.parametersValues->evaluateAndDeactivate()->map({p | $p->meta::pure::router::clustering::cluster($mapping, $runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug).cluster->evaluateAndDeactivate()})->cast(@meta::pure::router::clustering::ClusteredValueSpecification);
    let firstCluster = $subClusters->at(0);
-   let childNodes   = $subClusters->map(cls | $cls->plan($runtime, $sq.inScopeVars, $sq.advancedRouting, $exeCtx, $extensions, $debug));
+   let childNodes   = $subClusters->map(cls | $cls->plan($runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug));
    
    ^PlatformUnionExecutionNode
    (

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/XStore.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/XStore.pure
@@ -156,7 +156,7 @@ function meta::pure::mapping::xStore::performXStoreQuery(o:Any[1], p:PropertyMap
 
    let cluster = $clustered->at(0).expressionSequence->evaluateAndDeactivate()->cast(@ClusteredValueSpecification);
    
-   let res = $cluster->executeExpression($cluster.openVars->toOne(), [], $objectInfo.static.exeCtx, false, $extensions, $debug);
+   let res = $cluster->executeExpression($cluster.openVars->toOne(), [], $objectInfo.static.exeCtx, $extensions, $debug);
 
    $extensions.logActivities->map(e|$e->eval($res.activities));
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -42,7 +42,6 @@ Class meta::pure::mapping::StoreQuery
 {
     fe : FunctionExpression[1];
     inScopeVars : Map<String, List<Any>>[1];
-    advancedRouting : Boolean[0..1];
     store : Store[1];
     //sets : Pair<String, List<Any>>[*]; //inputs to either cross store ( query )
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
@@ -550,7 +550,7 @@ function <<access.private>> meta::pure::mapping::modelToModel::graphFetch::execu
   let subClusters  = $fe.parametersValues->at(0)->evaluateAndDeactivate()->cast(@InstanceValue).values->cast(@ValueSpecification)->map({p | $p->cluster($mapping, $runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug).cluster->evaluateAndDeactivate()})->cast(@ClusteredValueSpecification);
 
    let firstCluster = $subClusters->at(0);
-   let childNodes   = $subClusters->map(cls | $cls->plan($runtime, $sq.inScopeVars, $sq.advancedRouting, $exeCtx, $extensions, $debug)->cast(@GlobalGraphFetchExecutionNode))->mergeGraphFetchPlans($rootTree);
+   let childNodes   = $subClusters->map(cls | $cls->plan($runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug)->cast(@GlobalGraphFetchExecutionNode))->mergeGraphFetchPlans($rootTree);
    ^PlatformMergeExecutionNode
    (
       fromCluster    = ^$firstCluster(val = $fe),

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_execution.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_execution.pure
@@ -22,7 +22,7 @@ import meta::pure::router::printer::*;
 import meta::pure::router::clustering::*;
 import meta::pure::router::execution::*;
 
-function meta::pure::router::execution::executeExpression(clusters:ClusteredValueSpecification[*], inScopeVars:Map<String, List<Any>>[1], activities:Activity[*], exeCtx: ExecutionContext[0..1], advancedRouting:Boolean[1], extensions:Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
+function meta::pure::router::execution::executeExpression(clusters:ClusteredValueSpecification[*], inScopeVars:Map<String, List<Any>>[1], activities:Activity[*], exeCtx: ExecutionContext[0..1], extensions:Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
    let current = $clusters->head()->toOne()->evaluateAndDeactivate();
    print(if($debug.debug,|'\n'+$debug.space+'Start Execution: '+$current.val->asString()+'\n',|''));
@@ -31,41 +31,41 @@ function meta::pure::router::execution::executeExpression(clusters:ClusteredValu
    if ($fe.func == letFunction_String_1__T_m__T_m_,
          | let params = $fe.parametersValues->evaluateAndDeactivate();
            let paramName = $params->at(0)->cast(@InstanceValue).values->at(0)->cast(@String);
-           let paramResult = ^Container(value=$params->at(1))->resolve($inScopeVars, $advancedRouting, $extensions, ^$debug(space = $debug.space+' '));
+           let paramResult = ^Container(value=$params->at(1))->resolve($inScopeVars, $extensions, ^$debug(space = $debug.space+' '));
            let fullyRes = $paramResult.value->reactivate($inScopeVars)->toOneMany();
            let newVars = $inScopeVars->put($paramName, ^List<Any>(values=$fullyRes));
            let allActivities = $activities->concatenate($paramResult.activities);
            let tail = $clusters->tail();
            if($tail->isEmpty(), | ^Result<Any|*>(values = $fullyRes, activities=$allActivities), 
-                                |  executeExpression($tail, $newVars, $allActivities, $exeCtx, $advancedRouting, $extensions, ^$debug(space = $debug.space));
+                                |  executeExpression($tail, $newVars, $allActivities, $exeCtx, $extensions, ^$debug(space = $debug.space));
            );,
                    
          |
-           let storeQuery = getStoreQuery($current.store, $fe, $inScopeVars, $advancedRouting);
+           let storeQuery = getStoreQuery($current.store, $fe, $inScopeVars);
            let result = $current.s.executeStoreQuery->toOne()->eval($storeQuery, $current.val->match([r:RoutedValueSpecification[1]|$r, a:Any[*]|[]])->cast(@RoutedValueSpecification), $current.mapping, $current.runtime, $exeCtx, $extensions, ^$debug(space = $debug.space+' '));
            let allActivities = $activities->concatenate($result.activities);
            let tail = $clusters->tail();
            if($tail->isEmpty(), | ^Result<Any|*>(values=$result.values, activities=$allActivities),
-                                |  executeExpression($tail, $inScopeVars, $allActivities, $exeCtx, $advancedRouting, $extensions, ^$debug(space = $debug.space));
+                                |  executeExpression($tail, $inScopeVars, $allActivities, $exeCtx, $extensions, ^$debug(space = $debug.space));
            );
    );
 }
 
-function <<access.private>> meta::pure::router::execution::getStoreQuery(store: Store[1], fe : FunctionExpression[1], inScopeVars : Map<String, List<Any>>[1], advancedRouting:Boolean[1]):meta::pure::mapping::StoreQuery[1]
+function <<access.private>> meta::pure::router::execution::getStoreQuery(store: Store[1], fe : FunctionExpression[1], inScopeVars : Map<String, List<Any>>[1]):meta::pure::mapping::StoreQuery[1]
 {
-   ^meta::pure::mapping::StoreQuery(store=$store, fe=$fe, inScopeVars=$inScopeVars, advancedRouting = $advancedRouting);
+   ^meta::pure::mapping::StoreQuery(store=$store, fe=$fe, inScopeVars=$inScopeVars);
 }
 
-function meta::pure::router::execution::resolve(v:Container[1], openVariables:Map<String, List<Any>>[1], advancedRouting:Boolean[1], extensions:Extension[*], debug:DebugContext[1]):Container[1]
+function meta::pure::router::execution::resolve(v:Container[1], openVariables:Map<String, List<Any>>[1], extensions:Extension[*], debug:DebugContext[1]):Container[1]
 {
    print(if($debug.debug,|$debug.space+'Resolving  :'+$v.value->evaluateAndDeactivate()->asString()+'\n',|''));
    $v.value->evaluateAndDeactivate()->match([
-               f:FunctionExpression[1]|let params = $f.parametersValues->evaluateAndDeactivate()->map(pv|^$v(value = $pv)->resolve($openVariables, $advancedRouting, $extensions, ^$debug(space = $debug.space+' ')));
+               f:FunctionExpression[1]|let params = $f.parametersValues->evaluateAndDeactivate()->map(pv|^$v(value = $pv)->resolve($openVariables, $extensions, ^$debug(space = $debug.space+' ')));
                                        ^$v(value = ^$f(parametersValues = $params.value), activities += $params.activities);,
                r:ExtendedRoutedValueSpecification[1]| $v,
-               r:FunctionRoutedValueSpecification[1]| ^$v(value=$r.value)->resolve($openVariables, $advancedRouting, $extensions, ^$debug(space = $debug.space+' ')),
+               r:FunctionRoutedValueSpecification[1]| ^$v(value=$r.value)->resolve($openVariables, $extensions, ^$debug(space = $debug.space+' ')),
                i:InstanceValue[1]| let newValues = $i.values->evaluateAndDeactivate()->map(va|$va->match([
-                                                                  vs:ValueSpecification[1]|^$v(value=$vs)->resolve($openVariables, $advancedRouting, $extensions, ^$debug(space = $debug.space+' ')),
+                                                                  vs:ValueSpecification[1]|^$v(value=$vs)->resolve($openVariables, $extensions, ^$debug(space = $debug.space+' ')),
                                                                   a:Any[1]|$a
                                                               ]));
                                    ^$v(
@@ -74,15 +74,14 @@ function meta::pure::router::execution::resolve(v:Container[1], openVariables:Ma
                                                  ),
                                          activities += $newValues->filter(v|$v->instanceOf(Container))->cast(@Container).activities
 
-                                    );
-                                    ,
+                                    );,
                va:VariableExpression[1]| $v;,
-               c:ClusteredValueSpecification[1]|let recurseExec = ^$v(value=$c.val)->resolve($openVariables, $advancedRouting, $extensions, ^$debug(space = $debug.space+' '));
-                                                let res = $recurseExec.value->evaluateAndDeactivate()->match([r:ExtendedRoutedValueSpecification[1]|$r.value, v:ValueSpecification[1]|$v, r:FunctionRoutedValueSpecification[1]|^$v(value=$r.value)->resolve($openVariables, $advancedRouting, $extensions, ^$debug(space = $debug.space+' '))])
+               c:ClusteredValueSpecification[1]|let recurseExec = ^$v(value=$c.val)->resolve($openVariables, $extensions, ^$debug(space = $debug.space+' '));
+                                                let res = $recurseExec.value->evaluateAndDeactivate()->match([r:ExtendedRoutedValueSpecification[1]|$r.value, v:ValueSpecification[1]|$v, r:FunctionRoutedValueSpecification[1]|^$v(value=$r.value)->resolve($openVariables, $extensions, ^$debug(space = $debug.space+' '))])
                                                                             ->match(
                                                                [
                                                                   fe:FunctionExpression[1]| print(if($debug.debug,|$debug.space+'Store Execution  :'+$v.value->evaluateAndDeactivate()->asString()+'\n',|''));
-                                                                                            let storeQuery = getStoreQuery($c.store, $fe, $openVariables, $advancedRouting);//^meta::pure::router::execution::StoreQuery(fe=$fe, inScopeVars=$openVariables);
+                                                                                            let storeQuery = getStoreQuery($c.store, $fe, $openVariables);//^meta::pure::router::execution::StoreQuery(fe=$fe, inScopeVars=$openVariables);
                                                                                             $c.s.executeStoreQuery->toOne()->eval($storeQuery, $recurseExec.value->cast(@ExtendedRoutedValueSpecification), $c.mapping, $c.runtime, $c.exeCtx, $extensions, ^$debug(space = $debug.space+' '));,
                                                                   i:InstanceValue[1] | ^Result<Any|*>(values = if ($i.genericType.rawType->toOne()->_subTypeOf(Function),|$i.values, |$i->reactivate($openVariables)))
                                                                ]

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_execution.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_execution.pure
@@ -22,6 +22,12 @@ import meta::pure::router::printer::*;
 import meta::pure::router::clustering::*;
 import meta::pure::router::execution::*;
 
+function <<doc.deprecated>> meta::pure::router::execution::executeExpression(clusters:ClusteredValueSpecification[*], inScopeVars:Map<String, List<Any>>[1], activities:Activity[*], exeCtx: ExecutionContext[0..1], dummy:Boolean[1], extensions:Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
+{
+   // TODO: This is added for backward compatibility and would be removed in next release
+   executeExpression($clusters, $inScopeVars, $activities, $exeCtx, $extensions, $debug);
+}
+
 function meta::pure::router::execution::executeExpression(clusters:ClusteredValueSpecification[*], inScopeVars:Map<String, List<Any>>[1], activities:Activity[*], exeCtx: ExecutionContext[0..1], extensions:Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
    let current = $clusters->head()->toOne()->evaluateAndDeactivate();

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
@@ -34,7 +34,6 @@ Class meta::pure::router::RoutingQuery<T|m>
 Class meta::pure::router::RoutingResult
 {
    functions:FunctionDefinition<Any>[*];
-   advancedRouting : Boolean[1];
 }
 
 Class meta::pure::router::RoutedVariablePlaceHolder
@@ -281,7 +280,7 @@ function <<access.private>> meta::pure::router::execute<X|n>(rq:RoutingQuery<X|n
    print(if($debug.debug,|'\nExecuting:\n',|''));
    let results = $routed.functions->evaluateAndDeactivate()->fold({f:FunctionDefinition<Any>[1],a:Result<X|*>[1]|
                       let clusterVS = $f.expressionSequence->evaluateAndDeactivate()->cast(@ClusteredValueSpecification);
-                      let res = $clusterVS->executeExpression($clusterVS->at(0).openVars, [], $clusterVS->at(0).exeCtx, $routed.advancedRouting, $extensions, $debug);
+                      let res = $clusterVS->executeExpression($clusterVS->at(0).openVars, [], $clusterVS->at(0).exeCtx, $extensions, $debug);
                       let values = if ($a.values->isEmpty(),
                                         |$res.values,
                                         |if($a.values->at(0)->instanceOf(TabularDataSet),
@@ -330,8 +329,7 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
                                                                               let temp = $routed.functions->toOne();
           ^$a(
             first = ^RoutingResult(
-              functions       = ^$temp(expressionSequence = $a.first.functions.expressionSequence->concatenate($temp.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>),
-              advancedRouting = $a.first.advancedRouting || $routed.advancedRouting
+              functions       = ^$temp(expressionSequence = $a.first.functions.expressionSequence->concatenate($temp.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>)
             ),
             second = $vars
           );
@@ -350,7 +348,7 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
               let unRoutedFunction = ^$l(expressionSequence = $vs);
                                                                                                                            let vars = $a.second->put($varName->toOne(), ^List<RoutedVariablePlaceHolder>(values=^RoutedVariablePlaceHolder(name=$varName->toOne())));
                                                                                                                            let temp = $unRoutedFunction->toOne();
-                                                                                                                           ^$a(first=^RoutingResult(functions=^$temp(expressionSequence = $a.first.functions.expressionSequence->concatenate($temp.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>), advancedRouting=$a.first.advancedRouting), second=$vars);
+                                                                                                                           ^$a(first=^RoutingResult(functions=^$temp(expressionSequence = $a.first.functions.expressionSequence->concatenate($temp.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>)), second=$vars);
             },
             {|
               let re = $vs->reactivate($a.second);
@@ -361,7 +359,7 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
         }
       );
     },
-    pair(^RoutingResult(advancedRouting=false), $f->openVariableValues())
+    pair(^RoutingResult(), $f->openVariableValues())
   );
 
   let vs      = $expressions->last()->toOne();
@@ -378,8 +376,7 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
    let routed = routeFunction($newF, ^Mapping(name = ''), ^meta::pure::runtime::Runtime(), $exeCtx, $vars, $extensions, $debug);
    let temp   = $routed.functions->toOne();
    ^RoutingResult(
-     functions       = ^$temp(expressionSequence = $initStatements.first.functions.expressionSequence->concatenate($temp.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>),
-     advancedRouting = $initStatements.first.advancedRouting || $routed.advancedRouting
+     functions       = ^$temp(expressionSequence = $initStatements.first.functions.expressionSequence->concatenate($temp.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>)
    );
 }
 
@@ -460,14 +457,12 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], mapping
 
       ^RoutingResult
       (
-         functions = $nbuilt->doCluster($f, $mapping, $runtime, $exeCtx, $extensions, $debug),
-         advancedRouting = $permutations->size() > 1
+         functions = $nbuilt->doCluster($f, $mapping, $runtime, $exeCtx, $extensions, $debug)
       );
       ,
       |^RoutingResult
       (
-         functions = ^List<ValueSpecification>(values=$processedCollection.value->cast(@ValueSpecification))->doCluster($f, $mapping, $runtime, $exeCtx, $extensions, $debug),
-         advancedRouting = false
+         functions = ^List<ValueSpecification>(values=$processedCollection.value->cast(@ValueSpecification))->doCluster($f, $mapping, $runtime, $exeCtx, $extensions, $debug)
       );
    );
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/chain.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/chain.pure
@@ -116,9 +116,9 @@ function meta::pure::mapping::modelToModel::chain::planExecutionChain(sq:StoreQu
    let inScopeVars = $sq.inScopeVars;
 
    if ($clusters->size() == 1,
-       | $clusters->at(0)->plan($runtime, $inScopeVars, $routed.advancedRouting, $exeCtx, $extensions, $debug),
+       | $clusters->at(0)->plan($runtime, $inScopeVars, $exeCtx, $extensions, $debug),
        | let allNodes = $clusters->fold({c,a|let x = $a.vars;
-                                             let node = $c->plan($runtime, $x, $routed.advancedRouting, $exeCtx, $extensions, $debug);
+                                             let node = $c->plan($runtime, $x, $exeCtx, $extensions, $debug);
                                              let nVars = $node->match([a:AllocationExecutionNode[1]|let varValues = if($a.resultType.type ==TabularDataSet,
                                                                                                                        |^PlanSetPlaceHolder(name=$a.varName,tdsColumns = $a.resultType->match([x:TDSResultType[1]|$x.tdsColumns, a:Any[1]|[]])),
                                                                                                                        |^PlanVarPlaceHolder(name=$a.varName,type = $a.resultType.type, multiplicity=$a.resultSizeRange));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/inMemory.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/inMemory.pure
@@ -164,7 +164,7 @@ function meta::pure::mapping::modelToModel::inMemory::internal_getter(o:Any[1], 
            );
         );,
        |$pms->cast(@PurePropertyMapping)
-            ->filter(pm | $modelPayload.src->instanceOf($pm.owner->cast(@PureInstanceSetImplementation).srcClass->toOne()))
+            ->filter(pm | $modelPayload.src->toOne()->instanceOf($pm.owner->cast(@PureInstanceSetImplementation).srcClass->toOne()))
             ->map(pm|
                     let targetImpl = $modelPayload.static.mapping.classMappingById($pm->toOne().targetSetImplementationId)->toOne();
                     let src= $pm->toOne().transform->evaluate(list($modelPayload.src));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/inMemory.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/inMemory.pure
@@ -24,20 +24,17 @@ Class meta::pure::mapping::modelToModel::inMemory::ModelPayload extends MappingI
    src : Any[1];
 }
 
-function meta::pure::mapping::modelToModel::inMemory::executeInMemory(v:ValueSpecification[1], e:ExtendedRoutedValueSpecification[0..1], mapping: Mapping[1], mc:ModelConnection[1], runtime:Runtime[1], advancedRouting:Boolean[1], exeCtx:ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
+function meta::pure::mapping::modelToModel::inMemory::executeInMemory(v:ValueSpecification[1], e:ExtendedRoutedValueSpecification[0..1], mapping: Mapping[1], mc:ModelConnection[1], runtime:Runtime[1], exeCtx:ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
    let res = $v->match([
                f:FunctionExpression[1]|if($f.func.name == 'getAll_Class_1__T_MANY_' || $f.func.name == 'getAllVersions_Class_1__T_MANY_' || $f.func.name == 'getAll_Class_1__Date_1__T_MANY_',
                                           |let impls = $e.sets->resolveOperation($mapping)->cast(@PureInstanceSetImplementation);
                                            let res = $impls->map(impl|inMemoryGetAll($impl, $e->toOne(), $mapping, $mc, $runtime, $exeCtx, $extensions, $debug))->setOperation($e);,
-                                          |$f.func->evaluate($f.parametersValues->map(p|list($p->executeInMemory($e, $mapping, $mc, $runtime, $advancedRouting, $exeCtx, $extensions, $debug).values)))
+                                          |$f.func->evaluate($f.parametersValues->map(p|list($p->executeInMemory($e, $mapping, $mc, $runtime, $exeCtx, $extensions, $debug).values)))
                                        ),
-               r:FunctionRoutedValueSpecification[1]|if ($advancedRouting,
-                                                         |$r.value->cast(@InstanceValue).values->at(0)->cast(@LambdaFunction<Any>)->routeGettersInCode($e),
-                                                         |$r.originalFunction
-                                                     ),
-               e:ExtendedRoutedValueSpecification[1]|$e.value->executeInMemory($e, $mapping, $mc, $runtime, $advancedRouting, $exeCtx, $extensions, $debug).values;,
-               i:InstanceValue[1]|$i.values->map(v|$v->match([vs:ValueSpecification[1]|$vs->executeInMemory($e, $mapping, $mc, $runtime, $advancedRouting, $exeCtx, $extensions, $debug).values,a:Any[1]|$a]))
+               r:FunctionRoutedValueSpecification[1]|$r.value->cast(@InstanceValue).values->at(0)->cast(@LambdaFunction<Any>)->routeGettersInCode($e),
+               e:ExtendedRoutedValueSpecification[1]|$e.value->executeInMemory($e, $mapping, $mc, $runtime, $exeCtx, $extensions, $debug).values;,
+               i:InstanceValue[1]|$i.values->map(v|$v->match([vs:ValueSpecification[1]|$vs->executeInMemory($e, $mapping, $mc, $runtime, $exeCtx, $extensions, $debug).values,a:Any[1]|$a]))
              ]);
    ^Result<Any|*>(values=$res);
 }
@@ -166,37 +163,39 @@ function meta::pure::mapping::modelToModel::inMemory::internal_getter(o:Any[1], 
               $srcRes->map(v|$v->transformWithMapping($setImpl->toOne()->cast(@PureInstanceSetImplementation), [],$static));
            );
         );,
-       |$pms->cast(@PurePropertyMapping)->map(pm|
-             let targetImpl = $modelPayload.static.mapping.classMappingById($pm->toOne().targetSetImplementationId)->toOne();
-             let src= $pm->toOne().transform->evaluate(list($modelPayload.src));
-             let resolved   = if($targetImpl->instanceOf(OperationSetImplementation), 
-                                 |$targetImpl->cast(@OperationSetImplementation)->resolveOperation($modelPayload.static.mapping)->cast(@PureInstanceSetImplementation), 
-                                 |$targetImpl->cast(@PureInstanceSetImplementation)
-                              )
-                                           ->map(r| if($r.srcClass->isEmpty()  ||  $src->isEmpty() || $src->at(0)->instanceOf($r.srcClass->toOne())  ,
-                                               |$r ,
-                                               |[];
-                                             ););
-                                            
-            $resolved->map({pisi|
-                let filtered = if ($pisi.filter->isEmpty(),
-                                   |$src, 
-                                   |let f = $pisi.filter->toOne(); 
-                                    $src->filter(v|$f->evaluate(list($v))->toOne()->cast(@Boolean));
-                                  );
-                let static = ^StaticMappingInstanceData
-                              (
-                                 setImplementation = $pisi,
-                                 mapping           = $modelPayload.static.mapping->toOne(),
-                                 runtime           = $modelPayload.static.runtime,
-                                 systemMapping     = meta::pure::mapping::modelToModel::contract::modelStoreContract(),
-                                 exeCtx            = $modelPayload.static.exeCtx,
-                                 debug             = $modelPayload.static.debug,
-                                 extensions = $modelPayload.static.extensions
-                              );
-                $filtered->map(v|$v->transformWithMapping($pisi, [], $static));
-             });                                             
-        );
+       |$pms->cast(@PurePropertyMapping)
+            ->filter(pm | $modelPayload.src->instanceOf($pm.owner->cast(@PureInstanceSetImplementation).srcClass->toOne()))
+            ->map(pm|
+                    let targetImpl = $modelPayload.static.mapping.classMappingById($pm->toOne().targetSetImplementationId)->toOne();
+                    let src= $pm->toOne().transform->evaluate(list($modelPayload.src));
+                    let resolved   = if($targetImpl->instanceOf(OperationSetImplementation), 
+                                        |$targetImpl->cast(@OperationSetImplementation)->resolveOperation($modelPayload.static.mapping)->cast(@PureInstanceSetImplementation), 
+                                        |$targetImpl->cast(@PureInstanceSetImplementation)
+                                      )
+                                                  ->map(r| if($r.srcClass->isEmpty()  ||  $src->isEmpty() || $src->at(0)->instanceOf($r.srcClass->toOne())  ,
+                                                      |$r ,
+                                                      |[];
+                                                    ););
+                                                    
+                    $resolved->map({pisi|
+                        let filtered = if ($pisi.filter->isEmpty(),
+                                          |$src, 
+                                          |let f = $pisi.filter->toOne(); 
+                                            $src->filter(v|$f->evaluate(list($v))->toOne()->cast(@Boolean));
+                                          );
+                        let static = ^StaticMappingInstanceData
+                                      (
+                                        setImplementation = $pisi,
+                                        mapping           = $modelPayload.static.mapping->toOne(),
+                                        runtime           = $modelPayload.static.runtime,
+                                        systemMapping     = meta::pure::mapping::modelToModel::contract::modelStoreContract(),
+                                        exeCtx            = $modelPayload.static.exeCtx,
+                                        debug             = $modelPayload.static.debug,
+                                        extensions = $modelPayload.static.extensions
+                                      );
+                        $filtered->map(v|$v->transformWithMapping($pisi, [], $static));
+                    });                                             
+            );
    );
 }
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/storeContract.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/storeContract.pure
@@ -45,7 +45,7 @@ function meta::pure::mapping::modelToModel::contract::execution(sq:meta::pure::m
    let connection = $runtime->connectionByElement($sq.store);
    $connection->match(
                         [
-                           mc:ModelConnection[1]| executeInMemory($sq.fe, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mc, $runtime, $sq.advancedRouting->toOne(), $exeCtx, $extensions, $debug),
+                           mc:ModelConnection[1]| executeInMemory($sq.fe, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mc, $runtime, $exeCtx, $extensions, $debug),
                            mcc:ModelChainConnection[1]| executeChain($sq, $ext->cast(@ExtendedRoutedValueSpecification), $m, $mcc, $runtime, $exeCtx, $extensions, $debug)
                         ]
                );

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/platform/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/platform/executionPlan/executionPlan_generation.pure
@@ -24,7 +24,6 @@ import meta::pure::store::platform::metamodel::*;
 Class meta::pure::store::platform::executionPlan::generation::PlatformPlanGenerationState
 {
    inScopeVars     : Map<String, List<Any>>[1];
-   advancedRouting : Boolean[0..1];
    exeCtx          : ExecutionContext[1];
 
    checked         : Boolean[0..1];
@@ -45,7 +44,7 @@ function meta::pure::store::platform::executionPlan::generation::processValueSpe
 {
    $vs->match([
       f:SimpleFunctionExpression[1]         | $f->meta::pure::store::platform::executionPlan::generation::getFunctionProcessor($extensions)->eval($f, $state, $extensions, $debug), 
-      c:ClusteredValueSpecification[1]      | $c->plan($c.runtime, $state.inScopeVars, $state.advancedRouting, $state.exeCtx, $extensions, $debug),
+      c:ClusteredValueSpecification[1]      | $c->plan($c.runtime, $state.inScopeVars, $state.exeCtx, $extensions, $debug),
       e:ExtendedRoutedValueSpecification[1] | $e.value->processValueSpecification($state, $extensions, $debug),
       i:InstanceValue[1]                    | [],
       v:ValueSpecification[1]               | []

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/platform/storeContract.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/platform/storeContract.pure
@@ -41,14 +41,14 @@ function meta::pure::store::platform::contract::platformStoreContract():StoreCon
 // Platform Store Execution
 function meta::pure::store::platform::contract::execution(sq:meta::pure::mapping::StoreQuery[1], ext:RoutedValueSpecification[0..1], m:Mapping[0..1], runtime:Runtime[0..1], exeCtx:ExecutionContext[1], extensions:Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
-  let newOne = ^Container(value = $sq.fe)->resolve($sq.inScopeVars, $sq.advancedRouting->toOne(), $extensions, $debug);
+  let newOne = ^Container(value = $sq.fe)->resolve($sq.inScopeVars, $extensions, $debug);
   ^Result<Any|*>(activities = $newOne.activities, values=$newOne.value->reactivate($sq.inScopeVars));
 }
 
 // Platform Store Execution Plan Generation Flow
 function meta::pure::store::platform::contract::planExecution(sq:meta::pure::mapping::StoreQuery[1], ext:RoutedValueSpecification[0..1], m:Mapping[0..1], runtime:Runtime[0..1], exeCtx:ExecutionContext[1], extensions : Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
-   let state = ^meta::pure::store::platform::executionPlan::generation::PlatformPlanGenerationState(inScopeVars = $sq.inScopeVars, advancedRouting = $sq.advancedRouting, exeCtx = $exeCtx);
+   let state = ^meta::pure::store::platform::executionPlan::generation::PlatformPlanGenerationState(inScopeVars = $sq.inScopeVars, exeCtx = $exeCtx);
    $sq.fe->meta::pure::store::platform::executionPlan::generation::processValueSpecification($state, $extensions, $debug)->toOne();
 }
 

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/transform/fromPure/toSQLString.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/transform/fromPure/toSQLString.pure
@@ -109,7 +109,7 @@ function <<access.private>> meta::relational::functions::sqlstring::toSQL(cluste
               let params = $fe.parametersValues->evaluateAndDeactivate();
               let paramName = $params->at(0)->cast(@InstanceValue).values->at(0)->cast(@String);
               let exeCtx = $cluster.exeCtx->toOne();
-              let res = $cluster->executeExpression($vars, [], $exeCtx, false, $extensions, $debug);
+              let res = $cluster->executeExpression($vars, [], $exeCtx, $extensions, $debug);
 
               toSQL($clusters->tail(), $vars->put($paramName, ^List<Any>(values=$res.values)), $mapping, $databaseType, $dbTimeZone, $sqlQueryPostProcessors, $extensions, $debug, $sqlResult); ,
            |  let dbCluster = if ($cluster.store->toOne()->instanceOf(meta::relational::metamodel::Database),| $cluster, | $firstDbCluster->at(0)->cast(@ClusteredValueSpecification));


### PR DESCRIPTION
#### What type of PR is this?
This cleans-up routing logic

#### What does this PR do / why is it needed ?
This cleans-up routing logic by removing advancedRouting field

#### Which issue(s) this PR fixes:
Relates to : https://github.com/finos/legend-engine/issues/703 

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
