### PR TITLE
Parse date fix h2and presto

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/h2Extension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/h2Extension.pure
@@ -81,7 +81,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::g
     dynaFnToSql('monthNumber',            $allStates,            ^ToSql(format='month(%s)')),
     dynaFnToSql('mostRecentDayOfWeek',    $allStates,            ^ToSql(format='dateadd(DAY, case when %s - DAY_OF_WEEK(%s) > 0 then %s - DAY_OF_WEEK(%s) - 7 else %s - DAY_OF_WEEK(%s) end, %s)', transform={p:String[1..2] | $p->formatMostRecentH2('current_date()')}, parametersWithinWhenClause = [false, false])),
     dynaFnToSql('now',                    $allStates,            ^ToSql(format='current_timestamp()')),
-    dynaFnToSql('parseDate',              $allStates,            ^ToSql(format='parsedatetime(%s,%s)')),
+    dynaFnToSql('parseDate',              $allStates,            ^ToSql(format='parsedatetime(%s,%s)', transform={p:String[*]|$p->transformParseDateParams()})),
     dynaFnToSql('parseDecimal',           $allStates,            ^ToSql(format='cast(%s as decimal)')),
     dynaFnToSql('parseFloat',             $allStates,            ^ToSql(format='cast(%s as float)')),
     dynaFnToSql('parseInteger',           $allStates,            ^ToSql(format='cast(%s as integer)')),
@@ -155,6 +155,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::c
                                                                      $normalizedFormat;
                                                                      );
       'cast( parseDateTime('+$params->at(0)+','+$dateFormat +') as date)';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::h2::transformParseDateParams(params:String[*]):String[2]
+{
+  assert($params->size() <= 2,'Incorrect number of parseDate parameters for H2, passed ' + $params->size()->toString() + ' expecting 1 or 2');
+  let input = $params->at(0);
+  let format = if($params->size()>1,|$params->at(1),|'\'yyyy-MM-dd\'');
+  [$input, $format];
 }
 
 function meta::relational::functions::sqlQueryToString::h2::normalizeH2DateFormat(params:String[1]):String[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/prestoExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/prestoExtension.pure
@@ -77,7 +77,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::prest
     dynaFnToSql('monthNumber',            $allStates,            ^ToSql(format='month(%s)')),
     dynaFnToSql('mostRecentDayOfWeek',    $allStates,            ^ToSql(format='date_add(\'day\', case when %s - day_of_week(%s) > 0 then %s - day_of_week(%s) - 7 else %s - day_of_week(%s) end, %s)', transform={p:String[1..2] | $p->formatMostRecentPresto('current_date')}, parametersWithinWhenClause = [false, false])),
     dynaFnToSql('now',                    $allStates,            ^ToSql(format='current_timestamp')),
-    dynaFnToSql('parseDate',              $allStates,            ^ToSql(format='date_parse(%s,%s)')),
+    dynaFnToSql('parseDate',              $allStates,            ^ToSql(format='date_parse(%s,%s)', transform={p:String[*]|$p->transformParseDateParams()})),
     dynaFnToSql('parseFloat',             $allStates,            ^ToSql(format='cast(%s as double)')),
     dynaFnToSql('parseInteger',           $allStates,            ^ToSql(format='cast(%s as integer)')),
     dynaFnToSql('position',               $allStates,            ^ToSql(format='position(%s in %s)')),
@@ -130,6 +130,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::prest
    assert($params->size()==1 || dateFormatsPresto()->contains($params->at(1)->replace('\'', '')) , | $params->at(1) +' not supported ');
    let dateFormat = if( $params->size() == 1,|'\'%Y-%m-%d\'' ,| $params->at(1););
    'date( date_parse('+$params->at(0)+','+$dateFormat +') )';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::presto::transformParseDateParams(params:String[*]):String[2]
+{
+      assert($params->size() <= 2,'Incorrect number of parseDate parameters for Presto, passed ' + $params->size()->toString() + ' expecting 1 or 2');
+      let input = $params->at(0);
+      let format = if($params->size()>1,|$params->at(1),|'\'yyyy-MM-dd\'');
+      [$input, $format];
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::presto::dateFormatsPresto():String[*]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
@@ -46,6 +46,31 @@ function <<test.BeforePackage>> meta::relational::tests::mapping::sqlFunction::s
     true;
 }
 
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringParseDateForH2():Boolean[1]
+{
+  let result = execute(|SqlFunctionDemo.all()->project([s | $s.string2Date], ['date']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
+  assertEquals([%2016-06-23T00:00:00.000000000+0000, %2016-06-23T00:00:00.000000000+0000], $result.values->at(0).rows.values);
+  assertEquals('select parsedatetime("root".string2date,\'yyyy-MM-dd\') as "date" from dataTable as "root"',$result->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringWithParseDateInQueryForH2():Boolean[1]
+{  
+  let result = execute(|SqlFunctionDemo.all()->project([s | $s.string2DateStr->parseDate()], ['date']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
+  assertEquals([%2016-06-23T00:00:00.000000000+0000, %2016-06-23T00:00:00.000000000+0000], $result.values->at(0).rows.values);
+  assertEquals('select parsedatetime("root".string2date,\'yyyy-MM-dd\') as "date" from dataTable as "root"',$result->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringParseDateForPresto():Boolean[1]
+{
+  let prestoSql = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2Date], ['date']), testMapping, meta::relational::runtime::DatabaseType.Presto, meta::relational::extension::relationalExtensions());
+  assertEquals('select date_parse("root".string2date,\'yyyy-MM-dd\') as "date" from dataTable as "root"',$prestoSql->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringWithParseDateInQueryForPresto():Boolean[1]
+{
+  let prestoSql = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2DateStr->parseDate()], ['date']), testMapping, meta::relational::runtime::DatabaseType.Presto, meta::relational::extension::relationalExtensions());  
+  assertEquals('select date_parse("root".string2date,\'yyyy-MM-dd\') as "date" from dataTable as "root"',$prestoSql->sqlRemoveFormatting());
+}
 
 function <<test.Test>> meta::relational::tests::mapping::sqlFunction::concat::testProject():Boolean[1]
 {
@@ -1159,6 +1184,7 @@ Class meta::relational::tests::mapping::sqlFunction::model::domain::SqlFunctionD
    floatRemResult : Integer[1];
 
    string2Date: Date[1];
+   string2DateStr: String[1];
    string2DateTime: DateTime[1];
    convertToDate1: Date[1];
    convertToDate: Date[1];
@@ -1259,7 +1285,8 @@ Mapping meta::relational::tests::mapping::sqlFunction::model::mapping::testMappi
           string2Float : parseFloat(string2float),
           string2Decimal : parseDecimal(string2Decimal),
           string2decimal: trim(string2Decimal),
-          string2Date  : parseDate(string2date),
+          string2Date  : parseDate(string2date), 
+          string2DateStr : string2date,
           string2Integer  : parseInteger(string2Integer),
           convertToDate1: convertDate(stringDateFormat),
           convertToDate: convertDate(stringDateFormat,'yyyy-MM-dd'),


### PR DESCRIPTION
#### What type of PR is this?

Fix 

#### What does this PR do / why is it needed ?

parseDate is a pure function that is mapped to parsedatetime and date_parse in H2 and Presto databases.
Fixed this pure function to correctly generate SQL for these DBs.

#### Which issue(s) this PR fixes:
<!--
Fixes the parseDate pure function to SQL function transformation to correctly generate SQL for these DBs.
-->

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

