### PR TITLE
properly process connections for LegacyRuntime

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRuntimeBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRuntimeBuilder.java
@@ -174,7 +174,12 @@ public class HelperRuntimeBuilder
         {
             LegacyRuntime legacyRuntime = (LegacyRuntime) runtime;
             org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Runtime pureRuntime = new Root_meta_pure_runtime_Runtime_Impl("Root::meta::pure::runtime::Runtime");
-            ListIterate.forEach(legacyRuntime.connections, connection -> pureRuntime._connectionsAdd(connection.accept(new ConnectionFirstPassBuilder(context))));
+            ListIterate.forEach(legacyRuntime.connections, connection ->
+            {
+                final org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Connection pureConnection = connection.accept(new ConnectionFirstPassBuilder(context));
+                connection.accept(new ConnectionSecondPassBuilder(context, pureConnection));
+                pureRuntime._connectionsAdd(pureConnection);
+            });
             return pureRuntime;
         }
         if (runtime instanceof EngineRuntime)


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

On processing of legacy runtimes, the second pass visitor needs to be executed to accommodate extra processing of new connection parameters

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
