### PR TITLE
Increase nexus plugin staging timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,7 @@
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Increase nexus plugin staging timeout from the default 5 minutes to 10 minutes.

#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

This PR increases the timeout on the Nexus staging plugin. The 'release' action seems to be failing on the nexus timeout errors.

See https://pipelines.actions.githubusercontent.com/serviceHosts/519cc083-62da-4ea5-a01d-dfb72b89ad92/_apis/pipelines/1/runs/10770/signedlogcontent/2?urlExpires=2022-10-03T21%3A25%3A30.3480938Z&urlSigningMethod=HMACV1&urlSignature=FCamCU0kMLXMjub5TihwazhLBZO8lUL5WKNSvE84l9s%3D 

See https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment 

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No