### PR TITLE
Updating GCP build config

### DIFF
--- a/.gcp/cloud-build/build.sh
+++ b/.gcp/cloud-build/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
+# We have 64GB of available memory
+# (4 * 14 GB) + 6 GB = 62 GB
+# This leaves 2GB spare for system stability
+
 # printing tool versions
 java --version
 mvn --version
 gpg --version
 
 # setting env variables
-export MAVEN_OPTS="-Xms14g -Xmx14g"
+export MAVEN_OPTS="-Xms6g -Xmx6g"
 
 # running the build
-mvn -B -e -T 4 install
+mvn -B -e -T 4 install -DargLine="-Xms14g -Xmx14g"

--- a/.gcp/cloud-build/cloudbuild.yaml
+++ b/.gcp/cloud-build/cloudbuild.yaml
@@ -5,4 +5,5 @@ timeout: 7200s
 logsBucket: 'gs://finos-legend-engine-logs'
 options:
   logging: GCS_ONLY
-  machineType: E2_HIGHCPU_32
+  pool:
+    name: 'projects/legend-integration-testing/locations/us-east1/workerPools/cb-worker-pool'


### PR DESCRIPTION
#### What type of PR is this?

This changes the configuration for the GCP build job - now attempting to use a private cloud-build pool 

#### What does this PR do / why is it needed ?

Building in GCP with a private pool allows us greater control over the type of machines that can execute our builds.