### PR TITLE
Specifying GCP region

### DIFF
--- a/.gcp/cloud-build/build.sh
+++ b/.gcp/cloud-build/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# We have 64GB of available memory
-# (4 * 14 GB) + 6 GB = 62 GB
-# This leaves 2GB spare for system stability
-
 # printing tool versions
 java --version
 mvn --version
@@ -13,4 +9,4 @@ gpg --version
 export MAVEN_OPTS="-Xms6g -Xmx6g"
 
 # running the build
-mvn -B -e -T 4 install -DargLine="-Xms14g -Xmx14g"
+mvn -B -e -T 4 install -DargLine="-Xms12g -Xmx12g"

--- a/.github/workflows/trigger-gcp-build.yml
+++ b/.github/workflows/trigger-gcp-build.yml
@@ -17,6 +17,7 @@ name: Trigger GCP build
 env:
   GCP_API_KEY: ${{ secrets.GCP_API_KEY }}
   GCP_BUILD_TRIGGER_SECRET: ${{ secrets.GCP_BUILD_TRIGGER_SECRET }}
+  GCP_REGION: us-east1
 
 on:
   workflow_dispatch: {}
@@ -47,14 +48,14 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Get last build ID
-        run: echo "GCP_BUILD_ID=$(gcloud builds list --filter substitutions.TRIGGER_NAME='legend-engine-build-webhook' --sort-by create_time --limit 1 --format='value(id)')" >> $GITHUB_ENV
+        run: echo "GCP_BUILD_ID=$(gcloud builds list --region='${GCP_REGION}' --filter substitutions.TRIGGER_NAME='legend-engine-build-webhook' --sort-by create_time --format='value(id)' | tail -n 1)" >> $GITHUB_ENV
 
       - name: Stream build logs
-        run: gcloud builds log --stream '${{ env.GCP_BUILD_ID }}'
+        run: gcloud builds log --region='${GCP_REGION}' --stream '${{ env.GCP_BUILD_ID }}'
 
       - name: Report GCP build status
         run: |
-          buildStatus=$(gcloud builds list --filter id='${{ env.GCP_BUILD_ID }}' --format='value(status)')
+          buildStatus=$(gcloud builds list --region='${GCP_REGION}' --filter id='${{ env.GCP_BUILD_ID }}' --format='value(status)')
           
           echo "Logs streaming ended with the build having a status of '${buildStatus}'"
           echo "Check the full build logs at: https://storage.googleapis.com/finos-legend-engine-logs/log-${{ env.GCP_BUILD_ID }}.txt"


### PR DESCRIPTION
#### What type of PR is this?

This PR changes the GCP trigger action to specify the region the build is executed in.

#### What does this PR do / why is it needed ?

When using a private pool for GCP builds, the builds are locked to the region the pool is created in - this requires us to pass a --region flag when invoking gcloud commands