### PR TITLE
standardize engine port to `60xx` range

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,16 @@ Execution engine for Legend. It provides:
 
 ## Development setup
 
-- This application uses Maven 3.6+ and JDK 11. Simply run `mvn install` to compile.
-- In order to start the server, please use the Main class org.finos.legend.engine.server.Server with the parameters: `server legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json`.
-- You can test by trying http://127.0.0.1:6060 in a web browser. The swagger page can be accessed at http://127.0.0.1:6060/api/swagger.
+- This applications uses Maven 3.6+ and JDK 11. Simply run `mvn install` to compile.
+- In order to start the server, please use the `Main` class `org.finos.legend.engine.server.Server` with the parameters: `server legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json`.
+- You can test by trying http://127.0.0.1:6000 in a web browser. The swagger page can be accessed at http://127.0.0.1:6000/api/swagger
+
+### Starting Pure IDE
+
+If you're making changes to the `Pure` codebase, it's highly recommended that you also spin up our `Pure IDE` application:
+
+- In order to start the server, please use the `Main` class `org.finos.legend.engine.ide.PureIDELight` with the parameters: `server legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json`.
+- You can now access the IDE at http://127.0.0.1:9100/ide in a web browser.
 
 ## Roadmap
 

--- a/legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json
@@ -20,7 +20,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 9010
+      "port": 9100
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-server-integration-tests/config/config.json
+++ b/legend-engine-server-integration-tests/config/config.json
@@ -43,7 +43,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": []

--- a/legend-engine-server/config/config.json
+++ b/legend-engine-server/config/config.json
@@ -43,7 +43,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": []

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withFlowProvider.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withFlowProvider.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withMetadataFromIDELight.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withMetadataFromIDELight.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withVault.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withVault.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
+++ b/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6060
+      "port": 6000
     },
     "requestLog": {
       "appenders": [

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     <properties>
         <!-- Legend -->
         <legend.pure.version>3.7.0</legend.pure.version>
-        <legend.shared.version>0.22.0</legend.shared.version>
+        <legend.shared.version>0.22.5</legend.shared.version>
 
         <!-- SONAR -->
         <sonar.projectKey>legend-engine</sonar.projectKey>


### PR DESCRIPTION
- [x] standardize engine port to `6000`
- [x] standardize pure IDE port to `9100`
- [x] updated README development guide
- [x] upgraded `legend-shared` dep to `0.22.5`

Also updated doc at https://github.com/finos/legend/pull/542