### PR TITLE
standardize Engine port to 6300

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Execution engine for Legend. It provides:
 
 - This applications uses Maven 3.6+ and JDK 11. Simply run `mvn install` to compile.
 - In order to start the server, please use the `Main` class `org.finos.legend.engine.server.Server` with the parameters: `server legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json`.
-- You can test by trying http://127.0.0.1:6000 in a web browser. The swagger page can be accessed at http://127.0.0.1:6000/api/swagger
+- You can test by trying http://127.0.0.1:6300 in a web browser. The swagger page can be accessed at http://127.0.0.1:6000/api/swagger
 
 ### Starting Pure IDE
 

--- a/legend-engine-server-integration-tests/config/config.json
+++ b/legend-engine-server-integration-tests/config/config.json
@@ -43,7 +43,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": []

--- a/legend-engine-server/config/config.json
+++ b/legend-engine-server/config/config.json
@@ -43,7 +43,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": []

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withFlowProvider.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withFlowProvider.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withMetadataFromIDELight.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withMetadataFromIDELight.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withVault.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withVault.json
@@ -46,7 +46,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
+++ b/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
@@ -23,7 +23,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 6000
+      "port": 6300
     },
     "requestLog": {
       "appenders": [


### PR DESCRIPTION
standardize Engine port to `6300` since port `6000` was a reserved port for `X Window System` - https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=6000