### PR TITLE
allow specifying session cookie name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Execution engine for Legend. It provides:
 
 - This applications uses Maven 3.6+ and JDK 11. Simply run `mvn install` to compile.
 - In order to start the server, please use the `Main` class `org.finos.legend.engine.server.Server` with the parameters: `server legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json`.
-- You can test by trying http://127.0.0.1:6300 in a web browser. The swagger page can be accessed at http://127.0.0.1:6000/api/swagger
+- You can test by trying http://127.0.0.1:6300 in a web browser. The swagger page can be accessed at http://127.0.0.1:6300/api/swagger
 
 ### Starting Pure IDE
 

--- a/legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json
@@ -13,6 +13,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-server-integration-tests/config/config.json
+++ b/legend-engine-server-integration-tests/config/config.json
@@ -36,6 +36,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/api"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-server/config/config.json
+++ b/legend-engine-server/config/config.json
@@ -36,6 +36,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/api"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -166,7 +166,12 @@ public class Server<T extends ServerConfiguration> extends Application<T>
 
         // Session Management
         SessionTracker sessionTracker = new SessionTracker();
-        environment.servlets().setSessionHandler(new SessionHandler());
+        SessionHandler sessionHandler = new SessionHandler();
+        if (serverConfiguration.sessionCookie != null)
+        {
+            sessionHandler.setSessionCookie(serverConfiguration.sessionCookie);
+        }
+        environment.servlets().setSessionHandler(sessionHandler);
         environment.servlets().addServletListeners(sessionTracker);
         environment.jersey().register(new SessionInfo(sessionTracker));
 

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/ServerConfiguration.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/ServerConfiguration.java
@@ -30,6 +30,9 @@ import java.util.Map;
 
 public class ServerConfiguration extends Configuration
 {
+    // This can be set to avoid Jetty session cookie name collision between multiple servers running on `localhost` during development
+    // See https://stackoverflow.com/questions/16789495/two-applications-on-the-same-server-use-the-same-jsessionid
+    public String sessionCookie;
     public LegendPac4jConfiguration pac4j;
     public DeploymentConfiguration deployment = new DeploymentConfiguration();
     public SwaggerBundleConfiguration swagger;

--- a/legend-engine-server/src/main/resources/docker/config/config.json
+++ b/legend-engine-server/src/main/resources/docker/config/config.json
@@ -47,6 +47,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/api"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json
@@ -39,6 +39,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/api"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withFlowProvider.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withFlowProvider.json
@@ -39,6 +39,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/api"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withMetadataFromIDELight.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withMetadataFromIDELight.json
@@ -39,6 +39,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/api"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withVault.json
+++ b/legend-engine-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withVault.json
@@ -39,6 +39,7 @@
     "resourcePackage": "org.finos.legend",
     "uriPrefix": "/api"
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
+++ b/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
@@ -16,6 +16,7 @@
       }
     ]
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
@@ -16,6 +16,7 @@
       }
     ]
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
@@ -16,6 +16,7 @@
       }
     ]
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
@@ -16,6 +16,7 @@
       }
     ]
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
@@ -16,6 +16,7 @@
       }
     ]
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
@@ -16,6 +16,7 @@
       }
     ]
   },
+  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",


### PR DESCRIPTION
Allow specifying session cookie name to help with local development (when we have multiple Legend applications)

see https://stackoverflow.com/questions/16789495/two-applications-on-the-same-server-use-the-same-jsessionid