### PR TITLE
Update test server config to ignore unknown properties

### DIFF
--- a/legend-engine-test-server-shared/src/main/java/org/finos/legend/engine/server/test/shared/TestServerConfiguration.java
+++ b/legend-engine-test-server-shared/src/main/java/org/finos/legend/engine/server/test/shared/TestServerConfiguration.java
@@ -14,12 +14,14 @@
 
 package org.finos.legend.engine.server.test.shared;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.dropwizard.Configuration;
 import org.finos.legend.engine.shared.core.vault.VaultConfiguration;
 import org.finos.legend.server.pac4j.LegendPac4jConfiguration;
 
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TestServerConfiguration extends Configuration
 {
     public LegendPac4jConfiguration pac4j;

--- a/legend-engine-test-server-shared/src/main/java/org/finos/legend/engine/server/test/shared/TestServerConfiguration.java
+++ b/legend-engine-test-server-shared/src/main/java/org/finos/legend/engine/server/test/shared/TestServerConfiguration.java
@@ -14,14 +14,12 @@
 
 package org.finos.legend.engine.server.test.shared;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.dropwizard.Configuration;
 import org.finos.legend.engine.shared.core.vault.VaultConfiguration;
 import org.finos.legend.server.pac4j.LegendPac4jConfiguration;
 
 import java.util.List;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class TestServerConfiguration extends Configuration
 {
     public LegendPac4jConfiguration pac4j;

--- a/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
+++ b/legend-engine-xt-relationalStore-sqlserver-execution-tests/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSqlServerTestConnection.json
@@ -16,7 +16,6 @@
       }
     ]
   },
-  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withDatabricksTestConnection.json
@@ -16,7 +16,6 @@
       }
     ]
   },
-  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withH2TestConnection.json
@@ -16,7 +16,6 @@
       }
     ]
   },
-  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withPostgresTestConnection.json
@@ -16,7 +16,6 @@
       }
     ]
   },
-  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withRedshiftTestConnection.json
@@ -16,7 +16,6 @@
       }
     ]
   },
-  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
+++ b/legend-engine-xt-relationalStore-test-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig_withSnowflakeTestConnection.json
@@ -16,7 +16,6 @@
       }
     ]
   },
-  "sessionCookie": "LEGEND_ENGINE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",


### PR DESCRIPTION
#### What type of PR is this?

Enhancement

#### What does this PR do / why is it needed ?

This PR instructs the test server to ignore unknown properties in the server's JSON configuration.

PR #1020 introduced a new configuration property which is not recognized or needed by the test server. 

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No