### PR TITLE
unignore test failure in PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           MAVEN_OPTS: -Xmx4g
       - name: Build + Test
         if: (github.repository != 'finos/legend-engine') || (github.ref != 'refs/heads/master')
-        run: mvn install javadoc:javadoc -Dmaven.test.failure.ignore=true
+        run: mvn install javadoc:javadoc
         env:
           MAVEN_OPTS: -Xmx4g
       - name: Build + Test + Maven Deploy + Sonar + Docker Snapshot

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
-        <maven.enforcer.requireJavaVersion>[11.0.10,16)</maven.enforcer.requireJavaVersion>
+        <maven.enforcer.requireJavaVersion>[11.0.10,12)</maven.enforcer.requireJavaVersion>
 
         <!-- Databases -->
         <hikaricp.version>4.0.3</hikaricp.version>


### PR DESCRIPTION
@kevin-m-knight-gs pointed out that because we set `maven.test.failure.ignore=true` in PR CI, `maven-surefire-plugin` ends up not reporting failure at all, causing `test reporter` to be unaware of failure - which is bad 🤯 

We found the evidences from these 2 pipelines
https://github.com/finos/legend-engine/pull/1019/checks?check_run_id=8735398516
https://github.com/finos/legend-engine/pull/1020/checks?check_run_id=8735893546

The first is a good commit
The second is a bad commit, not getting caught in the PR CI

I'm doing it to see if the error bubbles up properly. Also I want to see if this change affects the `test reporter` anyhow, in which case, we would probably want to remove the test reporter altogether because it's just not suitable for our use case it would seem.