### PR TITLE
enhance relational compiler extension - Allow connection to flow to postprocessor

### DIFF
--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/IRelationalCompilerExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/IRelationalCompilerExtension.java
@@ -25,6 +25,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Comp
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.postprocessor.PostProcessor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
@@ -55,9 +56,14 @@ public interface IRelationalCompilerExtension extends CompilerExtension
         return process(authenticationStrategy, processors, context, "Authentication Strategy", authenticationStrategy.sourceInformation);
     }
 
-    static Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter> process(PostProcessor postProcessor, List<Function2<PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> processors, CompileContext context)
+    static Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter> process(Connection connection, PostProcessor postProcessor, List<Function3<Connection, PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> processors, CompileContext context)
     {
-        return process(postProcessor, processors, context, "Post Processor", postProcessor.sourceInformation);
+        SourceInformation srcInfo = postProcessor.sourceInformation;
+        return ListIterate
+                .collect(processors, processor-> processor.value(connection, postProcessor, context))
+                .select(Objects::nonNull)
+                .getFirstOptional()
+                .orElseThrow(() -> new EngineException("Unsupported Post Processor type '" + postProcessor.getClass() + "'", srcInfo, EngineErrorType.COMPILATION));
     }
 
     static PostProcessorWithParameter process(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.legacy.PostProcessorWithParameter postProcessorWithParameter, List<Function2<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.legacy.PostProcessorWithParameter, CompileContext, PostProcessorWithParameter>> processors, CompileContext context)
@@ -93,7 +99,7 @@ public interface IRelationalCompilerExtension extends CompilerExtension
         return Lists.immutable.with();
     }
 
-    default List<Function2<PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> getExtraConnectionPostProcessor()
+    default List<Function3<Connection, PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> getExtraConnectionPostProcessor()
     {
         return FastList.newList();
     }

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
@@ -350,6 +350,7 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
                         List<PostProcessor> postProcessors = relationalDatabaseConnection.postProcessors == null ? FastList.newList() : relationalDatabaseConnection.postProcessors;
 
                         MutableList<Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>> pp = ListIterate.collect(postProcessors, p -> IRelationalCompilerExtension.process(
+                                relationalDatabaseConnection,
                                 p,
                                 ListIterate.flatCollect(extensions, IRelationalCompilerExtension::getExtraConnectionPostProcessor),
                                 context));
@@ -530,9 +531,9 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
     }
 
     @Override
-    public List<Function2<PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> getExtraConnectionPostProcessor()
+    public List<Function3<Connection, PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> getExtraConnectionPostProcessor()
     {
-        return Lists.mutable.with((processor, context) ->
+        return Lists.mutable.with((connection, processor, context) ->
         {
             if (processor instanceof MapperPostProcessor)
             {


### PR DESCRIPTION
#### What type of PR is this?

Feature Enhancement

#### What does this PR do / why is it needed ?

- This change gives us access to connection information in the postprocessor during compile time
- This is useful when we want to do postprocessing based on the type of database

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
