### PR TITLE
enhance relational compiler extension - Allow connection to flow to postprocessor

### DIFF
--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
@@ -350,6 +350,7 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
                         List<PostProcessor> postProcessors = relationalDatabaseConnection.postProcessors == null ? FastList.newList() : relationalDatabaseConnection.postProcessors;
 
                         MutableList<Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>> pp = ListIterate.collect(postProcessors, p -> IRelationalCompilerExtension.process(
+                                relationalDatabaseConnection,
                                 p,
                                 ListIterate.flatCollect(extensions, IRelationalCompilerExtension::getExtraConnectionPostProcessor),
                                 context));
@@ -530,9 +531,9 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
     }
 
     @Override
-    public List<Function2<PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> getExtraConnectionPostProcessor()
+    public List<Function3<Connection, PostProcessor, CompileContext, Pair<Root_meta_pure_alloy_connections_PostProcessor, PostProcessorWithParameter>>> getExtraConnectionPostProcessor()
     {
-        return Lists.mutable.with((processor, context) ->
+        return Lists.mutable.with((connection, processor, context) ->
         {
             if (processor instanceof MapperPostProcessor)
             {


### PR DESCRIPTION
#### What type of PR is this?

Feature Enhancement

#### What does this PR do / why is it needed ?

- This change gives us access to connection information in the postprocessor during compile time
- This is useful when we want to do postprocessing based on the type of database

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No