### PR TITLE
Remove closing connections async since take CPU resources from other parallel executions

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/state/ExecutionState.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/state/ExecutionState.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.plan.execution.nodes.state;
 
 import io.opentracing.Span;
+import java.util.concurrent.Executor;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
@@ -62,6 +63,7 @@ public class ExecutionState
 
     public final List<Function3<ExecutionNode, MutableList<CommonProfile>, ExecutionState, Result>> extraNodeExecutors;
     public final List<Function3<ExecutionNode, MutableList<CommonProfile>, ExecutionState, Result>> extraSequenceNodeExecutors;
+    private final Executor executor;
 
     public ExecutionState(ExecutionState state)
     {
@@ -84,9 +86,15 @@ public class ExecutionState
         List<ExecutionExtension> extensions = ExecutionExtensionLoader.extensions();
         this.extraNodeExecutors = ListIterate.flatCollect(extensions, ExecutionExtension::getExtraNodeExecutors);
         this.extraSequenceNodeExecutors = ListIterate.flatCollect(extensions, ExecutionExtension::getExtraSequenceNodeExecutors);
+        this.executor = state.executor;
     }
 
     public ExecutionState(Map<String, Result> res, List<? extends String> templateFunctions, Iterable<? extends StoreExecutionState> extraStates, boolean isJavaCompilationAllowed, long graphFetchBatchMemoryLimit)
+    {
+        this(res, templateFunctions, extraStates, isJavaCompilationAllowed, graphFetchBatchMemoryLimit, null);
+    }
+
+    public ExecutionState(Map<String, Result> res, List<? extends String> templateFunctions, Iterable<? extends StoreExecutionState> extraStates, boolean isJavaCompilationAllowed, long graphFetchBatchMemoryLimit, Executor executor)
     {
         this.inAllocation = false;
         this.inLake = false;
@@ -99,6 +107,7 @@ public class ExecutionState
         List<ExecutionExtension> extensions = ExecutionExtensionLoader.extensions();
         this.extraNodeExecutors = ListIterate.flatCollect(extensions, ExecutionExtension::getExtraNodeExecutors);
         this.extraSequenceNodeExecutors = ListIterate.flatCollect(extensions, ExecutionExtension::getExtraSequenceNodeExecutors);
+        this.executor = executor;
     }
 
     public ExecutionState(Map<String, Result> res, List<? extends String> templateFunctions, Iterable<? extends StoreExecutionState> extraStates, boolean isJavaCompilationAllowed)
@@ -232,5 +241,10 @@ public class ExecutionState
     public List<? extends String> getTemplateFunctions()
     {
         return Collections.unmodifiableList(this.templateFunctions);
+    }
+
+    public Executor getSideTasksExecutor()
+    {
+        return this.executor;
     }
 }

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -410,6 +410,18 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-lifecycle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
         <!-- DropWizard -->
 
         <!-- Swagger -->
@@ -483,6 +495,11 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <!-- COMMONS IO -->
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
         <!-- LOG -->
         <dependency>

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/blockConnection/BlockConnectionContext.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/blockConnection/BlockConnectionContext.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.blockConnection;
 
+import java.util.concurrent.Executor;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.factory.Maps;
@@ -68,9 +69,16 @@ public class BlockConnectionContext
         this.blockConnectionMap.values().forEach(BlockConnection::close);
     }
 
-    public void closeAllBlockConnectionsAsync()
+    public void closeAllBlockConnectionsAsync(Executor executor)
     {
-        this.blockConnectionMap.values().forEach(blockConnection -> CompletableFuture.runAsync(blockConnection::close));
+        if (executor != null)
+        {
+            this.blockConnectionMap.values().forEach(blockConnection -> CompletableFuture.runAsync(blockConnection::close, executor));
+        }
+        else
+        {
+            this.closeAllBlockConnections();
+        }
     }
 
     private BlockConnection setBlockConnection(ConnectionManagerSelector connectionManager, DatabaseConnection databaseConnection, BlockConnection blockConnection)

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -592,7 +592,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             finally
             {
                 relationalStoreExecutionState.getBlockConnectionContext().unlockAllBlockConnections();
-                relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync();
+                relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync(executionState.getSideTasksExecutor());
                 relationalStoreExecutionState.setBlockConnectionContext(oldBlockConnectionContext);
                 relationalStoreExecutionState.setRetainConnection(oldRetainConnectionFlag);
             }
@@ -738,7 +738,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
                 }
 
                 relationalStoreExecutionState.getBlockConnectionContext().unlockAllBlockConnections();
-                relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync();
+                relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync(executionState.getSideTasksExecutor());
 
                 relationalStoreExecutionState.setBlockConnectionContext(oldBlockConnectionContext);
                 relationalStoreExecutionState.setRetainConnection(oldRetainConnectionFlag);
@@ -1307,7 +1307,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
                     finally
                     {
                         relationalStoreExecutionState.getBlockConnectionContext().unlockAllBlockConnections();
-                        relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync();
+                        relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync(executionState.getSideTasksExecutor());
                         relationalStoreExecutionState.setBlockConnectionContext(oldBlockConnectionContext);
                         relationalStoreExecutionState.setRetainConnection(oldRetainConnectionFlag);
                     }
@@ -1706,7 +1706,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             }
 
             relationalStoreExecutionState.getBlockConnectionContext().unlockAllBlockConnections();
-            relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync();
+            relationalStoreExecutionState.getBlockConnectionContext().closeAllBlockConnectionsAsync(executionState.getSideTasksExecutor());
             relationalStoreExecutionState.setBlockConnectionContext(oldBlockConnectionContext);
             relationalStoreExecutionState.setRetainConnection(oldRetainConnectionFlag);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1779,6 +1779,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-lifecycle</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-assets</artifactId>
                 <version>${dropwizard.version}</version>
             </dependency>


### PR DESCRIPTION
#### What type of PR is this?

Enhancement 

#### What does this PR do / why is it needed ?

This add support for sharing a thread executor for side tasks when executing plans.  This will allow us to move out of the fork join common pool, and into a pool that we can custom.

The current use-case is for IO tasks related to relational temp tables clean up.

The shared pool created for this will also be monitored using DW metrics to have visibility on execution stats.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

This could impact performance for connection that take longer to close.