### PR TITLE
Deserialize float value as BigDecimal in JSON assertion

### DIFF
--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/assertion/TestAssertionHelper.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/assertion/TestAssertionHelper.java
@@ -28,9 +28,14 @@ import java.io.IOException;
 
 public class TestAssertionHelper
 {
+    public static ObjectMapper buildObjectMapperForJSONComparison()
+    {
+        return new ObjectMapper().enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+    }
+
     protected static AssertionStatus compareAssertionJSON(TestAssertion parentAssertion, String _expected, String _actual) throws IOException
     {
-        ObjectMapper objectMapper = new ObjectMapper().enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+        ObjectMapper objectMapper = buildObjectMapperForJSONComparison();
         JsonNode expectedJsonNode = objectMapper.readTree(_expected.getBytes());
         JsonNode actualJsonNode = objectMapper.readTree(_actual.getBytes());
 

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/assertion/TestAssertionHelper.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/assertion/TestAssertionHelper.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.testable.assertion;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -29,7 +30,7 @@ public class TestAssertionHelper
 {
     protected static AssertionStatus compareAssertionJSON(TestAssertion parentAssertion, String _expected, String _actual) throws IOException
     {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper().enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
         JsonNode expectedJsonNode = objectMapper.readTree(_expected.getBytes());
         JsonNode actualJsonNode = objectMapper.readTree(_actual.getBytes());
 

--- a/legend-engine-testable/src/main/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
+++ b/legend-engine-testable/src/main/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
@@ -25,7 +25,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.Asse
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.EqualToJsonAssertFail;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CInteger;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Collection;
-import org.finos.legend.engine.testable.assertion.TestAssertionEvaluator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -129,5 +128,39 @@ public class TestTestAssertionEvaluator
         Assert.assertEquals("{\n  \"some\" : \"data\"\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
         Assert.assertEquals("{\n  \"some\" : \"wrong_data\"\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
+    }
+
+    @Test
+    public void testEqualToJsonAssertionWithDecimalPrecision()
+    {
+        ConstantResult constantResult = new ConstantResult("{\"some\":1234567890.123456789}");
+
+        ExternalFormatData data = new ExternalFormatData();
+        data.contentType = "application/json";
+
+        EqualToJson equalToJson = new EqualToJson();
+        equalToJson.id = "assert1";
+        equalToJson.expected = data;
+
+        data.data = "{\"some\":1234567890.1234567}";
+        AssertionStatus assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
+        Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
+        Assert.assertEquals("assert1", assertionStatus.id);
+        Assert.assertEquals("{\n  \"some\" : 1234567890.1234567\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals("{\n  \"some\" : 1234567890.123456789\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
+
+        data.data = "{\"some\":1234567890.123456789012}";
+        assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
+        Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
+        Assert.assertEquals("assert1", assertionStatus.id);
+        Assert.assertEquals("{\n  \"some\" : 1234567890.123456789012\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals("{\n  \"some\" : 1234567890.123456789\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
+
+        data.data = "{\"some\":1234567890.123456789000}";
+        assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
+        Assert.assertTrue(assertionStatus instanceof AssertPass);
+        Assert.assertEquals("assert1", assertionStatus.id);
     }
 }

--- a/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/assertion/PersistenceTestAssertionEvaluator.java
+++ b/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/assertion/PersistenceTestAssertionEvaluator.java
@@ -26,6 +26,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.Asse
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertPass;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertionStatus;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.EqualToJsonAssertFail;
+import org.finos.legend.engine.testable.assertion.TestAssertionHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class PersistenceTestAssertionEvaluator implements TestAssertionEvaluator
             ExternalFormatData externalFormatData = equaltoJson.expected;
             String expectedDataString = externalFormatData.data;
             AssertionStatus assertionStatus;
-            ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper mapper = TestAssertionHelper.buildObjectMapperForJSONComparison();
             String actualResult = "";
 
             try


### PR DESCRIPTION
#### What type of PR is this?

Bug

#### What does this PR do / why is it needed ?

Current JSON assertion code uses float type for decimal values which can lead to incorrect results due to rounding off and loss in precision.

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

