### PR TITLE
Bump apache commons text from 1.8 to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-csv.version>1.5</commons-csv.version>
         <commons-io.version>2.7</commons-io.version>
-        <commons-text.version>1.8</commons-text.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <freemarker.version>2.3.30</freemarker.version>
         <opentracing.version>0.32.0</opentracing.version>
         <prometheus.version>0.8.1</prometheus.version>


### PR DESCRIPTION
#### What type of PR is this?

Dependency change

#### What does this PR do / why is it needed ?

This is to avoid using dependency wit new discovered [vulnerability](https://www.cve.org/CVERecord?id=CVE-2022-42889).
 
#### Which issue(s) this PR fixes:

N/A

#### Other notes for reviewers:

N/A

#### Does this PR introduce a user-facing change?

N/A
