### PR TITLE
Add parameter values option to execute api

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/ExecuteNodeParameterTransformationHelper.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/ExecuteNodeParameterTransformationHelper.java
@@ -1,0 +1,65 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.nodes.helpers;
+
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.finos.legend.engine.plan.execution.result.ConstantResult;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.FunctionParametersValidationNode;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.Variable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ExecuteNodeParameterTransformationHelper
+{
+    public static void buildParameterToConstantResult(SingleExecutionPlan plan, Map<String, ?> parameterToValues, MutableMap<String, Result> parametersToConstantResult)
+    {
+        List<Variable> functionParameters = plan.rootExecutionNode.executionNodes.stream().filter(node -> node instanceof FunctionParametersValidationNode).map(executionNode -> ((FunctionParametersValidationNode) executionNode).functionParameters).flatMap(Collection::stream).collect(Collectors.toList());
+        Multiplicity paraMultiplicity = new Multiplicity();
+        for (Map.Entry<String, ?> parameterToValue : parameterToValues.entrySet())
+        {
+            paraMultiplicity = getFunctionParameterMultiplicity(functionParameters, paraMultiplicity, parameterToValue.getKey());
+            Object parameterValue = parameterToValue.getValue();
+            boolean isSingularListValue = parameterValue instanceof FastList && ((FastList) parameterValue).size() == 1 && paraMultiplicity.isUpperBoundEqualTo(1);
+            if (isSingularListValue)
+            {
+                parametersToConstantResult.put(parameterToValue.getKey(), new ConstantResult(((FastList) parameterValue).getFirst()));
+            }
+            else
+            {
+                parametersToConstantResult.put(parameterToValue.getKey(), new ConstantResult(parameterValue));
+            }
+        }
+    }
+
+    private static Multiplicity getFunctionParameterMultiplicity(List<Variable> functionParameters, Multiplicity paraMultiplicity, String parameterName)
+    {
+        for (Variable var : functionParameters)
+        {
+            if (var.name.equals(parameterName))
+            {
+                paraMultiplicity = var.multiplicity;
+                break;
+            }
+        }
+        return paraMultiplicity;
+    }
+}

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/HelperServiceBuilder.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/HelperServiceBuilder.java
@@ -34,7 +34,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedExecutionParameter;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedSingleExecutionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.MultiExecutionTest;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ParameterValue;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureMultiExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureSingleExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTest_Legacy;

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
@@ -39,7 +39,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedExecutionParameter;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedSingleExecutionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.MultiExecutionTest;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ParameterValue;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureMultiExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureSingleExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/HelperServiceGrammarComposer.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/HelperServiceGrammarComposer.java
@@ -30,7 +30,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedExecutionParameter;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedSingleExecutionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.MultiExecutionTest;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ParameterValue;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureMultiExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureSingleExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTest;

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/service/ServiceTest.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/service/ServiceTest.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service;
 
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTest;
 
 import java.util.List;

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/domain/ParameterValue.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/domain/ParameterValue.java
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service;
+package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain;
 
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 

--- a/legend-engine-query-pure/pom.xml
+++ b/legend-engine-query-pure/pom.xml
@@ -78,6 +78,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-execution-authorizer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-testable</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <dependency>
@@ -181,6 +185,26 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- TEST -->

--- a/legend-engine-query-pure/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestExecutionUtility.java
+++ b/legend-engine-query-pure/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestExecutionUtility.java
@@ -1,0 +1,69 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.query.pure.api.test.inMemory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class TestExecutionUtility
+{
+    public static String responseAsString(Response response) throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        StreamingOutput output = (StreamingOutput) response.getEntity();
+        output.write(baos);
+        return baos.toString("UTF-8");
+    }
+
+    public static class ReflectiveInvocationHandler implements InvocationHandler
+    {
+        private final Object[] delegates;
+
+        public ReflectiveInvocationHandler(Object... delegates)
+        {
+            this.delegates = delegates;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
+        {
+            for (Object delegate : delegates)
+            {
+                try
+                {
+                    return delegate.getClass().getMethod(method.getName(), method.getParameterTypes()).invoke(delegate, args);
+                }
+                catch (NoSuchMethodException e)
+                {
+                    // The loop will complete if all delegates fail
+                }
+            }
+            throw new UnsupportedOperationException("Method not simulated: " + method);
+        }
+    }
+
+    public static class Request
+    {
+        @SuppressWarnings("unused")
+        public String getRemoteUser()
+        {
+            return "someone";
+        }
+    }
+}

--- a/legend-engine-query-pure/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
+++ b/legend-engine-query-pure/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
@@ -247,7 +247,7 @@ public class TestM2MGrammarCompileAndExecute
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST);
         PlanExecutor executor = PlanExecutor.newPlanExecutor(InMemory.build());
-        HttpServletRequest request = (HttpServletRequest) Proxy.newProxyInstance(getClass().getClassLoader(), new java.lang.Class<?>[] {HttpServletRequest.class}, new ReflectiveInvocationHandler(new Request()));
+        HttpServletRequest request = (HttpServletRequest) Proxy.newProxyInstance(getClass().getClassLoader(), new java.lang.Class<?>[] {HttpServletRequest.class}, new TestExecutionUtility.ReflectiveInvocationHandler(new TestExecutionUtility.Request()));
         //Should use: core_pure_extensions_extension.Root_meta_pure_extension_defaultExtensions__Extension_MANY_(modelManager.)
         Response result = new Execute(modelManager, executor, (PureModel pureModel) -> core_pure_extensions_functions.Root_meta_pure_extension_defaultExtensions__Extension_MANY_(pureModel.getExecutionSupport()), LegendPlanTransformers.transformers).execute(request, input, SerializationFormat.defaultFormat, null, null);
         Assert.assertEquals(200, result.getStatus());
@@ -322,41 +322,5 @@ public class TestM2MGrammarCompileAndExecute
         LegacyRuntime runtime = new LegacyRuntime();
         runtime.connections = Collections.singletonList(connection);
         return runtime;
-    }
-
-    private static class ReflectiveInvocationHandler implements InvocationHandler
-    {
-        private final Object[] delegates;
-
-        private ReflectiveInvocationHandler(Object... delegates)
-        {
-            this.delegates = delegates;
-        }
-
-        @Override
-        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
-        {
-            for (Object delegate : delegates)
-            {
-                try
-                {
-                    return delegate.getClass().getMethod(method.getName(), method.getParameterTypes()).invoke(delegate, args);
-                }
-                catch (NoSuchMethodException e)
-                {
-                    // The loop will complete if all delegates fail
-                }
-            }
-            throw new UnsupportedOperationException("Method not simulated: " + method);
-        }
-    }
-
-    private static class Request
-    {
-        @SuppressWarnings("unused")
-        public String getRemoteUser()
-        {
-            return "someone";
-        }
     }
 }

--- a/legend-engine-query-pure/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestQueryExecutionWithParameters.java
+++ b/legend-engine-query-pure/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestQueryExecutionWithParameters.java
@@ -1,0 +1,72 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.query.pure.api.test.inMemory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.modelManager.ModelManager;
+import org.finos.legend.engine.plan.execution.PlanExecutor;
+import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
+import org.finos.legend.engine.plan.execution.stores.relational.plugin.RelationalStoreExecutor;
+import org.finos.legend.engine.plan.execution.stores.relational.plugin.RelationalStoreExecutorBuilder;
+import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransformers;
+import org.finos.legend.engine.query.pure.api.Execute;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
+import org.finos.legend.engine.shared.core.api.model.ExecuteInput;
+import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.Objects;
+
+import static org.finos.legend.pure.generated.core_relational_relational_extensions_extension.Root_meta_relational_extension_relationalExtensions__Extension_MANY_;
+import static org.junit.Assert.assertEquals;
+
+public class TestQueryExecutionWithParameters
+{
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
+
+    @Test
+    public void testQueryExecutionWithParameterZeroMany() throws IOException
+    {
+        ExecuteInput input = objectMapper.readValue(Objects.requireNonNull(getClass().getClassLoader().getResource("relationalQueryExecutionInputZeroMany.json")), ExecuteInput.class);
+        String json = TestExecutionUtility.responseAsString(runTest(input));
+        assertEquals("{\"builder\": {\"_type\":\"tdsBuilder\",\"columns\":[{\"name\":\"Age\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"}]}, \"activities\": [{\"_type\":\"relational\",\"sql\":\"select top 1000 \\\"root\\\".age as \\\"Age\\\" from PersonTable as \\\"root\\\" where \\\"root\\\".age in (20,30)\"}], \"result\" : {\"columns\" : [\"Age\"], \"rows\" : [{\"values\": [20]},{\"values\": [30]}]}}", json);
+    }
+
+    @Test
+    public void testQueryExecutionWithParameterEnumZeroOne() throws IOException
+    {
+        ExecuteInput input = objectMapper.readValue(Objects.requireNonNull(getClass().getClassLoader().getResource("relationalQueryExecutionInputEnumZeroOne.json")), ExecuteInput.class);
+        String json = TestExecutionUtility.responseAsString(runTest(input));
+        assertEquals("{\"builder\": {\"_type\":\"tdsBuilder\",\"columns\":[{\"name\":\"Inc Type\",\"type\":\"model::IncType\",\"relationalType\":\"VARCHAR(200)\"}]}, \"activities\": [{\"_type\":\"relational\",\"sql\":\"select top 1000 \\\"root\\\".Inc as \\\"Inc Type\\\" from FirmTable as \\\"root\\\" where \\\"root\\\".Inc = 'LLC'\"}], \"result\" : {\"columns\" : [\"Inc Type\"], \"rows\" : [{\"values\": [\"LLC\"]}]}}", json);
+    }
+
+    private Response runTest(ExecuteInput input)
+    {
+        ModelManager modelManager = new ModelManager(DeploymentMode.TEST);
+        RelationalStoreExecutor relationalStoreExecutor = new RelationalStoreExecutorBuilder().build();
+        PlanExecutor planExecutor = PlanExecutor.newPlanExecutor(relationalStoreExecutor);
+        HttpServletRequest request = (HttpServletRequest) Proxy.newProxyInstance(getClass().getClassLoader(), new java.lang.Class<?>[] {HttpServletRequest.class}, new TestExecutionUtility.ReflectiveInvocationHandler(new TestExecutionUtility.Request()));
+        Response result = new Execute(modelManager, planExecutor, (PureModel pureModel) -> Root_meta_relational_extension_relationalExtensions__Extension_MANY_(pureModel.getExecutionSupport()), LegendPlanTransformers.transformers).execute(request, input, SerializationFormat.defaultFormat, null, null);
+        Assert.assertEquals(200, result.getStatus());
+        return result;
+    }
+}
+

--- a/legend-engine-query-pure/src/test/resources/relationalQueryExecutionInputEnumZeroOne.json
+++ b/legend-engine-query-pure/src/test/resources/relationalQueryExecutionInputEnumZeroOne.json
@@ -1,0 +1,843 @@
+{
+  "clientVersion": "vX_X_X",
+  "function": {
+    "_type": "lambda",
+    "body": [
+      {
+        "_type": "func",
+        "function": "take",
+        "parameters": [
+          {
+            "_type": "func",
+            "function": "project",
+            "parameters": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "getAll",
+                    "parameters": [
+                      {
+                        "_type": "packageableElementPtr",
+                        "fullPath": "model::Firm"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "x"
+                              }
+                            ],
+                            "property": "incType"
+                          },
+                          {
+                            "_type": "var",
+                            "name": "var_1"
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "values": [
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "x"
+                          }
+                        ],
+                        "property": "incType"
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "values": [
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "values": [
+                      "Inc Type"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "_type": "integer",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "values": [
+              1000
+            ]
+          }
+        ]
+      }
+    ],
+    "parameters": [
+      {
+        "_type": "var",
+        "class": "model::IncType",
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
+        },
+        "name": "var_1"
+      }
+    ]
+  },
+  "mapping": "model::RelationalMapping",
+  "model": {
+    "_type": "data",
+    "elements": [
+      {
+        "_type": "profile",
+        "name": "MyExtension",
+        "package": "model",
+        "stereotypes": [
+          "important"
+        ],
+        "tags": [
+          "doc"
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "IncType",
+        "package": "model",
+        "values": [
+          {
+            "value": "Corp"
+          },
+          {
+            "value": "LLC"
+          }
+        ]
+      },
+      {
+        "_type": "class",
+        "name": "LegalEntity",
+        "package": "model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "legalName",
+            "type": "String"
+          }
+        ]
+      },
+      {
+        "_type": "class",
+        "constraints": [
+          {
+            "functionDefinition": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "func",
+                  "function": "startsWith",
+                  "parameters": [
+                    {
+                      "_type": "property",
+                      "property": "legalName",
+                      "parameters": [
+                        {
+                          "_type": "var",
+                          "name": "this"
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "string",
+                      "values": [
+                        "_"
+                      ],
+                      "multiplicity": {
+                        "lowerBound": 1,
+                        "upperBound": 1
+                      }
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            "name": "validName"
+          }
+        ],
+        "name": "Firm",
+        "package": "model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1
+            },
+            "name": "employees",
+            "type": "model::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "incType",
+            "type": "model::IncType"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "isApple",
+            "type": "Boolean"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "count",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "property": "employees",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeeSize",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Number"
+          }
+        ],
+        "stereotypes": [
+          {
+            "profile": "model::MyExtension",
+            "value": "important"
+          }
+        ],
+        "superTypes": [
+          "model::LegalEntity"
+        ],
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::MyExtension",
+              "value": "doc"
+            },
+            "value": "This is a model of a firm"
+          }
+        ]
+      },
+      {
+        "_type": "class",
+        "name": "Person",
+        "package": "model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "age",
+            "type": "Integer"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "values": [
+                      {
+                        "_type": "property",
+                        "property": "firstName",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "string",
+                        "values": [
+                          " "
+                        ],
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        }
+                      },
+                      {
+                        "_type": "property",
+                        "property": "lastName",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      }
+                    ],
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    }
+                  }
+                ]
+              }
+            ],
+            "name": "fullName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String"
+          }
+        ]
+      },
+      {
+        "_type": "relational",
+        "filters": [],
+        "includedStores": [],
+        "joins": [
+          {
+            "name": "FirmPerson",
+            "operation": {
+              "_type": "dynaFunc",
+              "funcName": "equal",
+              "parameters": [
+                {
+                  "_type": "column",
+                  "column": "firm_id",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                },
+                {
+                  "_type": "column",
+                  "column": "id",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "FirmTable"
+                  },
+                  "tableAlias": "FirmTable"
+                }
+              ]
+            }
+          }
+        ],
+        "name": "MyDatabase",
+        "package": "model",
+        "schemas": [
+          {
+            "name": "default",
+            "tables": [
+              {
+                "columns": [
+                  {
+                    "name": "id",
+                    "nullable": false,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  },
+                  {
+                    "name": "Legal_name",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  },
+                  {
+                    "name": "Inc",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  }
+                ],
+                "name": "FirmTable",
+                "primaryKey": [
+                  "id"
+                ]
+              },
+              {
+                "columns": [
+                  {
+                    "name": "id",
+                    "nullable": false,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  },
+                  {
+                    "name": "firm_id",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  },
+                  {
+                    "name": "firstName",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  },
+                  {
+                    "name": "lastName",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  },
+                  {
+                    "name": "age",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  }
+                ],
+                "name": "PersonTable",
+                "primaryKey": [
+                  "id"
+                ]
+              }
+            ],
+            "views": []
+          }
+        ]
+      },
+      {
+        "_type": "mapping",
+        "classMappings": [
+          {
+            "_type": "relational",
+            "class": "model::Firm",
+            "distinct": false,
+            "mainTable": {
+              "_type": "Table",
+              "database": "model::MyDatabase",
+              "mainTableDb": "model::MyDatabase",
+              "schema": "default",
+              "table": "FirmTable"
+            },
+            "primaryKey": [
+              {
+                "_type": "column",
+                "column": "id",
+                "table": {
+                  "_type": "Table",
+                  "database": "model::MyDatabase",
+                  "mainTableDb": "model::MyDatabase",
+                  "schema": "default",
+                  "table": "FirmTable"
+                },
+                "tableAlias": "FirmTable"
+              }
+            ],
+            "propertyMappings": [
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "legalName"
+                },
+                "relationalOperation": {
+                  "_type": "dynaFunc",
+                  "funcName": "concat",
+                  "parameters": [
+                    {
+                      "_type": "column",
+                      "column": "Legal_name",
+                      "table": {
+                        "_type": "Table",
+                        "database": "model::MyDatabase",
+                        "mainTableDb": "model::MyDatabase",
+                        "schema": "default",
+                        "table": "FirmTable"
+                      },
+                      "tableAlias": "FirmTable"
+                    },
+                    {
+                      "_type": "literal",
+                      "value": "_LTD"
+                    }
+                  ]
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "employees"
+                },
+                "relationalOperation": {
+                  "_type": "elemtWithJoins",
+                  "joins": [
+                    {
+                      "db": "model::MyDatabase",
+                      "name": "FirmPerson"
+                    }
+                  ]
+                },
+                "target": "model_Person"
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "isApple"
+                },
+                "relationalOperation": {
+                  "_type": "dynaFunc",
+                  "funcName": "case",
+                  "parameters": [
+                    {
+                      "_type": "dynaFunc",
+                      "funcName": "equal",
+                      "parameters": [
+                        {
+                          "_type": "column",
+                          "column": "Legal_name",
+                          "table": {
+                            "_type": "Table",
+                            "database": "model::MyDatabase",
+                            "mainTableDb": "model::MyDatabase",
+                            "schema": "default",
+                            "table": "FirmTable"
+                          },
+                          "tableAlias": "FirmTable"
+                        },
+                        {
+                          "_type": "literal",
+                          "value": "Apple"
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "literal",
+                      "value": "true"
+                    },
+                    {
+                      "_type": "literal",
+                      "value": "false"
+                    }
+                  ]
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "enumMappingId": "model_IncType",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "incType"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "Inc",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "FirmTable"
+                  },
+                  "tableAlias": "FirmTable"
+                }
+              }
+            ],
+            "root": true
+          },
+          {
+            "_type": "relational",
+            "class": "model::Person",
+            "distinct": false,
+            "mainTable": {
+              "_type": "Table",
+              "database": "model::MyDatabase",
+              "mainTableDb": "model::MyDatabase",
+              "schema": "default",
+              "table": "PersonTable"
+            },
+            "primaryKey": [
+              {
+                "_type": "column",
+                "column": "id",
+                "table": {
+                  "_type": "Table",
+                  "database": "model::MyDatabase",
+                  "mainTableDb": "model::MyDatabase",
+                  "schema": "default",
+                  "table": "PersonTable"
+                },
+                "tableAlias": "PersonTable"
+              }
+            ],
+            "propertyMappings": [
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Person",
+                  "property": "firstName"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "firstName",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Person",
+                  "property": "lastName"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "lastName",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Person",
+                  "property": "age"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "age",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                }
+              }
+            ],
+            "root": true
+          }
+        ],
+        "enumerationMappings": [
+          {
+            "enumValueMappings": [
+              {
+                "enumValue": "Corp",
+                "sourceValues": [
+                  {
+                    "_type": "stringSourceValue",
+                    "value": "Corp"
+                  },
+                  {
+                    "_type": "stringSourceValue",
+                    "value": "CORP"
+                  }
+                ]
+              },
+              {
+                "enumValue": "LLC",
+                "sourceValues": [
+                  {
+                    "_type": "stringSourceValue",
+                    "value": "LLC"
+                  }
+                ]
+              }
+            ],
+            "enumeration": "model::IncType"
+          }
+        ],
+        "includedMappings": [],
+        "name": "RelationalMapping",
+        "package": "model",
+        "tests": []
+      },
+      {
+        "_type": "runtime",
+        "name": "Runtime",
+        "package": "model",
+        "runtimeValue": {
+          "_type": "engineRuntime",
+          "connections": [
+            {
+              "store": {
+                "path": "model::MyDatabase",
+                "type": "STORE"
+              },
+              "storeConnections": [
+                {
+                  "connection": {
+                    "_type": "connectionPointer",
+                    "connection": "model::MyConnection"
+                  },
+                  "id": "my_connection"
+                }
+              ]
+            }
+          ],
+          "mappings": [
+            {
+              "path": "model::RelationalMapping",
+              "type": "MAPPING"
+            }
+          ]
+        }
+      },
+      {
+        "_type": "connection",
+        "connectionValue": {
+          "_type": "RelationalDatabaseConnection",
+          "authenticationStrategy": {
+            "_type": "h2Default"
+          },
+          "databaseType": "H2",
+          "datasourceSpecification": {
+            "_type": "h2Local",
+            "testDataSetupSqls": [
+              "Drop table if exists FirmTable;\nDrop table if exists PersonTable;\nCreate Table FirmTable(id INT, Legal_Name VARCHAR(200), Inc VARCHAR(200));\nCreate Table PersonTable(id INT, firm_id INT, lastName VARCHAR(200), firstName VARCHAR(200), age INT);\nInsert into FirmTable (id, Legal_Name, Inc) values (1, 'Finos', 'CORP');\nInsert into FirmTable (id, Legal_Name, Inc) values (2, 'Apple', 'Corp');\nInsert into FirmTable (id, Legal_Name, Inc) values (3, 'GS', 'Corp');\nInsert into FirmTable (id, Legal_Name, Inc) values (4, 'Google', 'Corp');\nInsert into FirmTable (id, Legal_Name, Inc) values (5, 'Alphabet', 'LLC');\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (1, 3, 'X1', 'Mauricio', 10);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (2, 3, 'X2', 'An', 20);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (3, 3, 'X3', 'Anne', 30);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (4, 3, 'X4', 'Gayathri', 40);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (5, 3, 'X5', 'Yannan', 50);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (6, 3, 'X6', 'Dave', 60);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (7, 3, 'X7', 'Mo', 70);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (8, 3, 'X9', 'Teddy', 80);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (9, 2, 'X8', 'Teddy', 90);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (10, 2, 'X8', 'Teddy', 100);\n\n"
+            ]
+          },
+          "element": "model::MyDatabase",
+          "type": "H2"
+        },
+        "name": "MyConnection",
+        "package": "model"
+      }
+    ]
+  },
+  "runtime": {
+    "_type": "runtimePointer",
+    "runtime": "model::Runtime"
+  },
+  "context": {
+    "_type": "BaseExecutionContext",
+    "queryTimeOutInSeconds": null,
+    "enableConstraints": true
+  },
+  "parameterValues": [
+    {
+      "name": "var_1",
+      "value": {
+        "_type": "enumValue",
+        "fullPath": "model::IncType",
+        "value": "LLC"
+      }
+    }
+  ]
+}

--- a/legend-engine-query-pure/src/test/resources/relationalQueryExecutionInputZeroMany.json
+++ b/legend-engine-query-pure/src/test/resources/relationalQueryExecutionInputZeroMany.json
@@ -1,0 +1,865 @@
+{
+  "clientVersion": "vX_X_X",
+  "function": {
+    "_type": "lambda",
+    "body": [
+      {
+        "_type": "func",
+        "function": "take",
+        "parameters": [
+          {
+            "_type": "func",
+            "function": "project",
+            "parameters": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "getAll",
+                    "parameters": [
+                      {
+                        "_type": "packageableElementPtr",
+                        "fullPath": "model::Person"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "in",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "x"
+                              }
+                            ],
+                            "property": "age"
+                          },
+                          {
+                            "_type": "var",
+                            "name": "var_1"
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "values": [
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "x"
+                          }
+                        ],
+                        "property": "age"
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "values": [
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "values": [
+                      "Age"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "_type": "integer",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "values": [
+              1000
+            ]
+          }
+        ]
+      }
+    ],
+    "parameters": [
+      {
+        "_type": "var",
+        "class": "Integer",
+        "multiplicity": {
+          "lowerBound": 0
+        },
+        "name": "var_1"
+      }
+    ]
+  },
+  "mapping": "model::RelationalMapping",
+  "model": {
+    "_type": "data",
+    "elements": [
+      {
+        "_type": "profile",
+        "name": "MyExtension",
+        "package": "model",
+        "stereotypes": [
+          "important"
+        ],
+        "tags": [
+          "doc"
+        ]
+      },
+      {
+        "_type": "Enumeration",
+        "name": "IncType",
+        "package": "model",
+        "values": [
+          {
+            "value": "Corp"
+          },
+          {
+            "value": "LLC"
+          }
+        ]
+      },
+      {
+        "_type": "class",
+        "name": "LegalEntity",
+        "package": "model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "legalName",
+            "type": "String"
+          }
+        ]
+      },
+      {
+        "_type": "class",
+        "constraints": [
+          {
+            "functionDefinition": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "func",
+                  "function": "startsWith",
+                  "parameters": [
+                    {
+                      "_type": "property",
+                      "property": "legalName",
+                      "parameters": [
+                        {
+                          "_type": "var",
+                          "name": "this"
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "string",
+                      "values": [
+                        "_"
+                      ],
+                      "multiplicity": {
+                        "lowerBound": 1,
+                        "upperBound": 1
+                      }
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            "name": "validName"
+          }
+        ],
+        "name": "Firm",
+        "package": "model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1
+            },
+            "name": "employees",
+            "type": "model::Person"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "incType",
+            "type": "model::IncType"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "isApple",
+            "type": "Boolean"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "count",
+                "parameters": [
+                  {
+                    "_type": "property",
+                    "property": "employees",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "this"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "name": "employeeSize",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "Number"
+          }
+        ],
+        "stereotypes": [
+          {
+            "profile": "model::MyExtension",
+            "value": "important"
+          }
+        ],
+        "superTypes": [
+          "model::LegalEntity"
+        ],
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::MyExtension",
+              "value": "doc"
+            },
+            "value": "This is a model of a firm"
+          }
+        ]
+      },
+      {
+        "_type": "class",
+        "name": "Person",
+        "package": "model",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "firstName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "lastName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "age",
+            "type": "Integer"
+          }
+        ],
+        "qualifiedProperties": [
+          {
+            "body": [
+              {
+                "_type": "func",
+                "function": "plus",
+                "parameters": [
+                  {
+                    "_type": "collection",
+                    "values": [
+                      {
+                        "_type": "property",
+                        "property": "firstName",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "string",
+                        "values": [
+                          " "
+                        ],
+                        "multiplicity": {
+                          "lowerBound": 1,
+                          "upperBound": 1
+                        }
+                      },
+                      {
+                        "_type": "property",
+                        "property": "lastName",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "this"
+                          }
+                        ]
+                      }
+                    ],
+                    "multiplicity": {
+                      "lowerBound": 3,
+                      "upperBound": 3
+                    }
+                  }
+                ]
+              }
+            ],
+            "name": "fullName",
+            "parameters": [],
+            "returnMultiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "returnType": "String"
+          }
+        ]
+      },
+      {
+        "_type": "relational",
+        "filters": [],
+        "includedStores": [],
+        "joins": [
+          {
+            "name": "FirmPerson",
+            "operation": {
+              "_type": "dynaFunc",
+              "funcName": "equal",
+              "parameters": [
+                {
+                  "_type": "column",
+                  "column": "firm_id",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                },
+                {
+                  "_type": "column",
+                  "column": "id",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "FirmTable"
+                  },
+                  "tableAlias": "FirmTable"
+                }
+              ]
+            }
+          }
+        ],
+        "name": "MyDatabase",
+        "package": "model",
+        "schemas": [
+          {
+            "name": "default",
+            "tables": [
+              {
+                "columns": [
+                  {
+                    "name": "id",
+                    "nullable": false,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  },
+                  {
+                    "name": "Legal_name",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  },
+                  {
+                    "name": "Inc",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  }
+                ],
+                "name": "FirmTable",
+                "primaryKey": [
+                  "id"
+                ]
+              },
+              {
+                "columns": [
+                  {
+                    "name": "id",
+                    "nullable": false,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  },
+                  {
+                    "name": "firm_id",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  },
+                  {
+                    "name": "firstName",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  },
+                  {
+                    "name": "lastName",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Varchar",
+                      "size": 200
+                    }
+                  },
+                  {
+                    "name": "age",
+                    "nullable": true,
+                    "type": {
+                      "_type": "Integer"
+                    }
+                  }
+                ],
+                "name": "PersonTable",
+                "primaryKey": [
+                  "id"
+                ]
+              }
+            ],
+            "views": []
+          }
+        ]
+      },
+      {
+        "_type": "mapping",
+        "classMappings": [
+          {
+            "_type": "relational",
+            "class": "model::Firm",
+            "distinct": false,
+            "mainTable": {
+              "_type": "Table",
+              "database": "model::MyDatabase",
+              "mainTableDb": "model::MyDatabase",
+              "schema": "default",
+              "table": "FirmTable"
+            },
+            "primaryKey": [
+              {
+                "_type": "column",
+                "column": "id",
+                "table": {
+                  "_type": "Table",
+                  "database": "model::MyDatabase",
+                  "mainTableDb": "model::MyDatabase",
+                  "schema": "default",
+                  "table": "FirmTable"
+                },
+                "tableAlias": "FirmTable"
+              }
+            ],
+            "propertyMappings": [
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "legalName"
+                },
+                "relationalOperation": {
+                  "_type": "dynaFunc",
+                  "funcName": "concat",
+                  "parameters": [
+                    {
+                      "_type": "column",
+                      "column": "Legal_name",
+                      "table": {
+                        "_type": "Table",
+                        "database": "model::MyDatabase",
+                        "mainTableDb": "model::MyDatabase",
+                        "schema": "default",
+                        "table": "FirmTable"
+                      },
+                      "tableAlias": "FirmTable"
+                    },
+                    {
+                      "_type": "literal",
+                      "value": "_LTD"
+                    }
+                  ]
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "employees"
+                },
+                "relationalOperation": {
+                  "_type": "elemtWithJoins",
+                  "joins": [
+                    {
+                      "db": "model::MyDatabase",
+                      "name": "FirmPerson"
+                    }
+                  ]
+                },
+                "target": "model_Person"
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "isApple"
+                },
+                "relationalOperation": {
+                  "_type": "dynaFunc",
+                  "funcName": "case",
+                  "parameters": [
+                    {
+                      "_type": "dynaFunc",
+                      "funcName": "equal",
+                      "parameters": [
+                        {
+                          "_type": "column",
+                          "column": "Legal_name",
+                          "table": {
+                            "_type": "Table",
+                            "database": "model::MyDatabase",
+                            "mainTableDb": "model::MyDatabase",
+                            "schema": "default",
+                            "table": "FirmTable"
+                          },
+                          "tableAlias": "FirmTable"
+                        },
+                        {
+                          "_type": "literal",
+                          "value": "Apple"
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "literal",
+                      "value": "true"
+                    },
+                    {
+                      "_type": "literal",
+                      "value": "false"
+                    }
+                  ]
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "enumMappingId": "model_IncType",
+                "property": {
+                  "class": "model::Firm",
+                  "property": "incType"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "Inc",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "FirmTable"
+                  },
+                  "tableAlias": "FirmTable"
+                }
+              }
+            ],
+            "root": true
+          },
+          {
+            "_type": "relational",
+            "class": "model::Person",
+            "distinct": false,
+            "mainTable": {
+              "_type": "Table",
+              "database": "model::MyDatabase",
+              "mainTableDb": "model::MyDatabase",
+              "schema": "default",
+              "table": "PersonTable"
+            },
+            "primaryKey": [
+              {
+                "_type": "column",
+                "column": "id",
+                "table": {
+                  "_type": "Table",
+                  "database": "model::MyDatabase",
+                  "mainTableDb": "model::MyDatabase",
+                  "schema": "default",
+                  "table": "PersonTable"
+                },
+                "tableAlias": "PersonTable"
+              }
+            ],
+            "propertyMappings": [
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Person",
+                  "property": "firstName"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "firstName",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Person",
+                  "property": "lastName"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "lastName",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                }
+              },
+              {
+                "_type": "relationalPropertyMapping",
+                "property": {
+                  "class": "model::Person",
+                  "property": "age"
+                },
+                "relationalOperation": {
+                  "_type": "column",
+                  "column": "age",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::MyDatabase",
+                    "mainTableDb": "model::MyDatabase",
+                    "schema": "default",
+                    "table": "PersonTable"
+                  },
+                  "tableAlias": "PersonTable"
+                }
+              }
+            ],
+            "root": true
+          }
+        ],
+        "enumerationMappings": [
+          {
+            "enumValueMappings": [
+              {
+                "enumValue": "Corp",
+                "sourceValues": [
+                  {
+                    "_type": "stringSourceValue",
+                    "value": "Corp"
+                  },
+                  {
+                    "_type": "stringSourceValue",
+                    "value": "CORP"
+                  }
+                ]
+              },
+              {
+                "enumValue": "LLC",
+                "sourceValues": [
+                  {
+                    "_type": "stringSourceValue",
+                    "value": "LLC"
+                  }
+                ]
+              }
+            ],
+            "enumeration": "model::IncType"
+          }
+        ],
+        "includedMappings": [],
+        "name": "RelationalMapping",
+        "package": "model",
+        "tests": []
+      },
+      {
+        "_type": "runtime",
+        "name": "Runtime",
+        "package": "model",
+        "runtimeValue": {
+          "_type": "engineRuntime",
+          "connections": [
+            {
+              "store": {
+                "path": "model::MyDatabase",
+                "type": "STORE"
+              },
+              "storeConnections": [
+                {
+                  "connection": {
+                    "_type": "connectionPointer",
+                    "connection": "model::MyConnection"
+                  },
+                  "id": "my_connection"
+                }
+              ]
+            }
+          ],
+          "mappings": [
+            {
+              "path": "model::RelationalMapping",
+              "type": "MAPPING"
+            }
+          ]
+        }
+      },
+      {
+        "_type": "connection",
+        "connectionValue": {
+          "_type": "RelationalDatabaseConnection",
+          "authenticationStrategy": {
+            "_type": "h2Default"
+          },
+          "databaseType": "H2",
+          "datasourceSpecification": {
+            "_type": "h2Local",
+            "testDataSetupSqls": [
+              "Drop table if exists FirmTable;\nDrop table if exists PersonTable;\nCreate Table FirmTable(id INT, Legal_Name VARCHAR(200), Inc VARCHAR(200));\nCreate Table PersonTable(id INT, firm_id INT, lastName VARCHAR(200), firstName VARCHAR(200), age INT);\nInsert into FirmTable (id, Legal_Name, Inc) values (1, 'Finos', 'CORP');\nInsert into FirmTable (id, Legal_Name, Inc) values (2, 'Apple', 'Corp');\nInsert into FirmTable (id, Legal_Name, Inc) values (3, 'GS', 'Corp');\nInsert into FirmTable (id, Legal_Name, Inc) values (4, 'Google', 'Corp');\nInsert into FirmTable (id, Legal_Name, Inc) values (5, 'Alphabet', 'LLC');\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (1, 3, 'X1', 'Mauricio', 10);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (2, 3, 'X2', 'An', 20);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (3, 3, 'X3', 'Anne', 30);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (4, 3, 'X4', 'Gayathri', 40);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (5, 3, 'X5', 'Yannan', 50);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (6, 3, 'X6', 'Dave', 60);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (7, 3, 'X7', 'Mo', 70);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (8, 3, 'X9', 'Teddy', 80);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (9, 2, 'X8', 'Teddy', 90);\nInsert into PersonTable (id, firm_id, lastName, firstName, age) values (10, 2, 'X8', 'Teddy', 100);\n\n"
+            ]
+          },
+          "element": "model::MyDatabase",
+          "type": "H2"
+        },
+        "name": "MyConnection",
+        "package": "model"
+      }
+    ]
+  },
+  "runtime": {
+    "_type": "runtimePointer",
+    "runtime": "model::Runtime"
+  },
+  "context": {
+    "_type": "BaseExecutionContext",
+    "queryTimeOutInSeconds": null,
+    "enableConstraints": true
+  },
+  "parameterValues": [
+    {
+      "name": "var_1",
+      "value": {
+        "_type": "collection",
+        "multiplicity": {
+          "lowerBound": 0
+        },
+        "values": [
+          {
+            "_type": "integer",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "values": [
+              20
+            ]
+          },
+          {
+            "_type": "integer",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "values": [
+              30
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/api/model/ExecuteInput.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/api/model/ExecuteInput.java
@@ -16,9 +16,11 @@ package org.finos.legend.engine.shared.core.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContext;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.executionContext.ExecutionContext;
+import java.util.List;
 
 public class ExecuteInput
 {
@@ -30,4 +32,6 @@ public class ExecuteInput
     public ExecutionContext context;
     @JsonProperty(required = true)
     public PureModelContext model;
+    @JsonProperty
+    public List<ParameterValue> parameterValues;
 }

--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
@@ -51,7 +51,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.StoreConnections;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ConnectionTestData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedExecutionParameter;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ParameterValue;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureMultiExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureSingleExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/helper/PrimitiveValueSpecificationToObjectVisitor.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/helper/PrimitiveValueSpecificationToObjectVisitor.java
@@ -123,7 +123,7 @@ public class PrimitiveValueSpecificationToObjectVisitor implements ValueSpecific
     @Override
     public Object visit(EnumValue enumValue)
     {
-        throw new UnsupportedOperationException("Unsupported value specification type");
+        return enumValue.value;
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?
Feature Request
<!--
Add one/more labels.
-->

#### What does this PR do / why is it needed ?
In Studio, We want to remove the usage of let statements when executing queries with parameters.
The use of let statements makes it difficult for engine to do type matching causing bugs when executing queries with parameters.
As a result we should move over and use engine to execute the queries with parameters.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/finos/legend-engine/issues/1018
Links to https://github.com/finos/legend-studio/issues/1535

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
