### PR TITLE
relay to appropriate extension instead of h2 for ddl commands

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/dbTestRunner/shared.pure
@@ -62,7 +62,7 @@ function meta::relational::dbTestRunner::doSetupOnConnection(records:String[1], 
         println('**** Warning **** : No connection available for given dbtype, Skipping execution of setup sqls');
         false;,
     |   
-        let setupSqls = meta::alloy::service::execution::setUpDataSQLs($records, $db);
+        let setupSqls = meta::alloy::service::execution::setUpDataSQLs($records, $db, meta::relational::functions::sqlQueryToString::createDbConfig($config.dbType));
 
         let con = $config.connection->cast(@RelationalDatabaseConnection)->toOne();
         let connWithDb= ^$con(element= $db);

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
@@ -127,22 +127,22 @@ function <<access.private>> meta::alloy::service::execution::replaceWithEmptyVal
    if ($replaced->contains(',,'), | meta::alloy::service::execution::replaceWithEmptyValue($replaced, $delimForEmptyCsvField), | $replaced);
 }
 
-function <<access.private>> meta::alloy::service::execution::schemaAndTableSetup(db:Database[1]):String[*]
+function <<access.private>> meta::alloy::service::execution::schemaAndTableSetup(db:Database[1], dbConfig:DbConfig[1]):String[*]
 {
    let allSchemas = $db->allSchemas();
 
    let schemaSetup = $allSchemas->map({schema |
       [
-         meta::relational::functions::toDDL::dropSchemaStatement($schema.name),
-         meta::relational::functions::toDDL::createSchemaStatement($schema.name)
+         meta::relational::functions::toDDL::dropSchemaStatement($schema.name, $dbConfig),
+         meta::relational::functions::toDDL::createSchemaStatement($schema.name, $dbConfig)
       ]
    });
 
    let tableSetup = $allSchemas->map({schema |
       $schema.tables->map({t |
          [
-            dropTableStatement($db, $schema.name, $t.name),
-            createTableStatement($db, $schema.name, $t.name)
+            dropTableStatement($db, $schema.name, $t.name, $dbConfig),
+            createTableStatement($db, $schema.name, $t.name, $dbConfig)
          ]
       })
    });
@@ -157,14 +157,13 @@ function <<doc.deprecated>> meta::alloy::service::execution::setUpDataSQLs(data:
 
 function meta::alloy::service::execution::setUpDataSQLs(data:String[1], db:Database[1], dbConfig:DbConfig[1]) : String[*]
 {
-
-   let schemaAndTableSetup = $db->meta::alloy::service::execution::schemaAndTableSetup();
+   let schemaAndTableSetup = $db->meta::alloy::service::execution::schemaAndTableSetup($dbConfig);
 
    let formattedData = $data->split('\n')
                             ->map(l|list($l->meta::alloy::service::execution::splitWithEmptyValue()))
                             ->concatenate(list(''));
 
-   $schemaAndTableSetup->concatenate(loadCsvDataToDbTable($formattedData, $db, t:Table[1]|$t));
+   $schemaAndTableSetup->concatenate(loadCsvDataToDbTable($formattedData, $db, $dbConfig, t:Table[1]|$t));
 }
 
 function <<doc.deprecated>> meta::alloy::service::execution::setUpDataSQLs(records:List<String>[*], db:Database[1]) : String[*]
@@ -174,8 +173,8 @@ function <<doc.deprecated>> meta::alloy::service::execution::setUpDataSQLs(recor
 
 function meta::alloy::service::execution::setUpDataSQLs(records:List<String>[*], db:Database[1], dbConfig:DbConfig[1]) : String[*]
 {
-   let schemaAndTableSetup = $db->meta::alloy::service::execution::schemaAndTableSetup();
-   $schemaAndTableSetup->concatenate(loadCsvDataToDbTable($records, $db, t:Table[1]|$t));
+   let schemaAndTableSetup = $db->meta::alloy::service::execution::schemaAndTableSetup($dbConfig);
+   $schemaAndTableSetup->concatenate(loadCsvDataToDbTable($records, $db, $dbConfig, t:Table[1]|$t));
 }
 
 function {service.contentType='text/csv', service.contentDisposition='attachment;filename=result.csv'} meta::relational::tests::csv::toCSV(t:TabularDataSet[1]):String[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
@@ -130,20 +130,16 @@ function <<access.private>> meta::alloy::service::execution::replaceWithEmptyVal
 function <<access.private>> meta::alloy::service::execution::schemaAndTableSetup(db:Database[1], dbConfig:DbConfig[1]):String[*]
 {
    let allSchemas = $db->allSchemas();
-
+   
    let schemaSetup = $allSchemas->map({schema |
-      [
-         meta::relational::functions::toDDL::dropSchemaStatement($schema.name, $dbConfig),
-         meta::relational::functions::toDDL::createSchemaStatement($schema.name, $dbConfig)
-      ]
+      meta::relational::functions::toDDL::dropSchemaStatement($schema.name, $dbConfig)->concatenate(
+          meta::relational::functions::toDDL::createSchemaStatement($schema.name, $dbConfig))
    });
 
    let tableSetup = $allSchemas->map({schema |
       $schema.tables->map({t |
-         [
-            dropTableStatement($db, $schema.name, $t.name, $dbConfig),
-            createTableStatement($db, $schema.name, $t.name, $dbConfig)
-         ]
+        dropTableStatement($db, $schema.name, $t.name, $dbConfig)->concatenate(
+            createTableStatement($db, $schema.name, $t.name, $dbConfig))
       })
    });
 

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/toDDL.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/toDDL.pure
@@ -76,76 +76,76 @@ function meta::relational::functions::toDDL::dropAndCreateSchemaInDb(schema: Str
 //use corresponding functions parameterized with dbType instead
 function <<doc.deprecated>> meta::relational::functions::toDDL::createSchemaStatement(schema:String[1]) : String[1]
 {
-   meta::relational::functions::toDDL::createSchemaStatement($schema, createDbConfig(DatabaseType.H2));
+   meta::relational::functions::toDDL::createSchemaStatement($schema, createDbConfig(DatabaseType.H2))->toOne();
 }
 
-function meta::relational::functions::toDDL::createSchemaStatement(schemaName:String[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::createSchemaStatement(schemaName:String[1], dbConfig:DbConfig[1]) : String[*]
 {
-  $dbConfig.translateCreateSchema(^CreateSchemaSQL(schema= ^Schema(name= $schemaName, database=^Database(name='dummy'))))->toOne();
+  $dbConfig.translateCreateSchema(^CreateSchemaSQL(schema= ^Schema(name= $schemaName, database=^Database(name='dummy'))));
 }
 
 function <<doc.deprecated>> meta::relational::functions::toDDL::dropSchemaStatement(schema:String[1]) : String[1]
 {
-   dropSchemaStatement($schema, createDbConfig(DatabaseType.H2));
+   dropSchemaStatement($schema, createDbConfig(DatabaseType.H2))->toOne();
 }
 
-function meta::relational::functions::toDDL::dropSchemaStatement(schemaName:String[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::dropSchemaStatement(schemaName:String[1], dbConfig:DbConfig[1]) : String[*]
 {
-   $dbConfig.translateDropSchema(^DropSchemaSQL(schema= ^Schema(name= $schemaName, database=^Database(name='dummy'))))->toOne();
+   $dbConfig.translateDropSchema(^DropSchemaSQL(schema= ^Schema(name= $schemaName, database=^Database(name='dummy'))));
 }
 
 function <<doc.deprecated>> meta::relational::functions::toDDL::dropTableStatement(database:Database[1], tableName: String[1]) : String[1]
 {
-    dropTableStatement($database, $tableName, createDbConfig(DatabaseType.H2));
+    dropTableStatement($database, $tableName, createDbConfig(DatabaseType.H2))->toOne();
 }
 
-function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], tableName: String[1], dbConfig:DbConfig[1]) : String[*]
 {
     dropTableStatement($database, 'default', $tableName, $dbConfig);
 }
 
 function <<doc.deprecated>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], tableName: String[1]) : String[1]
 {
-    createTableStatement($database, $tableName, createDbConfig(DatabaseType.H2));
+    createTableStatement($database, $tableName, createDbConfig(DatabaseType.H2))->toOne();
 }
 
-function meta::relational::functions::toDDL::createTableStatement(database:Database[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::createTableStatement(database:Database[1], tableName: String[1], dbConfig:DbConfig[1]) : String[*]
 {
     createTableStatement($database, 'default', $tableName, $dbConfig);
 }
 
 function <<doc.deprecated>> meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1]) : String[1]
 {
-   dropTableStatement($database, $schema, $tableName , createDbConfig(DatabaseType.H2));
+   dropTableStatement($database, $schema, $tableName , createDbConfig(DatabaseType.H2))->toOne();
 }
 
-function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], dbConfig:DbConfig[1]) : String[*]
 {
    dropTableStatement($database, $schema, $tableName, getTableToTableIdentityFunction(), $dbConfig);
 }
 
 function <<doc.deprecated>> meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1]) : String[1]
 {
-    dropTableStatement($database, $schema, $tableName, $tablePostProcess, createDbConfig(DatabaseType.H2));
+    dropTableStatement($database, $schema, $tableName, $tablePostProcess, createDbConfig(DatabaseType.H2))->toOne();
 }
 
-function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::dropTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], dbConfig:DbConfig[1]) : String[*]
 {
    let t = $tablePostProcess->eval(getTable($database, $schema, $tableName));
    dropTableStatement($t, $dbConfig);
 }
 
-function meta::relational::functions::toDDL::dropTableStatement(t:Table[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::dropTableStatement(t:Table[1], dbConfig:DbConfig[1]) : String[*]
 {
-   $dbConfig.translateDropTable(^DropTableSQL(table=$t))->toOne();
+   $dbConfig.translateDropTable(^DropTableSQL(table=$t));
 }
 
 function <<doc.deprecated>>  meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1]) : String[1]
 {
-   createTableStatement($database, $schema, $tableName, createDbConfig(DatabaseType.H2));
+   createTableStatement($database, $schema, $tableName, createDbConfig(DatabaseType.H2))->toOne();
 }
 
-function meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], dbConfig:DbConfig[1]) : String[*]
 {
    createTableStatement($database, $schema, $tableName, getTableToTableIdentityFunction(), true, $dbConfig);
 }
@@ -153,24 +153,24 @@ function meta::relational::functions::toDDL::createTableStatement(database:Datab
 //deprecated
 function <<access.private>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], applyConstraints:Boolean[1]) : String[1]
 {
-   createTableStatement($database, $schema, $tableName, $tablePostProcess, $applyConstraints, createDbConfig(DatabaseType.H2));
+   createTableStatement($database, $schema, $tableName, $tablePostProcess, $applyConstraints, createDbConfig(DatabaseType.H2))->toOne();
 }
 
 //deprecated
 function <<access.private>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], dbType:DatabaseType[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], applyConstraints:Boolean[1]) : String[1]
 {
-   createTableStatement($database, $schema, $tableName, $tablePostProcess, $applyConstraints, createDbConfig($dbType));
+   createTableStatement($database, $schema, $tableName, $tablePostProcess, $applyConstraints, createDbConfig($dbType))->toOne();
 }
 
-function <<access.private>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], applyConstraints:Boolean[1], dbConfig:DbConfig[1]) : String[1]
+function <<access.private>> meta::relational::functions::toDDL::createTableStatement(database:Database[1], schema: String[1], tableName: String[1], tablePostProcess: Function<{Table[1]->Table[1]}>[1], applyConstraints:Boolean[1], dbConfig:DbConfig[1]) : String[*]
 {
    let t = $tablePostProcess->eval(getTable($database, $schema, $tableName));
    $t->createTableStatement($applyConstraints, $dbConfig);
 }
 
-function meta::relational::functions::toDDL::createTableStatement(t:Table[1], applyConstraints:Boolean[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::toDDL::createTableStatement(t:Table[1], applyConstraints:Boolean[1], dbConfig:DbConfig[1]) : String[*]
 {
-   $dbConfig.translateCreateTable(^CreateTableSQL(table= $t, applyConstraints= $applyConstraints))->toOne();
+   $dbConfig.translateCreateTable(^CreateTableSQL(table= $t, applyConstraints= $applyConstraints));
 }
 
 //deprecated

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/defaultExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/defaultExtension.pure
@@ -396,23 +396,23 @@ function meta::relational::functions::sqlQueryToString::default::getDDLCommandsT
               );
 }
 
-function <<access.private>>  meta::relational::functions::sqlQueryToString::default::translateCreateSchemaStatementDefault(createSchemaSQL:CreateSchemaSQL[1]) : String[1]
+function meta::relational::functions::sqlQueryToString::default::translateCreateSchemaStatementDefault(createSchemaSQL:CreateSchemaSQL[1]) : String[1]
 {
    'Create Schema ' + $createSchemaSQL.schema.name + ';';
 }
 
-function <<access.private>>  meta::relational::functions::sqlQueryToString::default::translateDropSchemaStatementDefault(dropSchemaSQL:DropSchemaSQL[1]) : String[1]
+function meta::relational::functions::sqlQueryToString::default::translateDropSchemaStatementDefault(dropSchemaSQL:DropSchemaSQL[1]) : String[1]
 {
    'Drop schema if exists ' + $dropSchemaSQL.schema.name + ' cascade;';
 }
 
-function <<access.private>>  meta::relational::functions::sqlQueryToString::default::translateDropTableStatementDefault(dropTableSQL:DropTableSQL[1]) : String[1]
+function meta::relational::functions::sqlQueryToString::default::translateDropTableStatementDefault(dropTableSQL:DropTableSQL[1]) : String[1]
 {
   let t= $dropTableSQL.table;
   'Drop table if exists '+if($t.schema.name == 'default',|'',|$t.schema.name+'.')+$t.name+';';
 }
 
-function <<access.private>>  meta::relational::functions::sqlQueryToString::default::translateCreateTableStatementDefault(createTableSQL:CreateTableSQL[1], dbConfig:DbConfig[1]) : String[1]
+function meta::relational::functions::sqlQueryToString::default::translateCreateTableStatementDefault(createTableSQL:CreateTableSQL[1], dbConfig:DbConfig[1]) : String[1]
 {
   let t= $createTableSQL.table;
   let applyConstraints = $createTableSQL.applyConstraints;
@@ -425,7 +425,7 @@ function <<access.private>>  meta::relational::functions::sqlQueryToString::defa
       +');';
 }
 
-function <<access.private>>  meta::relational::functions::sqlQueryToString::default::getColumnTypeSqlTextDefault(columnType:meta::relational::metamodel::datatype::DataType[1]):String[1]
+function meta::relational::functions::sqlQueryToString::default::getColumnTypeSqlTextDefault(columnType:meta::relational::metamodel::datatype::DataType[1]):String[1]
 {
    $columnType->match([
       s : meta::relational::metamodel::datatype::SemiStructured[1] | 'VARCHAR(4000)',
@@ -433,7 +433,7 @@ function <<access.private>>  meta::relational::functions::sqlQueryToString::defa
    ])
 }
 
-function <<access.private>>  meta::relational::functions::sqlQueryToString::default::loadValuesToDbTableDefault(loadTableSQL:LoadTableSQL[1] , dbConfig: DbConfig[1]) : String[*]
+function meta::relational::functions::sqlQueryToString::default::loadValuesToDbTableDefault(loadTableSQL:LoadTableSQL[1] , dbConfig: DbConfig[1]) : String[*]
 {
 
     $loadTableSQL.parsedData.values->map(row |  let sql = 'insert into ' + if($loadTableSQL.table.schema.name=='default', |'' ,|$loadTableSQL.table.schema.name + '.') + $loadTableSQL.table.name + ' ('

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/aggregateFunctions/groupBy.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/aggregateFunctions/groupBy.pure
@@ -140,17 +140,15 @@ function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTe
 {
    let result = executeViaPlan(|Trade.all()
                          ->project([#/Trade/quantity!quantity#, #/Trade/product/name!prodName#])
-                         ->groupBy('prodName', agg('cnt', x|$x, y| $y->count()))
-                         ->sort(desc('prodName')), simpleRelationalMapping, meta::relational::tests::db, $config, meta::relational::extension::relationalExtensions());
+                         ->groupBy('prodName', agg('cnt', x|$x, y| $y->count())),
+                         simpleRelationalMapping, meta::relational::tests::db, $config, meta::relational::extension::relationalExtensions());
    
   if($result->isEmpty(), | true,
   |let tds = $result.values->at(0);
    assertEquals([String, Integer], $result.values.columns.type);
    assertEquals(4, $tds.rows->size());
-   assertEquals(['Firm X', 2], $tds.rows->at(0).values);
-   assertEquals(['Firm C', 5], $tds.rows->at(1).values);
-   assertEquals(['Firm A', 3], $tds.rows->at(2).values);
-   assertEquals([^TDSNull(), 1], $tds.rows->at(3).values);
+   let resultStrs = $tds.rows->map(r| if($r.values->at(0) == ^TDSNull(), |'Null', |$r.values->at(0)->cast(@String)) + ', ' + $r.values->at(1)->toString())->sort();
+   assertEquals(['Firm A, 3', 'Firm C, 5', 'Firm X, 2', 'Null, 1'], $resultStrs);
   );
 }
 

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/date.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/date.pure
@@ -246,7 +246,7 @@ function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTe
 {
   let dynaFunc = ^DynaFunction(name='today', parameters=[]);
   let expected = ^Literal(value=today()->convertToDateTime());                              
-  let equalityComparator = timestampEqualityComparatorGenerator([0] ,DurationUnit.DAYS);             
+  let equalityComparator = timestampEqualityComparatorGenerator([1] ,DurationUnit.DAYS);             
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }
 

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/shared.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/shared.pure
@@ -101,7 +101,23 @@ function meta::relational::tests::dbSpecificTests::createTableAndFillDb(config:D
                 '3,Firm C\n'+
                 '4,Firm D\n';
 
-  meta::relational::dbTestRunner::doSetupOnConnection($records, meta::relational::tests::db,
+  meta::relational::dbTestRunner::doSetupOnConnection($records, meta::relational::tests::dbSpecificTests::db,
                                                      $config, meta::relational::extension::relationalExtensions());
   true;
 }
+
+###Relational
+Database meta::relational::tests::dbSpecificTests::db
+(
+    Table personTable (ID INT PRIMARY KEY, FIRSTNAME VARCHAR(200), LASTNAME VARCHAR(200), AGE INT, ADDRESSID INT, FIRMID INT, MANAGERID INT)
+    Table firmTable(ID INT PRIMARY KEY, LEGALNAME VARCHAR(200), ADDRESSID INT, CEOID INT)
+    Table tradeTable(ID INT PRIMARY KEY, prodId INT, accountID INT, quantity FLOAT, tradeDate DATE, settlementDateTime TIMESTAMP)
+    Table addressTable(ID INT PRIMARY KEY, TYPE INT, NAME VARCHAR(200), STREET VARCHAR(100), COMMENTS VARCHAR(100))
+    Table orderTable(ID INT PRIMARY KEY, prodId INT, accountID INT, quantity INT, orderDate DATE, settlementDateTime TIMESTAMP)
+    Table orderPnlTable( ORDER_ID INT PRIMARY KEY, pnl FLOAT,from_z DATE,thru_z DATE )
+
+    Schema productSchema
+    (
+       Table synonymTable(ID INT PRIMARY KEY, PRODID INT, TYPE VARCHAR(200), NAME VARCHAR(200))
+    )
+)

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/shared.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/shared.pure
@@ -115,6 +115,8 @@ Database meta::relational::tests::dbSpecificTests::db
     Table addressTable(ID INT PRIMARY KEY, TYPE INT, NAME VARCHAR(200), STREET VARCHAR(100), COMMENTS VARCHAR(100))
     Table orderTable(ID INT PRIMARY KEY, prodId INT, accountID INT, quantity INT, orderDate DATE, settlementDateTime TIMESTAMP)
     Table orderPnlTable( ORDER_ID INT PRIMARY KEY, pnl FLOAT,from_z DATE,thru_z DATE )
+    Table accountTable(ID INT PRIMARY KEY, name VARCHAR(200), createDate DATE)
+    Table salesPersonTable(PERSON_ID INT PRIMARY KEY, ACCOUNT_ID INT PRIMARY KEY, NAME VARCHAR(200), from_z DATE, thru_z DATE)
 
     Schema productSchema
     (

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/shared.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/shared.pure
@@ -118,6 +118,6 @@ Database meta::relational::tests::dbSpecificTests::db
 
     Schema productSchema
     (
-       Table synonymTable(ID INT PRIMARY KEY, PRODID INT, TYPE VARCHAR(200), NAME VARCHAR(200))
+       Table productTable(ID INT PRIMARY KEY, NAME VARCHAR(200))
     )
 )

--- a/legend-engine-xt-relationalStore-test-server/src/main/java/org/finos/legend/engine/server/test/shared/ExecuteInRelationalDb.java
+++ b/legend-engine-xt-relationalStore-test-server/src/main/java/org/finos/legend/engine/server/test/shared/ExecuteInRelationalDb.java
@@ -76,7 +76,21 @@ public class ExecuteInRelationalDb
 
                 for (String sql : input.sqls)
                 {
-                    stmt.execute(sql);
+                    if (sql.startsWith("["))
+                    {
+                        try
+                        {
+                            stmt.execute(sql.substring(1, sql.length() - 1));
+                        }
+                        catch (SQLException e)
+                        {
+                            LOGGER.warn("sql execution failed", e);
+                        }
+                    }
+                    else
+                    {
+                        stmt.execute(sql);
+                    }
                 }
 
                 return Response.ok().build();


### PR DESCRIPTION
#### What type of PR is this?
BugFix

#### What does this PR do / why is it needed ?
Generic ddl functions were defaulting to H2 impl, instead of relaying to appropriate db extension

#### Does this PR introduce a user-facing change?
No. It should not affect existing h2 tests, but allow running setup based tests for other dbs, which expect different ddl sql than H2
