### PR TITLE
fix parseDate pure to relational transformation for H2, Presto, Snowflake, Memsql and SybaseIQ DBs.

### DIFF
--- a/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/tests/dbSpecificTests/bigQueryTests.pure
+++ b/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/tests/dbSpecificTests/bigQueryTests.pure
@@ -34,7 +34,7 @@ function meta::relational::tests::dbSpecificTests::bigQuery::testsFilter(f:Funct
   // currently hardcoding unsupported funcs, In future fetch this from db extensions and skip
   let unsupportedDynaFunctions = ['dateDiff','datePart','dayOfMonth','dayOfWeekNumber','firstDayOfMonth','firstDayOfQuarter',
                                   'firstDayOfThisMonth','firstDayOfThisQuarter','firstDayOfThisYear','firstDayOfWeek','firstDayOfYear',
-                                  'indexOf','left','length','ltrim','mostRecentDayOfWeek','previousDayOfWeek','year'];
+                                  'indexOf','left','length','ltrim','mostRecentDayOfWeek','previousDayOfWeek','toTimestamp', 'year'];
   //these dynafunctions need to be fixed , currently skipping to suppress github integration test failures
   // joinStrings fail on bigquery end as query constructed is wrong
   // adjust, weekOfYear fails on assertion

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -2230,6 +2230,16 @@ function meta::relational::functions::pureToSqlQuery::processPlus(f:FunctionExpr
 
 }
 
+function meta::relational::functions::pureToSqlQuery::processParseDate(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+    let formatInstance = ^InstanceValue(multiplicity = PureOne, genericType = ^GenericType(rawType=String), values = 'YYYY-MM-DD HH24:MI:SS'); 
+    let dynaFuncName = 'toTimestamp';
+    let oldFunc = $f.func;
+    let newFunc = ^$oldFunc(functionName=$dynaFuncName);
+    let functionExpression = ^$f(func = $newFunc, parametersValues=$f.parametersValues->concatenate($formatInstance));    
+    $functionExpression->processDynaFunction($currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+}
+
 function meta::relational::functions::pureToSqlQuery::findAliasOrFail(columnName:String[1], select:SelectSQLQuery[1]):Alias[1]
 {
    findAliasOrFail($columnName, $select.columns->filter(c|$c->instanceOf(Alias))->cast(@Alias));
@@ -7276,7 +7286,7 @@ function meta::relational::functions::pureToSqlQuery::getSupportedFunctions():Ma
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::multiplicity::toOne_T_MANY__T_1_, second=meta::relational::functions::pureToSqlQuery::processNoOp_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::multiplicity::toOneMany_T_MANY__T_$1_MANY$_, second=meta::relational::functions::pureToSqlQuery::processNoOp_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::meta::extractEnumValue_Enumeration_1__String_1__T_1_, second=meta::relational::functions::pureToSqlQuery::processEnumValue_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
-        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::string::parseDate_String_1__Date_1_,second=meta::relational::functions::pureToSqlQuery::processDynaFunction_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::string::parseDate_String_1__Date_1_,second=meta::relational::functions::pureToSqlQuery::processParseDate_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::string::parseFloat_String_1__Float_1_,second=meta::relational::functions::pureToSqlQuery::processDynaFunction_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::string::parseDecimal_String_1__Decimal_1_,second=meta::relational::functions::pureToSqlQuery::processDynaFunction_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::extend_TabularDataSet_1__BasicColumnSpecification_MANY__TabularDataSet_1_,second=meta::relational::functions::pureToSqlQuery::processTdsExtend_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/h2Extension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/h2Extension.pure
@@ -99,6 +99,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::g
     dynaFnToSql('stdDevSample',           $allStates,            ^ToSql(format='stddev_samp(%s)')),
     dynaFnToSql('today',                  $allStates,            ^ToSql(format='current_date()')),
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as varchar)')),
+    dynaFnToSql('toTimestamp',            $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformToTimestampH2()})),
     dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='week(%s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)'))
   ];
@@ -172,6 +173,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::c
    $params->convertDateTimeFunctionHasCorrectParams();
    let dateTimeFormat = if( $params->size() == 1,|'\'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]\'',| $params->at(1););
    'parseDateTime('+$params->at(0)+','+$dateTimeFormat +')';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::h2::transformToTimestampH2(params:String[2]):String[1]
+{
+  //Standardizing the format as per Postgres specification, will include mappings for the formats in future.
+   assert($params->at(1)->replace('\'', '') == 'YYYY-MM-DD HH24:MI:SS', | $params->at(1) +' not supported '); 
+   let timestampFormat = '\'yyyy-MM-dd hh:mm:ss\'';   
+   'parsedatetime('+$params->at(0)+','+ $timestampFormat+')';    
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::h2::processDateDiffDurationUnitForH2(durationUnit:String[1]):String[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/memSqlExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/memSqlExtension.pure
@@ -110,6 +110,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memSq
     dynaFnToSql('stdDevSample',           $allStates,            ^ToSql(format='stddev_samp(%s)')),
     dynaFnToSql('today',                  $allStates,            ^ToSql(format='curdate()')),
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as char)')),
+    dynaFnToSql('toTimestamp',            $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformToTimestampMemSQL()})), 
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)'))
   ];
 }
@@ -120,6 +121,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memSq
    assert($params->size()==1 || dateFormatsMemSQL()->contains($params->at(1)->replace('\'', '')) , | $params->at(1) +' not supported ');
    let dateFormat = if( $params->size() == 1,|'\'YYYY-MM-DD\'' ,| $params->at(1););
    'cast( to_date('+$params->at(0)+','+$dateFormat +') as date)';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::memSql::transformToTimestampMemSQL(params:String[2]):String[1]
+{
+  //Standardizing the format as per Postgres specification, will include mappings for the formats in future. 
+   assert($params->at(1)->replace('\'', '') == 'YYYY-MM-DD HH24:MI:SS', | $params->at(1) +' not supported ');
+   let timestampFormat = $params->at(1);   
+   'to_timestamp('+$params->at(0)+','+$timestampFormat+')';   
 }
 
 function  <<access.private>> meta::relational::functions::sqlQueryToString::memSql::generateDateDiffExpressionForMemSQL(params:String[*]):String[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/prestoExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/prestoExtension.pure
@@ -94,6 +94,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::prest
     dynaFnToSql('stdDevSample',           $allStates,            ^ToSql(format='stddev_samp(%s)')),
     dynaFnToSql('today',                  $allStates,            ^ToSql(format='current_date')),
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as varchar)')),
+    dynaFnToSql('toTimestamp',            $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformToTimestampPresto()})),
     dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='week(%s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)'))
   ];
@@ -142,6 +143,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::prest
    $params->convertDateTimeFunctionHasCorrectParams();
    let dateTimeFormat = if( $params->size() == 1,|'\'%Y-%m-%d %H:%i:%s\'',| $params->at(1););
    'date_parse('+$params->at(0)+','+$dateTimeFormat +')';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::presto::transformToTimestampPresto(params:String[2]):String[1]
+{
+  //Standardizing the format as per Postgres specification, will include mappings for the formats in future.
+   assert($params->at(1)->replace('\'', '') == 'YYYY-MM-DD HH24:MI:SS', | $params->at(1) +' not supported '); 
+   let timestampFormat = '\'%Y-%m-%d %H:%i:%s\'';   
+   'date_parse('+$params->at(0)+','+$timestampFormat+')';
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::presto::processDateDiffDurationUnitForPresto(durationUnit:String[1]):String[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/snowflakeExtension.pure
@@ -89,6 +89,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
     dynaFnToSql('stdDevSample',           $allStates,            ^ToSql(format='stddev_samp(%s)')),
     dynaFnToSql('today',                  $allStates,            ^ToSql(format='current_date')),
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as varchar)')),
+    dynaFnToSql('toTimestamp',            $allStates,            ^ToSql(format='%s' , transform={p:String[2] | $p->transformToTimestampSnowflake()})),
     dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='WEEKOFYEAR(%s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)'))
   ];
@@ -111,6 +112,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
    let dateTimeFormat = if( $params->size() == 1,|'\'YYYY-MM-DD HH24:MI:SS\'',| $params->at(1));
    //https://docs.snowflake.net/manuals/sql-reference/data-types-datetime.html
    'to_timestamp('+$params->at(0)+','+$dateTimeFormat +')';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::transformToTimestampSnowflake(params:String[2]):String[1]
+{
+  //Standardizing the format as per Postgres specification, will include mappings for the formats in future. 
+   assert($params->at(1)->replace('\'', '') == 'YYYY-MM-DD HH24:MI:SS', | $params->at(1) +' not supported ');
+   let timestampFormat = $params->at(1);   
+   'to_timestamp('+$params->at(0)+','+$timestampFormat+')';
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::dateFormatsSnowFlake():String[*]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/sybaseIQExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/sybaseIQExtension.pure
@@ -121,6 +121,7 @@ function meta::relational::functions::sqlQueryToString::sybaseIQ::getDynaFunctio
     dynaFnToSql('stdDevSample',           $allStates,            ^ToSql(format='stddev_samp(%s)')),
     dynaFnToSql('today',                  $allStates,            ^ToSql(format='today(%s)', transform={p:String[*] | ''})),
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as varchar)')),
+    dynaFnToSql('toTimestamp',            $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformToTimestampSybaseIQ()})),
     dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='datepart(WEEK,%s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)'))
   ];
@@ -167,6 +168,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::sybas
    let dateTimeFormat = if( $params->size() == 1,| 120 ,| dateTimeFormats()->get($params->at(1)->replace('\'', ''))->toOne(););
    //http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc38151.1520/html/iqrefbb/Dateformat.htm
    'convert( timestamp,'+$params->at(0)+','+$dateTimeFormat->toString() +')';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::sybaseIQ::transformToTimestampSybaseIQ(params:String[2]):String[1]
+{
+  //Standardizing the format as per Postgres specification, will include mappings for the formats in future. 
+   assert($params->at(1)->replace('\'', '') == 'YYYY-MM-DD HH24:MI:SS', | $params->at(1) +' not supported ');    
+   let timestampFormat = 121;   
+   'convert(datetime,'+$params->at(0)+','+$timestampFormat->toString() +')';
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::sybaseIQ::formatMostRecentSybase(p:String[1..2], defaultDay:String[1]):String[*]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/databricksTests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/databricksTests.pure
@@ -34,7 +34,7 @@ function <<test.TestCollection>> meta::relational::tests::dbSpecificTests::datab
 function meta::relational::tests::dbSpecificTests::databricks::testsFilter(f:FunctionDefinition<Any>[1]):Boolean[1]
 {
   // currently hardcoding unsupported funcs, In future fetch this from db extensions and skip
-  let unsupportedDynaFunctions = ['sqlTrue'];
+  let unsupportedDynaFunctions = ['toTimestamp','sqlTrue'];
 
   //these dynafunctions need to be fixed , currently skipping to suppress github integration test failures
   let failingSupportedDynaFunctions = ['sqlTrue', 'sqlFalse'];

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/postgresTests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/postgresTests.pure
@@ -35,7 +35,7 @@ function meta::relational::tests::dbSpecificTests::postgres::testsFilter(f:Funct
   let unsupportedDynaFunctions = ['concat' , 'dayOfMonth', 'dayOfWeekNumber', 'firstDayOfMonth', 'firstDayOfQuarter',
                                   'firstDayOfThisMonth', 'firstDayOfThisQuarter', 'firstDayOfThisYear','firstDayOfWeek', 'firstDayOfYear',
                                   'indexOf', 'left' , 'ltrim', 'minute', 'month', 'monthNumber', 'mostRecentDayOfWeek',
-                                  'previousDayOfWeek', 'right', 'rtrim', 'weekOfYear', 'year'];
+                                  'previousDayOfWeek', 'right', 'rtrim', 'toTimestamp', 'weekOfYear', 'year'];
   
   //these dynafunctions need to be fixed , currently skipping to suppress github integration test failures
   let failingSupportedDynaFunctions = ['dateDiff', 'quarterNumber' , 'quarter', 'second'];

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/redshiftTests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/redshiftTests.pure
@@ -36,7 +36,7 @@ function meta::relational::tests::dbSpecificTests::redshift::testsFilter(f:Funct
                                    'firstDayOfMonth', 'firstDayOfQuarter','firstDayOfThisMonth','firstDayOfThisQuarter', 'firstDayOfThisYear','firstDayOfWeek' ,'firstDayOfYear' , 
                                    'indexOf', 'left', 'length', 'ltrim',
                                   'mostRecentDayOfWeek','previousDayOfWeek',
-                                  'quarter', 'quarterNumber'];
+                                  'quarter', 'quarterNumber','toTimestamp'];
   
   //these dynafunctions need to be fixed , currently skipping to suppress github integration test failures
   let failingSupportedDynaFunctions = ['joinStrings'];

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/date.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/dbSpecificTests/suite/sqlQueryTests/dynaFunctions/date.pure
@@ -274,6 +274,14 @@ function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTe
   runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
 }       
 
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::toTimestamp::testToTimestamp(config:DbTestConfig[1]):Boolean[1]
+{
+  let dynaFunc = ^DynaFunction(name='toTimestamp', parameters=[^Literal(value='2016-06-23 13:20:10'), ^Literal(value='YYYY-MM-DD HH24:MI:SS')]);
+  let expected = ^Literal(value=parseDate(%2016-06-23T13:20:10->toString()));
+  let equalityComparator = timestampEqualityComparatorGenerator([0] ,DurationUnit.SECONDS);
+  runDynaFunctionDatabaseTest($dynaFunc, $expected, $equalityComparator, $config);
+}  
+
 function meta::relational::tests::dbSpecificTests::sqlQueryTests::dynaFunctions::convertToDateTime(d:Date[1]): DateTime[1]
 {
   $d->match([

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
@@ -46,6 +46,67 @@ function <<test.BeforePackage>> meta::relational::tests::mapping::sqlFunction::s
     true;
 }
 
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringWithParseDateInQueryForH2():Boolean[1]
+{  
+  let result = execute(|SqlFunctionDemo.all()->project([s | $s.string2TimestampStr->parseDate()], ['timestamp']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
+  assertEquals([%2016-06-23T00:00:00.000000000+0000, %2016-06-23T00:00:00.000000000+0000], $result.values->at(0).rows.values);
+  assertEquals('select parsedatetime("root".string2date,\'yyyy-MM-dd hh:mm:ss\') as "timestamp" from dataTable as "root"',$result->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringWithParseDateInQueryForPresto():Boolean[1]
+{
+  let prestoSql = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampStr->parseDate()], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.Presto, meta::relational::extension::relationalExtensions());  
+  assertEquals('select date_parse("root".string2date,\'%Y-%m-%d %H:%i:%s\') as "timestamp" from dataTable as "root"',$prestoSql->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringWithParseDateInQueryForSnowflake():Boolean[1]
+{
+  let snowflakeSql = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampStr->parseDate()], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());  
+  assertEquals('select to_timestamp("root".string2date,\'YYYY-MM-DD HH24:MI:SS\') as "timestamp" from dataTable as "root"',$snowflakeSql->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringWithParseDateInQueryForMemSQL():Boolean[1]
+{
+  let memSQLSql = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampStr->parseDate()], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.MemSQL, meta::relational::extension::relationalExtensions());  
+  assertEquals('select to_timestamp(`root`.string2date,\'YYYY-MM-DD HH24:MI:SS\') as `timestamp` from dataTable as `root`',$memSQLSql->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringWithParseDateInQueryForSybaseIQ():Boolean[1]
+{
+  let sybaseIqSql = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampStr->parseDate()], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions());  
+  assertEquals('select convert(datetime,"root".string2date,121) as "timestamp" from dataTable as "root"',$sybaseIqSql->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringParseDateForH2():Boolean[1]
+{
+  let result = execute(|SqlFunctionDemo.all()->project([s | $s.string2TimestampFormat], ['timestamp']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
+  assertEquals([%2016-06-23T13:00:00.000000000+0000, %2016-02-23T23:00:00.000000000+0000], $result.values->at(0).rows.values);
+  assertEquals('select parsedatetime("root".stringDateTimeFormat,\'yyyy-MM-dd hh:mm:ss\') as "timestamp" from dataTable as "root"',$result->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringParseDateForPresto():Boolean[1]
+{
+  let prestoSQL = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampFormat], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.Presto, meta::relational::extension::relationalExtensions());
+  assertEquals('select date_parse("root".stringDateTimeFormat,\'%Y-%m-%d %H:%i:%s\') as "timestamp" from dataTable as "root"',$prestoSQL->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringParseDateForSnowflake():Boolean[1]
+{
+  let trialSQL = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampFormat], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+  assertEquals('select to_timestamp("root".stringDateTimeFormat,\'YYYY-MM-DD HH24:MI:SS\') as "timestamp" from dataTable as "root"',$trialSQL->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringParseDateForMemSQL():Boolean[1]
+{
+  let trialSQL = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampFormat], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.MemSQL, meta::relational::extension::relationalExtensions());
+  assertEquals('select to_timestamp(`root`.stringDateTimeFormat,\'YYYY-MM-DD HH24:MI:SS\') as `timestamp` from dataTable as `root`',$trialSQL->sqlRemoveFormatting());
+}
+
+function <<test.Test>> meta::relational::tests::mapping::sqlFunction::parseDate::testToSQLStringParseDateForSybaseIQ():Boolean[1]
+{
+  let sybaseSQL = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2TimestampFormat], ['timestamp']), testMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions());
+  assertEquals('select convert(datetime,"root".stringDateTimeFormat,121) as "timestamp" from dataTable as "root"',$sybaseSQL->sqlRemoveFormatting());
+}
 
 function <<test.Test>> meta::relational::tests::mapping::sqlFunction::concat::testProject():Boolean[1]
 {
@@ -1159,6 +1220,8 @@ Class meta::relational::tests::mapping::sqlFunction::model::domain::SqlFunctionD
    floatRemResult : Integer[1];
 
    string2Date: Date[1];
+   string2TimestampStr: String[1];   
+   string2TimestampFormat : Date[1];
    string2DateTime: DateTime[1];
    convertToDate1: Date[1];
    convertToDate: Date[1];
@@ -1260,6 +1323,8 @@ Mapping meta::relational::tests::mapping::sqlFunction::model::mapping::testMappi
           string2Decimal : parseDecimal(string2Decimal),
           string2decimal: trim(string2Decimal),
           string2Date  : parseDate(string2date),
+          string2TimestampStr : string2date,                    
+          string2TimestampFormat : toTimestamp(stringDateTimeFormat,'YYYY-MM-DD HH24:MI:SS'),              
           string2Integer  : parseInteger(string2Integer),
           convertToDate1: convertDate(stringDateFormat),
           convertToDate: convertDate(stringDateFormat,'yyyy-MM-dd'),

--- a/legend-engine-xt-relationalStore-sqlserver-pure/src/main/resources/core_relational_sqlserver/relational/tests/dbSpecificTests/sqlServerTests.pure
+++ b/legend-engine-xt-relationalStore-sqlserver-pure/src/main/resources/core_relational_sqlserver/relational/tests/dbSpecificTests/sqlServerTests.pure
@@ -34,7 +34,7 @@ function meta::relational::tests::dbSpecificTests::sqlServer::testsFilter(f:Func
   // currently hardcoding unsupported funcs, In future fetch this from db extensions and skip
    let unsupportedDynaFunctions = [
      'adjust', 'dateDiff', 'dayOfMonth', 'firstDayOfWeek', 'indexOf', 'joinStrings', 'mod',
-     'mostRecentDayOfWeek', 'previousDayOfWeek', 'rem'
+     'mostRecentDayOfWeek', 'previousDayOfWeek', 'rem', 'toTimestamp'
     ];
 
   //these dynafunctions need to be fixed , currently skipping to suppress github integration test failures


### PR DESCRIPTION
#### What type of PR is this?

-Code Fix

#### What does this PR do / why is it needed ?

-parseDate is a pure function that is mapped to db specific functions that expect two parameters , timestamp as string and timestamp format.

-Fixing pure to relational transformation to correctly generate SQL by introducing a handler to handle the second parameter, timestampFormat aligning it with Postgres specification.

#### Which issue(s) this PR fixes:

Fixes #

SQL generation for DBs like H2, Presto, Snowflake, MemSQL and SybaseIQ.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
