### PR TITLE
Fix Relational Tree Scanning for Union with Views

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelations.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelations.pure
@@ -510,7 +510,7 @@ function <<access.private>> meta::pure::lineage::scanRelations::addChildTree(par
    let parentRelation = $parent.relation->toOne();
    let parentRelationFromJoin = $child.join.otherTable($child.relation->toOne()).relation->toOne();
    
-   if(getRelationName($parentRelation) == getRelationName($parentRelationFromJoin), 
+   if(getRelationName($parentRelation) == getRelationName($parentRelationFromJoin),
       | ^$parent(children += $child);, 
       | ^$parent(children = $parent.children->map(pc | addChildTree($pc, $child))));
 }
@@ -534,13 +534,13 @@ function meta::pure::lineage::scanRelations::addColumnToRelationTree(tree:Relati
 function <<access.private>> meta::pure::lineage::scanRelations::processJoinFromTreeNode(j:JoinTreeNode[1], sourceOperation:TableAlias[1], sourceRelations:NamedRelation[*], targetRelation:NamedRelation[1], targetTree:RelationTree[1], sourceTree:RelationTree[1], debug:meta::pure::tools::DebugContext[1], extensions:Extension[*]):Join[0..1]
 {
    let relationIndentifiers     = $sourceRelations->concatenate($targetRelation)->map(rel | $rel->getRelationName());
-   
+
    let targetOperation          = $j.alias;
    let targetAliasName          = $targetOperation.name;
    let sourceAliasName          = $sourceOperation.name;
-   
+
    let tableAliasColumns        = $j.join.operation->extractTableAliasColumns()->removeDuplicates();
-   
+
    let oldToNewTableColumnAlias = $tableAliasColumns->map(tac | let orgColumn     = $tac.column;
                                                           
                                                                 assert($tac.alias.name->in([$targetAliasName, $sourceAliasName]), | 'Columns in join should refer either source alias or target alias');
@@ -555,7 +555,7 @@ function <<access.private>> meta::pure::lineage::scanRelations::processJoinFromT
                                                                     let newTableAliasColumn = ^TableAliasColumn(alias=^TableAlias(name = $namedRelation.name, relationalElement=$namedRelation), column = $sourceColumn->toOne(), columnName = $sourceColumn.name->toOne());
                                                                     pair($tac, $newTableAliasColumn);
                                                                 ););
-   
+
    let nonNullPairs             = $oldToNewTableColumnAlias->filter(p | $p.second->instanceOf(TableAliasColumn))->cast(@Pair<TableAliasColumn, TableAliasColumn>);
    let newAliases               = $nonNullPairs.second.alias->removeDuplicatesBy(ta | $ta.relation->getRelationName());
    
@@ -641,14 +641,25 @@ function <<access.private>> meta::pure::lineage::scanRelations::extractSourceCol
 {
    $sourceOperation->match([
                               // v:ViewSelectSQLQuery[1]| if(getRelationName($v.view)->in($relationIdentifiers), |$tableAliasColumn.column, |[]), // Need not handle views in generated SQL query (as they should have been converted to subqueries)
-                              t:Table[1]             | if(getRelationName($t)->in($relationIdentifiers), |$tableAliasColumn.column, |[]),
+                              t:Table[1]             | if(getRelationName($t)->in($relationIdentifiers) || meta::pure::lineage::scanRelations::canUseTableAlias($tableAliasColumn, $t, $relationIdentifiers), |$tableAliasColumn.column, |[]);,
                               // v:View[1]              | if(getRelationName($v)->in($relationIdentifiers), |$tableAliasColumn.column, |[]), // Need not handle views in generated SQL query (as they should have been converted to subqueries)
                               ta:TableAlias[1]       | if($tableAliasColumn.alias.name == $ta.name,| $tableAliasColumn->extractSourceColumn($ta.relation, $relationIdentifiers, $sourceTree), | []);,
                               s:SelectSQLQuery[1]    | $s->extractSourceColumnFromSelectSQLQuery($tableAliasColumn, $relationIdentifiers, $sourceTree);,
-                              u:Union[1]             | let colNames = $u.queries->map(query | $query->extractSourceColumnFromSelectSQLQuery($tableAliasColumn, $relationIdentifiers, $sourceTree))->removeDuplicates()->filter(c | $c.name->in($sourceTree.columns.name));
+                              u:Union[1]             | let colNames = $u.queries->map(query | $query->extractSourceColumnFromSelectSQLQuery($tableAliasColumn, $relationIdentifiers, $sourceTree))->removeDuplicates()->filter(c | $c.name->in($sourceTree.columns.name) && $c.owner->in($sourceTree.columns.owner));
                                                        assert($colNames->size() <=1 ,|'Expected max 1 column. Found : ' + $colNames->size()->toString());
                                                        if($colNames->isEmpty(), | [], | $colNames->toOne());
                            ]);
+}
+
+//check the table if its a view that has a table included in the db that the table alias column's table is in;
+function <<access.private>> meta::pure::lineage::scanRelations::canUseTableAlias(ta:TableAliasColumn[1],table:Table[1], relationalIdentifiers:String[*]):Boolean[1]
+{
+  if($table->instanceOf(ViewSelectSQLQuery),
+    |let v =$table->cast(@ViewSelectSQLQuery);
+     let viewIdentifier = '['+$v.view.schema.database->elementToPath()+']'+$table.schema.name+'_'+ $table.name;
+     $viewIdentifier->in($relationalIdentifiers);,
+    |false
+  )
 }
 
 function <<access.private>> meta::pure::lineage::scanRelations::extractSourceColumnFromSelectSQLQuery(select : SelectSQLQuery[1], tableAliasColumn:TableAliasColumn[1], relationIdentifiers:String[*], sourceTree:RelationTree[1]):Column[0..1]
@@ -658,7 +669,7 @@ function <<access.private>> meta::pure::lineage::scanRelations::extractSourceCol
                                                            $colName == $tableAliasColumn.column.name;)->extractTableAliasColumns()->removeDuplicates();
 
    assert($reqTableAliasColumn->size() <= 1 ,|'Expected max 1 column. Found : ' + $reqTableAliasColumn->size()->toString());
-   
+
    if($reqTableAliasColumn->isEmpty() || $select.data->isEmpty(), 
       |[], 
       |let rootTree        = $select.data->toOne();

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelationsTestWithViewsAndUnions.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelationsTestWithViewsAndUnions.pure
@@ -1,0 +1,148 @@
+import meta::pure::lineage::scanRelations::*;
+
+function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations::test::testRelationalTreeCalculation():Any[*]
+{
+
+  let relationTree =   meta::pure::lineage::scanRelations::scanRelations({|meta::pure::lineage::scanRelations::test::Party.all()->project([r | $r.identifier.identifier],['id'])->distinct()}
+                               , meta::pure::lineage::scanRelations::test::TopMapping
+                               , meta::relational::extension::relationalExtensions());
+  let expected =  'root\n'+
+                  '  ------> (t) Entity [entityID]\n'+
+                  '    ------> (v) AltID_View(Entity_AltId_View) [entityID, txt]\n'+
+                  '      root\n'+
+                  '        ------> (t) AltIDToEntityMapping [alternativeID, entityID]\n'+
+                  '          ------> (t) AlternativeID(AltIDToEntityMapping_AlternativeID) [alternativeID, alternativeNameTXT, alternativeTypeID]\n'+
+                  '            ------> (t) LookupTable(AlternativeID_AltIdentifierType) [altrnIdentTypeCD, altrnIdentTypeID, altrnIdentTypeNameTXT]\n'+
+                  '    ------> (t) Entity(Entity_Self) [entityID]\n';
+   assertEquals($expected, $relationTree-> relationTreeAsString());
+}
+
+Class meta::pure::lineage::scanRelations::test::Party
+{
+   isLegallyCompetent: Boolean[1];
+   recognitionDate: Date[0..1];
+}
+
+Association meta::pure::lineage::scanRelations::test::Party_Identifier {
+   party: meta::pure::lineage::scanRelations::test::Party[1];
+   identifier: meta::pure::lineage::scanRelations::test::Identifier[*];
+}
+
+
+Class meta::pure::lineage::scanRelations::test::Identifier
+{
+    identifier: String[1];
+    version: Integer[0..1];
+ 
+}
+
+
+###Mapping
+import meta::pure::lineage::scanRelations::test::*;
+import meta::pure::router::operations::*;
+
+Mapping meta::pure::lineage::scanRelations::test::TopMapping
+(
+   
+  include meta::pure::lineage::scanRelations::test::DetailMapping
+   
+  *Identifier[idAll] : Operation 
+  {
+    union_OperationSetImplementation_1__SetImplementation_MANY_(id1, id2)
+  }
+  
+)
+
+###Mapping
+import meta::pure::lineage::scanRelations::test::*;
+
+Mapping meta::pure::lineage::scanRelations::test::DetailMapping
+(
+
+  Party [p] : Relational
+  {
+     ~mainTable [DB1] E.Entity
+     
+      identifier [id1]: [DB2]@Entity_AltId_View,
+      identifier [id2]: [DB2]@Entity_Self
+ 
+  }
+ 
+   Identifier [id1]: Relational
+   {
+      scope([DB2]E.AltID_View)
+      (
+         identifier: txt
+      )
+   }   
+   
+   *Identifier [id2]: Relational
+   {
+     scope([DB2]E.Entity)
+     (
+         identifier : convertVarchar128(entityID)
+     )
+   }
+   
+)
+
+###Relational
+Database meta::pure::lineage::scanRelations::test::DB2 
+(
+   include meta::pure::lineage::scanRelations::test::DB1
+
+   Schema E 
+   (        
+      View AltID_View
+      (
+         altID: E.AltIDToEntityMapping.alternativeID  PRIMARY KEY,
+         entityID:   E.AltIDToEntityMapping.entityID       PRIMARY KEY,
+         txt:        @AltIDToEntityMapping_AlternativeID | AlternativeID.alternativeNameTXT,
+         idtype:     @AltIDToEntityMapping_AlternativeID | AlternativeID.alternativeTypeID,
+         idcode:     @AltIDToEntityMapping_AlternativeID > @AlternativeID_AltIdentifierType | LookupTable.altrnIdentTypeCD,
+         iddesc:     @AltIDToEntityMapping_AlternativeID > @AlternativeID_AltIdentifierType | LookupTable.altrnIdentTypeNameTXT
+      )
+
+   )
+   Join Entity_AltId_View( E.Entity.entityID = E.AltID_View.entityID )
+   Join Entity_Self( E.Entity.entityID = {target}.entityID)
+
+
+)
+
+###Relational 
+Database meta::pure::lineage::scanRelations::test::DB1 
+(
+
+   Schema E (
+    Table Entity (
+      entityID                      INT                  PRIMARY KEY
+                
+    )
+
+    Table AlternativeID (
+        alternativeID                 INT                  PRIMARY KEY,
+        alternativeNameTXT            VARCHAR(255)         ,
+        alternativeTypeID             INT                  
+        
+    )
+
+    Table AltIDToEntityMapping (
+      alternativeID                 INT                  PRIMARY KEY,
+      entityID                      INT                  PRIMARY KEY
+     
+    )
+
+    Table LookupTable (
+      altrnIdentTypeCD              CHAR(4)              PRIMARY KEY,
+      altrnIdentTypeID              INT                  NOT NULL,
+      altrnIdentTypeNameTXT         CHAR(60)       
+     
+    )
+
+   )
+  Join AltIDToEntityMapping_AlternativeID(E.AltIDToEntityMapping.alternativeID = E.AlternativeID.alternativeID)
+  Join AlternativeID_AltIdentifierType(E.AlternativeID.alternativeTypeID = E.LookupTable.altrnIdentTypeID)
+
+
+)


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Fixes the way we scan properties in unions that use views and chained joins

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes, enables calculation of lineage tree
