### PR TITLE
java generation fix for missing types

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/platformBinding/typeInfo/typeInfo.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/platformBinding/typeInfo/typeInfo.pure
@@ -21,6 +21,7 @@ import meta::pure::mapping::*;
 import meta::pure::metamodel::constraint::*;
 import meta::pure::metamodel::serialization::grammar::*;
 import meta::pure::milestoning::*;
+import meta::pure::router::metamodel::*;
 
 
 
@@ -140,6 +141,13 @@ function meta::pure::executionPlan::platformBinding::typeInfo::addProperties(inf
 function meta::pure::executionPlan::platformBinding::typeInfo::addForGraphFetchTree(info:TypeInfoSet[1], tree: GraphFetchTree[1]): TypeInfoSet[1]
 {
    $info->typeInfoFromTree($tree);
+}
+
+
+// function adds extra types by Re-scanning targetTree and its property mappings for new types ( which are not part of calculated source Tree)
+function meta::pure::executionPlan::platformBinding::typeInfo::addExtraTypesForGraphFetchTree(info:TypeInfoSet[1], tree: GraphFetchTree[1]): TypeInfoSet[1]
+{
+   $info->typeInfoFromTreeExtra($tree, noDebug());
 }
 
 function meta::pure::executionPlan::platformBinding::typeInfo::addConstraintsForGraphFetchTree(info:TypeInfoSet[1], tree: GraphFetchTree[1]): TypeInfoSet[1]
@@ -648,4 +656,129 @@ function  <<access.private>> meta::pure::executionPlan::platformBinding::typeInf
 function  <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::elementsEquals():Function<{PackageableElement[1],PackageableElement[1]->Boolean[1]}>[1]
 {
    {pe1:PackageableElement[1], pe2:PackageableElement[1] | $pe1->elementToPath() == $pe2->elementToPath()};
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::typeInfoFromTreeExtra(info:TypeInfoSet[1],tree:GraphFetchTree[1], debug:DebugContext[1]): TypeInfoSet[1]
+{
+  print(if($debug.debug,|$debug.space+'getting extra types from tree : '+  + $tree->asString(false) + '\n',|''));
+                                    
+  let extraTypesAndProperties= $tree->match([
+    p:RoutedPropertyGraphFetchTree[1]| 
+             $p.propertyMapping->map(pm|  
+                  $pm->match([
+                        //TODO : move this to M2M extension
+                        ppm: meta::pure::mapping::modelToModel::PurePropertyMapping[1] | 
+                            $ppm.transform->evaluateAndDeactivate()->scanTypesAndPropertiesFromAny([], $debug->indent()->indent());,
+                        apm: Any[1] | []
+                    ]));,
+    r:RootGraphFetchTree<Any>[1] | []
+  ])->removeDuplicates();
+  print(if($debug.debug,|$debug->indent().space+'found extraTypesAndProeprties: '+ $extraTypesAndProperties->map(t|$t->typeToString())->makeString('[', ', ', ']') + '\n',|''));
+  
+  
+  let extraTypes= $extraTypesAndProperties->map(x|$x->match([
+                    t:Type[1]| $t,
+                    a:Any[1]| []
+                ]))->cast(@Type)->meta::pure::executionPlan::platformBinding::typeInfo::filterTypes($info);
+  print(if($debug.debug,|$debug->indent().space+'found extraTypes: '+ $extraTypes->map(t|$t->typeToString())->makeString('[', ', ', ']') + '\n',|''));
+  let withExtraTypes = $extraTypes->fold({t, tis| $tis->addBasicTypeInfoIfMissing([], $t , true)}, $info);    // only add basic typeInfo
+    
+  let extraProperties= $extraTypesAndProperties->map(x|$x->match([
+                    p:Property<Nil,Any|*>[1]| $p,
+                    a:Any[1]| []
+                ]))->cast(@Property<Nil,Any|*>)->meta::pure::executionPlan::platformBinding::typeInfo::filterProperties($info);
+  print(if($debug.debug,|$debug->indent().space+'found extraProperties: '+ $extraProperties->map(t|$t.owner.name->toOne() +'.' +$t.name->toOne())->makeString('[', ', ', ']') + '\n',|''));
+  let withExtraProperties = $extraProperties->fold({p, ti| $ti->addPropertyForTypeIfMissing($p, true)}, $withExtraTypes);          // only add accessed properties 
+
+   $tree.subTrees->map(x | $x->meta::pure::graphFetch::routing::byPassClusteringInfo())->cast(@PropertyGraphFetchTree)
+                 ->fold({pgft, tis| typeInfoFromTreeExtra($tis, $pgft, $debug->indent())}, $withExtraProperties);
+}
+
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::scanTypesAndPropertiesFromAny(a:Any[1], processed:Function<Any>[*], debug:DebugContext[1]):Any[*]
+{
+  $a->match([
+    vs:ValueSpecification[1] | $vs->scanTypesAndPropertiesFromValueSpecification($processed, $debug);,
+    f:Function<Any>[1] |       $f->scanTypesAndPropertiesFromFunction($processed, $debug);,
+    t:Type[1]          |        $t;, 
+    an:Any[1]          |        print(if($debug.debug,|$debug.space+'  Unknown\n',|''));[];
+  ]);
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::scanTypesAndPropertiesFromValueSpecification(vs:ValueSpecification[1], processed:Function<Any>[*], debug: meta::pure::tools::DebugContext[1]):Any[*]
+{
+   let res = $vs->evaluateAndDeactivate()->match([
+               fe:FunctionExpression[1] | print(if($debug.debug,|$debug.space+'Processing Function Expression : ' + $fe->printValueSpecification('') + '\n',|''));
+                                          let params = $fe.parametersValues->evaluateAndDeactivate();
+                                          $fe.func->evaluateAndDeactivate()->match([
+                                                            p:Property<Nil,Any|*>[1]|print(if($debug.debug,|$debug.space+'  property:'+$p.name->toOne()+'\n', |''));
+                                                                                     let leftSide = $params->at(0)->scanTypesAndPropertiesFromAny($processed,$debug->indent());
+                                                                                     $p->concatenate($leftSide);,
+                                                            q:QualifiedProperty<Any>[1]|print(if($debug.debug,|$debug.space+'  qualifier:'+$q.name->toOne()+'\n', |''));
+                                                                                        let leftSide = $params->at(0)->scanTypesAndPropertiesFromValueSpecification($processed->concatenate($q), $debug->indent());
+                                                                                        let fTypes= $q->scanTypesAndPropertiesFromFunction($processed, $debug->indent());
+                                                                                        $leftSide->concatenate($fTypes);,
+                                                            z:Function<Any>[1]|print(if($debug.debug,|$debug.space+'  function: \''+$fe.func.name->toOne()+'\'\n',|''));
+                                                                    let pp = $params->map(v|$v->scanTypesAndPropertiesFromAny($processed->concatenate($z),$debug->indent()));
+                                                                    let fTypes= $z->scanTypesAndPropertiesFromFunction($processed, $debug->indent());
+                                                                    $pp->concatenate($fTypes);
+                                                                          
+                                                          ]);,
+               i:InstanceValue[1] | print(if($debug.debug,|$debug.space+'Processing Instance'+  + $i->printValueSpecification('') + '\n',|''));
+                                    $i.values->evaluateAndDeactivate()->map( v | $v->scanTypesAndPropertiesFromAny($processed, $debug->indent()));
+                                    ,
+               ve:VariableExpression[1] | print(if($debug.debug,|$debug.space+'Processing Variable '+$ve->printValueSpecification('') +'\n',|''));
+                                         $ve->evaluateAndDeactivate().genericType.rawType;,
+               ervs:ExtendedRoutedValueSpecification[1] | print(if($debug.debug,|$debug.space+'Bypassing ExtendedRoutedValueSpecification\n',|''));
+                                                          $ervs.value->scanTypesAndPropertiesFromValueSpecification($processed, $debug->indent());,
+               frvs:FunctionRoutedValueSpecification[1] | print(if($debug.debug,|$debug.space+'Bypassing FunctionRoutedValueSpecification\n',|''));
+                                                          $frvs.value->scanTypesAndPropertiesFromValueSpecification($processed, $debug->indent());
+               default: ValueSpecification[1]  | print(if($debug.debug,|$debug.space+' UNKNOWN ValueSpecification\n',|''));    []->cast(@Type);
+             ]
+          );
+
+   print(if($debug.debug,|$debug.space+'Current:'+$res->map(t|$t->typeToString())->makeString('[',', ',']')+'\n',|''));
+   $res;
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::scanTypesAndPropertiesFromFunction(f:Function<Any>[1],processed:Function<Any>[*], debug:DebugContext[1]):Any[*]
+{
+   let fn= if(shouldProcess($f, $processed),|$f,|[]);
+   print(if($debug.debug,|$debug.space+'  - func '+if($fn->isEmpty(), |'not found or excuded', |if($fn.name->isEmpty(), |$fn->toOne()->type().name->toOne(), |$fn.name->toOne()))+'\n',|''));
+   $fn->match([
+      {f0:Function<Any>[0] | []},
+      {f1 :Function<Any>[1] |
+         let paramExtraTypes=  $f1->functionType().parameters->map(p|$p->scanTypesAndPropertiesFromAny($processed->concatenate($f1), $debug->indent()));
+         let expressions = $f1->match([l:FunctionDefinition<Any>[1]| $l.expressionSequence, n:NativeFunction<Any>[1]| []]);
+         let expExtraTypes= $expressions->map(e| $e->scanTypesAndPropertiesFromValueSpecification($processed->concatenate($f1), $debug->indent()));
+         $paramExtraTypes->concatenate($expExtraTypes);
+      }
+   ]);
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::shouldProcess(f:Function<Any>[1], processed:Function<Any>[*]):Boolean[1]
+{
+   let pkgOk = !$f->isWithinPackage(meta) || $f->meta::alloy::isMetaAlloyTestDependency();
+   $pkgOk && !$processed->contains($f);
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::filterTypes(ts:Type[*], info:TypeInfoSet[1]):Type[*]
+{
+  $ts->filter(t| !$info.typeInfos.type->contains($t))                                                             // dont add already present typeinfos 
+     ->filter(t|!$t->isWithinPackage(meta) || $t->meta::alloy::isMetaAlloyTestDependency())
+     ->remove(Any)->remove(Function)->cast(@Type)
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::filterProperties(ps:Property<Nil,Any|*>[*], info:TypeInfoSet[1]):Property<Nil,Any|*>[*]
+{
+  $ps->filter(p |!$info->containsProperty($p))                                                                  // dont add already present properties
+      ->filter(p|!$p.owner->isWithinPackage(meta) || $p.owner->meta::alloy::isMetaAlloyTestDependency())->cast(@Property<Nil,Any|*>);
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::typeToString(ts:Any[1]):String[1]
+{
+  $ts->match([
+     p:Property<Nil,Any|*>[1] | $p.owner.name->toOne() +'.' +$p.name->toOne();,
+     t:Type[1]   | $t->toString();
+  ])
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/extraTypeInfo.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/extraTypeInfo.pure
@@ -1,0 +1,121 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::*;
+import meta::pure::executionPlan::profiles::*;
+import meta::pure::graphFetch::execution::*;
+import meta::pure::runtime::*;
+import  meta::pure::mapping::modelToModel::*;
+import meta::json::*;
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> {serverVersion.start='v1_19_0'} 
+meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::testSubtypeOfRootWithoutPropertyAccess() : Boolean[1]
+{
+   let tree = #{TargetPolygon {area} }#;
+
+   let result = execute(
+      |meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::TargetPolygon.all()->graphFetch($tree)->serialize($tree),
+      meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::mappingWithExtraTypes,
+      ^Runtime(connections = ^JsonModelConnection(
+                                element=^ModelStore(), 
+                                class=meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Polygon, 
+                                url='data:application/json,\n{}\n'
+                             )
+      ),
+      meta::pure::extension::defaultExtensions()
+   );
+
+   assert(jsonEquivalent('{"area":0.0}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> { serverVersion.start='v1_19_0'} 
+meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::testPropertyAccessOnSubtypeOfRoot() : Boolean[1]
+{
+   let tree = #{TargetPolygon {area} }#;
+
+   let result = execute(
+      |meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::TargetPolygon.all()->graphFetch($tree)->serialize($tree),
+      meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::mapping,
+      ^Runtime(connections = ^JsonModelConnection(
+                                element=^ModelStore(), 
+                                class=meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Polygon, 
+                                url='data:application/json,\n{}\n'
+                             )
+      ),
+      meta::pure::extension::defaultExtensions()
+   );
+
+   assert(jsonEquivalent('{"area":0.0}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Polygon
+{
+
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Triangle extends Polygon
+{
+  base :Float[1];
+  height : Float[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Rectangle extends Polygon
+{
+  base :Float[1];
+  height : Float[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::TargetPolygon
+{
+  area: Float[1];
+}
+
+function meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::getAreaOfPolygon(p:Polygon[1]) :Float[1]
+{
+  $p->match([
+    triangle:meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Triangle[1] | $triangle.base * $triangle.height*0.5,
+    rectangle:meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Rectangle[1]| $rectangle.base * $rectangle.height,
+    default : meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Polygon[1] | 0.0
+  ])
+}
+
+function meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::getAreaOfPolygonNoPropertyAccess(p:Polygon[1]) :Float[1]
+{
+  $p->match([
+    triangle:meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Triangle[1] | 0.0,
+    rectangle:meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Rectangle[1]| 0.0,
+    default : meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Polygon[1] | 0.0
+  ])
+}
+
+###Mapping
+import meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::*;
+
+Mapping meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::mapping
+(
+  meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::TargetPolygon : Pure
+   {
+      ~src  meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Polygon
+      area: $src->meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::getAreaOfPolygon()
+   }
+)
+
+Mapping meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::mappingWithExtraTypes
+(
+  meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::TargetPolygon : Pure
+   {
+      ~src  meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::Polygon
+      area: $src->meta::pure::mapping::modelToModel::test::alloy::typeInfo::extraTypes::getAreaOfPolygonNoPropertyAccess()
+   }
+)

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchInMemory.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchInMemory.pure
@@ -105,8 +105,11 @@ function meta::pure::executionPlan::engine::java::graphFetch::inMemory::prepareF
                                                                
    ]);
    
+   // add extra types that are not found in source tree  > these are not property acces , these are referenced in some other contexts - eg as a match type 
+   let withExtraTypeInfos=   meta::pure::executionPlan::platformBinding::typeInfo::addExtraTypesForGraphFetchTree($newTypeInfos, $node.graphFetchTree);
+
    ^$context(
-      typeInfos = $newTypeInfos,
+      typeInfos = $withExtraTypeInfos,
       nodeInfos = $context.nodeInfos->concatenate($currentNodeInfo)
    );
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one/more labels.
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->
This PR fixes 'types not found' issue  in generated java code for M2M mapping cases where types are being referred to in mapping but there is no property access. So the corresponding generated Source Tree does not have type info for that extra type. So we need to re-scan property mappings from target tree to find these extra types being referred to.

eg  In this Mapping : 

> Mapping meta::pure::platformBinding::test::mappingWithExtraTypes
> (
>   meta::pure::platformBinding::test::TargetPolygon : Pure
>    {
>       ~src  meta::pure::platformBinding::test::Polygon
>       area: $src->getAreaOfPolygonNoPropertyAccess()
>    }
> )
> function meta::pure::platformBinding::test::getAreaOfPolygonNoPropertyAccess(p:Polygon[1]) :Float[1]
>             {
>               $p->match([
>                        triangle:meta::pure::platformBinding::test::Triangle[1] | 0.0,
>                        rectangle:meta::pure::platformBinding::test::Rectangle[1]| 0.0,
>                        default : meta::pure::platformBinding::test::Polygon[1] | 0.0
>               ])
>             }

for target tree

> #{TargetPolygon {area} }#;`
 
source tree generated is 

> #{ polygon } #

which does not contain these extra types referred in property mapping lambda : 

> Triangle , Rectangle 

as there is no property access on these extra types

   

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
