### PR TITLE
Fix service store mapping processing bug

### DIFF
--- a/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
@@ -821,6 +821,46 @@ public class ServiceStoreJsonShowcaseTest extends ServiceStoreTestSuite
     }
 
     @Test
+    public void serviceStoreExampleWithPureExpressionInParamGenLogic()
+    {
+        String query = "###Pure\n" +
+                "function showcase::query(): Any[1]\n" +
+                "{\n" +
+                "   {name:String[1]|meta::external::store::service::showcase::domain::S_Product.all()\n" +
+                "       ->filter(s | $s.s_productName == $name)" +
+                "       ->graphFetch(#{\n" +
+                "           meta::external::store::service::showcase::domain::S_Product {\n" +
+                "               s_productId,\n" +
+                "               s_productName,\n" +
+                "               s_description,\n" +
+                "               s_synonyms {\n" +
+                "                   s_name,\n" +
+                "                   s_type\n" +
+                "               }\n" +
+                "           }\n" +
+                "         }#)\n" +
+                "       ->serialize(#{\n" +
+                "           meta::external::store::service::showcase::domain::S_Product {\n" +
+                "               s_productId,\n" +
+                "               s_productName,\n" +
+                "               s_description,\n" +
+                "               s_synonyms {\n" +
+                "                   s_name,\n" +
+                "                   s_type\n" +
+                "               }\n" +
+                "           }\n" +
+                "        }#)};\n" +
+                "}";
+
+        SingleExecutionPlan plan = buildPlanForQuery(pureGrammar + "\n\n" + query, "meta::external::store::service::showcase::mapping::ServiceStoreMapping2", "meta::external::store::service::showcase::runtime::ServiceStoreRuntime");
+
+        String expectedRes = "{\"builder\":{\"_type\":\"json\"},\"values\":{\"s_productId\":\"30\",\"s_productName\":\"Product 30\",\"s_description\":\"Product 30 description\",\"s_synonyms\":[{\"s_name\":\"product 30 synonym 1\",\"s_type\":\"isin\"},{\"s_name\":\"product 30 synonym 2\",\"s_type\":\"cusip\"}]}}";
+
+        Assert.assertEquals(expectedRes, executePlan(plan, Maps.mutable.with("name", "product 30")));
+        Assert.assertEquals(expectedRes, executePlan(plan, Maps.mutable.with("name", "product 30_clutter")));
+    }
+
+    @Test
     public void serviceStoreExampleWithTakeAndCrossStore()
     {
         String query = "###Pure\n" +

--- a/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/testGrammar.pure
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/testGrammar.pure
@@ -308,6 +308,17 @@ Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping2
   *meta::external::store::service::showcase::domain::S_Product[s_prod_set]: ServiceStore
   {
      ~service [meta::external::store::service::showcase::store::ShowcaseServiceStore] ProductServices.GetAllProductsService
+
+     ~service [meta::external::store::service::showcase::store::ShowcaseServiceStore] ProductServices.ProductByNameService
+     (
+       ~request
+       (
+         parameters
+         (
+           name = if($this.s_productName->length() > 10, | $this.s_productName->substring(0, 10), | $this.s_productName)
+         )
+       )
+     )
   }
 )
 

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
@@ -255,9 +255,9 @@ function meta::external::store::service::executionPlan::generation::getServiceMa
    let propToServiceMappingMap = $serviceSetImpl.servicesMapping->map(sm | let reqPropPaths = $sm.requestBuildInfo.requestParametersBuildInfo.parameterBuildInfoList
                                                                                                                    ->map(pb | $pb.transform.expressionSequence->toOne()->findAndReplacePropertyPathsInValueSpecification([]).second.values)
                                                                                                                    ->concatenate($sm.requestBuildInfo.requestBodyBuildInfo.transform.expressionSequence->map(x | $x->findAndReplacePropertyPathsInValueSpecification([]).second.values));
-                                                                           let propPaths    = if($reqPropPaths->isEmpty(), |'', |$reqPropPaths);
+                                                                           let propPaths    = if($reqPropPaths->isEmpty(), |'', |$reqPropPaths)->removeDuplicates();
                                                                            pair($propPaths->sort()->joinStrings(','), $sm);)->newMap();
-   
+
    let reqServiceMapping       = $propToServiceMappingMap->get($availablePropPaths->sort()->joinStrings(','));
    assert($reqServiceMapping->isNotEmpty(), |'No service mapping found for available parameters. Available params - ' + $availablePropPaths->sort()->joinStrings('[', ', ', ']') + '. Available paths - ' +  $propToServiceMappingMap->keys()->joinStrings('[', ', ', ']'));
 


### PR DESCRIPTION
#### What type of PR is this?
BugFix

#### What does this PR do / why is it needed ?
If a property is being referenced multiple times in a parameter resolution logic of service store mapping, current platform logic has a bug that causes issues resolving correct service mapping for the query.
This PR fixes this bug

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/finos/legend-engine/issues/1099

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
