### PR TITLE
Refactor IDs to use identifiers 2 (Revert 1091) 

### DIFF
--- a/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryLexerGrammar.g4
+++ b/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryLexerGrammar.g4
@@ -1,7 +1,6 @@
-lexer grammar MasteryLexerGrammar;
+    lexer grammar MasteryLexerGrammar;
 
 import M3LexerGrammar;
-//import DomainLexerGrammar;
 
 // -------------------------------------- KEYWORD --------------------------------------
 

--- a/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryParserGrammar.g4
+++ b/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryParserGrammar.g4
@@ -14,6 +14,8 @@ identifier:                                 VALID_STRING | STRING
                                             | MASTER_RECORD_DEFINITION | MODEL_CLASS | RECORD_SOURCES | SOURCE_PARTITIONS
 ;
 
+masteryIdentifier:                          (VALID_STRING | '-' | INTEGER) (VALID_STRING | '-' | INTEGER)*;
+
 // -------------------------------------- DEFINITION --------------------------------------
 
 definition:                                 //imports
@@ -25,9 +27,8 @@ imports:                                    (importStatement)*
 importStatement:                            IMPORT packagePath PATH_SEPARATOR STAR SEMI_COLON
 ;
 
-/*************
- * Common
- *************/
+// -------------------------------------- COMMON --------------------------------------
+
 boolean_value:                              TRUE | FALSE
 ;
 modelClass:                                 MODEL_CLASS COLON qualifiedName SEMI_COLON
@@ -44,9 +45,9 @@ tags:                                       TAGS COLON
                                             BRACKET_CLOSE
                                             SEMI_COLON
 ;
-/*************
- * MasterRecordDefinition
- *************/
+
+// -------------------------------------- MASTER_RECORD_DEFIMNITION --------------------------------------
+
 mastery:                                    MASTER_RECORD_DEFINITION qualifiedName
                                                 BRACE_OPEN
                                                 (
@@ -57,9 +58,8 @@ mastery:                                    MASTER_RECORD_DEFINITION qualifiedNa
                                                 BRACE_CLOSE
 ;
 
-/****************
- * RecordSources
- ****************/
+// -------------------------------------- RECORD_SOURCES --------------------------------------
+
 recordSources:                              RECORD_SOURCES COLON
                                             BRACKET_OPEN
                                             (
@@ -71,10 +71,9 @@ recordSources:                              RECORD_SOURCES COLON
                                             )
                                             BRACKET_CLOSE
 ;
-recordSource:                               BRACE_OPEN
+recordSource:                               masteryIdentifier COLON BRACE_OPEN
                                             (
-                                                id
-                                                | recordStatus
+                                                recordStatus
                                                 | description
                                                 | parseService
                                                 | transformService
@@ -120,18 +119,16 @@ sourcePartitions:                           SOURCE_PARTITIONS COLON
                                             )
                                             BRACKET_CLOSE
 ;
-sourcePartiton:                             BRACE_OPEN
+sourcePartiton:                             masteryIdentifier COLON BRACE_OPEN
                                             (
-                                                 id
-                                                 | tags
+                                                 tags
                                             )*
                                             BRACE_CLOSE
 ;
 
 
-/*************
- * Resolution
- *************/
+// -------------------------------------- RESOLUTION --------------------------------------
+
 identityResolution:                         IDENTITIY_RESOLUTION COLON
                                             BRACE_OPEN
                                             (

--- a/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
+++ b/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
@@ -92,9 +92,7 @@ public class MasteryParseTreeWalker
     {
         RecordSource source = new RecordSource();
         source.sourceInformation = walkerSourceInformation.getSourceInformation(ctx);
-
-        MasteryParserGrammar.IdContext idContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.id(), "id", source.sourceInformation);
-        source.id = PureGrammarParserUtility.fromGrammarString(idContext.STRING().getText(), true);
+        source.id = PureGrammarParserUtility.fromIdentifier(ctx.masteryIdentifier());
 
         MasteryParserGrammar.DescriptionContext descriptionContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.description(), "description", source.sourceInformation);
         source.description = PureGrammarParserUtility.fromGrammarString(descriptionContext.STRING().getText(), true);
@@ -195,9 +193,7 @@ public class MasteryParseTreeWalker
     {
         SourceInformation sourceInformation = walkerSourceInformation.getSourceInformation(ctx);
         RecordSourcePartition partition = new RecordSourcePartition();
-
-        MasteryParserGrammar.IdContext idContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.id(), "id", sourceInformation);
-        partition.id = PureGrammarParserUtility.fromGrammarString(idContext.STRING().getText(), true);
+        partition.id = PureGrammarParserUtility.fromIdentifier(ctx.masteryIdentifier());
 
         MasteryParserGrammar.TagsContext tagsContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.tags(), "tags", sourceInformation);
         if (tagsContext != null)

--- a/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
+++ b/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
@@ -72,7 +72,7 @@ public class HelperMasteryGrammarComposer
                 .append(getTabString(indentLevel)).append("[\n");
                 ListIterate.forEachWithIndex(sources, (source, i) ->
                 {
-                    sourcesStr.append(i > 0 ? ",\n" : "").append(getTabString(indentLevel + 1)).append("{\n");;
+                    sourcesStr.append(i > 0 ? ",\n" : "");
                     sourcesStr.append(source.accept(new RecordSourceComposer(indentLevel, context)));
                     sourcesStr.append(getTabString(indentLevel + 1)).append("}");
                 });
@@ -94,7 +94,7 @@ public class HelperMasteryGrammarComposer
         @Override
         public String visit(RecordSource val)
         {
-              return getTabString(indentLevel + 2) + "id: " + convertString(val.id, true) + ";\n" +
+              return getTabString(indentLevel + 1) + val.id + ": {\n" +
                     getTabString(indentLevel + 2) + "description: " + convertString(val.description, true) + ";\n" +
                     getTabString(indentLevel + 2) + "status: " + val.status + ";\n" +
                       (val.parseService != null ? (getTabString(indentLevel + 2) + "parseService: " + val.parseService + ";\n") : "") +
@@ -115,7 +115,7 @@ public class HelperMasteryGrammarComposer
         strBuf.append(getTabString(indentLevel + 2)).append("[");
         ListIterate.forEachWithIndex(source.partitions, (partition, i) ->
         {
-            strBuf.append(i > 0 ? "," : "").append("\n").append(getTabString(indentLevel + 3)).append("{\n");;
+            strBuf.append(i > 0 ? "," : "").append("\n");
             strBuf.append(renderPartition(partition, indentLevel + 3)).append("\n");
             strBuf.append(getTabString(indentLevel + 3)).append("}");
         });
@@ -130,7 +130,7 @@ public class HelperMasteryGrammarComposer
 
     private static String renderPartition(RecordSourcePartition partition, int indentLevel)
     {
-        StringBuffer strBuf = new StringBuffer().append(getTabString(indentLevel + 1)).append("id: ").append(convertString(partition.id, true)).append(";");
+        StringBuffer strBuf = new StringBuffer().append(getTabString(indentLevel)).append(partition.id).append(": {");
         strBuf.append((partition.getTags() != null && !partition.getTags().isEmpty()) ? "\n" + renderTags(partition, indentLevel + 1) : "");
         return strBuf.toString();
     }

--- a/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
+++ b/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
@@ -124,8 +124,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "  }\n" +
             "  recordSources:\n" +
             "  [\n" +
-            "    {\n" +
-            "      id: \'widget-file-single-partition\';\n" +
+            "    widget-file-single-partition-14: {\n" +
             "      description: \'Single partition source.\';\n" +
             "      status: Development;\n" +
             "      parseService: org::dataeng::ParseWidget;\n" +
@@ -137,14 +136,12 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      tags: [\'Refinitive DSP\'];\n" +
             "      partitions:\n" +
             "      [\n" +
-            "        {\n" +
-            "          id: \'partition-1\';\n" +
+            "        partition-1-of-5: {\n" +
             "          tags: [\'Equity\', \'Global\', \'Full-Universe\'];\n" +
             "        }\n" +
             "      ]\n" +
             "    },\n" +
-            "    {\n" +
-            "      id: \'widget-file-multiple-partitions\';\n" +
+            "    widget-file-multiple-partition: {\n" +
             "      description: \'Multiple partition source.\';\n" +
             "      status: Production;\n" +
             "      parseService: org::dataeng::ParseWidget;\n" +
@@ -156,16 +153,13 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      tags: [\'Refinitive DSP Delta Files\'];\n" +
             "      partitions:\n" +
             "      [\n" +
-            "        {\n" +
-            "          id: \'ASIA-Equity\';\n" +
+            "        ASIA_Equity: {\n" +
             "          tags: [\'Equity\', \'ASIA\'];\n" +
             "        },\n" +
-            "        {\n" +
-            "          id: \'EMEA-Equity\';\n" +
+            "        EMEA_Equity: {\n" +
             "          tags: [\'Equity\', \'EMEA\'];\n" +
             "        },\n" +
-            "        {\n" +
-            "          id: \'US-Equity\';\n" +
+            "        US_Equity: {\n" +
             "          tags: [\'Equity\', \'US\'];\n" +
             "        }\n" +
             "      ]\n" +
@@ -211,15 +205,13 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "  }\n" +
             "  recordSources:\n" +
             "  [\n" +
-            "    {\n" +
-            "      id: \'widget-file-single-partition\';\n" +
+            "    widget-file-single-partition: {\n" +
             "      description: \'Single partition source.\';\n" +
             "      status: Development;\n" +
             "      transformService: org::dataeng::TransformWidget;\n" +
             "      partitions:\n" +
             "      [\n" +
-            "        {\n" +
-            "          id: \'partition-1\';\n" +
+            "        partition-1a: {\n" +
             "        }\n" +
             "      ]\n" +
             "    }\n" +
@@ -250,8 +242,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "  }\n" +
             "  recordSources:\n" +
             "  [\n" +
-            "    {\n" +
-            "      id: \'widget-file-single-partition\';\n" +
+            "    widget-file-single-partition: {\n" +
             "      description: \'Single partition source.\';\n" +
             "      status: Development;\n" +
             "      parseService: org::dataeng::ParseWidget;\n" +
@@ -263,8 +254,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      tags: [\'Refinitive DSP\'];\n" +
             "      partitions:\n" +
             "      [\n" +
-            "        {\n" +
-            "          id: \'partition-1\';\n" +
+            "        partition-1a: {\n" +
             "          tags: [\'Equity\'];\n" +
             "        }\n" +
             "      ]\n" +
@@ -308,7 +298,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
         {
             if (i == 0)
             {
-                assertEquals("widget-file-single-partition", source._id());
+                assertEquals("widget-file-single-partition-14", source._id());
                 assertEquals("Development", source._status().getName());
                 assertEquals(true, source._sequentialData());
                 assertEquals(false, source._stagedLoad());
@@ -317,13 +307,13 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
                 assertEquals("[Refinitive DSP]", source._tags().toString());
                 ListIterate.forEachWithIndex(source._partitions().toList(), (partition, j) ->
                 {
-                    assertEquals("partition-1", partition._id());
+                    assertEquals("partition-1-of-5", partition._id());
                     assertEquals("[Equity, Global, Full-Universe]", partition._tags().toString());
                 });
             }
             else if (i == 1)
             {
-                assertEquals("widget-file-multiple-partitions", source._id());
+                assertEquals("widget-file-multiple-partition", source._id());
                 assertEquals("Production", source._status().getName());
                 assertEquals(false, source._sequentialData());
                 assertEquals(true, source._stagedLoad());
@@ -334,17 +324,17 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
                 {
                     if (j == 0)
                     {
-                        assertEquals("ASIA-Equity", partition._id());
+                        assertEquals("ASIA_Equity", partition._id());
                         assertEquals("[Equity, ASIA]", partition._tags().toString());
                     }
                     else if (j == 1)
                     {
-                        assertEquals("EMEA-Equity", partition._id());
+                        assertEquals("EMEA_Equity", partition._id());
                         assertEquals("[Equity, EMEA]", partition._tags().toString());
                     }
                     else if (j == 2)
                     {
-                        assertEquals("US-Equity", partition._id());
+                        assertEquals("US_Equity", partition._id());
                         assertEquals("[Equity, US]", partition._tags().toString());
                     }
                     else
@@ -391,6 +381,6 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
     @Override
     public String getDuplicatedElementTestExpectedErrorMessage()
     {
-        return "COMPILATION error at [8:1-45:1]: Duplicated element 'org::dataeng::Widget'";
+        return "COMPILATION error at [8:1-43:1]: Duplicated element 'org::dataeng::Widget'";
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

Merging changes to use identifiers for RecordSources and RecordPartitions.

#### What does this PR do / why is it needed ?

Ensures IDs for RecordSources and RecordPartitions are identifiers.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:
Also requires an Alloy test fix, after teh Studio release Alloy will break until this PR is merged.
https://gitlab.aws.site.gs.com/data-engineering/data-architecture-qubits/Alloy/-/merge_requests/501 

#### Does this PR introduce a user-facing change?
Yes in Studio.
https://github.com/finos/legend-studio/pull/1607


