### PR TITLE
Disable non-mapped service parameters to be populated while processing the url

### DIFF
--- a/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/ServiceExecutor.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/ServiceExecutor.java
@@ -63,55 +63,22 @@ import java.util.Objects;
 
 public class ServiceExecutor
 {
-    public static InputStreamResult executeHttpService(String url, List<ServiceParameter> params, List<String> mappedParameters, RequestBodyDescription requestBodyDescription, HttpMethod httpMethod, String mimeType, List<SecurityScheme> securitySchemes, ExecutionState state, MutableList<CommonProfile> profiles)
+    public static InputStreamResult executeHttpService(String url, List<Header> headers, StringEntity requestBodyEntity, HttpMethod httpMethod, String mimeType, List<SecurityScheme> securitySchemes, MutableList<CommonProfile> profiles)
     {
-        Span span = GlobalTracer.get().activeSpan();
-
-        List<ServiceParameter> pathParams = params == null ? Lists.mutable.empty() : ListIterate.select(params, param -> param.location == Location.PATH);
-        List<ServiceParameter> queryParams = params == null ? Lists.mutable.empty() : ListIterate.select(params, param -> param.location == Location.QUERY);
-        List<ServiceParameter> headerParams = params == null ? Lists.mutable.empty() : ListIterate.select(params, param -> param.location == Location.HEADER);
-
-        String urlProcessedWithPathParams = processUrlWithPathParams(url, pathParams, state);
-        String urlProcessedWithQueryParams = processUrlWithQueryParams(urlProcessedWithPathParams, queryParams, mappedParameters, state);
-        List<Header> headers = processHeaderParams(headerParams, mappedParameters, state);
-
-        if (span != null)
-        {
-            span.setTag("processed url", urlProcessedWithQueryParams);
-        }
-
         URI uri;
         try
         {
-            URIBuilder uriBuilder = new URIBuilder(urlProcessedWithQueryParams);
+            URIBuilder uriBuilder = new URIBuilder(url);
             uri = uriBuilder.build();
         }
         catch (URISyntaxException e)
         {
-            String errMsg = String.format("Cannot build URI from url (%s)", urlProcessedWithQueryParams);
+            String errMsg = String.format("Cannot build URI from url (%s)", url);
             throw new RuntimeException(errMsg, e);
         }
 
-        StringEntity requestBodyEntity = null;
-        if (requestBodyDescription != null)
-        {
-            String requestBody;
-            try
-            {
-                StreamingResult streamingResult = (StreamingResult) state.getResult(requestBodyDescription.resultKey);
-                requestBody = streamingResult.flush(streamingResult.getSerializer(SerializationFormat.RAW));
-            }
-            catch (Exception e)
-            {
-                throw new RuntimeException("Error serializing requestBody value.\n" + e);
-            }
-            ContentType contentType = ContentType.create(requestBodyDescription.mimeType, StandardCharsets.UTF_8);
-            requestBodyEntity = new StringEntity(requestBody, contentType);
-        }
-
-
         InputStream response = executeRequest(httpMethod, uri, headers, requestBodyEntity, mimeType, securitySchemes, profiles);
-        return new InputStreamResult(response, org.eclipse.collections.api.factory.Lists.mutable.with(new ServiceStoreExecutionActivity(urlProcessedWithQueryParams)));
+        return new InputStreamResult(response, org.eclipse.collections.api.factory.Lists.mutable.with(new ServiceStoreExecutionActivity(url)));
     }
 
     public static InputStream executeRequest(HttpMethod httpMethod, URI uri, List<Header> headers, StringEntity requestBodyDescription, String mimeType, List<SecurityScheme> securitySchemes, MutableList<CommonProfile> profiles)
@@ -175,6 +142,52 @@ public class ServiceExecutor
             throw new RuntimeException(e);
         }
     }
+
+    public static String getProcessedUrl(String url, List<ServiceParameter> params, List<String> mappedParameters, ExecutionState state)
+    {
+        Span span = GlobalTracer.get().activeSpan();
+
+        List<ServiceParameter> pathParams = params == null ? Lists.mutable.empty() : ListIterate.select(params, param -> param.location == Location.PATH);
+        List<ServiceParameter> queryParams = params == null ? Lists.mutable.empty() : ListIterate.select(params, param -> param.location == Location.QUERY);
+
+        String urlProcessedWithPathParams = processUrlWithPathParams(url, pathParams, state);
+        String urlProcessedWithQueryParams = processUrlWithQueryParams(urlProcessedWithPathParams, queryParams, mappedParameters, state);
+
+        if (span != null)
+        {
+            span.setTag("processed url", urlProcessedWithQueryParams);
+        }
+
+        return urlProcessedWithQueryParams;
+    }
+
+    public static List<Header> getProcessedHeaders(List<ServiceParameter> params, List<String> mappedParameters, ExecutionState state)
+    {
+        List<ServiceParameter> headerParams = params == null ? Lists.mutable.empty() : ListIterate.select(params, param -> param.location == Location.HEADER);
+        return processHeaderParams(headerParams, mappedParameters, state);
+    }
+
+    public static StringEntity getRequestBodyEntity(RequestBodyDescription requestBodyDescription, ExecutionState state)
+    {
+        StringEntity requestBodyEntity = null;
+        if (requestBodyDescription != null)
+        {
+            String requestBody;
+            try
+            {
+                StreamingResult streamingResult = (StreamingResult) state.getResult(requestBodyDescription.resultKey);
+                requestBody = streamingResult.flush(streamingResult.getSerializer(SerializationFormat.RAW));
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Error serializing requestBody value.\n" + e);
+            }
+            ContentType contentType = ContentType.create(requestBodyDescription.mimeType, StandardCharsets.UTF_8);
+            requestBodyEntity = new StringEntity(requestBody, contentType);
+        }
+        return requestBodyEntity;
+    }
+
 
     private static String processUrlWithPathParams(String url, List<ServiceParameter> pathParams, ExecutionState state)
     {

--- a/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/plugin/ServiceExecutionNodeExecutor.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/plugin/ServiceExecutionNodeExecutor.java
@@ -16,6 +16,8 @@ package org.finos.legend.engine.plan.execution.stores.service.plugin;
 
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
+import org.apache.http.Header;
+import org.apache.http.entity.StringEntity;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
@@ -87,7 +89,11 @@ public class ServiceExecutionNodeExecutor implements ExecutionNodeVisitor<Result
                 {
                     mappedParameters = ListIterate.collect(node.requiredVariableInputs, v -> v.name);
                 }
-                return ServiceExecutor.executeHttpService(node.url, node.params, mappedParameters, node.requestBodyDescription, node.method, node.mimeType, node.securitySchemes, this.executionState, this.profiles);
+
+                String processedUrl = ServiceExecutor.getProcessedUrl(node.url, node.params, mappedParameters, this.executionState);
+                List<Header> headers = ServiceExecutor.getProcessedHeaders(node.params, mappedParameters, this.executionState);
+                StringEntity requestBodyEntity = ServiceExecutor.getRequestBodyEntity(node.requestBodyDescription, this.executionState);
+                return ServiceExecutor.executeHttpService(processedUrl, headers, requestBodyEntity, node.method, node.mimeType, node.securitySchemes, this.profiles);
             }
         }
         else if (executionNode instanceof ServiceParametersResolutionExecutionNode)

--- a/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/plugin/ServiceExecutionNodeExecutor.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/plugin/ServiceExecutionNodeExecutor.java
@@ -52,6 +52,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.graphF
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.graphFetch.store.inMemory.StoreStreamReadingExecutionNode;
 import org.pac4j.core.profile.CommonProfile;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -76,7 +77,17 @@ public class ServiceExecutionNodeExecutor implements ExecutionNodeVisitor<Result
                 scope.span().setTag("raw url", ((RestServiceExecutionNode) executionNode).url);
                 scope.span().setTag("method", ((RestServiceExecutionNode) executionNode).method.toString());
                 RestServiceExecutionNode node = (RestServiceExecutionNode) executionNode;
-                return ServiceExecutor.executeHttpService(node.url, node.params, node.requestBodyDescription, node.method, node.mimeType, node.securitySchemes, this.executionState, this.profiles);
+
+                List<String> mappedParameters;
+                if (node.requiredVariableInputs == null)
+                {
+                    mappedParameters = Collections.emptyList();
+                }
+                else
+                {
+                    mappedParameters = ListIterate.collect(node.requiredVariableInputs, v -> v.name);
+                }
+                return ServiceExecutor.executeHttpService(node.url, node.params, mappedParameters, node.requestBodyDescription, node.method, node.mimeType, node.securitySchemes, this.executionState, this.profiles);
             }
         }
         else if (executionNode instanceof ServiceParametersResolutionExecutionNode)

--- a/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
@@ -685,6 +685,37 @@ public class ServiceStoreJsonShowcaseTest extends ServiceStoreTestSuite
     }
 
     @Test
+    public void serviceStoreQueryWithLambdaAndServiceParamSharingSameName()
+    {
+        String query = "###Pure\n" +
+                "function showcase::query(): Any[1]\n" +
+                "{\n" +
+                "   {firstName:String[1], middleName:String[0..1]|meta::external::store::service::showcase::domain::Person.all()\n" +
+                "       ->filter(p | $p.firstName == $firstName)\n" +
+                "       ->graphFetch(#{\n" +
+                "           meta::external::store::service::showcase::domain::Person {\n" +
+                "               firstName,\n" +
+                "               middleName,\n" +
+                "               lastName\n" +
+                "           }\n" +
+                "         }#)" +
+                "       ->serialize(#{\n" +
+                "           meta::external::store::service::showcase::domain::Person {\n" +
+                "               firstName,\n" +
+                "               middleName,\n" +
+                "               lastName\n" +
+                "           }\n" +
+                "        }#)};\n" +
+                "}";
+
+        SingleExecutionPlan plan = buildPlanForQuery(pureGrammar + "\n\n" + query);
+
+        String expectedRes = "{\"builder\":{\"_type\":\"json\"},\"values\":[{\"firstName\":\"Steve\",\"middleName\":\"Patricio\",\"lastName\":\"Smith\"},{\"firstName\":\"Steve\",\"middleName\":null,\"lastName\":\"Smith2\"},{\"firstName\":\"Steve\",\"middleName\":null,\"lastName\":\"Smith3\"}]}";
+        Assert.assertEquals(expectedRes, executePlan(plan, Maps.immutable.with("firstName", "Steve", "middleName", "Patricio").toMap()));
+        Assert.assertEquals(expectedRes, executePlan(plan, Maps.immutable.with("firstName", "Steve").toMap()));
+    }
+
+    @Test
     public void serviceStoreQueryWithOptionalParameter()
     {
         String query = "###Pure\n" +

--- a/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/mappings/stub.json
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/mappings/stub.json
@@ -328,6 +328,38 @@
           }
         ]
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/persons/getPersonsByFirstAndMiddleName",
+        "queryParameters": {
+          "firstName": {
+            "equalTo": "Steve"
+          },
+          "middleName": {
+            "absent": true
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "firstName": "Steve",
+            "middleName": "Patricio",
+            "lastName": "Smith"
+          },
+          {
+            "firstName": "Steve",
+            "lastName": "Smith2"
+          },
+          {
+            "firstName": "Steve",
+            "lastName": "Smith3"
+          }
+        ]
+      }
     }
   ]
 }

--- a/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/testGrammar.pure
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/testGrammar.pure
@@ -247,6 +247,17 @@ Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping
             )
          )
      )
+
+     ~service [meta::external::store::service::showcase::store::ShowcaseServiceStore] PersonServices.PersonsByFirstAndMiddleName
+     (
+         ~request
+         (
+            parameters
+            (
+                firstName = $this.firstName
+            )
+         )
+     )
   }
 
   meta::external::store::service::showcase::domain::Trade[trade_set]: Pure

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
@@ -165,14 +165,14 @@ function meta::external::store::service::executionPlan::generation::processServi
    let serviceStoreQuery = $sq.fe->toServiceStoreQuery($sq.inScopeVars, $debug);
    let paramValues       = $serviceStoreQuery.processedParamValueMap->keyValues();
 
-   let literalParams     = $paramValues->filter(p | $p.second->instanceOf(meta::external::store::service::functions::pureToServiceStoreQuery::LiteralValue));
-   let varParams         = $paramValues->filter(p | $p.second->instanceOf(meta::external::store::service::functions::pureToServiceStoreQuery::VariableValue));
+   let literalParams     = $paramValues->filter(p | $p.second->instanceOf(LiteralValue));
+   let varParams         = $paramValues->filter(p | $p.second->instanceOf(VariableValue));
 
    let allocationNodes   = $literalParams->map(param | ^AllocationExecutionNode(varName        = $param.first,
                                                                                 executionNodes = ^ConstantExecutionNode(
                                                                                                      //TODO: This is valid now because we don't support in for service store but would need to be fixed when in is supported.
                                                                                                      //When value is a list it get translated to CList with CString values which cause issues in parsing at execution time.
-                                                                                                     values     = $param.second->cast(@meta::external::store::service::functions::pureToServiceStoreQuery::LiteralValue).value->toOne(),
+                                                                                                     values     = $param.second->cast(@LiteralValue).value->toOne(),
                                                                                                      resultType = ^ResultType(type = Any)
                                                                                                   ),
                                                                                 resultType     = ^ResultType(type = Any)
@@ -212,15 +212,17 @@ function meta::external::store::service::executionPlan::generation::nodeFromServ
   let requestBodyDescription     = if($serviceBodyResolutionNode->isEmpty(),
                                       | [],
                                       |^RequestBodyDescription(mimeType = $serviceMapping.service.requestBody->cast(@ComplexTypeReference).binding.contentType->toOne(),
-                                                                resultKey = $serviceBodyResolutionNode->toOne()->cast(@AllocationExecutionNode).varName));
+                                                               resultKey = $serviceBodyResolutionNode->toOne()->cast(@AllocationExecutionNode).varName));
 
+  let mappedParameters           = $serviceMapping.requestBuildInfo.requestParametersBuildInfo.parameterBuildInfoList.serviceParameter;
   let serviceStoreNode           = ^RestServiceExecutionNode(url             = $s.baseUrl + $serviceMapping.service.resolveFullPathRecursively(),
-                                                              method          = $serviceMapping.service.method,
-                                                              mimeType        = $serviceMapping.service.response.binding.contentType,
-                                                              params          = $serviceMapping.service.parameters,
-                                                              securitySchemes = $serviceMapping.service.security,
-                                                              requestBodyDescription = $requestBodyDescription,
-                                                              resultType      = ^DataTypeResultType(type = String));
+                                                             method          = $serviceMapping.service.method,
+                                                             mimeType        = $serviceMapping.service.response.binding.contentType,
+                                                             params          = $serviceMapping.service.parameters,
+                                                             securitySchemes = $serviceMapping.service.security,
+                                                             requestBodyDescription = $requestBodyDescription,
+                                                             requiredVariableInputs = $mappedParameters.name->concatenate($requestBodyDescription.resultKey)->map(v | ^VariableInput(name = $v, type = Any, multiplicity = ZeroMany)),
+                                                             resultType      = ^DataTypeResultType(type = String));
 
   let allNodes = $serviceStoreQueryProcessedState.executionNodes->concatenate($serviceParamResolutionNode)
                                                                 ->concatenate($serviceBodyResolutionNode)
@@ -271,12 +273,12 @@ function meta::external::store::service::executionPlan::generation::getServicePa
       |[],
       |let updatedMappingAndSources = $parameterBuildInfoList->map(pb | let transform                = $pb.transform;
                                                                         let updatedTransformAndPaths = $transform.expressionSequence->toOne()->findAndReplacePropertyPathsInValueSpecification([], $paramMap)->toOne();
-                                                                        let requiredVariableInputs  = $updatedTransformAndPaths.second.values->map(path | ^VariableInput(name = $paramMap->get(pathAsString($path))->toOne(),
-                                                                                                                                                                           type = $path.path->at(0)->cast(@PropertyPathElement).property->functionReturnType().rawType->toOne(),
-                                                                                                                                                                           multiplicity = $path.path->at(0)->cast(@PropertyPathElement).property->functionReturnMultiplicity()));
+                                                                        let requiredVariableInputs   = $updatedTransformAndPaths.second.values->map(path | ^VariableInput(name = $paramMap->get(pathAsString($path))->toOne(),
+                                                                                                                                                                          type = $path.path->at(0)->cast(@PropertyPathElement).property->functionReturnType().rawType->toOne(),
+                                                                                                                                                                          multiplicity = $path.path->at(0)->cast(@PropertyPathElement).property->functionReturnMultiplicity()));
                                                                         pair(^$pb(transform = ^$transform(expressionSequence = $updatedTransformAndPaths.first->cast(@ValueSpecification))), ^List<VariableInput>(values = $requiredVariableInputs)););
    
-       ^ServiceParametersResolutionExecutionNode(requiredVariableInputs    = $updatedMappingAndSources.second.values,
+       ^ServiceParametersResolutionExecutionNode(requiredVariableInputs     = $updatedMappingAndSources.second.values,
                                                  requestParametersBuildInfo = ^ServiceRequestParametersBuildInfo(parameterBuildInfoList = $updatedMappingAndSources.first),
                                                  resultType                 = ^DataTypeResultType(type = Map)););
 }


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed?
In the current state, users can bypass parameter building in service store mapping and are able to directly add query/header params in the processed URL by adding lambda params with the same name.
Adding lambda parameters with the same name ensures that we have Result in executionState against that parameter and the current logic has a flaw that makes this sufficient to process query params.
This PR blocks such behavior.

#### Which issue(s) this PR fixes:
Fixes # https://github.com/finos/legend-engine/issues/1106 

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes, It blocks wrong usages of service store