### PR TITLE
Support user defined functions in service store parameter gen logic

### DIFF
--- a/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/showcase/jsonApis/ServiceStoreJsonShowcaseTest.java
@@ -861,6 +861,46 @@ public class ServiceStoreJsonShowcaseTest extends ServiceStoreTestSuite
     }
 
     @Test
+    public void serviceStoreExampleWithUserFunctionInParamGenLogic()
+    {
+        String query = "###Pure\n" +
+                "function showcase::query(): Any[1]\n" +
+                "{\n" +
+                "   {name:String[1]|meta::external::store::service::showcase::domain::S_Product.all()\n" +
+                "       ->filter(s | $s.s_productName == $name)" +
+                "       ->graphFetch(#{\n" +
+                "           meta::external::store::service::showcase::domain::S_Product {\n" +
+                "               s_productId,\n" +
+                "               s_productName,\n" +
+                "               s_description,\n" +
+                "               s_synonyms {\n" +
+                "                   s_name,\n" +
+                "                   s_type\n" +
+                "               }\n" +
+                "           }\n" +
+                "         }#)\n" +
+                "       ->serialize(#{\n" +
+                "           meta::external::store::service::showcase::domain::S_Product {\n" +
+                "               s_productId,\n" +
+                "               s_productName,\n" +
+                "               s_description,\n" +
+                "               s_synonyms {\n" +
+                "                   s_name,\n" +
+                "                   s_type\n" +
+                "               }\n" +
+                "           }\n" +
+                "        }#)};\n" +
+                "}";
+
+        SingleExecutionPlan plan = buildPlanForQuery(pureGrammar + "\n\n" + query, "meta::external::store::service::showcase::mapping::ServiceStoreMapping3", "meta::external::store::service::showcase::runtime::ServiceStoreRuntime");
+
+        String expectedRes = "{\"builder\":{\"_type\":\"json\"},\"values\":{\"s_productId\":\"30\",\"s_productName\":\"Product 30\",\"s_description\":\"Product 30 description\",\"s_synonyms\":[{\"s_name\":\"product 30 synonym 1\",\"s_type\":\"isin\"},{\"s_name\":\"product 30 synonym 2\",\"s_type\":\"cusip\"}]}}";
+
+        Assert.assertEquals(expectedRes, executePlan(plan, Maps.mutable.with("name", "product 30")));
+        Assert.assertEquals(expectedRes, executePlan(plan, Maps.mutable.with("name", "product 30_clutter")));
+    }
+
+    @Test
     public void serviceStoreExampleWithTakeAndCrossStore()
     {
         String query = "###Pure\n" +

--- a/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/utils/ServiceStoreTestUtils.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/utils/ServiceStoreTestUtils.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.plan.execution.stores.service.utils;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperValueSpecificationBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -87,7 +88,7 @@ public class ServiceStoreTestUtils
         extensions.add(core_external_format_flatdata_externalFormatContract.Root_meta_external_format_flatdata_extension_flatDataFormatExtension__Extension_1_(pureModel.getExecutionSupport()));
         extensions.add(core_external_format_json_externalFormatContract.Root_meta_external_format_json_extension_jsonSchemaFormatExtension__Extension_1_(pureModel.getExecutionSupport()));
 
-        Function queryFunctionExpressions = contextData.getElementsOfType(Function.class).get(0);
+        Function queryFunctionExpressions = ListIterate.detect(contextData.getElementsOfType(Function.class), f -> "query__Any_1_".equals(f.name));
 
         return PlanGenerator.generateExecutionPlan(
                 HelperValueSpecificationBuilder.buildLambda(((Lambda) queryFunctionExpressions.body.get(0)).body, ((Lambda) queryFunctionExpressions.body.get(0)).parameters, pureModel.getContext()),

--- a/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/testGrammar.pure
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/resources/showcase/json/testGrammar.pure
@@ -106,6 +106,11 @@ Class meta::external::store::service::showcase::domain::Person
   lastName   : String[1];
 }
 
+function meta::external::store::service::showcase::domain::getProductName(rawProductName: String[1]):String[1]
+{
+    if($rawProductName->length() > 10, | $rawProductName->substring(0, 10), | $rawProductName)
+}
+
 ###Mapping
 Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping
 (
@@ -316,6 +321,25 @@ Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping2
          parameters
          (
            name = if($this.s_productName->length() > 10, | $this.s_productName->substring(0, 10), | $this.s_productName)
+         )
+       )
+     )
+  }
+)
+
+Mapping meta::external::store::service::showcase::mapping::ServiceStoreMapping3
+(
+  *meta::external::store::service::showcase::domain::S_Product[s_prod_set]: ServiceStore
+  {
+     ~service [meta::external::store::service::showcase::store::ShowcaseServiceStore] ProductServices.GetAllProductsService
+
+     ~service [meta::external::store::service::showcase::store::ShowcaseServiceStore] ProductServices.ProductByNameService
+     (
+       ~request
+       (
+         parameters
+         (
+           name = meta::external::store::service::showcase::domain::getProductName($this.s_productName)
          )
        )
      )

--- a/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/javaRuntime/executionPlanNodes/serviceParametersResolution/serviceParametersResolution.pure
+++ b/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/javaRuntime/executionPlanNodes/serviceParametersResolution/serviceParametersResolution.pure
@@ -91,7 +91,7 @@ function meta::external::store::service::executionPlan::engine::java::generateIm
    let resolveServiceParamsMethod     = javaMethod(['public'], javaMap(javaString(), javaObject()), 'resolveServiceParameters', [$inputMap], $resolveServiceParamsMethodBody); 
    
    let executeClass   = $executeClassWithImports->addMethod($resolveServiceParamsMethod);
-   let project        = newProject()->addClasses($executeClass);
+   let project        = newProject()->addClasses($executeClass)->concatenate($propertiesMappingCodecs->dependencies()->resolveAndGetProjects())->toOneMany()->mergeProjects();
 
    generatedCode($project, $executeClass);
 }


### PR DESCRIPTION
#### What type of PR is this?
Enhancement

#### What does this PR do / why is it needed?
Currently, users are not able to use user-defined functions inside their parameter-building logic in service store mapping. This PR adds support to this feature

#### Which issue(s) this PR fixes:
Fixes # https://github.com/finos/legend-engine/issues/1108

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes, users will be able to use user-defined functions in service store mapping