### PR TITLE
update java Docker image to `eclipse-temurin:11.0.17_8-jdk-jammy`

### DIFF
--- a/legend-engine-server/Dockerfile
+++ b/legend-engine-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:11.0.16-bullseye
+FROM eclipse-temurin:11.0.17_8-jdk-jammy
 COPY target/legend-engine-server-*.jar /app/bin/
 COPY src/main/resources/docker/config/config.json /config/config.json
 COPY src/main/resources/docker/config/vault.properties /config/vault.properties


### PR DESCRIPTION
It seems that `openjdk` no longer publish docker images for jdk11 - https://github.com/docker-library/openjdk/issues/505
So per their recommendation, we are trying out the alternative - `eclipse-temurin`