### PR TITLE
update Pure IDE port to 9200 to avoid port conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Execution engine for Legend. It provides:
 If you're making changes to the `Pure` codebase, it's highly recommended that you also spin up our `Pure IDE` application:
 
 - In order to start the server, please use the `Main` class `org.finos.legend.engine.ide.PureIDELight` with the parameters: `server legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json`.
-- You can now access the IDE at http://127.0.0.1:9100/ide in a web browser.
+- You can now access the IDE at http://127.0.0.1:9200/ide in a web browser.
 
 ## Roadmap
 

--- a/legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json
@@ -21,7 +21,7 @@
     "connector": {
       "maxRequestHeaderSize": "32KiB",
       "type": "http",
-      "port": 9100
+      "port": 9200
     },
     "requestLog": {
       "appenders": [


### PR DESCRIPTION
#### What type of PR is this?

bug fix

#### What does this PR do / why is it needed ?

update Pure IDE port to 9200 to avoid port conflicts with printer port 9100
https://www.speedguide.net/port.php?port=9100

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
