### PR TITLE
make GraphQL API endpoints support fetching models from depot/metadata server

### DIFF
--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.query.graphQL.api.debug;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
@@ -65,6 +66,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ServiceLoader;
 import java.util.function.Function;
@@ -99,64 +101,77 @@ public class GraphQLDebug extends GraphQL
         }
     }
 
-    @POST
-    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using Prod metadata")
-    @Path("generateGraphFetch/prod/{groupId}/{artifact}/{version}/query/{queryClassPath}")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response generateGraphFetchProd(@Context HttpServletRequest request, @PathParam("branch") String branch, @PathParam("projectId") String projectId, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    private Response generateGraphFetch(String queryClassPath, Query query, PureModel pureModel) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, JsonProcessingException
     {
-        throw new RuntimeException("Not implemented yet");
+        RichIterable<? extends Root_meta_pure_extension_Extension> extensions = this.extensionsFunc.apply(pureModel);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class = pureModel.getClass(queryClassPath);
+        Root_meta_external_query_graphQL_transformation_queryToPure_GraphFetchResult graphFetch = buildGraphFetch(_class, toPureModel(GraphQLGrammarParser.newInstance().parseDocument(query.query), pureModel), pureModel);
+
+        // Serialize the tree to production protocol
+        String version = PureClientVersions.production;
+        Class cl = Class.forName("org.finos.legend.pure.generated.core_pure_protocol_" + version + "_transfers_valueSpecification");
+        Method graphFetchProtocolMethod = cl.getMethod("Root_meta_protocols_pure_" + version + "_transformation_fromPureGraph_valueSpecification_transformGraphFetchTree_GraphFetchTree_1__String_MANY__Map_1__Extension_MANY__GraphFetchTree_1_", GraphFetchTree.class, RichIterable.class, PureMap.class, RichIterable.class, org.finos.legend.pure.m3.execution.ExecutionSupport.class);
+        Object res = graphFetchProtocolMethod.invoke(null, graphFetch._graphFetchTree(), Lists.mutable.empty(), new PureMap(Maps.mutable.empty()), extensions, pureModel.getExecutionSupport());
+        String asJSON = Root_meta_alloy_metadataServer_alloyToJSON_Any_1__String_1_(res, pureModel.getExecutionSupport());
+        RootGraphFetchTree protocolSerializedTree = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(asJSON, RootGraphFetchTree.class);
+
+        return Response.ok(new GraphFetchResult(
+                protocolSerializedTree,
+                graphFetch._explodedDomain().collect(c ->
+                {
+                    ValueSpecification val = null;
+                    try
+                    {
+                        Method functionProtocolMethod = cl.getMethod("Root_meta_protocols_pure_" + version + "_transformation_fromPureGraph_valueSpecification_transformFunctionBody_FunctionDefinition_1__Extension_MANY__ValueSpecification_MANY_", FunctionDefinition.class, RichIterable.class, ExecutionSupport.class);
+                        Object res2 = functionProtocolMethod.invoke(null, c._second(), extensions, pureModel.getExecutionSupport());
+                        String asJSON2 = Root_meta_alloy_metadataServer_alloyToJSON_Any_1__String_1_(res2, pureModel.getExecutionSupport());
+                        val = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(asJSON2, ValueSpecification.class);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    return new GraphFetchResult.DomainUnit(c._first(), val);
+                }).toList()
+        )).build();
     }
 
     @POST
-    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using Dev metadata")
-    @Path("generateGraphFetch/dev/{projectId}/{branch}/query/{queryClassPath}")
+    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using metadata from SDLC project")
+    @Path("generateGraphFetch/dev/{projectId}/{workspaceId}/query/{queryClassPath}")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public Response generateGraphFetchDev(@Context HttpServletRequest request, @PathParam("branch") String branch, @PathParam("projectId") String projectId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response generateGraphFetchDev(@Context HttpServletRequest request, @PathParam("workspaceId") String workspaceId, @PathParam("projectId") String projectId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         try (Scope scope = GlobalTracer.get().buildSpan("GraphQL: Generate Graph Fetch").startActive(true))
         {
-            PureModel pureModel = loadModel(profiles, request, projectId, branch);
-            RichIterable<? extends Root_meta_pure_extension_Extension> extensions = this.extensionsFunc.apply(pureModel);
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class = pureModel.getClass(queryClassPath);
-            Root_meta_external_query_graphQL_transformation_queryToPure_GraphFetchResult graphFetch = buildGraphFetch(_class, toPureModel(GraphQLGrammarParser.newInstance().parseDocument(query.query), pureModel), pureModel);
-
-            // Serialize the tree to production protocol
-            String version = PureClientVersions.production;
-            Class cl = Class.forName("org.finos.legend.pure.generated.core_pure_protocol_" + version + "_transfers_valueSpecification");
-            Method graphFetchProtocolMethod = cl.getMethod("Root_meta_protocols_pure_" + version + "_transformation_fromPureGraph_valueSpecification_transformGraphFetchTree_GraphFetchTree_1__String_MANY__Map_1__Extension_MANY__GraphFetchTree_1_", GraphFetchTree.class, RichIterable.class, PureMap.class, RichIterable.class, org.finos.legend.pure.m3.execution.ExecutionSupport.class);
-            Object res = graphFetchProtocolMethod.invoke(null, graphFetch._graphFetchTree(), Lists.mutable.empty(), new PureMap(Maps.mutable.empty()), extensions, pureModel.getExecutionSupport());
-            String asJSON = Root_meta_alloy_metadataServer_alloyToJSON_Any_1__String_1_(res, pureModel.getExecutionSupport());
-            RootGraphFetchTree protocolSerializedTree = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(asJSON, RootGraphFetchTree.class);
-
-            return Response.ok(new GraphFetchResult(
-                    protocolSerializedTree,
-                    graphFetch._explodedDomain().collect(c ->
-                    {
-                        ValueSpecification val = null;
-                        try
-                        {
-                            Method functionProtocolMethod = cl.getMethod("Root_meta_protocols_pure_" + version + "_transformation_fromPureGraph_valueSpecification_transformFunctionBody_FunctionDefinition_1__Extension_MANY__ValueSpecification_MANY_", FunctionDefinition.class, RichIterable.class, ExecutionSupport.class);
-                            Object res2 = functionProtocolMethod.invoke(null, c._second(), extensions, pureModel.getExecutionSupport());
-                            String asJSON2 = Root_meta_alloy_metadataServer_alloyToJSON_Any_1__String_1_(res2, pureModel.getExecutionSupport());
-                            val = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(asJSON2, ValueSpecification.class);
-                        }
-                        catch (Exception e)
-                        {
-                            throw new RuntimeException(e);
-                        }
-                        return new GraphFetchResult.DomainUnit(c._first(), val);
-                    }).toList()
-            )).build();
+            return this.generateGraphFetch(queryClassPath, query, loadSDLCProjectModel(profiles, request, projectId, workspaceId, false));
         }
         catch (Exception ex)
         {
             return ExceptionTool.exceptionManager(ex, LoggingEventType.EXECUTE_INTERACTIVE_ERROR, profiles);
         }
     }
+
+    @POST
+    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query")
+    @Path("generateGraphFetch/prod/{groupId}/{artifactId}/{versionId}/query/{queryClassPath}")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response generateGraphFetchProd(@Context HttpServletRequest request, @PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId, @PathParam("versionId") String versionId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    {
+        MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
+        try (Scope scope = GlobalTracer.get().buildSpan("GraphQL: Generate Graph Fetch").startActive(true))
+        {
+            return this.generateGraphFetch(queryClassPath, query, loadProjectModel(profiles, request, groupId, artifactId, versionId));
+        }
+        catch (Exception ex)
+        {
+            return ExceptionTool.exceptionManager(ex, LoggingEventType.EXECUTE_INTERACTIVE_ERROR, profiles);
+        }
+    }
+
 
     private static Root_meta_external_query_graphQL_transformation_queryToPure_GraphFetchResult buildGraphFetch(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class, org.finos.legend.pure.generated.Root_meta_external_query_graphQL_metamodel_sdl_Document document, PureModel pureModel)
     {
@@ -187,6 +202,4 @@ public class GraphQLDebug extends GraphQL
     {
         return core_pure_protocol_generation_builder_generation.Root_meta_protocols_generation_builder_builderGeneration_Any_1__String_1_(pureInstance, pureModel.getExecutionSupport());
     }
-
-
 }

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
@@ -68,10 +68,10 @@ import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.kerberos.ProfileManagerHelper;
 import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionTool;
 import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
-import org.finos.legend.pure.generated.core_external_query_graphql_transformation_transformation_graphFetch;
-import org.finos.legend.pure.generated.core_external_query_graphql_transformation_transformation_introspection_query;
 import org.finos.legend.pure.generated.Root_meta_pure_executionPlan_ExecutionPlan;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
+import org.finos.legend.pure.generated.core_external_query_graphql_transformation_transformation_graphFetch;
+import org.finos.legend.pure.generated.core_external_query_graphql_transformation_transformation_introspection_query;
 import org.finos.legend.pure.generated.core_pure_executionPlan_executionPlan_print;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
@@ -129,57 +129,52 @@ public class GraphQLExecute extends GraphQL
         }
     }
 
-    @POST
-    @ApiOperation(value = "Generate plans from a GraphQL query in the context of a Mapping and a Runtime.")
-    @Path("generatePlans/prod/{groupId}/{artifact}/{version}/query/{queryClassPath}/mapping/{mappingPath}")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
-    public Response generatePlansProd(@Context HttpServletRequest request, @PathParam("branch") String branch, @PathParam("projectId") String projectId, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    private Response generateQueryPlans(String queryClassPath, String mappingPath, Query query, PureModel pureModel) throws IOException
     {
-        throw new RuntimeException("Not implemented yet");
+        RichIterable<? extends Root_meta_pure_extension_Extension> extensions = this.extensionsFunc.apply(pureModel);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class = pureModel.getClass(queryClassPath);
+        Mapping mapping = pureModel.getMapping(mappingPath);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Runtime runtime = HelperRuntimeBuilder.buildPureRuntime(ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(GraphQLExecute.class.getClassLoader().getResourceAsStream("exampleRuntime.json"), org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime.class), pureModel.getContext());
+
+        Document document = GraphQLGrammarParser.newInstance().parseDocument(query.query);
+        org.finos.legend.pure.generated.Root_meta_external_query_graphQL_metamodel_sdl_Document queryDoc = toPureModel(document, pureModel);
+        if (isQueryIntrospection(findQuery(document)))
+        {
+            return Response.ok("").type(MediaType.TEXT_HTML_TYPE).build();
+        }
+        else
+        {
+            RichIterable<? extends Pair<? extends String, ? extends Root_meta_pure_executionPlan_ExecutionPlan>> purePlans = core_external_query_graphql_transformation_transformation_graphFetch.Root_meta_external_query_graphQL_transformation_queryToPure_getPlansFromGraphQL_Class_1__Mapping_1__Runtime_1__Document_1__Extension_MANY__Pair_MANY_(_class, mapping, runtime, queryDoc, extensions, pureModel.getExecutionSupport());
+            Collection<PlansResult.PlanUnit> plans = Iterate.collect(purePlans, p ->
+                    {
+                        Root_meta_pure_executionPlan_ExecutionPlan nPlan = PlanPlatform.JAVA.bindPlan(p._second(), "ID", pureModel, extensions);
+                        try
+                        {
+                            return new PlansResult.PlanUnit(p._first(),
+                                    ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(PlanGenerator.serializeToJSON(nPlan, PureClientVersions.production, pureModel, extensions, this.transformers), ExecutionPlan.class),
+                                    core_pure_executionPlan_executionPlan_print.Root_meta_pure_executionPlan_toString_planToString_ExecutionPlan_1__Boolean_1__Extension_MANY__String_1_(nPlan, true, extensions, pureModel.getExecutionSupport())
+                            );
+                        }
+                        catch (JsonProcessingException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                    }
+            );
+            return Response.ok(new PlansResult(plans)).build();
+        }
     }
 
     @POST
-    @ApiOperation(value = "Generate plans from a GraphQL query in the context of a Mapping and a Runtime.")
-    @Path("generatePlans/dev/{projectId}/{branch}/query/{queryClassPath}/mapping/{mappingPath}")
+    @ApiOperation(value = "Generate plans from a GraphQL query in the context of a mapping and a runtime from a SDLC project")
+    @Path("generatePlans/dev/{projectId}/{workspaceId}/query/{queryClassPath}/mapping/{mappingPath}")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
-    public Response generatePlansDev(@Context HttpServletRequest request, @PathParam("projectId") String projectId, @PathParam("branch") String branch, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response generatePlansDev(@Context HttpServletRequest request, @PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         try (Scope scope = GlobalTracer.get().buildSpan("GraphQL: Execute").startActive(true))
         {
-            PureModel pureModel = loadModel(profiles, request, projectId, branch);
-            RichIterable<? extends Root_meta_pure_extension_Extension> extensions = this.extensionsFunc.apply(pureModel);
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class = pureModel.getClass(queryClassPath);
-            Mapping mapping = pureModel.getMapping(mappingPath);
-            org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Runtime runtime = HelperRuntimeBuilder.buildPureRuntime(ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(GraphQLExecute.class.getClassLoader().getResourceAsStream("exampleRuntime.json"), org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime.class), pureModel.getContext());
-
-            Document document = GraphQLGrammarParser.newInstance().parseDocument(query.query);
-            org.finos.legend.pure.generated.Root_meta_external_query_graphQL_metamodel_sdl_Document queryDoc = toPureModel(document, pureModel);
-            if (isQueryIntrospection(findQuery(document)))
-            {
-                return Response.ok("").type(MediaType.TEXT_HTML_TYPE).build();
-            }
-            else
-            {
-                RichIterable<? extends Pair<? extends String, ? extends Root_meta_pure_executionPlan_ExecutionPlan>> purePlans = core_external_query_graphql_transformation_transformation_graphFetch.Root_meta_external_query_graphQL_transformation_queryToPure_getPlansFromGraphQL_Class_1__Mapping_1__Runtime_1__Document_1__Extension_MANY__Pair_MANY_(_class, mapping, runtime, queryDoc, extensions, pureModel.getExecutionSupport());
-                Collection<PlansResult.PlanUnit> plans = Iterate.collect(purePlans, p ->
-                        {
-                            Root_meta_pure_executionPlan_ExecutionPlan nPlan = PlanPlatform.JAVA.bindPlan(p._second(), "ID", pureModel, extensions);
-                            try
-                            {
-                                return new PlansResult.PlanUnit(p._first(),
-                                        ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(PlanGenerator.serializeToJSON(nPlan, PureClientVersions.production, pureModel, extensions, this.transformers), ExecutionPlan.class),
-                                        core_pure_executionPlan_executionPlan_print.Root_meta_pure_executionPlan_toString_planToString_ExecutionPlan_1__Boolean_1__Extension_MANY__String_1_(nPlan, true, extensions, pureModel.getExecutionSupport())
-                                );
-                            }
-                            catch (JsonProcessingException e)
-                            {
-                                throw new RuntimeException(e);
-                            }
-                        }
-                );
-                return Response.ok(new PlansResult(plans)).build();
-            }
+            return generateQueryPlans(queryClassPath, mappingPath, query, loadSDLCProjectModel(profiles, request, projectId, workspaceId, false));
         }
         catch (Exception ex)
         {
@@ -188,82 +183,111 @@ public class GraphQLExecute extends GraphQL
     }
 
     @POST
-    @ApiOperation(value = "Execute a GraphQL query in the context of a Mapping and a Runtime.")
-    @Path("execute/prod/{groupId}/{artifact}/{version}/query/{queryClassPath}/mapping/{mappingPath}/runtime/{runtimePath}")
+    @ApiOperation(value = "Generate plans from a GraphQL query in the context of a mapping and a runtime")
+    @Path("generatePlans/prod/{groupId}/{artifactId}/{versionId}/query/{queryClassPath}/mapping/{mappingPath}")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
-    public Response executeProd(@Context HttpServletRequest request, @PathParam("branch") String branch, @PathParam("projectId") String projectId, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
-    {
-        throw new RuntimeException("Not implemented yet");
-    }
-
-    @POST
-    @ApiOperation(value = "Execute a GraphQL query in the context of a Mapping and a Runtime.")
-    @Path("execute/dev/{projectId}/{branch}/query/{queryClassPath}/mapping/{mappingPath}/runtime/{runtimePath}")
-    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
-    public Response executeDev(@Context HttpServletRequest request, @PathParam("projectId") String projectId, @PathParam("branch") String branch, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, @PathParam("runtimePath") String runtimePath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    public Response generatePlansProd(@Context HttpServletRequest request, @PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId, @PathParam("versionId") String versionId, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         try (Scope scope = GlobalTracer.get().buildSpan("GraphQL: Execute").startActive(true))
         {
-            PureModel pureModel = loadModel(profiles, request, projectId, branch);
-            RichIterable<? extends Root_meta_pure_extension_Extension> extensions = this.extensionsFunc.apply(pureModel);
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class = pureModel.getClass(queryClassPath);
+            return generateQueryPlans(queryClassPath, mappingPath, query, loadProjectModel(profiles, request, groupId, artifactId, versionId));
+        }
+        catch (Exception ex)
+        {
+            return ExceptionTool.exceptionManager(ex, LoggingEventType.EXECUTE_INTERACTIVE_ERROR, profiles);
+        }
+    }
 
-            Document document = GraphQLGrammarParser.newInstance().parseDocument(query.query);
-            org.finos.legend.pure.generated.Root_meta_external_query_graphQL_metamodel_sdl_Document queryDoc = toPureModel(document, pureModel);
-            if (isQueryIntrospection(findQuery(document)))
-            {
-                return Response.ok("{" +
-                        "  \"data\":" + core_external_query_graphql_transformation_transformation_introspection_query.Root_meta_external_query_graphQL_transformation_introspection_graphQLIntrospectionQuery_Class_1__Document_1__String_1_(_class, queryDoc, pureModel.getExecutionSupport()) +
-                        "}").type(MediaType.TEXT_HTML_TYPE).build();
-            }
-            else
-            {
-                Mapping mapping = pureModel.getMapping(mappingPath);
-                org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Runtime runtime = pureModel.getRuntime(runtimePath);
-                RichIterable<? extends Pair<? extends String, ? extends Root_meta_pure_executionPlan_ExecutionPlan>> purePlans = core_external_query_graphql_transformation_transformation_graphFetch.Root_meta_external_query_graphQL_transformation_queryToPure_getPlansFromGraphQL_Class_1__Mapping_1__Runtime_1__Document_1__Extension_MANY__Pair_MANY_(_class, mapping, runtime, queryDoc, extensions, pureModel.getExecutionSupport());
-                Collection<org.eclipse.collections.api.tuple.Pair<String, SingleExecutionPlan>> plans = Iterate.collect(purePlans, p ->
-                        {
-                            Root_meta_pure_executionPlan_ExecutionPlan nPlan = PlanPlatform.JAVA.bindPlan(p._second(), "ID", pureModel, extensions);
-                            return Tuples.pair(p._first(), PlanGenerator.stringToPlan(PlanGenerator.serializeToJSON(nPlan, PureClientVersions.production, pureModel, extensions, this.transformers)));
-                        }
-                );
+    private Response executeGraphQLQuery(String queryClassPath, String mappingPath, String runtimePath, Query query, PureModel pureModel)
+    {
+        RichIterable<? extends Root_meta_pure_extension_Extension> extensions = this.extensionsFunc.apply(pureModel);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> _class = pureModel.getClass(queryClassPath);
 
-                return Response.ok(
-                        (StreamingOutput) outputStream ->
+        Document document = GraphQLGrammarParser.newInstance().parseDocument(query.query);
+        org.finos.legend.pure.generated.Root_meta_external_query_graphQL_metamodel_sdl_Document queryDoc = toPureModel(document, pureModel);
+        if (isQueryIntrospection(findQuery(document)))
+        {
+            return Response.ok("{" +
+                    "  \"data\":" + core_external_query_graphql_transformation_transformation_introspection_query.Root_meta_external_query_graphQL_transformation_introspection_graphQLIntrospectionQuery_Class_1__Document_1__String_1_(_class, queryDoc, pureModel.getExecutionSupport()) +
+                    "}").type(MediaType.TEXT_HTML_TYPE).build();
+        }
+        else
+        {
+            Mapping mapping = pureModel.getMapping(mappingPath);
+            org.finos.legend.pure.m3.coreinstance.meta.pure.runtime.Runtime runtime = pureModel.getRuntime(runtimePath);
+            RichIterable<? extends Pair<? extends String, ? extends Root_meta_pure_executionPlan_ExecutionPlan>> purePlans = core_external_query_graphql_transformation_transformation_graphFetch.Root_meta_external_query_graphQL_transformation_queryToPure_getPlansFromGraphQL_Class_1__Mapping_1__Runtime_1__Document_1__Extension_MANY__Pair_MANY_(_class, mapping, runtime, queryDoc, extensions, pureModel.getExecutionSupport());
+            Collection<org.eclipse.collections.api.tuple.Pair<String, SingleExecutionPlan>> plans = Iterate.collect(purePlans, p ->
+                    {
+                        Root_meta_pure_executionPlan_ExecutionPlan nPlan = PlanPlatform.JAVA.bindPlan(p._second(), "ID", pureModel, extensions);
+                        return Tuples.pair(p._first(), PlanGenerator.stringToPlan(PlanGenerator.serializeToJSON(nPlan, PureClientVersions.production, pureModel, extensions, this.transformers)));
+                    }
+            );
+
+            return Response.ok(
+                    (StreamingOutput) outputStream ->
+                    {
+                        try (JsonGenerator generator = new JsonFactory().createGenerator(outputStream)
+                                .disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)
+                                .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);)
                         {
-                            try (JsonGenerator generator = new JsonFactory().createGenerator(outputStream)
-                                    .disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)
-                                    .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);)
+                            generator.writeStartObject();
+                            generator.setCodec(new ObjectMapper());
+                            generator.writeFieldName("data");
+                            generator.writeStartObject();
+
+                            plans.forEach(p ->
                             {
-                                generator.writeStartObject();
-                                generator.setCodec(new ObjectMapper());
-                                generator.writeFieldName("data");
-                                generator.writeStartObject();
-
-                                plans.forEach(p ->
+                                JsonStreamingResult result = null;
+                                try
                                 {
-                                    JsonStreamingResult result = null;
-                                    try
-                                    {
-                                        generator.writeFieldName(p.getOne());
-                                        result = (JsonStreamingResult) planExecutor.execute(p.getTwo());
-                                        result.getJsonStream().accept(generator);
-                                    }
-                                    catch (IOException e)
-                                    {
-                                        throw new RuntimeException(e);
-                                    }
-                                    finally
-                                    {
-                                        result.close();
-                                    }
-                                });
-                                generator.writeEndObject();
-                                generator.writeEndObject();
-                            }
-                        }).build();
-            }
+                                    generator.writeFieldName(p.getOne());
+                                    result = (JsonStreamingResult) planExecutor.execute(p.getTwo());
+                                    result.getJsonStream().accept(generator);
+                                }
+                                catch (IOException e)
+                                {
+                                    throw new RuntimeException(e);
+                                }
+                                finally
+                                {
+                                    result.close();
+                                }
+                            });
+                            generator.writeEndObject();
+                            generator.writeEndObject();
+                        }
+                    }).build();
+        }
+    }
+
+    @POST
+    @ApiOperation(value = "Execute a GraphQL query in the context of a mapping and a runtime from a SDLC project")
+    @Path("execute/dev/{projectId}/{workspaceId}/query/{queryClassPath}/mapping/{mappingPath}/runtime/{runtimePath}")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    public Response executeDev(@Context HttpServletRequest request, @PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, @PathParam("runtimePath") String runtimePath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    {
+        MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
+        try (Scope scope = GlobalTracer.get().buildSpan("GraphQL: Execute").startActive(true))
+        {
+            return this.executeGraphQLQuery(queryClassPath, mappingPath, runtimePath, query, loadSDLCProjectModel(profiles, request, projectId, workspaceId, false));
+        }
+        catch (Exception ex)
+        {
+            return Response.ok(new GraphQLErrorMain(ex.getMessage())).build();
+        }
+    }
+
+    @POST
+    @ApiOperation(value = "Execute a GraphQL query in the context of a mapping and a runtime")
+    @Path("execute/prod/{groupId}/{artifactId}/{versionId}/query/{queryClassPath}/mapping/{mappingPath}/runtime/{runtimePath}")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    public Response executeProd(@Context HttpServletRequest request, @PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId, @PathParam("versionId") String versionId, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, @PathParam("runtimePath") String runtimePath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    {
+        MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
+        try (Scope scope = GlobalTracer.get().buildSpan("GraphQL: Execute").startActive(true))
+        {
+            return this.executeGraphQLQuery(queryClassPath, mappingPath, runtimePath, query, loadProjectModel(profiles, request, groupId, artifactId, versionId));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
#### What type of PR is this?

new feature

#### What does this PR do / why is it needed ?

Currently, GraphQL API endpoints only allow specifying the SDLC project coordinate to fetch model data, we would like to allow specifying pure model context data as input for more flexibility

This will work when https://github.com/finos/legend-depot/pull/139 is merged

