### PR TITLE
Fix sql generation for AllVersions query

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
@@ -487,13 +487,14 @@ function meta::relational::milestoning::manageMilestoningContextPropogationForPr
    if(!$milestoningContext->isEmpty() && !$milestoningContext->toOne().currentProcessingStateIsMilestonedClassProperty(),|^$swc(milestoningContext=[]),|$swc);
 }
 
-function meta::relational::milestoning::updateMilestoningContextProcessingStateForProperties(swc: SelectWithCursor[1], milestoningProcessingState: MilestoningProcessingState[0..1]): SelectWithCursor[1]{
+function meta::relational::milestoning::updateMilestoningContextProcessingStateForProperties(swc: SelectWithCursor[1], milestoningProcessingState: MilestoningProcessingState[0..1]): SelectWithCursor[1]
+{
     let milestoningContext=$swc.milestoningContext;
-    if(!$milestoningContext->isEmpty() && !$milestoningContext->toOne().currentProcessingStateIsMilestonedClassProperty(),|
-                                             let milestoningContextToOne = $milestoningContext->toOne();
-                                             let milestoningContextUpdated=^$milestoningContextToOne(currentProcessingState=$milestoningProcessingState);
-                                             ^$swc(milestoningContext=$milestoningContextUpdated);
-                                       ,| $swc);
+    if(!$milestoningContext->isEmpty() && !$milestoningContext->toOne().currentProcessingStateIsMilestonedClassProperty() && !$milestoningContext->toOne().isAllVersions(),
+       | let milestoningContextToOne = $milestoningContext->toOne();
+         let milestoningContextUpdated=^$milestoningContextToOne(currentProcessingState=$milestoningProcessingState);
+         ^$swc(milestoningContext=$milestoningContextUpdated);,
+       | $swc);
 }
 
 function meta::relational::milestoning::unknownDefaultBusinessDate():Date[1]{

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -578,6 +578,14 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
    assertSameSQL('select "root".name as "name" from ProductTable as "root" left outer join ProductClassificationSystemTable as "ProductClassificationSystemTable_d#5_d#2_m1" on ("root".classificationSystemId = "ProductClassificationSystemTable_d#5_d#2_m1".id and "ProductClassificationSystemTable_d#5_d#2_m1".from_z <= \'2015-01-01\' and "ProductClassificationSystemTable_d#5_d#2_m1".thru_z > \'2015-01-01\') left outer join SystemTable as "SystemTable_d#5_l_d#2_m1_r" on ("ProductClassificationSystemTable_d#5_d#2_m1".name = "SystemTable_d#5_l_d#2_m1_r".name) where "SystemTable_d#5_l_d#2_m1_r".name = \'SYS1\' and "root".from_z <= \'2015-10-16\' and "root".thru_z > \'2015-10-16\'', $sql);
 }
 
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testAllVersionsQueryWithMilestonedProperty():Boolean[1]
+{
+   let query = {|Product.allVersions()->filter(p|$p.classificationAllVersions.system.name=='SYS1')->project([p|$p.name],['name'])};
+   let sql = toSQLString($query, milestoningMapWithEmbeddedSimple, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   
+   assertSameSQL('select "root".name as "name" from ProductTable as "root" left outer join ProductClassificationSystemTable as "ProductClassificationSystemTable_d#6_f_d_d#2_m1" on ("root".classificationSystemId = "ProductClassificationSystemTable_d#6_f_d_d#2_m1".id) left outer join SystemTable as "SystemTable_d#6_f_d_l_d#2_m1_r" on ("ProductClassificationSystemTable_d#6_f_d_d#2_m1".name = "SystemTable_d#6_f_d_l_d#2_m1_r".name) where "SystemTable_d#6_f_d_l_d#2_m1_r".name = \'SYS1\'', $sql);
+}
+
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testMilestoningCriteriaAppliedToViewRoot():Boolean[1]
 {
    let businessDate = %2016-7-22;


### PR DESCRIPTION
#### What type of PR is this?
Bug fix 

#### What does this PR do / why is it needed ?
Current SQL generation logic has a bug that impacts allVersions use-cases querying from milestoned tables. Our logic to build milestoning filters is flawed which causes issues and milestoned filters to end up in the query.
This PR fixes this bug

#### Which issue(s) this PR fixes:
No issue was raised

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes, it fixes SQL generated for impacted use-case