### PR TITLE
Adding build action with the large runner

### DIFF
--- a/.github/workflows/build-large-runner.yml
+++ b/.github/workflows/build-large-runner.yml
@@ -1,0 +1,23 @@
+name: Build (Large Runner)
+
+on: [workflow_dispatch]
+
+jobs:
+  build-large-runner:
+
+    runs-on: ubuntu-latest-16-cores
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+
+      - name: Build
+        run: mvn -B -e -T 4 install -DargLine="-Xms12g -Xmx12g"
+        env:
+          MAVEN_OPTS: -Xms10g -Xmx10g


### PR DESCRIPTION
#### What type of PR is this?

Adding a test action that uses large GitHub runners

#### What does this PR do / why is it needed ?

This new action will allow us to easily test the availability of the large runners without having to perform a release.
