### PR TITLE
Ability to consume java Json representation of results

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/json/JsonStreamingResult.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/json/JsonStreamingResult.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.plan.execution.result.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.plan.execution.result.ResultVisitor;
@@ -24,20 +25,21 @@ import org.finos.legend.engine.plan.execution.result.serialization.Serialization
 import org.finos.legend.engine.plan.execution.result.serialization.Serializer;
 
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 public class JsonStreamingResult extends StreamingResult
 {
-    private final Consumer<JsonGenerator> jsonStream;
+    private final JsonStreamHandler jsonStream;
     private final Result childResult;
     private final Builder builder;
 
     @Deprecated
-    public JsonStreamingResult(Consumer<JsonGenerator> jsonStream)
+    public JsonStreamingResult(JsonStreamHandler jsonStream)
     {
         this(jsonStream, null);
     }
 
-    public JsonStreamingResult(Consumer<JsonGenerator> jsonStream, Result result)
+    public JsonStreamingResult(JsonStreamHandler jsonStream, Result result)
     {
         super(Lists.mutable.empty());
         this.childResult = result;
@@ -59,7 +61,7 @@ public class JsonStreamingResult extends StreamingResult
 
     public Consumer<JsonGenerator> getJsonStream()
     {
-        return jsonStream;
+        return jsonStream::writeTo;
     }
 
     @Override
@@ -77,14 +79,25 @@ public class JsonStreamingResult extends StreamingResult
         switch (format)
         {
             case PURE:
-                return new JsonStreamToPureFormatSerializer(this);
             case RAW:
                 return new JsonStreamToPureFormatSerializer(this);
             case DEFAULT:
                 return new JsonStreamToJsonDefaultSerializer(this);
             default:
                 this.close();
-                throw new RuntimeException(format.toString() + " format not currently supported with JsonStreamingResult");
+                throw new RuntimeException(format + " format not currently supported with JsonStreamingResult");
         }
+    }
+
+    public Stream<ObjectNode> toStream()
+    {
+        return this.jsonStream.toStream().onClose(this::close);
+    }
+
+    public interface JsonStreamHandler
+    {
+        void writeTo(JsonGenerator generator);
+
+        Stream<ObjectNode> toStream();
     }
 }

--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/ExecutionResultObjectMapperFactory.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/ExecutionResultObjectMapperFactory.java
@@ -44,7 +44,7 @@ public class ExecutionResultObjectMapperFactory
         @Override
         public void serialize(PureDate value, JsonGenerator gen, SerializerProvider serializers) throws IOException
         {
-            gen.writeRawValue("\"" + value.toString() + "\"");
+            gen.writeString(value.toString());
         }
     }
 

--- a/legend-engine-protocol-pure/pom.xml
+++ b/legend-engine-protocol-pure/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/test/TestCompatibilityAndMigration.java
+++ b/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/test/TestCompatibilityAndMigration.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.protocol.test;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import net.javacrumbs.jsonunit.JsonAssert;
 import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.junit.Assert;
@@ -932,7 +933,7 @@ public class TestCompatibilityAndMigration
         PureModelContextData context = objectMapper.readValue(input, PureModelContextData.class);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(context);
-        Assert.assertEquals(output, json);
+        JsonAssert.assertJsonEquals(output, json);
     }
 
 }

--- a/legend-engine-testable/src/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
+++ b/legend-engine-testable/src/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
@@ -113,8 +113,8 @@ public class TestTestAssertionEvaluator
 
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
         Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : \"data\"\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : \"wrong_data\"\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : \"data\"%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : \"wrong_data\"%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
     }
 
@@ -133,17 +133,16 @@ public class TestTestAssertionEvaluator
         data.data = "{\"some\":1234567890.1234567}";
         AssertionStatus assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
-        Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : 1234567890.1234567\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : 1234567890.123456789\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : 1234567890.1234567%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : 1234567890.123456789%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
 
         data.data = "{\"some\":1234567890.123456789012}";
         assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
         Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : 1234567890.123456789012\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : 1234567890.123456789\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : 1234567890.123456789012%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : 1234567890.123456789%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
 
         data.data = "{\"some\":1234567890.123456789000}";
@@ -168,32 +167,32 @@ public class TestTestAssertionEvaluator
         AssertionStatus assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
         Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : 2\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : 2.0\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2.0%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
 
         data.data = "{\"some\":2.000000000000000001}";
         assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
         Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : 2.000000000000000001\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : 2.0\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2.000000000000000001%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2.0%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
 
         data.data = "{\"some\":2000000000000000000}";
         assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
         Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : 2000000000000000000\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : 2.0\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2000000000000000000%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2.0%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
 
         data.data = "{\"some\":20}";
         assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
         Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : 20\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : 2.0\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : 20%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2.0%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
 
         data.data = "{\"some\":2.00000000000000000}";
@@ -207,8 +206,8 @@ public class TestTestAssertionEvaluator
         assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult1));
         Assert.assertTrue(assertionStatus instanceof EqualToJsonAssertFail);
         Assert.assertEquals("assert1", assertionStatus.id);
-        Assert.assertEquals("{\n  \"some\" : 2.0\n}", ((EqualToJsonAssertFail) assertionStatus).expected);
-        Assert.assertEquals("{\n  \"some\" : 2\n}", ((EqualToJsonAssertFail) assertionStatus).actual);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2.0%n}"), ((EqualToJsonAssertFail) assertionStatus).expected);
+        Assert.assertEquals(String.format("{%n  \"some\" : 2%n}"), ((EqualToJsonAssertFail) assertionStatus).actual);
         Assert.assertEquals("Actual result does not match Expected result", ((EqualToJsonAssertFail) assertionStatus).message);
 
         data.data = "{\"some\":2}";

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/javaRuntime/executionPlanNodes/graphFetch/graphFetchRelational.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/javaRuntime/executionPlanNodes/graphFetch/graphFetchRelational.pure
@@ -310,7 +310,7 @@ function <<access.private>> meta::pure::executionPlan::engine::java::graphFetch:
                            j_throw(j_new(javaRuntimeException(), [
                               j_string('Enumeration mapping failure. Cannot find transformation for source value \'')
                               ->j_plus($r)
-                              ->j_plus(j_string('\' for enumeration property \'' + $property.name->toOne() + '\' of type ' + $propertyType->elementToPath() + ' in enumeration mapping ' + $currentPropertyMapping.transformer->cast(@EnumerationMapping<Any>).name->toOne() + '.'))
+                              ->j_plus(j_string('\' for enumeration property \'' + $property.name->toOne() + '\' of type ' + $propertyType->elementToPath() + ' in enumeration mapping ' + $currentPropertyMapping.transformer->cast(@EnumerationMapping<Any>).name->concatenate('{missing enum mapping}')->first()->toOne() + '.'))
                            ]))
                         ),
                         $enumResVar->j_assign(javaClass('java.lang.Enum')->j_invoke('valueOf', [$javaEnumeration->j_classField(), $transformedR], $javaEnumeration))


### PR DESCRIPTION
#### What type of PR is this?

Enhancement 

#### What does this PR do / why is it needed ?

Enhance the service Result classes, providing the result output on a Java json object (jackson JsonNode), allowing for more simpler and efficient consumption of result when results are meant to be consume by a Java process.

Before, all results were required to be written to output stream, not a format that is easy to consume efficiently on a Java process.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
