### PR TITLE
Make workflow logs readable

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/test/java/org/finos/legend/engine/pure/code/core/Test_Pure_Core.java
+++ b/legend-engine-pure-code-compiled-core/src/test/java/org/finos/legend/engine/pure/code/core/Test_Pure_Core.java
@@ -24,6 +24,7 @@ public class Test_Pure_Core
     public static TestSuite suite()
     {
         CompiledExecutionSupport executionSupport = PureTestBuilderHelper.getClassLoaderExecutionSupport();
+        executionSupport.getConsole().disable();
         TestSuite suite = new TestSuite();
         suite.addTest(PureTestBuilderHelper.buildSuite(TestCollection.collectTests("meta::json", executionSupport.getProcessorSupport(), fn -> PureTestBuilderHelper.generatePureTestCollection(fn, executionSupport), ci -> PureTestBuilderHelper.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
         suite.addTest(PureTestBuilderHelper.buildSuite(TestCollection.collectTests("meta::protocols", executionSupport.getProcessorSupport(), fn -> PureTestBuilderHelper.generatePureTestCollection(fn, executionSupport), ci -> PureTestBuilderHelper.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));

--- a/legend-engine-xt-relationalStore-executionPlan-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/DbSpecificTests.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/DbSpecificTests.java
@@ -50,7 +50,7 @@ public abstract class DbSpecificTests
                     {
                         for (int i1 = 1; i1 < resultSet.getMetaData().getColumnCount() + 1; i1++)
                         {
-                            assert resultSet.getMetaData().getColumnLabel(i1) != null;
+                            resultSet.getMetaData().getColumnLabel(i1);
                             resultSet.getObject(i1);
                         }
                     }

--- a/legend-engine-xt-relationalStore-executionPlan-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/DbSpecificTests.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/DbSpecificTests.java
@@ -50,7 +50,8 @@ public abstract class DbSpecificTests
                     {
                         for (int i1 = 1; i1 < resultSet.getMetaData().getColumnCount() + 1; i1++)
                         {
-                            System.out.println(resultSet.getMetaData().getColumnLabel(i1) + " = " + resultSet.getObject(i1));
+                            assert resultSet.getMetaData().getColumnLabel(i1) != null;
+                            resultSet.getObject(i1);
                         }
                     }
                     return true;

--- a/legend-engine-xt-relationalStore-pure/src/test/java/org/finos/legend/pure/code/core/relational/Test_Pure_Relational.java
+++ b/legend-engine-xt-relationalStore-pure/src/test/java/org/finos/legend/pure/code/core/relational/Test_Pure_Relational.java
@@ -24,6 +24,7 @@ public class Test_Pure_Relational
     public static TestSuite suite()
     {
         CompiledExecutionSupport executionSupport = PureTestBuilderHelper.getClassLoaderExecutionSupport();
+        executionSupport.getConsole().disable();
         TestSuite suite = new TestSuite();
         //NOTE- we are not collecting parameterized test collection in meta::relational here
         suite.addTest(PureTestBuilderHelper.buildSuite(TestCollection.collectTests("meta::relational", executionSupport.getProcessorSupport(), ci -> PureTestBuilderHelper.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,7 @@
                         <skip>${javadoc.skip}</skip>
                         <source>8</source>
                         <doclint>none</doclint>
+                        <quiet>true</quiet>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

This PR is aimed at significantly reducing the build job log size making it readable and easy to monitor (old build log size: 17.6MB, new build log size: 2.5MB)

#### Which issue(s) this PR fixes:

Fixes https://github.com/finos/legend-engine/issues/1146

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
