### PR TITLE
Setting arguments for release:perform

### DIFF
--- a/.github/workflows/release-large-runner.yml
+++ b/.github/workflows/release-large-runner.yml
@@ -67,4 +67,4 @@ jobs:
         run: mvn -B -e release:prepare -DpreparationGoals=clean -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
 
       - name: Perform release
-        run: mvn -B -e -T 4 release:perform -DargLine="-Xms12g -Xmx12g" -P release,docker
+        run: mvn -B -e -T 4 release:perform -Darguments="-DargLine=-Xms12g -Xmx12g" -P release,docker


### PR DESCRIPTION
#### What type of PR is this?

This PR corrects the way that additional maven parameters need to be set when calling release:perform

#### What does this PR do / why is it needed ?

This change should correctly pass the argLine parameter when calling release:perform