### PR TITLE
Adding a manual action to close an OSSRH staging repo

### DIFF
--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -1,0 +1,57 @@
+# Copyright 2022 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This action retries closing the staging repository in Nexus (Maven Central)
+# This should only be run if a release fails with the following message:
+# [ERROR] Remote staging finished with a failure: java.net.SocketException: Connection timed out (Read failed)
+name: Close Staging Repository
+
+env:
+  CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+  CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+  CI_GPG_PASSPHRASE: ${{ secrets.CI_GPG_PASSPHRASE }}
+
+on: [workflow_dispatch]
+
+jobs:
+  close-staging-repo:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.FINOS_GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "37706051+finos-admin@users.noreply.github.com"
+          git config --global user.name "FINOS Administrator"
+
+      - name: Set up Maven Central
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+          server-id: ossrh
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+          gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
+          gpg-passphrase: CI_GPG_PASSPHRASE
+
+      - name: Close staging repo
+        run: mvn nexus-staging:close


### PR DESCRIPTION
#### What type of PR is this?

This is a new action to attempt to manually close an OSSRH staging repo in case the release action fails on that step.

#### What does this PR do / why is it needed ?

We've observed issues with the Sonatype server that cause the uploaded artifacts to not get released. This new action attempts to re-try the artifact release step.
