### PR TITLE
Close and release staging repo action

### DIFF
--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Get last open nexus repo Id
         run: |
           mvn nexus-staging:rc-list | tee rc-list.log
-          idLine=$(grep 'orgfinoslegend' rc-list.log | | grep '${{ github.event.inputs.releaseVersion }}')
+          idLine=$(grep 'orgfinoslegend' rc-list.log | grep '${{ github.event.inputs.releaseVersion }}')
           arrLine=(${idLine// / })
           repoId=${arrLine[1]}
           echo "NEXUS_REPO_ID=${repoId}" >> $GITHUB_ENV

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -16,7 +16,7 @@
 # This action retries closing a staging repository in Nexus (Maven Central)
 # This should only be run if a release fails with the following message:
 # [ERROR] Remote staging finished with a failure: java.net.SocketException: Connection timed out (Read failed)
-name: Close Staging Repository
+name: Close and Release Staging Repository (In case of release failure)
 
 env:
   CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -54,4 +54,4 @@ jobs:
           gpg-passphrase: CI_GPG_PASSPHRASE
 
       - name: Close staging repo
-        run: mvn nexus-staging:close
+        run: mvn nexus-staging:rc-list

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -23,7 +23,12 @@ env:
   CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
   CI_GPG_PASSPHRASE: ${{ secrets.CI_GPG_PASSPHRASE }}
 
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "Version of the release that failed to close it's staging repo"
+        required: true
 
 jobs:
   close-staging-repo:
@@ -55,8 +60,8 @@ jobs:
 
       - name: Get last open nexus repo Id
         run: |
-          mvn nexus-staging:rc-list > rc-list.log
-          idLine=$(grep 'orgfinoslegend' rc-list.log | tail -1)
+          mvn nexus-staging:rc-list | tee rc-list.log
+          idLine=$(grep 'orgfinoslegend' rc-list.log | | grep '${{ github.event.inputs.releaseVersion }}')
           arrLine=(${idLine// / })
           repoId=${arrLine[1]}
           echo "NEXUS_REPO_ID=${repoId}" >> $GITHUB_ENV

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# This action retries closing the staging repository in Nexus (Maven Central)
+# This action retries closing a staging repository in Nexus (Maven Central)
 # This should only be run if a release fails with the following message:
 # [ERROR] Remote staging finished with a failure: java.net.SocketException: Connection timed out (Read failed)
 name: Close Staging Repository
@@ -58,7 +58,7 @@ jobs:
           gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
           gpg-passphrase: CI_GPG_PASSPHRASE
 
-      - name: Get last open nexus repo Id
+      - name: Get staging repo Id
         run: |
           mvn nexus-staging:rc-list | tee rc-list.log
           idLine=$(grep 'orgfinoslegend' rc-list.log | grep '${{ github.event.inputs.releaseVersion }}')
@@ -66,5 +66,8 @@ jobs:
           repoId=${arrLine[1]}
           echo "NEXUS_REPO_ID=${repoId}" >> $GITHUB_ENV
 
-      - name: Print repo Id
-        run: echo ${{ env.NEXUS_REPO_ID }}
+      - name: Close staging repo
+        run: mvn nexus-staging:rc-close -DstagingRepositoryId=${{ env.NEXUS_REPO_ID }}
+
+      - name: Release staging repo
+        run: mvn nexus-staging:rc-release -DstagingRepositoryId=${{ env.NEXUS_REPO_ID }}

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -53,5 +53,13 @@ jobs:
           gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
           gpg-passphrase: CI_GPG_PASSPHRASE
 
-      - name: Close staging repo
-        run: mvn nexus-staging:rc-list
+      - name: Get last open nexus repo Id
+        run: |
+          mvn nexus-staging:rc-list > rc-list.log
+          idLine=$(grep 'orgfinoslegend' rc-list.log | tail -1)
+          arrLine=(${idLine// / })
+          repoId=${arrLine[1]}
+          echo "NEXUS_REPO_ID=${repoId}" >> $GITHUB_ENV
+
+      - name: Print repo Id
+        run: echo ${{ env.NEXUS_REPO_ID }}


### PR DESCRIPTION
#### What type of PR is this?

This updates the OSSRH action to close and release the Nexus staging repo

#### What does this PR do / why is it needed ?

The maven release plugin often fails to close the staging repository in Nexus after uploading the artifacts. This new action will allow us to manually retry closing and releasing the staging repository. This means we don't need to trigger a full new release in case of that failure.