### PR TITLE
Remove un-necessary casting in round dyna fn for snowflake

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/snowflake/snowflakeExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/snowflake/snowflakeExtension.pure
@@ -81,7 +81,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
     dynaFnToSql('quarterNumber',          $allStates,            ^ToSql(format='quarter(%s)')),
     dynaFnToSql('rem',                    $allStates,            ^ToSql(format='mod(%s,%s)')),
     dynaFnToSql('right',                  $allStates,            ^ToSql(format='right(%s,%s)')),
-    dynaFnToSql('round',                  $allStates,            ^ToSql(format='round((%s)::numeric, %s)', transform=transformRound_String_MANY__String_MANY_)),
+    dynaFnToSql('round',                  $allStates,            ^ToSql(format='round((%s), %s)', transform=transformRound_String_MANY__String_MANY_)),
     dynaFnToSql('rtrim',                  $allStates,            ^ToSql(format='rtrim(%s)')),
     dynaFnToSql('second',                 $allStates,            ^ToSql(format='second(%s)')),
     dynaFnToSql('substring',              $allStates,            ^ToSql(format='substring%s', transform={p:String[*]|$p->joinStrings('(', ', ', ')')})),


### PR DESCRIPTION
#### What type of PR is this?

Sql gen fix 

#### What does this PR do / why is it needed ?

Remove un-necessary casting in round dyna fn for snowflake

#### Does this PR introduce a user-facing change?
Yes, it should fix round dyna fn for snowflake. There may be a fallout in case, people depend on that cast functionality, and we may need to fix those incorrect use cases.
