### PR TITLE
Creating Keys for MultiExec Test Blocks 11-17-22

### DIFF
--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceLexerGrammar.g4
@@ -33,7 +33,7 @@ SERVICE_TEST_TESTS:                 'tests';
 SERVICE_TEST_ASSERTS:               'asserts';
 SERVICE_TEST_SERIALIZATION_FORMAT:  'serializationFormat';
 SERVICE_TEST_PARAMETERS:            'parameters';
-
+ASSERT_FOR_KEYS:                    'keys';
 PARAM_GROUP:                        'list';
 
 // -------------------------------------- LEGACY --------------------------------------

--- a/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
+++ b/legend-engine-language-pure-dsl-service/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/ServiceParserGrammar.g4
@@ -18,7 +18,7 @@ identifier:                             VALID_STRING | STRING
                                         | SERVICE_PATTERN | SERVICE_OWNERS | SERVICE_DOCUMENTATION | SERVICE_AUTO_ACTIVATE_UPDATES
                                         | SERVICE_EXECUTION | SERVICE_FUNCTION | SERVICE_EXECUTION_KEY | SERVICE_EXECUTION_EXECUTIONS | SERVICE_RUNTIME | SERVICE_MAPPING
                                         | SERVICE_TEST_SUITES | SERVICE_TEST_DATA | SERVICE_TEST_CONNECTION_DATA | SERVICE_TEST_TESTS | SERVICE_TEST_ASSERTS | SERVICE_TEST_PARAMETERS
-                                        | SERVICE_TEST_SERIALIZATION_FORMAT | SERVICE_TEST | PARAM_GROUP
+                                        | SERVICE_TEST_SERIALIZATION_FORMAT | SERVICE_TEST | PARAM_GROUP | ASSERT_FOR_KEYS
 ;
 
 
@@ -133,7 +133,7 @@ embeddedDataContent:                    ISLAND_START | ISLAND_BRACE_OPEN | ISLAN
 ;
 serviceTestSuiteTests:                  SERVICE_TEST_TESTS COLON BRACKET_OPEN ( serviceTestBlock ( COMMA serviceTestBlock )* )? BRACKET_CLOSE
 ;
-serviceTestBlock:                       identifier COLON BRACE_OPEN ( serviceTestParameters | serviceTestSerialization | serviceTestAsserts )* BRACE_CLOSE
+serviceTestBlock:                       identifier COLON BRACE_OPEN ( serviceTestParameters | serviceTestSerialization | keys | serviceTestAsserts )* BRACE_CLOSE
 ;
 serviceTestParameters:                  SERVICE_TEST_PARAMETERS COLON BRACKET_OPEN ( serviceTestParameter ( COMMA serviceTestParameter )* )? BRACKET_CLOSE
 ;
@@ -144,6 +144,12 @@ serviceTestParameter:                   identifier EQUAL primitiveValue
 serviceTestAsserts:                     SERVICE_TEST_ASSERTS COLON BRACKET_OPEN ( serviceTestAssert ( COMMA serviceTestAssert )* )? BRACKET_CLOSE
 ;
 serviceTestAssert:                      identifier COLON testAssertion
+;
+keys:                                   ASSERT_FOR_KEYS COLON
+                                                 BRACKET_OPEN
+                                                            (STRING (COMMA STRING)*)
+                                                 BRACKET_CLOSE
+                                        SEMI_COLON
 ;
 testAssertion:                          identifier ISLAND_OPEN (testAssertionContent)*
 ;

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
@@ -27,6 +27,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.PackageableConnection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.PackageableRuntime;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureSingleExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTestSuite;
@@ -34,6 +35,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.Test;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_ParameterValue;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_PureExecution;
+import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_PureSingleExecution_Impl;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_Service;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_ServiceTest;
 import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_ServiceTestSuite;
@@ -94,7 +96,14 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
                             for (Root_meta_pure_test_AtomicTest pureTest : pureServiceTestSuite._tests())
                             {
                                 Root_meta_legend_service_metamodel_ServiceTest pureServiceTest = (Root_meta_legend_service_metamodel_ServiceTest) pureTest;
+
+                                if (pureService._execution() instanceof Root_meta_legend_service_metamodel_PureSingleExecution_Impl && pureServiceTest._keys() != null)
+                                {
+                                    throw new EngineException("Service Test cannot have keys for SingleExecution Tests", service.sourceInformation, EngineErrorType.COMPILATION);
+                                }
+
                                 HelperServiceBuilder.validateServiceTestParameterValues((List<Root_meta_legend_service_metamodel_ParameterValue>) pureServiceTest._parameters().toList(), parameters, ListIterate.detect(suite.tests, t -> t.id.equals(pureServiceTest._id())).sourceInformation);
+
                             }
                             return pureServiceTestSuite;
                         }));
@@ -150,6 +159,7 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
                 {
                     pureServiceTest._serializationFormat(serviceTest.serializationFormat);
                 }
+                pureServiceTest._keysAddAll(Lists.mutable.withAll(serviceTest.keys));
                 if (serviceTest.assertions == null || serviceTest.assertions.isEmpty())
                 {
                     throw new EngineException("Service Tests should have atleast 1 assert", serviceTest.sourceInformation, EngineErrorType.COMPILATION);

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
@@ -97,7 +97,7 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
                             {
                                 Root_meta_legend_service_metamodel_ServiceTest pureServiceTest = (Root_meta_legend_service_metamodel_ServiceTest) pureTest;
 
-                                if (pureService._execution() instanceof Root_meta_legend_service_metamodel_PureSingleExecution_Impl && pureServiceTest._keys() != null)
+                                if (pureService._execution() instanceof Root_meta_legend_service_metamodel_PureSingleExecution_Impl && pureServiceTest._keys().size() != 0)
                                 {
                                     throw new EngineException("Service Test cannot have keys for SingleExecution Tests", service.sourceInformation, EngineErrorType.COMPILATION);
                                 }

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/from/ServiceParseTreeWalker.java
@@ -192,6 +192,10 @@ public class ServiceParseTreeWalker
             serviceTest.parameters = ListIterate.collect(testParametersContext.serviceTestParameter(), this::visitServiceTestParameter);
         }
 
+        //keys
+        ServiceParserGrammar.KeysContext scopeContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.keys(), "keys", serviceTest.sourceInformation);
+        serviceTest.keys = scopeContext != null && scopeContext.STRING() != null ? ListIterate.collect(scopeContext.STRING(), keyInScopeCtx -> PureGrammarParserUtility.fromGrammarString(keyInScopeCtx.getText(), true)) : new ArrayList<>();
+
         // asserts
         ServiceParserGrammar.ServiceTestAssertsContext testAssertsContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.serviceTestAsserts(), "asserts", serviceTest.sourceInformation);
         serviceTest.assertions = ListIterate.collect(testAssertsContext.serviceTestAssert(), this::visitServiceTestAsserts);

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/HelperServiceGrammarComposer.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/grammar/to/HelperServiceGrammarComposer.java
@@ -183,6 +183,12 @@ public class HelperServiceGrammarComposer
             str.append(getTabString(baseIndentation + 1)).append("]\n");
         }
 
+        // keys
+        if (!test.keys.isEmpty() && test.keys != null)
+        {
+            str.append(getTabString(baseIndentation + 1)).append("keys:\n").append(getTabString(baseIndentation + 1)).append("[\n").append(getTabString(baseIndentation + 2)).append(LazyIterate.collect(test.keys, k -> convertString(k, true)).makeString(",\n")).append("\n").append(getTabString(baseIndentation + 1)).append("];\n");
+        }
+
         // Asserts
         if (test.assertions != null)
         {

--- a/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/service/ServiceTest.java
+++ b/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/service/ServiceTest.java
@@ -17,10 +17,12 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.servic
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTest;
 
+import java.util.Collections;
 import java.util.List;
 
 public class ServiceTest extends AtomicTest
 {
     public String serializationFormat;
     public List<ParameterValue> parameters;
+    public List<String> keys = Collections.emptyList();
 }

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarParser.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarParser.java
@@ -992,6 +992,88 @@ public class TestServiceGrammarParser extends TestGrammarParser.TestGrammarParse
                 "PARSER error at [22:7-42:7]: Field 'connections' should be specified only once"
         );
 
+        //assert keys should have atleast one element
+        test("###Service\n" +
+                "Service meta::pure::myServiceSingle\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  owners:\n" +
+                "  [\n" +
+                "    'ownerName',\n" +
+                "    'ownerName2'\n" +
+                "  ];\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Multi\n" +
+                "  {\n" +
+                "    query: |model::pure::mapping::modelToModel::test::shared::dest::Product.all()->graphFetchChecked(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#)->serialize(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#);\n" +
+                "    key: 'env';\n" +
+                "    executions['QA']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping1;\n" +
+                "      runtime: test::runtime;\n" +
+                "    }\n" +
+                "    executions['UAT']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping2;\n" +
+                "      runtime: meta::myRuntime;\n" +
+                "    }\n" +
+                "  }\n" +
+                "  testSuites:\n" +
+                "  [\n" +
+                "    testSuite1:\n" +
+                "    {\n" +
+                "      data:\n" +
+                "      [\n" +
+                "        connections:\n" +
+                "        [\n" +
+                "          connection1:\n" +
+                "            ExternalFormat\n" +
+                "            #{\n" +
+                "              contentType: 'application/x.flatdata';\n" +
+                "              data: 'FIRST_NAME,LAST_NAME\\nFred,Bloggs\\nJane,Doe';\n" +
+                "            }#,\n" +
+                "          connection2:\n" +
+                "            ModelStore\n" +
+                "            #{\n" +
+                "              my::Person:\n" +
+                "                [\n" +
+                "                  ^my::Person(\n" +
+                "                    givenNames = ['Fred', 'William'],\n" +
+                "                    address = ^my::Address(street = 'A Road')\n" +
+                "                  )\n" +
+                "                ]\n" +
+                "            }#\n" +
+                "        ]\n" +
+                "      ]\n" +
+                "      tests:\n" +
+                "      [\n" +
+                "        test1:\n" +
+                "        {\n" +
+                "          keys:\n" +
+                "          [\n" +
+                "          ];\n" +
+                "          asserts:\n" +
+                "          [\n" +
+                "            assert1:\n" +
+                "              EqualToJson\n" +
+                "              #{\n" +
+                "                expected : \n" +
+                "                  ExternalFormat\n" +
+                "                  #{\n" +
+                "                    contentType: 'application/json';\n" +
+                "                    data: '{Age:12, Name:\"dummy\"}';\n" +
+                "                  }#;\n" +
+                "              }#\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n",
+                "PARSER error at [60:11]: Unexpected token"
+        );
+
         //Unknown assert type
         test("###Service\n" +
                         "Service meta::pure::myServiceSingle\n" +

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
@@ -617,6 +617,88 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "}\n"
         );
 
+        //Test Single Execution with Test Assertion containing KeysInScope size() > 1
+        test("###Service\n" +
+                "Service meta::pure::myServiceSingle\n" +
+                "{\n" +
+                "  pattern: 'url/myUrl/';\n" +
+                "  owners:\n" +
+                "  [\n" +
+                "    'ownerName',\n" +
+                "    'ownerName2'\n" +
+                "  ];\n" +
+                "  documentation: 'this is just for context';\n" +
+                "  autoActivateUpdates: true;\n" +
+                "  execution: Multi\n" +
+                "  {\n" +
+                "    query: |model::pure::mapping::modelToModel::test::shared::dest::Product.all()->graphFetchChecked(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#)->serialize(#{model::pure::mapping::modelToModel::test::shared::dest::Product{name}}#);\n" +
+                "    key: 'env';\n" +
+                "    executions['QA']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping1;\n" +
+                "      runtime: test::runtime;\n" +
+                "    }\n" +
+                "    executions['UAT']:\n" +
+                "    {\n" +
+                "      mapping: meta::myMapping2;\n" +
+                "      runtime: meta::myRuntime;\n" +
+                "    }\n" +
+                "  }\n" +
+                "  testSuites:\n" +
+                "  [\n" +
+                "    testSuite1:\n" +
+                "    {\n" +
+                "      data:\n" +
+                "      [\n" +
+                "        connections:\n" +
+                "        [\n" +
+                "          connection1:\n" +
+                "            ExternalFormat\n" +
+                "            #{\n" +
+                "              contentType: 'application/x.flatdata';\n" +
+                "              data: 'FIRST_NAME,LAST_NAME\\nFred,Bloggs\\nJane,Doe';\n" +
+                "            }#,\n" +
+                "          connection2:\n" +
+                "            ModelStore\n" +
+                "            #{\n" +
+                "              my::Person:\n" +
+                "                [\n" +
+                "                  ^my::Person(\n" +
+                "                    givenNames = ['Fred', 'William'],\n" +
+                "                    address = ^my::Address(street = 'A Road')\n" +
+                "                  )\n" +
+                "                ]\n" +
+                "            }#\n" +
+                "        ]\n" +
+                "      ]\n" +
+                "      tests:\n" +
+                "      [\n" +
+                "        test1:\n" +
+                "        {\n" +
+                "          keys:\n" +
+                "          [\n" +
+                "            'UAT'\n" +
+                "          ];\n" +
+                "          asserts:\n" +
+                "          [\n" +
+                "            assert1:\n" +
+                "              EqualToJson\n" +
+                "              #{\n" +
+                "                expected : \n" +
+                "                  ExternalFormat\n" +
+                "                  #{\n" +
+                "                    contentType: 'application/json';\n" +
+                "                    data: '{Age:12, Name:\"dummy\"}';\n" +
+                "                  }#;\n" +
+                "              }#\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n"
+        );
+
         //Test Single TestSuite with multiple tests
         test("###Service\n" +
                 "Service meta::pure::myServiceSingle\n" +

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/legend/service/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/legend/service/metamodel.pure
@@ -95,6 +95,7 @@ Class meta::legend::service::metamodel::ServiceTest extends meta::pure::test::At
 {
   serializationFormat: String[0..1];
   parameters : ParameterValue[*];
+  keys: String[*];
 }
 
 Class meta::legend::service::metamodel::ParameterValue

--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
@@ -109,13 +109,17 @@ public class ServiceTestRunner implements TestRunner
 
         Service service = ListIterate.detect(data.getElementsOfType(Service.class), ele -> ele.getPath().equals(getElementFullPath(pureService, pureModel.getExecutionSupport())));
         ServiceTestSuite suite = ListIterate.detect(service.testSuites, ts -> ts.id.equals(testSuite._id()));
-        List<String> testIds = ListIterate.collect(atomicTestIds, testId -> testId.atomicTestId);
 
         if (service.execution instanceof PureMultiExecution)
         {
             Map<String, MultiExecutionServiceTestResult> testResultsByTestId = Maps.mutable.empty();
             for (AtomicTest test : suite.tests)
             {
+                List<String> testIds = Lists.mutable.empty();
+                List<String> allKeys = Lists.mutable.empty();
+                List<KeyedExecutionParameter> allValidKeys = Lists.mutable.empty();
+                testIds.add(test.id);
+
                 MultiExecutionServiceTestResult multiExecutionServiceTestResult = new MultiExecutionServiceTestResult();
                 multiExecutionServiceTestResult.testable = getElementFullPath(pureService, pureModel.getExecutionSupport());
                 multiExecutionServiceTestResult.atomicTestId = new AtomicTestId();
@@ -123,26 +127,35 @@ public class ServiceTestRunner implements TestRunner
                 multiExecutionServiceTestResult.atomicTestId.testSuiteId = suite.id;
 
                 testResultsByTestId.put(test.id, multiExecutionServiceTestResult);
+
+                allKeys.addAll(((ServiceTest)test).keys);
+
+                if (allKeys.isEmpty())
+                {
+                    allValidKeys.addAll(((PureMultiExecution) service.execution).executionParameters);
+                }
+                else
+                {
+                    allValidKeys = ((PureMultiExecution) service.execution).executionParameters.stream().filter(s -> allKeys.contains(s.key)).collect(Collectors.toList());
+                }
+                for (KeyedExecutionParameter param : allValidKeys)
+                {
+                    PureSingleExecution pureSingleExecution = new PureSingleExecution();
+                    pureSingleExecution.func = ((PureMultiExecution) service.execution).func;
+                    pureSingleExecution.mapping = param.mapping;
+                    pureSingleExecution.runtime = param.runtime;
+                    pureSingleExecution.executionOptions = param.executionOptions;
+
+                    List<TestResult> testResultsForKey = executeSingleExecutionTestSuite(pureSingleExecution, suite, testIds, pureModel, data, routerExtensions, planTransformers);
+                    Map<String, TestResult> testResultsForKeyById = Iterate.groupByUniqueKey(testResultsForKey, e -> e.atomicTestId.atomicTestId);
+                    testResultsForKeyById.forEach((key, value) -> testResultsByTestId.get(key).addTestResult(param.key, value));
+                }
             }
-
-            for (KeyedExecutionParameter param : ((PureMultiExecution) service.execution).executionParameters)
-            {
-                PureSingleExecution pureSingleExecution = new PureSingleExecution();
-                pureSingleExecution.func = ((PureMultiExecution) service.execution).func;
-                pureSingleExecution.mapping = param.mapping;
-                pureSingleExecution.runtime = param.runtime;
-                pureSingleExecution.executionOptions = param.executionOptions;
-
-                List<TestResult> testResultsForKey = executeSingleExecutionTestSuite(pureSingleExecution, suite, testIds, pureModel, data, routerExtensions, planTransformers);
-                Map<String, TestResult> testResultsForKeyById = Iterate.groupByUniqueKey(testResultsForKey, e -> e.atomicTestId.atomicTestId);
-
-                testResultsForKeyById.forEach((key, value) -> testResultsByTestId.get(key).addTestResult(param.key, value));
-            }
-
             return new ArrayList<>(testResultsByTestId.values());
         }
         else if (service.execution instanceof PureSingleExecution)
         {
+            List<String> testIds = ListIterate.collect(atomicTestIds, testId -> testId.atomicTestId);
             return executeSingleExecutionTestSuite((PureSingleExecution) service.execution, suite, testIds, pureModel, data, routerExtensions, planTransformers);
         }
         else

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarForFailedTestModel.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarForFailedTestModel.pure
@@ -1,0 +1,137 @@
+###ServiceStore
+ServiceStore testServiceStoreTestSuites::ServiceStore
+(
+  ServiceGroup EmployeeServices
+  (
+    path : '/employees';
+    Service EmployeeService
+    (
+      path : '/allEmployees';
+      method : GET;
+      response : [testServiceStoreTestSuites::Employee <- testServiceStoreTestSuites::employeeServiceStoreSchemaBinding];
+      security : [];
+    )
+    Service EmployeeServiceWithParameters
+    (
+      path : '/employeesWithParameters';
+      method : GET;
+      parameters :
+      (
+          stringParam : String (location = query),
+          integerParam : Integer (location = query),
+          floatParam : Float (location = query),
+          booleanParam : Boolean (location = query)
+      );
+      response : [testServiceStoreTestSuites::Employee2 <- testServiceStoreTestSuites::employeeServiceStoreSchemaBinding];
+      security : [];
+    )
+  )
+)
+
+
+###Data
+Data testServiceStoreTestSuites::TestData
+{
+  ServiceStore #{
+    [
+      {
+        request:
+        {
+          method: GET;
+          url: '/employees/allEmployees';
+        };
+        response:
+        {
+          body:
+            ExternalFormat
+            #{
+              contentType: 'application/json';
+              data: '[ { \"kerberos\": \"dummy kerberos\", \"employeeID\": \"dummy id\", \"title\": \"dummy title\", \"firstName\": \"dummy firstName\", \"lastName\": \"dummy lastname\", \"countryCode\": \"dummy countryCode\" } ]';
+            }#;
+        };
+      }
+    ]
+  }#
+}
+
+
+###ExternalFormat
+Binding testServiceStoreTestSuites::employeeServiceStoreSchemaBinding
+{
+  contentType: 'application/json';
+  modelIncludes:
+  [
+    testServiceStoreTestSuites::Employee,
+    testServiceStoreTestSuites::Employee2
+  ];
+}
+
+
+###Pure
+Class testServiceStoreTestSuites::Employee
+{
+  kerberos: String[1];
+  employeeID: String[1];
+  title: String[0..1];
+  firstName: String[0..1];
+  lastName: String[0..1];
+  countryCode: String[0..1];
+}
+Class testServiceStoreTestSuites::Employee2
+{
+  stringParam : String[1];
+  integerParam :  Integer[1];
+  floatParam :  Float[1];
+  booleanParam :  Boolean[1];
+}
+
+
+###Mapping
+Mapping testServiceStoreTestSuites::ServiceStoreMapping
+(
+  *testServiceStoreTestSuites::Employee[employee_set]: ServiceStore
+  {
+    ~service [testServiceStoreTestSuites::ServiceStore] EmployeeServices.EmployeeService
+  }
+  *testServiceStoreTestSuites::Employee2[employee2_set]: ServiceStore
+  {
+    ~service [testServiceStoreTestSuites::ServiceStore] EmployeeServices.EmployeeServiceWithParameters
+    (
+      ~request
+      (
+        parameters
+        (
+          stringParam = $this.stringParam,
+          integerParam = $this.integerParam,
+          floatParam = $this.floatParam,
+          booleanParam = $this.booleanParam
+        )
+      )
+    )
+  }
+)
+
+
+###Connection
+ServiceStoreConnection testServiceStoreTestSuites::ServiceStoreConnection
+{
+  store: testServiceStoreTestSuites::ServiceStore;
+  baseUrl: 'https://prodUrl.com';
+}
+
+
+###Runtime
+Runtime testServiceStoreTestSuites::ServiceStoreRuntime
+{
+  mappings:
+  [
+    testServiceStoreTestSuites::ServiceStoreMapping
+  ];
+  connections:
+  [
+    testServiceStoreTestSuites::ServiceStore:
+    [
+      connection_1: testServiceStoreTestSuites::ServiceStoreConnection
+    ]
+  ];
+}

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarModel.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarModel.pure
@@ -1,0 +1,173 @@
+###Data
+Data testServiceStoreTestSuites::TestData
+{
+   ExternalFormat
+   #{
+       contentType: 'application/json';
+       data: '{\n  "sFirm_tbl": {\n    "legalName": "legalName 18",\n    "firmId": 22,\n    "ceoId": 49,\n    "addressId": 88,\n    "employees": {\n      "firstName": "firstName 69",\n      "lastName": "lastName 2",\n      "age": 14,\n      "id": 52,\n      "addressId": 83,\n      "firmId": 73\n    }\n  },\n  "sPerson_tbl": {\n    "firstName": "firstName 69",\n    "lastName": "lastName 4",\n    "age": 98,\n    "id": 87,\n    "addressId": 46,\n    "firmId": 26\n  }\n}';
+   }#
+}
+Data testServiceStoreTestSuites::TestData2
+{
+   ExternalFormat
+   #{
+       contentType: 'application/json';
+       data: '{\n  "sFirm_tbl": {\n    "legalName": "legalName 18",\n    "firmId": 22,\n    "ceoId": 49,\n    "addressId": 88,\n    "employees": {\n      "firstName": "firstName 69",\n      "lastName": "lastName 2",\n      "age": 14,\n      "id": 52,\n      "addressId": 83,\n      "firmId": 73\n    }\n  },\n  "sPerson_tbl": {\n    "firstName": "firstName 69",\n    "lastName": "lastName 4",\n    "age": 98,\n    "id": 87,\n    "addressId": 46,\n    "firmId": 26\n  }\n}';
+   }#
+}
+Data testServiceStoreTestSuites::TestData3
+{
+   ExternalFormat
+   #{
+       contentType: 'application/json';
+       data: '{\n  "sFirm_tbl": {\n    "legalName": "legalName 18",\n    "firmId": 22,\n    "ceoId": 49,\n    "addressId": 88,\n    "employees": {\n      "firstName": "firstName 69",\n      "lastName": "lastName 2",\n      "age": 14,\n      "id": 52,\n      "addressId": 83,\n      "firmId": 73\n    }\n  },\n  "sPerson_tbl": {\n    "firstName": "firstName 69",\n    "lastName": "lastName 4",\n    "age": 98,\n    "id": 87,\n    "addressId": 46,\n    "firmId": 26\n  }\n}';
+   }#
+}
+
+###Pure
+Class testModelStoreTestSuites::model::Doc
+{
+  firm_tbl: testModelStoreTestSuites::model::Firm_TBL[1];
+  person_tbl: testModelStoreTestSuites::model::Person_TBL[1];
+}
+
+Class testModelStoreTestSuites::model::Firm_TBL
+{
+  legalName: String[1];
+  <<equality.Key>> firmId: Integer[1];
+  ceoId: Integer[1];
+  addressId: Integer[1];
+}
+
+Class testModelStoreTestSuites::model::Person_TBL
+{
+  firstName: String[1];
+  lastName: String[1];
+  age: Integer[1];
+  <<equality.Key>> id: Integer[1];
+  addressId: Integer[1];
+  firmId: Integer[1];
+}
+
+Class testModelStoreTestSuites::model::sDoc
+{
+  sFirm_tbl: testModelStoreTestSuites::model::sFirm_TBL[1];
+  sPerson_tbl: testModelStoreTestSuites::model::sPerson_TBL[1];
+}
+
+Class testModelStoreTestSuites::model::sFirm_TBL
+{
+  legalName: String[1];
+  firmId: Integer[1];
+  ceoId: Integer[1];
+  addressId: Integer[1];
+  employees: testModelStoreTestSuites::model::sPerson_TBL[1];
+}
+
+Class testModelStoreTestSuites::model::sPerson_TBL
+{
+  firstName: String[1];
+  lastName: String[1];
+  age: Integer[1];
+  id: Integer[1];
+  addressId: Integer[1];
+  firmId: Integer[1];
+}
+
+
+###Mapping
+Mapping testModelStoreTestSuites::mapping::DocM2MMapping
+(
+  *testModelStoreTestSuites::model::Doc: Pure
+  {
+    ~src testModelStoreTestSuites::model::sDoc
+    firm_tbl: $src.sFirm_tbl,
+    person_tbl: $src.sPerson_tbl
+  }
+  *testModelStoreTestSuites::model::Firm_TBL: Pure
+  {
+    ~src testModelStoreTestSuites::model::sFirm_TBL
+    legalName: $src.legalName + 'x',
+    firmId: $src.firmId,
+    ceoId: $src.ceoId,
+    addressId: $src.addressId
+  }
+  *testModelStoreTestSuites::model::Person_TBL: Pure
+  {
+    ~src testModelStoreTestSuites::model::sPerson_TBL
+    firstName: $src.firstName,
+    lastName: $src.lastName,
+    age: $src.age,
+    id: $src.id,
+    addressId: $src.addressId,
+    firmId: $src.firmId
+  }
+)
+
+
+###Runtime
+Runtime testModelStoreTestSuites::runtime::DocM2MRuntime
+{
+  mappings:
+  [
+    testModelStoreTestSuites::mapping::DocM2MMapping
+  ];
+  connections:
+  [
+    ModelStore:
+    [
+      connection_1:
+      #{
+        JsonModelConnection
+        {
+          class: testModelStoreTestSuites::model::sDoc;
+          url: 'executor:default';
+        }
+      }#
+    ]
+  ];
+}
+
+Runtime testModelStoreTestSuites::runtime::DocM2MRuntime2
+{
+  mappings:
+  [
+    testModelStoreTestSuites::mapping::DocM2MMapping
+  ];
+  connections:
+  [
+    ModelStore:
+    [
+      connection_1:
+      #{
+        JsonModelConnection
+        {
+          class: testModelStoreTestSuites::model::sDoc;
+          url: 'executor:default';
+        }
+      }#
+    ]
+  ];
+}
+
+Runtime testModelStoreTestSuites::runtime::DocM2MRuntime3
+{
+  mappings:
+  [
+    testModelStoreTestSuites::mapping::DocM2MMapping
+  ];
+  connections:
+  [
+    ModelStore:
+    [
+      connection_2:
+      #{
+        JsonModelConnection
+        {
+          class: testModelStoreTestSuites::model::sDoc;
+          url: 'executor:default';
+        }
+      }#
+    ]
+  ];
+}

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithFailedServiceTestKeys.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithFailedServiceTestKeys.pure
@@ -1,0 +1,59 @@
+###Service
+Service testServiceStoreTestSuites::TestService
+{
+  pattern: '/testServiceStoreTestSuites/testService';
+  owners:
+  [
+    'dummy1',
+    'dummy2'
+  ];
+  autoActivateUpdates: true;
+  documentation: 'Service to test Service testSuite';
+  execution: Single
+  {
+    query: |testServiceStoreTestSuites::Employee.all()->graphFetch(#{testServiceStoreTestSuites::Employee{kerberos,employeeID,title,firstName,lastName,countryCode}}#)->serialize(#{testServiceStoreTestSuites::Employee{kerberos,employeeID,title,firstName,lastName,countryCode}}#);
+    mapping: testServiceStoreTestSuites::ServiceStoreMapping;
+    runtime: testServiceStoreTestSuites::ServiceStoreRuntime;
+  }
+  testSuites:
+  [
+    testSuite1:
+    {
+      data:
+      [
+        connections:
+        [
+          connection_1:
+            Reference 
+            #{ 
+              testServiceStoreTestSuites::TestData 
+            }#
+        ]
+      ]
+      tests:
+      [
+        test1:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'QA' 
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected : 
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{ \"kerberos\": \"dummy kerberos\", \"employeeID\": \"dummy id\", \"title\": \"dummy title\", \"firstName\": \"dummy firstName\", \"lastName\": \"dummy lastname\", \"countryCode\": \"dummy countryCode\" }';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithServiceTestKeys2.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithServiceTestKeys2.pure
@@ -1,0 +1,109 @@
+###Service
+Service testModelStoreTestSuites::service::DocM2MService2
+{
+  pattern: '/testModelStoreTestSuites/service';
+  owners:
+  [
+    'dummy',
+    'dummy1'
+  ];
+  documentation: 'Service to test refiner flow';
+  autoActivateUpdates: true;
+  execution: Multi
+  {
+    query: |testModelStoreTestSuites::model::Doc.all()->graphFetchChecked(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#)->serialize(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#);
+    key: 'env';
+    executions['QA1']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
+    }
+    executions['QA2']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime2;
+    }
+    executions['QA3']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
+    }
+    executions['QA4']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime2;
+    }
+    executions['UAT']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
+    }
+  }
+  testSuites:
+  [
+    testSuite1:
+    {
+      data:
+      [
+        connections:
+        [
+          connection_1:
+            ExternalFormat
+            #{
+              contentType: 'application/json';
+              data: '{\n  "sFirm_tbl": {\n    "legalName": "legalName 85",\n    "firmId": 78,\n    "ceoId": 40,\n    "addressId": 78,\n    "employees": {\n      "firstName": "firstName 52",\n      "lastName": "lastName 77",\n      "age": 89,\n      "id": 59,\n      "addressId": 88,\n      "firmId": 49\n    }\n  },\n  "sPerson_tbl": {\n    "firstName": "firstName 99",\n    "lastName": "lastName 62",\n    "age": 75,\n    "id": 53,\n    "addressId": 50,\n    "firmId": 70\n  }\n}';
+            }#,
+          connection_2:
+            Reference
+            #{
+              testServiceStoreTestSuites::TestData2
+            }#
+        ]
+      ]
+      tests:
+      [
+        test1:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'QA1','UAT'
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 85\\",\\"firmId\\":78,\\"ceoId\\":40,\\"addressId\\":78,\\"employees\\":{\\"firstName\\":\\"firstName 52\\",\\"lastName\\":\\"lastName 77\\",\\"age\\":89,\\"id\\":59,\\"addressId\\":88,\\"firmId\\":49}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 99\\",\\"lastName\\":\\"lastName 62\\",\\"age\\":75,\\"id\\":53,\\"addressId\\":50,\\"firmId\\":70}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 78,\n        "ceoId" : 40,\n        "firmId" : 78,\n        "legalName" : "legalName 85"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 50,\n        "age" : 75,\n        "firmId" : 70,\n        "firstName" : "firstName 99",\n        "id" : 53,\n        "lastName" : "lastName 62"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 78,\n      "firmId" : 78,\n      "legalName" : "legalName 85x",\n      "ceoId" : 40\n    },\n    "person_tbl" : {\n      "addressId" : 50,\n      "age" : 75,\n      "firmId" : 70,\n      "firstName" : "firstName 99",\n      "id" : 53,\n      "lastName" : "lastName 62"\n    }\n  }\n}';
+                  }#;
+              }#,
+            assert2:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 85\\",\\"firmId\\":78,\\"ceoId\\":40,\\"addressId\\":78,\\"employees\\":{\\"firstName\\":\\"firstName 52\\",\\"lastName\\":\\"lastName 77\\",\\"age\\":89,\\"id\\":59,\\"addressId\\":88,\\"firmId\\":49}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 99\\",\\"lastName\\":\\"lastName 62\\",\\"age\\":75,\\"id\\":53,\\"addressId\\":50,\\"firmId\\":70}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 78,\n        "ceoId" : 40,\n        "firmId" : 78,\n        "legalName" : "legalName 85"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 50,\n        "age" : 75,\n        "firmId" : 70,\n        "firstName" : "firstName 99",\n        "id" : 53,\n        "lastName" : "lastName 62"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 78,\n      "firmId" : 78,\n      "legalName" : "legalName 85x",\n      "ceoId" : 40\n    },\n    "person_tbl" : {\n      "addressId" : 50,\n      "age" : 75,\n      "firmId" : 70,\n      "firstName" : "firstName 99",\n      "id" : 53,\n      "lastName" : "lastName 62"\n    }\n  }\n}';
+                  }#;
+              }#,
+            assert3:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 85\\",\\"firmId\\":78,\\"ceoId\\":40,\\"addressId\\":78,\\"employees\\":{\\"firstName\\":\\"firstName 52\\",\\"lastName\\":\\"lastName 77\\",\\"age\\":89,\\"id\\":59,\\"addressId\\":88,\\"firmId\\":49}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 99\\",\\"lastName\\":\\"lastName 62\\",\\"age\\":75,\\"id\\":53,\\"addressId\\":50,\\"firmId\\":70}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 78,\n        "ceoId" : 40,\n        "firmId" : 78,\n        "legalName" : "legalName 85"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 50,\n        "age" : 75,\n        "firmId" : 70,\n        "firstName" : "firstName 99",\n        "id" : 53,\n        "lastName" : "lastName 62"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 78,\n      "firmId" : 78,\n      "legalName" : "legalName 85x",\n      "ceoId" : 40\n    },\n    "person_tbl" : {\n      "addressId" : 50,\n      "age" : 75,\n      "firmId" : 70,\n      "firstName" : "firstName 99",\n      "id" : 53,\n      "lastName" : "lastName 62"\n    }\n  }\n}';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithTestKeys1.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithTestKeys1.pure
@@ -1,0 +1,95 @@
+###Service
+Service testModelStoreTestSuites::service::DocM2MService
+{
+  pattern: '/testModelStoreTestSuites/service';
+  owners:
+  [
+    'dummy',
+    'dummy1'
+  ];
+  documentation: 'Service to test refiner flow';
+  autoActivateUpdates: true;
+  execution: Multi
+  {
+    query: |testModelStoreTestSuites::model::Doc.all()->graphFetchChecked(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#)->serialize(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#);
+    key: 'env';
+    executions['QA']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
+    }
+    executions['UAT']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
+    }
+  }
+  testSuites:
+  [
+    testSuite1:
+    {
+      data:
+      [
+        connections:
+        [
+          connection_1:
+            Reference
+            #{
+              testServiceStoreTestSuites::TestData
+            }#,
+          connection_2:
+            Reference
+            #{
+              testServiceStoreTestSuites::TestData2
+            }#
+        ]
+      ]
+      tests:
+      [
+        test1:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'QA'
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 18\\",\\"firmId\\":22,\\"ceoId\\":49,\\"addressId\\":88,\\"employees\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 2\\",\\"age\\":14,\\"id\\":52,\\"addressId\\":83,\\"firmId\\":73}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 4\\",\\"age\\":98,\\"id\\":87,\\"addressId\\":46,\\"firmId\\":26}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 88,\n        "ceoId" : 49,\n        "firmId" : 22,\n        "legalName" : "legalName 18"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 46,\n        "age" : 98,\n        "firmId" : 26,\n        "firstName" : "firstName 69",\n        "id" : 87,\n        "lastName" : "lastName 4"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 88,\n      "firmId" : 22,\n      "legalName" : "legalName 18x",\n      "ceoId" : 49\n    },\n    "person_tbl" : {\n      "addressId" : 46,\n      "age" : 98,\n      "firmId" : 26,\n      "firstName" : "firstName 69",\n      "id" : 87,\n      "lastName" : "lastName 4"\n    }\n  }\n}';
+                  }#;
+              }#
+          ]
+        },
+        test2:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'UAT'
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 18\\",\\"firmId\\":22,\\"ceoId\\":49,\\"addressId\\":88,\\"employees\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 2\\",\\"age\\":14,\\"id\\":52,\\"addressId\\":83,\\"firmId\\":73}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 4\\",\\"age\\":98,\\"id\\":87,\\"addressId\\":46,\\"firmId\\":26}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 88,\n        "ceoId" : 49,\n        "firmId" : 22,\n        "legalName" : "legalName 18"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 46,\n        "age" : 98,\n        "firmId" : 26,\n        "firstName" : "firstName 69",\n        "id" : 87,\n        "lastName" : "lastName 4"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 88,\n      "firmId" : 22,\n      "legalName" : "legalName 18x",\n      "ceoId" : 49\n    },\n    "person_tbl" : {\n      "addressId" : 46,\n      "age" : 98,\n      "firmId" : 26,\n      "firstName" : "firstName 69",\n      "id" : 87,\n      "lastName" : "lastName 4"\n    }\n  }\n}';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one/more labels.
--> Feature Development

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> Adding a new component to Service Grammar, specifically inside Service Test Block for MultiExecution

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # Issues where User faces inability to run tests for incomplete environments when wishing to test some environments only

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> Yes, user will be able to select env keys for each test in multiexec services
