### PR TITLE
Update large runner release flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build + Test
         if: (github.repository != 'finos/legend-engine') || (github.ref != 'refs/heads/master')
-        run: mvn install javadoc:javadoc -DargLine="-Xmx2200m"
+        run: mvn -B -e install javadoc:javadoc -DargLine="-Xmx2200m"
 
       - name: Build + Test + Maven Deploy + Sonar + Docker Snapshot
         if: (github.repository == 'finos/legend-engine') && (github.ref == 'refs/heads/master')
@@ -76,8 +76,8 @@ jobs:
           DOCKER_USERNAME: finos
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-          mvn install -DskipTests=true
-          mvn javadoc:javadoc deploy -DargLine="-Xmx2200m" -P docker-snapshot
+          mvn -B -e install -DskipTests=true
+          mvn -B -e javadoc:javadoc deploy -DargLine="-Xmx2200m" -P docker-snapshot
 
       - name: Upload Test Results
         if: always()

--- a/.github/workflows/release-large-runner.yml
+++ b/.github/workflows/release-large-runner.yml
@@ -64,7 +64,7 @@ jobs:
           echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
 
       - name: Prepare release
-        run: mvn -B -e release:prepare -DpreparationGoals=clean -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+        run: mvn -B -e release:prepare -Darguments='-B -e' -DpreparationGoals=clean -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
 
       - name: Perform release
-        run: mvn -B -e -T 4 release:perform -Darguments='-DargLine="-Xmx12g"' -P release,docker
+        run: mvn -B -e release:perform -Darguments='-B -e -T 4 -DargLine="-Xmx12g"' -P release,docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
 
       - name: Prepare release
-        run: mvn -B release:prepare -DpreparationGoals=clean -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+        run: mvn -B -e release:prepare -Darguments='-B -e' -DpreparationGoals=clean -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
 
       - name: Perform release
-        run: mvn -B release:perform -Darguments='-DargLine="-Xmx2200m"' -P release,docker
+        run: mvn -B -e release:perform -Darguments='-B -e -DargLine="-Xmx2200m"' -P release,docker


### PR DESCRIPTION
#### What type of PR is this?

This PR moves the flags for setting a maven build to use 4 threads.

#### What does this PR do / why is it needed ?

This change is necessary to allow the process that's forked by the release:perform command to execute a maven build with multiple threads.
