### PR TITLE
Throw warnings for incompatible types in relational property mappings

### DIFF
--- a/legend-engine-xt-relationalStore-grammar/pom.xml
+++ b/legend-engine-xt-relationalStore-grammar/pom.xml
@@ -159,6 +159,13 @@
         </dependency>
         <!-- ANTLR -->
 
+        <!-- LOGGING -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <!-- LOGGING -->
+
         <!-- ECLIPSE COLLECTIONS -->
         <dependency>
             <groupId>org.eclipse.collections</groupId>

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -175,15 +175,20 @@ import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.slf4j.Logger;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
+import static org.finos.legend.pure.generated.core_relational_relational_relationalMappingExecution.Root_meta_relational_mapping_getIncompatibleTypesInRelationalPropertyMapping_RelationalPropertyMapping_$0_1$__Pair_$0_1$_;
+
 public class HelperRelationalBuilder
 {
     private static final String DEFAULT_SCHEMA_NAME = "default";
     private static final String SELF_JOIN_TABLE_NAME = "{target}";
+
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(HelperRelationalBuilder.class);
 
     private static final Predicate2<Schema, Object> SCHEMA_NAME_PREDICATE = Predicates2.attributeEqual(SchemaAccessor::_name);
     private static final Predicate2<RelationalOperationElement, Object> COLUMN_NAME_PREDICATE = Predicates2.attributeEqual(column -> ((Column) column)._name());
@@ -961,6 +966,20 @@ public class HelperRelationalBuilder
             Assert.assertTrue(eMap != null, () -> "Can't find enumeration mapping '" + propertyMapping.enumMappingId + "'");
             res = res._transformer(eMap);
         }
+        try
+        {
+            Pair<String, String> incompatiblePropertyMappingTypes = (Pair<String, String>) Root_meta_relational_mapping_getIncompatibleTypesInRelationalPropertyMapping_RelationalPropertyMapping_$0_1$__Pair_$0_1$_(res, context.pureModel.getExecutionSupport());
+
+            if (incompatiblePropertyMappingTypes != null)
+            {
+                context.pureModel.addWarnings(Lists.mutable.with(new Warning(SourceInformationHelper.fromM3SourceInformation(res.getSourceInformation()), "Types of class property: " + incompatiblePropertyMappingTypes._first() + " and its mapped relational property: " + incompatiblePropertyMappingTypes._second() + " are incompatible")));
+            }
+        }
+        catch (Exception exception)
+        {
+            LOGGER.warn("Ignored exception: ", exception.getMessage());
+        }
+
         return res;
     }
 

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -968,16 +968,16 @@ public class HelperRelationalBuilder
         }
         try
         {
-            Pair<String, String> incompatiblePropertyMappingTypes = (Pair<String, String>) Root_meta_relational_mapping_getIncompatibleTypesInRelationalPropertyMapping_RelationalPropertyMapping_$0_1$__Pair_$0_1$_(res, context.pureModel.getExecutionSupport());
+            Pair<Type, Type> incompatiblePropertyMappingTypes = (Pair<Type, Type>) Root_meta_relational_mapping_getIncompatibleTypesInRelationalPropertyMapping_RelationalPropertyMapping_$0_1$__Pair_$0_1$_(res, context.pureModel.getExecutionSupport());
 
             if (incompatiblePropertyMappingTypes != null)
             {
-                context.pureModel.addWarnings(Lists.mutable.with(new Warning(SourceInformationHelper.fromM3SourceInformation(res.getSourceInformation()), "Types of class property: " + incompatiblePropertyMappingTypes._first() + " and its mapped relational property: " + incompatiblePropertyMappingTypes._second() + " are incompatible")));
+                context.pureModel.addWarnings(Lists.mutable.with(new Warning(SourceInformationHelper.fromM3SourceInformation(res.getSourceInformation()), "Type of class property \"" + res._property()._name() + "\" i.e " + incompatiblePropertyMappingTypes._first()._name() + " is incompatible with it's mapped relational property type i.e " + incompatiblePropertyMappingTypes._second()._name())));
             }
         }
         catch (Exception exception)
         {
-            LOGGER.warn("Ignored exception: ", exception.getMessage());
+            LOGGER.warn("Ignored exception: ", exception);
         }
 
         return res;

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -435,6 +435,67 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
 
 
     @Test
+    public void testCompareTypesInRelationalPropertyMapping()
+    {
+        test("Class model::Person {\n" +
+                "   name:String[1];\n" +
+                "}\n" +
+                "###Relational\n" +
+                "Database model::store::db\n" +
+                "(\n" +
+                "   Table myTable(name2 int)\n" +
+                ")\n" +
+                "###Mapping\n" +
+                "Mapping \n" +
+                "model::mapping::myMap\n" +
+                "(\n" +
+                "   model::Person: Relational\n" +
+                "   {\n" +
+                "      name : [model::store::db]myTable.name2\n" +
+                "   }\n" +
+                ")", null, Arrays.asList("COMPILATION error at [15:12-44]: Types of class property: String and its mapped relational property: Integer are incompatible")
+        );
+
+        test("Class model::Person {\n" +
+                "   name:Boolean[1];\n" +
+                "}\n" +
+                "###Relational\n" +
+                "Database model::store::db\n" +
+                "(\n" +
+                "   Table myTable(name2 varchar(200))\n" +
+                ")\n" +
+                "###Mapping\n" +
+                "Mapping \n" +
+                "model::mapping::myMap\n" +
+                "(\n" +
+                "   model::Person: Relational\n" +
+                "   {\n" +
+                "      name : [model::store::db]myTable.name2\n" +
+                "   }\n" +
+                ")", null, Arrays.asList("COMPILATION error at [15:12-44]: Types of class property: Boolean and its mapped relational property: String are incompatible")
+        );
+
+        test("Class model::Person {\n" +
+                "   name:String[1];\n" +
+                "}\n" +
+                "###Relational\n" +
+                "Database model::store::db\n" +
+                "(\n" +
+                "   Table myTable(name2 varchar(200))\n" +
+                ")\n" +
+                "###Mapping\n" +
+                "Mapping \n" +
+                "model::mapping::myMap\n" +
+                "(\n" +
+                "   model::Person: Relational\n" +
+                "   {\n" +
+                "      name : [model::store::db]myTable.name2\n" +
+                "   }\n" +
+                ")",null, Arrays.asList()
+        );
+    }
+
+    @Test
     public void testRelationalMapping()
     {
         test("Class simple::Person\n" +

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -453,7 +453,7 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
                 "   {\n" +
                 "      name : [model::store::db]myTable.name2\n" +
                 "   }\n" +
-                ")", null, Arrays.asList("COMPILATION error at [15:12-44]: Types of class property: String and its mapped relational property: Integer are incompatible")
+                ")", null, Arrays.asList("COMPILATION error at [15:12-44]: Type of class property \"name\" i.e String is incompatible with it's mapped relational property type i.e Integer")
         );
 
         test("Class model::Person {\n" +
@@ -472,7 +472,7 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
                 "   {\n" +
                 "      name : [model::store::db]myTable.name2\n" +
                 "   }\n" +
-                ")", null, Arrays.asList("COMPILATION error at [15:12-44]: Types of class property: Boolean and its mapped relational property: String are incompatible")
+                ")", null, Arrays.asList("COMPILATION error at [15:12-44]: Type of class property \"name\" i.e Boolean is incompatible with it's mapped relational property type i.e String")
         );
 
         test("Class model::Person {\n" +

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
@@ -119,6 +119,31 @@ function meta::relational::mapping::generateInstantiationExecutionNode(sq:meta::
    ]);
 }
 
+function meta::relational::mapping::getIncompatibleTypesInRelationalPropertyMapping(r:RelationalPropertyMapping[0..1]):Pair<Type, Type>[0..1]
+{
+  let classPropertyPureType = $r.property.genericType.rawType;
+  $classPropertyPureType->match([
+      p:PrimitiveType[1] | 
+         let ropType = meta::relational::mapping::getRelationalTypeFromRelationalPropertyMapping($r, '');
+         let ropCompatiblePureType = if($ropType->isEmpty(),
+            | []
+           ,| dataTypeToCompatiblePureType($ropType->toOne());
+           );
+
+         let ropCompatiblePureTypeGeneralizations = if($ropCompatiblePureType->isEmpty(),
+            | [] 
+           ,| $ropCompatiblePureType->toOne()->meta::pure::functions::meta::getAllTypeGeneralisations();
+           );
+
+         if($p->isEmpty() || $ropCompatiblePureType->isEmpty() || 
+            $ropCompatiblePureTypeGeneralizations->filter(f| $f != Any)->exists(m|$p->toOne()->_subTypeOf($m)), 
+            |[],
+            |^Pair<Type, Type>(first = $p->toOne(), second = $ropCompatiblePureType->toOne() ));,
+      a:Any[0..1] | 
+         []
+   ]);
+}
+
 function <<access.private>> meta::relational::mapping::getRelationalTypeFromRelationalPropertyMapping(r:RelationalPropertyMapping[0..1], propertyName:String[1]):meta::relational::metamodel::datatype::DataType[0..1]
 {
 

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testRelationalExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testRelationalExtension.pure
@@ -176,10 +176,28 @@ Class meta::relational::tests::runtime::extractDBs::SubstitutionTestClass1
    prop1: Integer[1];
 }
 
+Class meta::relational::tests::runtime::extractDBs::TestClassWithBoolProperty
+{
+   prop1: Boolean[1];
+}
+
+Class meta::relational::tests::runtime::extractDBs::TestClassWithDateProperty
+{
+   prop1: Date[1];
+}
+
 ###Relational
 Database meta::relational::tests::runtime::extractDBs::SubstitutionTestDB1_Inc
 (
    Table testTable1(prop1 INT)
+)
+
+###Relational
+Database meta::relational::tests::runtime::extractDBs::TestDifferentTypesDB
+(
+   Table testTableFloat(prop1 FLOAT)
+   Table testTableTimestamp(prop1 TIMESTAMP)
+   Table testTableBit(prop1 BIT)
 )
 
 ###Relational
@@ -196,10 +214,62 @@ Mapping meta::relational::tests::runtime::extractDBs::SubstitutionTestMappingLev
    }
 )
 
+Mapping meta::relational::tests::runtime::extractDBs::TestIntFloatPropertyMapping
+(
+   meta::relational::tests::runtime::extractDBs::SubstitutionTestClass1 : Relational {
+      prop1: [meta::relational::tests::runtime::extractDBs::TestDifferentTypesDB]testTableFloat.prop1
+   }
+)
+
+Mapping meta::relational::tests::runtime::extractDBs::TestDateTimestampPropertyMapping
+(
+   meta::relational::tests::runtime::extractDBs::TestClassWithDateProperty : Relational {
+      prop1: [meta::relational::tests::runtime::extractDBs::TestDifferentTypesDB]testTableTimestamp.prop1
+   }
+)
+
+Mapping meta::relational::tests::runtime::extractDBs::TestBooleanBitPropertyMapping
+(
+   meta::relational::tests::runtime::extractDBs::TestClassWithBoolProperty : Relational {
+      prop1: [meta::relational::tests::runtime::extractDBs::TestDifferentTypesDB]testTableBit.prop1
+   }
+)
+
 ###Pure
 function <<test.Test>> meta::relational::tests::runtime::extractDBs::testExtractDBsWithSubstituition():Boolean[1]
 {
    let dbs = meta::relational::tests::runtime::extractDBs::SubstitutionTestMappingLevel1->meta::relational::runtime::extractDBs();
    assertSize($dbs, 1);
    assert($dbs->at(0) == meta::relational::tests::runtime::extractDBs::SubstitutionTestDB1);
+}
+
+function <<test.Test>> meta::relational::tests::runtime::extractDBs::testAssertCompatibleTypesInRelationalPropertyMapping():Boolean[1]
+{
+  //Test compatibility of int and float in relational property mapping
+  assert(meta::relational::tests::runtime::extractDBs::TestIntFloatPropertyMapping.classMappings
+  ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation).propertyMappings->at(0)
+  ->cast(@meta::relational::mapping::RelationalPropertyMapping)->meta::relational::mapping::getIncompatibleTypesInRelationalPropertyMapping()->isEmpty());
+   
+  //Test compatibility of date and timestamp in relational property mapping
+  assert(meta::relational::tests::runtime::extractDBs::TestDateTimestampPropertyMapping.classMappings
+  ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation).propertyMappings->at(0)
+  ->cast(@meta::relational::mapping::RelationalPropertyMapping)->meta::relational::mapping::getIncompatibleTypesInRelationalPropertyMapping()->isEmpty());
+  
+  //Test compatibility of boolean and bit in relational  property mapping
+  assert(meta::relational::tests::runtime::extractDBs::TestBooleanBitPropertyMapping.classMappings
+  ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation).propertyMappings->at(0)
+  ->cast(@meta::relational::mapping::RelationalPropertyMapping)->meta::relational::mapping::getIncompatibleTypesInRelationalPropertyMapping()->isEmpty());
+
+  //Test compatibility of join in relational property mapping
+  assert(meta::relational::tests::caseSentitiveMapping
+  .rootClassMappingByClass(meta::relational::tests::model::simple::Firm)->toOne()
+  ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation).propertyMappingsByPropertyName('employees')->at(0)
+  ->cast(@meta::relational::mapping::RelationalPropertyMapping)->meta::relational::mapping::getIncompatibleTypesInRelationalPropertyMapping()->isEmpty());
+
+  //Test compatibility of enumeration in relational property mapping
+  assert(meta::relational::tests::mapping::enumeration::model::mapping::employeeTestMapping2
+  .rootClassMappingByClass(meta::relational::tests::mapping::enumeration::model::domain::Employee)->toOne()
+  ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation).propertyMappingsByPropertyName('type')->at(0)
+  ->cast(@meta::relational::mapping::RelationalPropertyMapping)->meta::relational::mapping::getIncompatibleTypesInRelationalPropertyMapping()->isEmpty());
+
 }


### PR DESCRIPTION
What type of PR is this?
New feature

What does this PR do / why is it needed ?
It adds compilation check for incompatible type is mapping

Which issue(s) this PR fixes:
Fixes #

Other notes for reviewers:
Does this PR introduce a user-facing change?
yes