### PR TITLE
prevent overriding of generated milestoning date properties

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/Milestoning.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/Milestoning.java
@@ -476,6 +476,18 @@ public class Milestoning
         return p -> p._stereotypes().anySatisfy(s -> s._value().equals(GeneratedMilestoningStereotype.generatedmilestoningproperty.name()));
     }
 
+    public static MutableList<Property<?, ?>> restrictedMilestoningProperties(Class _class, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Class srcClass, MutableList<Property<?, ?>> properties, PureModel pureModel)
+    {
+        MilestoningStereotype ms = Milestoning.temporalStereotypes(_class._stereotypes());
+        if (ms != null)
+        {
+            MutableList<Property<?, ?>> restrictedMilestoningProperties = properties.select(p -> ms.getTemporalDatePropertyNames().contains(p.getName()));
+            pureModel.addWarnings(!restrictedMilestoningProperties.isEmpty() ? Lists.mutable.with(new Warning(srcClass.sourceInformation, "Class " + pureModel.buildPackageString(srcClass._package, srcClass.name) + " has temporal specification: [" + ms.getPurePlatformStereotypeName() + "] properties: " + ms.getTemporalDatePropertyNames().toString() + " are reserved and should not be explicit in the Model")) : Lists.immutable.empty());
+            return restrictedMilestoningProperties;
+        }
+        return Lists.mutable.empty();
+    }
+
     public static MilestoningStereotype temporalStereotypes(RichIterable<? extends Stereotype> stereotypes)
     {
         List<MilestoningStereotype> milestoningStereotypes = ArrayIterate.select(MilestoningStereotypeEnum.values(), e -> stereotypes.anySatisfy(s -> s._value().equals(e.getPurePlatformStereotypeName())));

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
@@ -116,7 +116,8 @@ public class PackageableElementSecondPassBuilder implements PackageableElementVi
         });
 
         MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?>> properties = ListIterate.collect(srcClass.properties, HelperModelBuilder.processProperty(this.context, _classGenericType, _class));
-        MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?>> withMilestoningProperties = properties.withAll(Milestoning.generateMilestoningProperties(_class, this.context));
+        MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?>> restrictedMilestoningProperties = Milestoning.restrictedMilestoningProperties(_class, srcClass, properties, this.context.pureModel);
+        MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?>> withMilestoningProperties = properties.select(p -> !restrictedMilestoningProperties.contains(p)).withAll(Milestoning.generateMilestoningProperties(_class, this.context));
 
         ProcessingContext ctx = new ProcessingContext("Class '" + this.context.pureModel.buildPackageString(srcClass._package, srcClass.name) + "' Second Pass");
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification thisVariable = HelperModelBuilder.createThisVariableForClass(this.context, this.context.pureModel.buildPackageString(srcClass._package, srcClass.name));

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -16,9 +16,11 @@ package org.finos.legend.engine.language.pure.compiler.test.fromGrammar;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.test.TestCompilationFromGrammar;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.Milestoning;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
@@ -28,10 +30,12 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Concre
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.SimpleFunctionExpression;
 import org.junit.Assert;
@@ -2251,6 +2255,74 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty> singleDateQPWithArgAndNoArg = collectionsQPs.select(p -> p.getName().equals("productType"));
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty singleDateQP = singleDateQPWithArgAndNoArg.getFirst();
         Assert.assertTrue("The productType property for Class in my::domainModel::migration::test::product::Classification _qualifiedProperties should contain one argument for Date", ((Root_meta_pure_metamodel_type_FunctionType_Impl) singleDateQP._classifierGenericType()._typeArguments().getFirst()._rawType())._parameters.size() == 2);
+    }
+
+    @Test
+    public void testMilestoningSimplePropertiesAreNotOverridenByUserProperties()
+    {
+        String grammar = "###Pure\n" +
+                "Class <<temporal.processingtemporal>> test::ProcessingTemporalAddress\n" +
+                "{\n" +
+                "  processingDate: Date[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class <<temporal.businesstemporal>> test::BusinessTemporalAddress\n" +
+                "{\n" +
+                "  businessDate: Date[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class <<temporal.bitemporal>> test::BiTemporalAddress\n" +
+                "{\n" +
+                "  processingDate: Date[1];\n" +
+                "  businessDate: Date[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::Person\n" +
+                "{\n" +
+                "  processingTemporalAddress : test::ProcessingTemporalAddress[1];\n" +
+                "  businessTemporalAddress : test::BusinessTemporalAddress[1];\n" +
+                "  biTemporalAddress : test::BiTemporalAddress[1];\n" +
+                "}";
+        PureModel pm = test(grammar, null, Lists.mutable.with(
+                "COMPILATION error at [2:1-5:1]: Class test::ProcessingTemporalAddress has temporal specification: [processingtemporal] properties: [processingDate] are reserved and should not be explicit in the Model",
+                "COMPILATION error at [7:1-10:1]: Class test::BusinessTemporalAddress has temporal specification: [businesstemporal] properties: [businessDate] are reserved and should not be explicit in the Model",
+                "COMPILATION error at [12:1-16:1]: Class test::BiTemporalAddress has temporal specification: [bitemporal] properties: [processingDate, businessDate] are reserved and should not be explicit in the Model"
+
+        )).getTwo();
+
+        java.util.function.Function<Property, Boolean> isGeneratedMilestoningProperty = p -> p._stereotypes().anySatisfy(s -> s._value().equals(Milestoning.GeneratedMilestoningStereotype.generatedmilestoningdateproperty.name()));
+
+        Property processingDateProperty = pm.getClass("test::ProcessingTemporalAddress")._properties().select(p -> p.getName().equals("processingDate")).getOnly();
+        Property businessDateProperty = pm.getClass("test::BusinessTemporalAddress")._properties().select(p -> p.getName().equals("businessDate")).getOnly();
+
+        Assert.assertTrue(isGeneratedMilestoningProperty.apply(processingDateProperty));
+        Assert.assertTrue(isGeneratedMilestoningProperty.apply(businessDateProperty));
+        RichIterable<? extends QualifiedProperty<?>> personQualifiedProperties = pm.getClass("test::Person")._qualifiedProperties();
+
+        boolean classProcessingDatePropertyIsUsedInMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(processingDateProperty, personQualifiedProperties.detect(p -> p.getName().equals("processingTemporalAddress")));
+        boolean classBusinessPropertyIsUsedInMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(businessDateProperty, personQualifiedProperties.detect(p -> p.getName().equals("businessTemporalAddress")));
+        Assert.assertTrue("Class generated milestoning processingDate property should be used in the generated milestoning expression", classProcessingDatePropertyIsUsedInMiletoningExpression);
+        Assert.assertTrue("Class generated milestoning businessDate property should be used in the generated milestoning expression", classBusinessPropertyIsUsedInMiletoningExpression);
+
+        RichIterable<? extends Property<?, ?>> biTemporalMilestoningDateProperties = pm.getClass("test::BiTemporalAddress")._properties().select(p -> Arrays.asList("businessDate", "processingDate").contains(p.getName()));
+        Assert.assertTrue(biTemporalMilestoningDateProperties.size() == 2 && biTemporalMilestoningDateProperties.anySatisfy(p -> p.getName().equals("businessDate")) && biTemporalMilestoningDateProperties.anySatisfy(p -> p.getName().equals("processingDate")));
+        Assert.assertTrue(biTemporalMilestoningDateProperties.allSatisfy(p -> isGeneratedMilestoningProperty.apply(p)));
+        boolean classProcessingDatePropertyIsUsedInBiTemporalMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(biTemporalMilestoningDateProperties.detect(p -> p.getName().equals("processingDate")), personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress")));
+        boolean classBusinessPropertyIsUsedInBiTemporalMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(biTemporalMilestoningDateProperties.detect(p -> p.getName().equals("businessDate")), personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress")));
+        Assert.assertTrue("Class generated milestoning processingDate property should be used in the generated milestoning expression", classProcessingDatePropertyIsUsedInBiTemporalMiletoningExpression);
+        Assert.assertTrue("Class generated milestoning businessDate property should be used in the generated milestoning expression", classBusinessPropertyIsUsedInBiTemporalMiletoningExpression);
+    }
+
+    private boolean generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(Property generatedMilestoningClassSimpleProperty, QualifiedProperty generatedMilestoningClassQualifiedProperty)
+    {
+        FunctionExpression topLevelExpression = (FunctionExpression) ((LambdaFunction) ((InstanceValue) ((FunctionExpression) generatedMilestoningClassQualifiedProperty._expressionSequence().getFirst())._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
+        if (topLevelExpression._func()._functionName().equals("and"))
+        {
+            int idx = generatedMilestoningClassSimpleProperty.getName().equals("processingDate") ? 0 : 1;
+            topLevelExpression = (FunctionExpression) topLevelExpression._parametersValues().toList().get(idx);
+        }
+        Property filterMilestoningDateProperty = (Property) ((FunctionExpression) topLevelExpression._parametersValues().toList().get(0))._func();
+        return generatedMilestoningClassSimpleProperty.equals(filterMilestoningDateProperty);
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

Ensure that generated milestoning simple Date properties are not overriden by users. In addition, provides warnings to users in this scenario.

#### What does this PR do / why is it needed ?

The generated properties have associated stereotypes which impact relational processing, when the properties are overriden it changes the relational milestoning functionality.

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes, users will now see Warnings when they use property names which conflict with the milestoning ones i.e. processingDate and businessDate