### PR TITLE
Support nested sequence node on java binding

### DIFF
--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/bindPlanToLegendJavaPlatform.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/bindPlanToLegendJavaPlatform.pure
@@ -80,7 +80,8 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::legendJa
             g:GlobalGraphFetchExecutionNode[1]       | $g->prepareForGlobalGraphFetchNode($path, $updatedContextForChildren, $debug),
             p:PureExpressionPlatformExecutionNode[1] | $p->prepareForPlatformNode($path, $updatedContextForChildren, $extensions, $debug),
             p:PlatformMergeExecutionNode[1]          | $p->prepareForPlatformMergeNode($path, $updatedContextForChildren, $extensions, $debug),
-            p:PlatformUnionExecutionNode[1]          | $p->prepareForPlatformUnionNode($path, $updatedContextForChildren, $extensions, $debug),      
+            p:PlatformUnionExecutionNode[1]          | $p->prepareForPlatformUnionNode($path, $updatedContextForChildren, $extensions, $debug),
+            s:SequenceExecutionNode[1]               | $s->prepareForSequenceNode($path, $updatedContextForChildren, $debug),
             e:ExecutionNode[1]                       | $updatedContextForChildren
          ])
    );

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchCommon.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchCommon.pure
@@ -50,6 +50,15 @@ function meta::pure::executionPlan::engine::java::graphFetch::common::prepareFor
    )
 }
 
+function meta::pure::executionPlan::engine::java::graphFetch::common::prepareForSequenceNode(node: SequenceExecutionNode[1], path: String[1], context:GenerationContext[1], debug:DebugContext[1]):GenerationContext[1]
+{
+   let lastOnSequence = $context->childNodeInfosForPath($path)->last();
+   if($lastOnSequence->isEmpty(),
+       |$context,
+       |^$context(nodeInfos = $context.nodeInfos->concatenate(^NodeInfo(path = $path, returnType = $lastOnSequence->toOne().returnType, graphFetchTrees = $lastOnSequence->toOne().graphFetchTrees)))
+   );
+}
+
 function meta::pure::executionPlan::engine::java::graphFetch::common::localGraphFetchNodePathPrefix():String[1]
 {
    '.localGraph'

--- a/legend-engine-xt-relationalStore-javaPlatformBinding-pure/src/main/resources/core_relational_java_platform_binding/legendJavaPlatformBinding/executionPlanTest.pure
+++ b/legend-engine-xt-relationalStore-javaPlatformBinding-pure/src/main/resources/core_relational_java_platform_binding/legendJavaPlatformBinding/executionPlanTest.pure
@@ -126,7 +126,136 @@ function <<test.Test>> meta::relational::executionPlan::platformBinding::legendJ
    assertEquals($expectedJava, $withJava->planToString(meta::relational::extension::relationalExtensions()));
 }
 
+function <<test.Test>> meta::relational::executionPlan::platformBinding::legendJava::tests::withNestedSequenceNode() : Boolean[1]
+{
+   let tree = #{
+      meta::relational::graphFetch::tests::chain::Target_Firm {
+         firmName,
+         employeeCount
+      }
+   }#;
+   
+   let query = {|meta::relational::graphFetch::tests::chain::Target_Firm.all()->graphFetch($tree)->serialize($tree)};
+  
+   let modelChainConnection = ^meta::pure::mapping::modelToModel::ModelChainConnection(
+      element = ^meta::pure::mapping::modelToModel::ModelStore(),
+      mappings = [meta::relational::tests::simpleRelationalMapping]
+   );
+   let runtime = ^meta::pure::runtime::Runtime(
+      connections = meta::relational::tests::testRuntime().connections->concatenate($modelChainConnection)
+   );
 
+   let res = meta::pure::executionPlan::executionPlan($query, meta::relational::graphFetch::tests::chain::M2M_Mapping, $runtime, meta::relational::extension::relationalExtensions());
+
+   let root = $res.rootExecutionNode->cast(@PureExpressionPlatformExecutionNode);
+   let globalGraphFetch = $root.executionNodes->toOne()->cast(@GlobalGraphFetchExecutionNode);
+   let localGraphFetch = $globalGraphFetch.localGraphFetchExecutionNode;
+
+   let newLocalGraphFetchWithSequence = ^$localGraphFetch(executionNodes = ^SequenceExecutionNode(executionNodes = $localGraphFetch.executionNodes, resultType = $localGraphFetch.executionNodes->last()->toOne().resultType));
+   let newGlobalGraphFetchWithSequence = ^$globalGraphFetch(localGraphFetchExecutionNode = $newLocalGraphFetchWithSequence);
+   let newRoot = ^$root(executionNodes = $newGlobalGraphFetchWithSequence);
+
+   let plan = ^$res(rootExecutionNode = $newRoot);  
+
+   let expected =
+    'PureExp\n'+
+    '(\n'+
+    '  type = String\n'+
+    '  expression =  -> serialize(#{meta::relational::graphFetch::tests::chain::Target_Firm {firmName, employeeCount}}#)\n'+
+    '  (\n'+
+    '    GlobalGraphFetch\n'+
+    '    (\n'+
+    '      type = PartialClass[impls=[(meta::relational::graphFetch::tests::chain::Target_Firm | M2M_Mapping.meta_relational_graphFetch_tests_chain_Target_Firm)], propertiesWithParameters = [employeeCount, firmName]]\n'+
+    '      resultSizeRange = *\n'+
+    '      store = MODEL\n'+
+    '      localGraphFetchExecutionNode = \n'+
+    '         InMemoryRootGraphFetch\n'+
+    '         (\n'+
+    '           type = PartialClass[impls=[(meta::relational::graphFetch::tests::chain::Target_Firm | M2M_Mapping.meta_relational_graphFetch_tests_chain_Target_Firm)], propertiesWithParameters = [employeeCount, firmName]]\n'+
+    '           graphFetchTree = [meta_relational_graphFetch_tests_chain_Target_Firm/meta::relational::graphFetch::tests::chain::Target_Firm]{@(meta_relational_graphFetch_tests_chain_Target_Firm->)@[/employeeCount],@(meta_relational_graphFetch_tests_chain_Target_Firm->)@[/firmName]}\n'+
+    '           nodeIndex = 0\n'+
+    '           batchSize = 1\n'+
+    '           checked = false\n'+
+    '           (\n'+
+    '             Sequence\n'+
+    '             (\n'+
+    '               type = PartialClass[impls=[(meta::relational::tests::model::simple::Firm | simpleRelationalMappingInc.meta_relational_tests_model_simple_Firm)], propertiesWithParameters = [employees, legalName]]\n'+
+    '               (\n'+
+    '                 GlobalGraphFetch\n'+
+    '                 (\n'+
+    '                   type = PartialClass[impls=[(meta::relational::tests::model::simple::Firm | simpleRelationalMappingInc.meta_relational_tests_model_simple_Firm)], propertiesWithParameters = [employees, legalName]]\n'+
+    '                   resultSizeRange = *\n'+
+    '                   store = meta::relational::tests::db\n'+
+    '                   localGraphFetchExecutionNode = \n'+
+    '                      RelationalGraphFetch\n'+
+    '                      (\n'+
+    '                        type = PartialClass[impls=[(meta::relational::tests::model::simple::Firm | simpleRelationalMappingInc.meta_relational_tests_model_simple_Firm)], propertiesWithParameters = [employees, legalName]]\n'+
+    '                        nodeIndex = 0\n'+
+    '                        relationalNode = \n'+
+    '                           SQL\n'+
+    '                           (\n'+
+    '                             type = meta::pure::metamodel::type::Any\n'+
+    '                             resultColumns = [("pk_0", INT), ("legalName", VARCHAR(200))]\n'+
+    '                             sql = select "root".ID as "pk_0", "root".LEGALNAME as "legalName" from firmTable as "root"\n'+
+    '                             connection = TestDatabaseConnection(type = "H2")\n'+
+    '                           )\n'+
+    '                        children = [\n'+
+    '                           RelationalGraphFetch\n'+
+    '                           (\n'+
+    '                             type = PartialClass[impls=[(meta::relational::tests::model::simple::Person | simpleRelationalMappingInc.meta_relational_tests_model_simple_Person)], propertiesWithParameters = []]\n'+
+    '                             nodeIndex = 1\n'+
+    '                             relationalNode = \n'+
+    '                                SQL\n'+
+    '                                (\n'+
+    '                                  type = meta::pure::metamodel::type::Any\n'+
+    '                                  resultColumns = [("parent_key_gen_0", INT), ("pk_0", INT)]\n'+
+    '                                  sql = select distinct "temp_table_node_0_0".pk_0 as "parent_key_gen_0", "persontable_0".ID as "pk_0" from (select * from (${temp_table_node_0}) as "root") as "temp_table_node_0_0" inner join firmTable as "root" on ("temp_table_node_0_0".pk_0 = "root".ID) left outer join personTable as "persontable_0" on ("root".ID = "persontable_0".FIRMID) where "persontable_0".ID is not null\n'+
+    '                                  connection = TestDatabaseConnection(type = "H2")\n'+
+    '                                )\n'+
+    '                             children = [\n'+
+    '                                \n'+
+    '                             ]\n'+
+    '                             implementation\n'+
+    '                             (\n'+
+    '                               calls = _pure.plan.root.n1.localGraph.n1.n1.localGraph.localChild0.Execute\n'+
+    '                             )\n'+
+    '                           )\n'+
+    '\n'+
+    '                        ]\n'+
+    '                        implementation\n'+
+    '                        (\n'+
+    '                          calls = _pure.plan.root.n1.localGraph.n1.n1.localGraph.Execute\n'+
+    '                        )\n'+
+    '                      )\n'+
+    '                   children = [\n'+
+    '                      \n'+
+    '                   ]\n'+
+    '                 )\n'+
+    '               )\n'+
+    '             )\n'+
+    '           )\n'+
+    '           children = [\n'+
+    '              \n'+
+    '           ]\n'+
+    '           implementation\n'+
+    '           (\n'+
+    '             calls = _pure.plan.root.n1.localGraph.Execute\n'+
+    '           )\n'+
+    '         )\n'+
+    '      children = [\n'+
+    '         \n'+
+    '      ]\n'+
+    '    )\n'+
+    '  )\n'+
+    '  implementation\n'+
+    '  (\n'+
+    '    calls = _pure.plan.root.Serialize\n'+
+    '  )\n'+
+    ')\n';
+
+   let withJava = $plan->generatePlatformCode(meta::pure::executionPlan::platformBinding::legendJava::legendJavaPlatformBindingId(), ^meta::pure::executionPlan::platformBinding::legendJava::LegendJavaPlatformBindingConfig(), relationalExtensionsWithLegendJavaPlatformBinding());
+   assertEquals($expected, $withJava->planToString(meta::relational::extension::relationalExtensions()));
+}
 
 function <<test.Test>> meta::relational::executionPlan::platformBinding::legendJava::tests::letVariableFunctionAdjustNow() : Boolean[1]
 {


### PR DESCRIPTION
#### What type of PR is this?

Bugfix

#### What does this PR do / why is it needed ?

Fixes bug on handle java binding of execution plans where the graph fetch node is inside a sequence node.

#### Other notes for reviewers:

N/A

#### Does this PR introduce a user-facing change?

No