### PR TITLE
Remove deprecated GraphQL API constructors

### DIFF
--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
@@ -80,25 +80,10 @@ public class GraphQLDebug extends GraphQL
 {
     private final Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> extensionsFunc;
 
-    @Deprecated
-    public GraphQLDebug(ModelManager modelManager, MetaDataServerConfiguration metadataserver)
-    {
-        this(modelManager, metadataserver, null);
-    }
-
     public GraphQLDebug(ModelManager modelManager, MetaDataServerConfiguration metadataserver, Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> extensionsFunc)
     {
         super(modelManager, metadataserver);
-
-        if (extensionsFunc != null)
-        {
-            this.extensionsFunc = extensionsFunc;
-        }
-        else
-        {
-            MutableList<PlanGeneratorExtension> planGeneratorExtensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
-            this.extensionsFunc = (PureModel pureModel) -> planGeneratorExtensions.flatCollect(e -> e.getExtraExtensions(pureModel));
-        }
+        this.extensionsFunc = extensionsFunc;
     }
 
     private Response generateGraphFetch(String queryClassPath, Query query, PureModel pureModel) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, JsonProcessingException

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
@@ -106,27 +106,12 @@ public class GraphQLExecute extends GraphQL
     private final MutableList<PlanTransformer> transformers;
     private final Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> extensionsFunc;
 
-    @Deprecated
-    public GraphQLExecute(ModelManager modelManager, PlanExecutor planExecutor, MetaDataServerConfiguration metadataserver, MutableList<PlanTransformer> transformers)
-    {
-        this(modelManager, planExecutor, metadataserver, null, transformers);
-    }
-
     public GraphQLExecute(ModelManager modelManager, PlanExecutor planExecutor, MetaDataServerConfiguration metadataserver, Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> extensionsFunc, MutableList<PlanTransformer> transformers)
     {
         super(modelManager, metadataserver);
         this.planExecutor = planExecutor;
         this.transformers = transformers;
-
-        if (extensionsFunc != null)
-        {
-            this.extensionsFunc = extensionsFunc;
-        }
-        else
-        {
-            MutableList<PlanGeneratorExtension> planGeneratorExtensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
-            this.extensionsFunc = (PureModel pureModel) -> planGeneratorExtensions.flatCollect(e -> e.getExtraExtensions(pureModel));
-        }
+        this.extensionsFunc = extensionsFunc;
     }
 
     private Response generateQueryPlans(String queryClassPath, String mappingPath, Query query, PureModel pureModel) throws IOException

--- a/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLAPI.java
+++ b/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLAPI.java
@@ -183,78 +183,11 @@ public class TestGraphQLAPI
     }
 
     @Test
-    @Deprecated
-    public void testGraphQLExecuteDevAPIDeprecated() throws Exception
-    {
-        ModelManager modelManager = new ModelManager(DeploymentMode.TEST);
-        PlanExecutor executor = PlanExecutor.newPlanExecutorWithAvailableStoreExecutors();
-        GraphQLExecute graphQLExecute = new GraphQLExecute(modelManager, executor, metaDataServerConfiguration, Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class)).flatCollect(PlanGeneratorExtension::getExtraPlanTransformers));
-        HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(mockRequest.getCookies()).thenReturn(new Cookie[0]);
-        Query query = new Query();
-        query.query = "query Query {\n" +
-                "  allFirms {\n" +
-                "      legalName,\n" +
-                "      employees {\n" +
-                "        firstName,\n" +
-                "        lastName\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }";
-        Response response = graphQLExecute.executeDev(mockRequest, "Project1", "Workspace1", "simple::model::Query", "simple::mapping::Map", "simple::runtime::Runtime", query, null);
-
-        String expected = "{" +
-                    "\"data\":{" +
-                        "\"allFirms\":[" +
-                            "{\"legalName\":\"Firm X\",\"employees\":[{\"firstName\":\"Peter\",\"lastName\":\"Smith\"},{\"firstName\":\"John\",\"lastName\":\"Johnson\"},{\"firstName\":\"John\",\"lastName\":\"Hill\"},{\"firstName\":\"Anthony\",\"lastName\":\"Allen\"}]}," +
-                            "{\"legalName\":\"Firm A\",\"employees\":[{\"firstName\":\"Fabrice\",\"lastName\":\"Roberts\"}]}," +
-                            "{\"legalName\":\"Firm B\",\"employees\":[{\"firstName\":\"Oliver\",\"lastName\":\"Hill\"},{\"firstName\":\"David\",\"lastName\":\"Harris\"}]}" +
-                        "]" +
-                    "}" +
-                "}";
-        Assert.assertEquals(expected, responseAsString(response));
-    }
-
-    @Test
     public void testGraphQLDebugGenerateGraphFetchDevAPI()
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST);
         MutableList<PlanGeneratorExtension> generatorExtensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
         GraphQLDebug graphQLDebug = new GraphQLDebug(modelManager, metaDataServerConfiguration, (pm) -> generatorExtensions.flatCollect(g -> g.getExtraExtensions(pm)));
-        HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(mockRequest.getCookies()).thenReturn(new Cookie[0]);
-        Query query = new Query();
-        query.query = "query Query {\n" +
-                "  allFirms {\n" +
-                "      legalName,\n" +
-                "      employees {\n" +
-                "        firstName,\n" +
-                "        lastName\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }";
-        Response response = graphQLDebug.generateGraphFetchDev(mockRequest, "Workspace1", "Project1", "simple::model::Query", query, null);
-        Assert.assertTrue(response.getEntity() instanceof GraphFetchResult);
-        String expected = "#{\n" +
-                "  simple::model::Query{\n" +
-                "    allFirms{\n" +
-                "      legalName,\n" +
-                "      employees{\n" +
-                "        firstName,\n" +
-                "        lastName\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}#";
-        Assert.assertEquals(expected, DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(RenderStyle.PRETTY).build().processGraphFetchTree(((GraphFetchResult) response.getEntity()).graphFetchTree, 2));
-    }
-
-    @Test
-    @Deprecated
-    public void testGraphQLDebugGenerateGraphFetchDevAPIDeprecated()
-    {
-        ModelManager modelManager = new ModelManager(DeploymentMode.TEST);
-        GraphQLDebug graphQLDebug = new GraphQLDebug(modelManager, metaDataServerConfiguration);
         HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
         Mockito.when(mockRequest.getCookies()).thenReturn(new Cookie[0]);
         Query query = new Query();


### PR DESCRIPTION
#### What type of PR is this?

Deprecated code removal

#### What does this PR do / why is it needed ?

Removing deprecated GraphQL APIs which do not take extensions as inputs

#### Does this PR introduce a user-facing change?

No