### PR TITLE
Update Maven Dependency plugin to 3.4.0

### DIFF
--- a/legend-engine-external-format-jsonSchema/pom.xml
+++ b/legend-engine-external-format-jsonSchema/pom.xml
@@ -84,15 +84,7 @@
         <!-- JACKSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
         </dependency>
         <!-- JACKSON -->
 
@@ -137,6 +129,16 @@
         <!-- PAC4J -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-external-shared-format-model/pom.xml
+++ b/legend-engine-external-shared-format-model/pom.xml
@@ -31,6 +31,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <!-- The dependency plugin analyzer raises these as false positives -->
+                    <ignoredUsedUndeclaredDependencies>
+                        <dependency>org.finos.legend.pure:legend-pure-runtime-java-extension-dsl-mapping</dependency>
+                        <dependency>org.finos.legend.pure:legend-pure-m2-dsl-mapping</dependency>
+                        <dependency>org.finos.legend.pure:legend-pure-runtime-java-engine-compiled</dependency>
+                    </ignoredUsedUndeclaredDependencies>
+                </configuration>
                 <executions>
                     <execution>
                         <id>copy-antlr-core-grammar</id>
@@ -49,18 +57,6 @@
                                     <includes>antlr/*.g4</includes>
                                 </artifactItem>
                             </artifactItems>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>dependency-analyze</id>
-                        <configuration>
-                            <!-- The dependency plugin analyzer raises these as false positives -->
-                            <ignoredUsedUndeclaredDependencies>
-                                <dependency>org.finos.legend.pure:legend-pure-runtime-java-extension-dsl-mapping
-                                </dependency>
-                                <dependency>org.finos.legend.pure:legend-pure-m2-dsl-mapping</dependency>
-                                <dependency>org.finos.legend.pure:legend-pure-runtime-java-engine-compiled</dependency>
-                            </ignoredUsedUndeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/legend-engine-language-pure-dsl-service-generation/pom.xml
+++ b/legend-engine-language-pure-dsl-service-generation/pom.xml
@@ -61,11 +61,6 @@
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
 
@@ -94,6 +89,11 @@
         <!-- JSON -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-query-pure/pom.xml
+++ b/legend-engine-query-pure/pom.xml
@@ -52,10 +52,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-language-pure-grammar</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
         </dependency>
         <dependency>
@@ -157,6 +153,11 @@
         <!-- LOG -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -62,6 +62,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>*:*</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/legend-engine-test-runner-mapping/pom.xml
+++ b/legend-engine-test-runner-mapping/pom.xml
@@ -110,6 +110,11 @@
         </dependency>
         <!-- JACKSON -->
 
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
         <!-- TEST -->
         <dependency>
             <groupId>junit</groupId>

--- a/legend-engine-test-runner-service/pom.xml
+++ b/legend-engine-test-runner-service/pom.xml
@@ -122,10 +122,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-language-pure-grammar</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
         </dependency>
         <dependency>
@@ -149,6 +145,10 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <!-- OPEN TRACING -->
         <dependency>
@@ -203,6 +203,11 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/legend-engine-xt-avro/pom.xml
+++ b/legend-engine-xt-avro/pom.xml
@@ -87,15 +87,7 @@
         <!-- JACKSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
         </dependency>
         <!-- JACKSON -->
 
@@ -140,6 +132,16 @@
         <!-- PAC4J -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-data-space-protocol/pom.xml
+++ b/legend-engine-xt-data-space-protocol/pom.xml
@@ -32,20 +32,12 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-core</artifactId>
-        </dependency>
         <!-- ENGINE -->
 
         <!-- JACKSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
         </dependency>
         <!-- JACKSON -->
 
@@ -57,6 +49,16 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-diagram-protocol/pom.xml
+++ b/legend-engine-xt-diagram-protocol/pom.xml
@@ -36,20 +36,12 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-core</artifactId>
-        </dependency>
         <!-- ENGINE -->
 
         <!-- JACKSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
         </dependency>
         <!-- JACKSON -->
 
@@ -61,6 +53,16 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-flatdata-model/pom.xml
+++ b/legend-engine-xt-flatdata-model/pom.xml
@@ -41,10 +41,6 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-protocol-pure</artifactId>
-        </dependency>
         <!-- ENGINE -->
 
         <!-- PURE -->
@@ -70,6 +66,11 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>

--- a/legend-engine-xt-graphQL-compiler/pom.xml
+++ b/legend-engine-xt-graphQL-compiler/pom.xml
@@ -116,10 +116,6 @@
     <dependencies>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-graphQL-pure-metamodel</artifactId>
         </dependency>
         <dependency>
@@ -150,6 +146,11 @@
         <!-- ENGINE -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-graphQL-pure/pom.xml
+++ b/legend-engine-xt-graphQL-pure/pom.xml
@@ -191,6 +191,7 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-graphQL-grammar</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-xt-json-model/pom.xml
+++ b/legend-engine-xt-json-model/pom.xml
@@ -37,10 +37,6 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-protocol-pure</artifactId>
-        </dependency>
         <!-- ENGINE -->
 
         <!-- PURE -->
@@ -68,6 +64,11 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>

--- a/legend-engine-xt-mastery-grammar/pom.xml
+++ b/legend-engine-xt-mastery-grammar/pom.xml
@@ -31,6 +31,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>org.finos.legend.pure:legend-pure-runtime-java-engine-compiled:*</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
                 <executions>
                     <execution>
                         <id>copy-antlr-core-grammar</id>

--- a/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/HelperMasterRecordDefinitionBuilder.java
+++ b/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/HelperMasterRecordDefinitionBuilder.java
@@ -91,8 +91,8 @@ public class HelperMasterRecordDefinitionBuilder
         public Root_meta_pure_mastery_metamodel_identity_IdentityResolution visit(IdentityResolution protocolVal)
         {
             Root_meta_pure_mastery_metamodel_identity_IdentityResolution_Impl resImpl = new Root_meta_pure_mastery_metamodel_identity_IdentityResolution_Impl("");
-            resImpl._modelClass(context.resolveClass(protocolVal.modelClass));
-            resImpl._resolutionQueriesAddAll(ListIterate.flatCollect(protocolVal.resolutionQueries, this::visitResolutionQuery));
+            //resImpl._modelClass(context.resolveClass(protocolVal.modelClass));
+            //resImpl._resolutionQueriesAddAll(ListIterate.flatCollect(protocolVal.resolutionQueries, this::visitResolutionQuery));
             return resImpl;
         }
 

--- a/legend-engine-xt-morphir/pom.xml
+++ b/legend-engine-xt-morphir/pom.xml
@@ -91,17 +91,6 @@
         </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
-        <!-- JACKSON -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <!-- JACKSON -->
-
         <!-- OPEN TRACING -->
         <dependency>
             <groupId>io.opentracing</groupId>
@@ -132,6 +121,16 @@
         <!-- PAC4J -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-persistence-cloud-grammar/pom.xml
+++ b/legend-engine-xt-persistence-cloud-grammar/pom.xml
@@ -56,7 +56,6 @@
                         <configuration>
                             <!-- The dependency plugin analyzer raises these as false positives -->
                             <ignoredUnusedDeclaredDependencies>
-                                <dependency>org.finos.legend.pure:legend-pure-m3-core</dependency>
                                 <dependency>org.finos.legend.engine:legend-engine-protocol</dependency>
                                 <dependency>org.finos.legend.engine:legend-engine-protocol-pure</dependency>
                                 <dependency>org.finos.legend.engine:legend-engine-pure-code-compiled-core</dependency>

--- a/legend-engine-xt-persistence-cloud-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/cloud/compiler/toPureGraph/HelperPersistenceCloudBuilder.java
+++ b/legend-engine-xt-persistence-cloud-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/cloud/compiler/toPureGraph/HelperPersistenceCloudBuilder.java
@@ -18,6 +18,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.cloud.context.AwsGluePersistencePlatform;
 import org.finos.legend.pure.generated.Root_meta_external_persistence_aws_metamodel_AwsGluePersistencePlatform;
 import org.finos.legend.pure.generated.Root_meta_external_persistence_aws_metamodel_AwsGluePersistencePlatform_Impl;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
 
 public class HelperPersistenceCloudBuilder
 {
@@ -27,7 +28,8 @@ public class HelperPersistenceCloudBuilder
 
     public static Root_meta_external_persistence_aws_metamodel_AwsGluePersistencePlatform buildAwsGluePersistencePlatform(AwsGluePersistencePlatform persistencePlatform, CompileContext context)
     {
-        return new Root_meta_external_persistence_aws_metamodel_AwsGluePersistencePlatform_Impl("", null, context.pureModel.getClass("meta::external::persistence::aws::metamodel::AwsGluePersistencePlatform"))
+        Class<?> aClass = context.pureModel.getClass("meta::external::persistence::aws::metamodel::AwsGluePersistencePlatform");
+        return new Root_meta_external_persistence_aws_metamodel_AwsGluePersistencePlatform_Impl("", null, aClass)
                 ._dataProcessingUnits(persistencePlatform.dataProcessingUnits);
     }
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/pom.xml
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/pom.xml
@@ -25,15 +25,6 @@
     <name>Legend Engine - XT - Persistence - Component - Relational Test</name>
 
     <dependencies>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
-        </dependency>
-
         <!-- IMMUTABLES -->
         <dependency>
             <groupId>org.immutables</groupId>
@@ -41,6 +32,16 @@
         </dependency>
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-persistence-component-logical-plan</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-persistence-component-relational-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/legend-engine-xt-persistence-grammar/pom.xml
+++ b/legend-engine-xt-persistence-grammar/pom.xml
@@ -149,13 +149,14 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-persistence-test-runner/pom.xml
+++ b/legend-engine-xt-persistence-test-runner/pom.xml
@@ -40,11 +40,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-language-pure-grammar</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-code-compiled-core</artifactId>
         </dependency>
         <dependency>
@@ -127,10 +122,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -144,6 +135,16 @@
         </dependency>
 
         <!--TEST -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-protobuf/pom.xml
+++ b/legend-engine-xt-protobuf/pom.xml
@@ -86,10 +86,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-language-pure-grammar</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>
         </dependency>
         <dependency>
@@ -140,24 +136,9 @@
         <!-- JACKSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
         <!-- JACKSON -->
-
-        <!-- JSON -->
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-        </dependency>
-        <!-- JSON -->
 
         <!-- ECLIPSE COLLECTIONS -->
         <dependency>
@@ -200,6 +181,26 @@
         <!-- PAC4J -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-relationalStore-bigquery-execution-tests/pom.xml
+++ b/legend-engine-xt-relationalStore-bigquery-execution-tests/pom.xml
@@ -24,6 +24,15 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>org.finos.legend.engine:legend-engine-xt-relationalStore-bigquery-protocol:*</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -32,6 +41,7 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -44,6 +54,7 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-shared-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -70,6 +81,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- JACKSON -->
 

--- a/legend-engine-xt-relationalStore-executionPlan-connection-authentication-default/pom.xml
+++ b/legend-engine-xt-relationalStore-executionPlan-connection-authentication-default/pom.xml
@@ -27,6 +27,16 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>org.finos.legend.engine:legend-engine-xt-relationalStore-bigquery-protocol:*</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>org.finos.legend.engine:legend-engine-xt-relationalStore-spanner-protocol:*</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
             <!-- Block running the External Integration Tests-->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -84,10 +94,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication</artifactId>
         </dependency>
         <dependency>
@@ -112,24 +118,6 @@
         </dependency>
         <!-- ENGINE -->
 
-        <!-- JACKSON -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <!-- JACKSON -->
-
-        <!-- DRIVERS -->
-        <dependency>
-            <groupId>net.snowflake</groupId>
-            <artifactId>snowflake-jdbc</artifactId>
-        </dependency>
-        <!-- DRIVERS -->
-
         <!-- ECLIPSE COLLECTIONS -->
         <dependency>
             <groupId>org.eclipse.collections</groupId>
@@ -142,6 +130,26 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-relationalStore-executionPlan-connection-tests/pom.xml
+++ b/legend-engine-xt-relationalStore-executionPlan-connection-tests/pom.xml
@@ -171,16 +171,19 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-shared-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.finos.legend.pure</groupId>
@@ -196,15 +199,18 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication-default</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- ENGINE -->
 
@@ -212,10 +218,12 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
@@ -223,6 +231,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- POOLING -->
 
@@ -230,6 +239,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Test -->

--- a/legend-engine-xt-relationalStore-executionPlan/pom.xml
+++ b/legend-engine-xt-relationalStore-executionPlan/pom.xml
@@ -93,10 +93,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-javaCompiler</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication</artifactId>
         </dependency>
         <!-- ENGINE -->
@@ -219,6 +215,11 @@
         <!-- ANNOTATIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-javaCompiler</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-relationalStore-grammar/pom.xml
+++ b/legend-engine-xt-relationalStore-grammar/pom.xml
@@ -170,13 +170,6 @@
         </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
-        <!-- JACKSON -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <!-- JACKSON -->
-
         <!-- For String Manipulation -->
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -185,6 +178,11 @@
         <!-- For String Manipulation -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-relationalStore-sqlserver-execution-tests/pom.xml
+++ b/legend-engine-xt-relationalStore-sqlserver-execution-tests/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -93,6 +94,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- JACKSON -->
 

--- a/legend-engine-xt-rosetta/pom.xml
+++ b/legend-engine-xt-rosetta/pom.xml
@@ -80,17 +80,6 @@
         </dependency>
         <!-- ANNOTATIONS -->
 
-        <!-- JACKSON -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <!-- JACKSON -->
-
         <!-- ECLIPSE COLLECTIONS -->
         <dependency>
             <groupId>org.eclipse.collections</groupId>
@@ -132,6 +121,16 @@
         <!-- PAC4J -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-serviceStore-executionPlan/pom.xml
+++ b/legend-engine-xt-serviceStore-executionPlan/pom.xml
@@ -131,10 +131,6 @@
             <groupId>org.pac4j</groupId>
             <artifactId>pac4j-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.shared</groupId>
-            <artifactId>legend-shared-pac4j-kerberos</artifactId>
-        </dependency>
         <!-- Authentication -->
 
         <!-- Http Client -->
@@ -170,6 +166,11 @@
         </dependency>
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.shared</groupId>
+            <artifactId>legend-shared-pac4j-kerberos</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-sql-compiler/pom.xml
+++ b/legend-engine-xt-sql-compiler/pom.xml
@@ -99,10 +99,6 @@
     <dependencies>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-sql-pure-metamodel</artifactId>
         </dependency>
         <dependency>
@@ -133,6 +129,11 @@
         <!-- ENGINE -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-text-protocol/pom.xml
+++ b/legend-engine-xt-text-protocol/pom.xml
@@ -32,18 +32,7 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-core</artifactId>
-        </dependency>
         <!-- ENGINE -->
-
-        <!-- JACKSON -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <!-- JACKSON -->
 
         <!-- ECLIPSE COLLECTIONS -->
         <dependency>
@@ -53,6 +42,16 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/legend-engine-xt-xml-model/pom.xml
+++ b/legend-engine-xt-xml-model/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-protocol-pure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
         </dependency>
         <dependency>
@@ -81,6 +77,11 @@
         <!-- ECLIPSE COLLECTIONS -->
 
         <!-- TEST -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         <maven.source.plugin.version>3.2.0</maven.source.plugin.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
-        <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
+        <maven.dependency.plugin.version>3.4.0</maven.dependency.plugin.version>
         <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
         <maven.plugin.plugin.version>3.6.0</maven.plugin.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M1</maven.enforcer.plugin.version>
@@ -335,6 +335,7 @@
         <build-helper.maven.plugin.version>3.2.0</build-helper.maven.plugin.version>
         <dockerfile.maven.plugin.version>1.4.13</dockerfile.maven.plugin.version>
         <maven.plugin.puppycrawl.version>8.25</maven.plugin.puppycrawl.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
     </properties>
 
     <scm>
@@ -564,8 +565,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
-                    <failOnWarning>true</failOnWarning>
+                    <failOnWarning>false</failOnWarning>
                     <ignoreNonCompile>true</ignoreNonCompile>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>junit:junit:*</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>org.eclipse.collections:eclipse-collections:*</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>org.eclipse.collections:eclipse-collections-api:*</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
                 </configuration>
                 <executions>
                     <execution>
@@ -2308,17 +2314,17 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
-                <version>1.16.3</version>
+                <version>${testcontainers.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>mssqlserver</artifactId>
-                <version>1.16.3</version>
+                <version>${testcontainers.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>1.16.3</version>
+                <version>${testcontainers.version}</version>
             </dependency>
             <!-- Test Containers -->
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one/more labels.
-->

Enhancement

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

This update the Maven Dependency Plugin to 3.4.0.  The current version does not work with code compiled at higher level than 8.  

As part of Elasticsearch, I plan to add a integration test module that is simplified if we compiled on Java 11 byte code, hence this update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
No