### PR TITLE
GraphQL - Fix empty schema

### DIFF
--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/sdl/fromPure_sdl.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/sdl/fromPure_sdl.pure
@@ -45,10 +45,12 @@ function meta::external::query::graphQL::binding::fromPure::sdl::transformPureTo
     );
   )->meta::pure::functions::collection::sortBy(t|$t->match([o:ObjectTypeDefinition[1]|$o.name,e:EnumTypeDefinition[1]|$e.name])->toOne())
   ->concatenate(
-    ^SchemaDefinition
+    if($query->concatenate($mutation)->concatenate($subscription)->isNotEmpty(),
+    |^SchemaDefinition
     (
       rootOperationTypeDefinitions = $query->concatenate($mutation)->concatenate($subscription)
-    )
+    ),
+    |[])
   );
 }
 

--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/deprecated/tests/generationTests.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/deprecated/tests/generationTests.pure
@@ -1,0 +1,91 @@
+import meta::external::query::graphQL::generation::*;
+import meta::external::query::graphQL::generation::tests::model::*;
+import meta::external::query::graphQL::binding::*;
+
+Enum meta::external::query::graphQL::generation::tests::model::IncType
+{
+  LLC, CORP
+}
+
+Class meta::external::query::graphQL::generation::tests::model::Firm
+{
+  legalName : String[1];
+  employees : Person[*];
+  incType : meta::external::query::graphQL::generation::tests::model::IncType[1];
+}
+
+Class meta::external::query::graphQL::generation::tests::model::Person
+{
+  firstName : String[0..1];
+  lastName : String[1];
+  age : Integer[1];
+}
+
+Class <<GraphQL.Query>> meta::external::query::graphQL::generation::tests::model::Query
+{
+  firmByName(name:String[1]){Firm.all()->filter(f|$f.legalName == $name)->first()}:Firm[0..1];
+}
+
+Class <<GraphQL.Query>> meta::external::query::graphQL::generation::tests::model::Query2
+{
+  persons(){Person.all()}:Person[*];
+}
+
+
+function <<test.Test>> meta::external::query::graphQL::generation::tests::testGenerateQuery():Boolean[1]
+{
+  let res = meta::external::query::graphQL::generation::generateGraphQL(
+    ^meta::external::query::graphQL::generation::GraphQLConfig
+    (
+      scopeElements = [Query]
+    )
+  );
+
+  assertEquals(
+    'type Firm {\n' +
+    '  legalName: String!\n' +
+    '  employees: [Person!]!\n' +
+    '  incType: IncType!\n' +
+    '}\n' +
+    'enum IncType {\n' +
+    '  LLC\n' +
+    '  CORP\n' +
+    '}\n' +
+    'type Person {\n' +
+    '  firstName: String\n' +
+    '  lastName: String!\n' +
+    '  age: Int!\n' +
+    '}\n' +
+    'type Query {\n' +
+    '  firmByName(name: String!): Firm\n' +
+    '}\n' +
+    'schema {\n' +
+    '  query : Query\n' +
+    '}', $res.content);
+}
+
+function <<test.Test>> meta::external::query::graphQL::generation::tests::testGenerateClass():Boolean[1]
+{
+  let res = meta::external::query::graphQL::generation::generateGraphQL(
+    ^meta::external::query::graphQL::generation::GraphQLConfig
+    (
+      scopeElements = [Firm]
+    )
+  );
+
+  assertEquals(
+    'type Firm {\n' +
+    '  legalName: String!\n' +
+    '  employees: [Person!]!\n' +
+    '  incType: IncType!\n' +
+    '}\n' +
+    'enum IncType {\n' +
+    '  LLC\n' +
+    '  CORP\n' +
+    '}\n' +
+    'type Person {\n' +
+    '  firstName: String\n' +
+    '  lastName: String!\n' +
+    '  age: Int!\n' +
+    '}', $res.content);
+}

--- a/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLFileGeneration.java
+++ b/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLFileGeneration.java
@@ -45,7 +45,7 @@ public class TestGraphQLFileGeneration
             Assert.assertEquals(outputs.size(), 4);
             outputs.forEach(o ->
             {
-                Assert.assertEquals(o._content(), getResourceAsString("schema.graphql"));
+                Assert.assertEquals(getResourceAsString("schema.graphql"), o._content());
             });
         }
         catch (Exception e)

--- a/legend-engine-xt-graphQL-query/src/test/resources/org/finos/legend/engine/query/graphQL/api/test/schema.graphql
+++ b/legend-engine-xt-graphQL-query/src/test/resources/org/finos/legend/engine/query/graphQL/api/test/schema.graphql
@@ -16,6 +16,3 @@ type Person {
   addresses: [Address!]!
   firm: Firm
 }
-schema {
-
-}


### PR DESCRIPTION
#### What type of PR is this?

Issue Fix
<!--
Add one/more labels.
-->

#### What does this PR do / why is it needed ?

Fixes the empty hanging schema present in generated GraphQL schemas. It's needed as current schema generated is considered invalid by one or more graphql engines.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes
<!--
-->
