### PR TITLE
Provide Pure metadata url override in Pure SDLC

### DIFF
--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
@@ -158,7 +158,7 @@ public class SDLCLoader implements ModelLoader
                     return ListIterate.injectInto(
                             new PureModelContextData.Builder(),
                             context.sdlcInfo.packageableElementPointers,
-                            (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos"))
+                            (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos", ((PureSDLC) context.sdlcInfo).overrideUrl))
                     ).distinct().sorted().build();
                 }
             };

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
@@ -155,19 +155,10 @@ public class SDLCLoader implements ModelLoader
                 parentSpan.setTag("sdlc", "pure");
                 try (Scope scope = GlobalTracer.get().buildSpan("Request Pure Metadata").startActive(true))
                 {
-                    String overrideUrl = ((PureSDLC) context.sdlcInfo).overrideUrl;
-                    if (overrideUrl == null)
-                    {
-                        return ListIterate.injectInto(
-                                new PureModelContextData.Builder(),
-                                context.sdlcInfo.packageableElementPointers,
-                                (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos"))
-                        ).distinct().sorted().build();
-                    }
                     return ListIterate.injectInto(
                             new PureModelContextData.Builder(),
                             context.sdlcInfo.packageableElementPointers,
-                            (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos", overrideUrl))
+                            (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos", ((PureSDLC) context.sdlcInfo).overrideUrl))
                     ).distinct().sorted().build();
                 }
             };

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
@@ -155,10 +155,19 @@ public class SDLCLoader implements ModelLoader
                 parentSpan.setTag("sdlc", "pure");
                 try (Scope scope = GlobalTracer.get().buildSpan("Request Pure Metadata").startActive(true))
                 {
+                    String overrideUrl = ((PureSDLC) context.sdlcInfo).overrideUrl;
+                    if (overrideUrl == null)
+                    {
+                        return ListIterate.injectInto(
+                                new PureModelContextData.Builder(),
+                                context.sdlcInfo.packageableElementPointers,
+                                (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos"))
+                        ).distinct().sorted().build();
+                    }
                     return ListIterate.injectInto(
                             new PureModelContextData.Builder(),
                             context.sdlcInfo.packageableElementPointers,
-                            (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos", ((PureSDLC) context.sdlcInfo).overrideUrl))
+                            (builder, pointers) -> builder.withPureModelContextData(this.pureLoader.loadPurePackageableElementPointer(pm, pointers, clientVersion, subject == null ? "" : "?auth=kerberos", overrideUrl))
                     ).distinct().sorted().build();
                 }
             };

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/api/MetadataServerInfo.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/api/MetadataServerInfo.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.language.pure.modelManager.sdlc.api;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.engine.language.pure.modelManager.sdlc.configuration.MetaDataServerConfiguration;
+import org.finos.legend.engine.language.pure.modelManager.sdlc.configuration.PureServerConnectionConfiguration;
 import org.slf4j.Logger;
 
 import javax.ws.rs.GET;
@@ -35,12 +36,21 @@ public class MetadataServerInfo
 
     public MetadataServerInfo(MetaDataServerConfiguration metaDataServerConfiguration)
     {
+        String typeOfServerConnectionConfiguration = "";
+        String allowedOverrideUrls = "";
+        if (metaDataServerConfiguration.pure instanceof PureServerConnectionConfiguration)
+        {
+            typeOfServerConnectionConfiguration = "      \"_type\":\"pureServerConnectionConfiguration\"";
+            allowedOverrideUrls = "," + "      \"allowedOverrideUrls\":" + (((PureServerConnectionConfiguration) metaDataServerConfiguration.pure).allowedOverrideUrls == null ? "[]" : "[\"" + String.join("\",\"", ((PureServerConnectionConfiguration) metaDataServerConfiguration.pure).allowedOverrideUrls) + "\"]");
+        }
         this.message = "{" +
                 "\"metadataserver\": {" +
                 "   \"pure\":" +
                 "   {" +
+                typeOfServerConnectionConfiguration +
                 "      \"host\":\"" + metaDataServerConfiguration.getPure().host + "\"," +
                 "      \"port\":" + metaDataServerConfiguration.getPure().port +
+                allowedOverrideUrls +
                 "   }," +
                 "   \"alloy\":" +
                 "   {" +

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/api/MetadataServerInfo.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/api/MetadataServerInfo.java
@@ -40,7 +40,7 @@ public class MetadataServerInfo
         String allowedOverrideUrls = "";
         if (metaDataServerConfiguration.pure instanceof PureServerConnectionConfiguration)
         {
-            typeOfServerConnectionConfiguration = "      \"_type\":\"pureServerConnectionConfiguration\"";
+            typeOfServerConnectionConfiguration = "      \"_type\":\"pureServerConnectionConfiguration\",";
             allowedOverrideUrls = "," + "      \"allowedOverrideUrls\":" + (((PureServerConnectionConfiguration) metaDataServerConfiguration.pure).allowedOverrideUrls == null ? "[]" : "[\"" + String.join("\",\"", ((PureServerConnectionConfiguration) metaDataServerConfiguration.pure).allowedOverrideUrls) + "\"]");
         }
         this.message = "{" +

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/configuration/PureServerConnectionConfiguration.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/configuration/PureServerConnectionConfiguration.java
@@ -14,32 +14,28 @@
 
 package org.finos.legend.engine.language.pure.modelManager.sdlc.configuration;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, defaultImpl = ServerConnectionConfiguration.class, property = "_type")
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = PureServerConnectionConfiguration.class, name = "pureServerConnectionConfiguration")
-})
-public class ServerConnectionConfiguration
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PureServerConnectionConfiguration extends ServerConnectionConfiguration
 {
-    public String host;
-    public Integer port;
-    public String prefix = "";
+    public List<String> allowedOverrideUrls;
 
-    public ServerConnectionConfiguration()
+    public PureServerConnectionConfiguration()
     {
         // DO NOT DELETE: this resets the default constructor for Jackson
     }
 
-    public ServerConnectionConfiguration(String host, Integer port)
+    public PureServerConnectionConfiguration(String host, Integer port)
     {
-        this.host = host;
-        this.port = port;
+        this(host, port, null);
     }
 
-    public String getBaseUrl()
+    public PureServerConnectionConfiguration(String host, Integer port, List<String> allowedOverrideUrls)
     {
-        return "http://" + host + ":" + port + prefix;
+        super(host, port);
+        this.allowedOverrideUrls = allowedOverrideUrls;
     }
 }

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/pure/PureServerLoader.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/pure/PureServerLoader.java
@@ -65,6 +65,7 @@ public class PureServerLoader
         return getBaseUrl(overrideUrl) + "/alloy/pureServerBaseVersion" + urlSuffix;
     }
 
+    @Deprecated
     protected String buildPureMetadataURL(PackageableElementPointer pointer, String urlSegment, String clientVersion, String urlSuffix)
     {
         return buildPureMetadataURL(pointer, urlSegment, clientVersion, urlSuffix, null);
@@ -113,6 +114,7 @@ public class PureServerLoader
         return deepCopy;
     }
 
+    @Deprecated
     public PureModelContextData loadPurePackageableElementPointer(MutableList<CommonProfile> pm, PackageableElementPointer pointer, String clientVersion, String urlSuffix)
     {
         return loadPurePackageableElementPointer(pm, pointer, clientVersion, urlSuffix, null);

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/pure/PureServerLoader.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/pure/PureServerLoader.java
@@ -48,7 +48,7 @@ public class PureServerLoader
 
     public String getBaseUrl(String overrideUrl)
     {
-        if (overrideUrl == null || overrideUrl.equals(metaDataServerConfiguration.getPure().getBaseUrl()))
+        if (overrideUrl == null || overrideUrl.equals(metaDataServerConfiguration.getPure().getBaseUrl()) || !(metaDataServerConfiguration.pure instanceof PureServerConnectionConfiguration))
         {
             return metaDataServerConfiguration.getPure().getBaseUrl();
         }

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/context/PureSDLC.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/context/PureSDLC.java
@@ -18,15 +18,26 @@ import java.util.Objects;
 
 public class PureSDLC extends SDLC
 {
+    public String overrideUrl;
+
     @Override
     public boolean equals(Object o)
     {
-        return super.equals(o);
+        if (this == o)
+        {
+            return true;
+        }
+        if ((o == null) || (o.getClass() != this.getClass()))
+        {
+            return false;
+        }
+        PureSDLC that = (PureSDLC) o;
+        return Objects.equals(this.overrideUrl, that.overrideUrl) && Objects.equals(this.version, that.version) && Objects.equals(this.baseVersion, that.baseVersion) && Objects.equals(this.packageableElementPointers, that.packageableElementPointers);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(super.hashCode());
+        return Objects.hash(this.overrideUrl, this.version, this.baseVersion, this.packageableElementPointers);
     }
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/execution.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/execution.pure
@@ -116,10 +116,10 @@ function meta::protocols::pure::vX_X_X::invocation::execution::execute::executeP
 
 function meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], runtime:Runtime[1],  exeCtx:ExecutionContext[0..1], version:String[1], serializationKind:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
 {
-  meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput($f, $m, $runtime, $exeCtx, $version, $serializationKind, $executionMode, $extensions, [])
+  meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput($f, $m, $runtime, $exeCtx, $version, $serializationKind, $executionMode, [], $extensions)
 }
 
-function meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], runtime:Runtime[1],  exeCtx:ExecutionContext[0..1], version:String[1], serializationKind:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*], pureMetadataServer:String[0..1]):String[1]
+function meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], runtime:Runtime[1],  exeCtx:ExecutionContext[0..1], version:String[1], serializationKind:String[1], executionMode:String[1], pureMetadataServer:String[0..1], extensions:meta::pure::extension::Extension[*]):String[1]
 {
          let transformedContext = if($exeCtx->isNotEmpty(), | $exeCtx->toOne()->transformContext($extensions),| []);
          let execMode = ExecutionMode->extractEnumValue($executionMode);

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/execution.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/execution.pure
@@ -116,6 +116,11 @@ function meta::protocols::pure::vX_X_X::invocation::execution::execute::executeP
 
 function meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], runtime:Runtime[1],  exeCtx:ExecutionContext[0..1], version:String[1], serializationKind:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*]):String[1]
 {
+  meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput($f, $m, $runtime, $exeCtx, $version, $serializationKind, $executionMode, $extensions, [])
+}
+
+function meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput<T|m>(f:FunctionDefinition<{->T[m]}>[1], m:Mapping[1], runtime:Runtime[1],  exeCtx:ExecutionContext[0..1], version:String[1], serializationKind:String[1], executionMode:String[1], extensions:meta::pure::extension::Extension[*], pureMetadataServer:String[0..1]):String[1]
+{
          let transformedContext = if($exeCtx->isNotEmpty(), | $exeCtx->toOne()->transformContext($extensions),| []);
          let execMode = ExecutionMode->extractEnumValue($executionMode);
 
@@ -152,6 +157,7 @@ function meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExe
                                           _type = 'pure',
                                           baseVersion = '-1', //meta::vcs::svn::metamodel::getCurrentSvnRevisionNumber('/system')->toString(),
                                           version = 'none',
+                                          overrideUrl = $pureMetadataServer,
                                           packageableElementPointers = $stores->concatenate($transformedMappings)
                                        )
                          );,

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/testBuildExecutionInput.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/testBuildExecutionInput.pure
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/testbuilExecutionInput.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/testbuilExecutionInput.pure
@@ -1,0 +1,25 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::*;
+import meta::pure::runtime::*;
+import meta::pure::extension::*;
+import meta::protocols::pure::vX_X_X::invocation::execution::*;
+
+function <<test.Test>> meta::protocols::pure::vX_X_X::invocation::execution::testbuildExecutionInput():Boolean[1]
+{
+   let outputString = meta::protocols::pure::vX_X_X::invocation::execution::execute::buildExecutionInput((|[]), ^Mapping(), ^Runtime(), ^ExecutionContext(), 'v1', 'json', 'SEMI_INTERACTIVE', 'http://pure.metadataserver.com', meta::pure::extension::defaultExtensions());
+   let expectedString = '{"function":{"_type":"lambda","body":[{"multiplicity":{"upperBound":0,"lowerBound":0},"_type":"collection"}]},"context":{"_type":"BaseExecutionContext"},"model":{"sdlcInfo":{"baseVersion":"-1","_type":"pure","version":"none","overrideUrl":"http:\/\/pure.metadataserver.com"},"_type":"pointer","serializer":{"name":"pure","version":"vX_X_X"}},"clientVersion":"vX_X_X"}';
+   meta::pure::functions::boolean::equalJsonStrings($outputString, $expectedString);
+}

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/executionPlan.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/executionPlan.pure
@@ -312,6 +312,7 @@ Class meta::protocols::pure::vX_X_X::metamodel::SDLC
 
 Class meta::protocols::pure::vX_X_X::metamodel::PureSDLC extends meta::protocols::pure::vX_X_X::metamodel::SDLC
 {
+   overrideUrl : String[0..1];
    packageableElementPointers : meta::protocols::pure::vX_X_X::metamodel::PackageableElementPointer[*];
 }
 


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?

This change gives flexibility to choose a metadata url in Pure Sdlc. We use it to build Pure Metadata URL. We allow a list of allowed hosts to be specified in the server configuration, and we check that the specified override url is one of them.

#### Which issue(s) this PR fixes:
 

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
