### PR TITLE
Add all valid assertion IDs to assertion not found exception

### DIFF
--- a/legend-engine-service-post-validation-runner/src/main/java/org/finos/legend/engine/service/post/validation/runner/ServicePostValidationRunner.java
+++ b/legend-engine-service-post-validation-runner/src/main/java/org/finos/legend/engine/service/post/validation/runner/ServicePostValidationRunner.java
@@ -159,10 +159,14 @@ abstract class ServicePostValidationRunner
 
     private Pair<RichIterable<?>, LambdaFunction<?>> findParamsWithAssertion(String assertionId)
     {
+        List<String> locatedAssertionIds = FastList.newList();
+
         for (Root_meta_legend_service_metamodel_PostValidation<?> postValidation : pureService._postValidations())
         {
             for (Root_meta_legend_service_metamodel_PostValidationAssertion<?> assertion : postValidation._assertions())
             {
+                locatedAssertionIds.add(assertion._id());
+
                 if (assertion._id().equals(assertionId))
                 {
                     return Tuples.pair(postValidation._parameters(), (LambdaFunction<?>) assertion._assertion());
@@ -170,7 +174,7 @@ abstract class ServicePostValidationRunner
             }
         }
 
-        throw new NoSuchElementException("Assertion " + assertionId + " not found");
+        throw new NoSuchElementException("Assertion " + assertionId + " not found, expected one of " + locatedAssertionIds);
     }
 
     protected Result executePlan(SingleExecutionPlan plan, Map<String, Result> params) throws PrivilegedActionException


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

Updates the exception thrown when an assertion ID isn't found to be more user friendly, e.g.:
`Assertion nonExistentAssertion not found, expected one of [noFirstNamesWithLetterT, rowCountGreaterThan10]`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

Yes - user experience change in exception