### PR TITLE
Add Java return value to compileAndExecuteJava result

### DIFF
--- a/legend-engine-xt-java-runtime-compiler/src/main/java/org/finos/legend/engine/external/language/java/runtime/compiler/compiled/JavaRuntimeCompilerCompiledExtension.java
+++ b/legend-engine-xt-java-runtime-compiler/src/main/java/org/finos/legend/engine/external/language/java/runtime/compiler/compiled/JavaRuntimeCompilerCompiledExtension.java
@@ -14,21 +14,77 @@
 
 package org.finos.legend.engine.external.language.java.runtime.compiler.compiled;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.SetIterable;
+import org.eclipse.collections.api.tuple.Pair;
 import org.finos.legend.engine.external.language.java.runtime.compiler.compiled.natives.CompileAndExecuteJava;
 import org.finos.legend.engine.external.language.java.runtime.compiler.compiled.natives.CompileJava;
-import org.finos.legend.pure.runtime.java.compiled.extension.BaseCompiledExtension;
+import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.compiled.compiler.StringJavaSource;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtension;
+import org.finos.legend.pure.runtime.java.compiled.generation.JavaSourceCodeGenerator;
+import org.finos.legend.pure.runtime.java.compiled.generation.ProcessorContext;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.Native;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Bridge;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.Procedure3;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.Procedure4;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureFunction1;
 
-public class JavaRuntimeCompilerCompiledExtension extends BaseCompiledExtension
+import java.util.List;
+import java.util.function.Function;
+
+public class JavaRuntimeCompilerCompiledExtension implements CompiledExtension
 {
-    public JavaRuntimeCompilerCompiledExtension()
+    @Override
+    public List<StringJavaSource> getExtraJavaSources()
     {
-        super("core_external_language_java_compiler",
-                () -> Lists.fixedSize.with(new CompileJava(), new CompileAndExecuteJava()),
-                Lists.fixedSize.empty(),
-                Lists.fixedSize.empty(),
-                Lists.fixedSize.empty());
+        return Lists.fixedSize.empty();
+    }
+
+    @Override
+    public List<Native> getExtraNatives()
+    {
+        return Lists.fixedSize.with(new CompileJava(), new CompileAndExecuteJava());
+    }
+
+    @Override
+    public List<Procedure3<CoreInstance, JavaSourceCodeGenerator, ProcessorContext>> getExtraPackageableElementProcessors()
+    {
+        return Lists.fixedSize.empty();
+    }
+
+    @Override
+    public List<Procedure4<CoreInstance, CoreInstance, ProcessorContext, ProcessorSupport>> getExtraClassMappingProcessors()
+    {
+        return Lists.fixedSize.empty();
+    }
+
+    @Override
+    public RichIterable<? extends Pair<String, Function<? super CoreInstance, String>>> getExtraIdBuilders(ProcessorSupport processorSupport)
+    {
+        return Lists.immutable.empty();
+    }
+
+    @Override
+    public SetIterable<String> getExtraCorePath()
+    {
+        return Sets.immutable.empty();
+    }
+
+    @Override
+    public PureFunction1<Object, Object> getExtraFunctionEvaluation(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function<?> func, Bridge bridge, ExecutionSupport es)
+    {
+        return null;
+    }
+
+    @Override
+    public String getRelatedRepository()
+    {
+        return "core_external_language_java_compiler";
     }
 
     public static CompiledExtension extension()

--- a/legend-engine-xt-java-runtime-compiler/src/main/java/org/finos/legend/engine/external/language/java/runtime/compiler/shared/PureResultBuilder.java
+++ b/legend-engine-xt-java-runtime-compiler/src/main/java/org/finos/legend/engine/external/language/java/runtime/compiler/shared/PureResultBuilder.java
@@ -1,0 +1,261 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.external.language.java.runtime.compiler.shared;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Array;
+import java.util.Map;
+
+class PureResultBuilder
+{
+    private static final String COMP_RESULT_CLASS = "meta::external::language::java::compiler::CompilationResult";
+    private static final String EXEC_RESULT_CLASS = "meta::external::language::java::compiler::ExecutionResult";
+    private static final String COMP_AND_EXEC_RESULT_CLASS = "meta::external::language::java::compiler::CompileAndExecuteResult";
+
+    private static final String JAVA_NULL_CLASS = "meta::external::language::java::compiler::JavaNull";
+    private static final String JAVA_ARRAY_CLASS = "meta::external::language::java::compiler::JavaArray";
+    private static final String JAVA_ENUM_CLASS = "meta::external::language::java::compiler::JavaEnum";
+    private static final String JAVA_PRIMITIVE_CLASS = "meta::external::language::java::compiler::JavaPrimitive";
+    private static final String JAVA_ITERABLE_CLASS = "meta::external::language::java::compiler::JavaIterable";
+    private static final String JAVA_MAP_CLASS = "meta::external::language::java::compiler::JavaMap";
+    private static final String JAVA_OBJECT_CLASS = "meta::external::language::java::compiler::JavaObject";
+
+    private final ProcessorSupport processorSupport;
+
+    PureResultBuilder(ProcessorSupport processorSupport)
+    {
+        this.processorSupport = processorSupport;
+    }
+
+    CoreInstance buildCompilationResult(CompilationResult javaCompResult)
+    {
+        CoreInstance pureCompResult = newCoreInstance(COMP_RESULT_CLASS);
+
+        CoreInstance success = newBooleanCoreInstance(javaCompResult.isSuccess());
+        setProperty(pureCompResult, "successful", success);
+
+        if (!javaCompResult.isSuccess())
+        {
+            ListIterable<CoreInstance> errorMessages = javaCompResult.getErrorMessages().collect(this::newStringCoreInstance);
+            setProperty(pureCompResult, "errors", errorMessages);
+        }
+
+        return pureCompResult;
+
+    }
+
+    CoreInstance buildExecutionResult(ExecutionResult javaExecResult)
+    {
+        CoreInstance pureExecResult = newCoreInstance(EXEC_RESULT_CLASS);
+
+        CoreInstance success = newBooleanCoreInstance(javaExecResult.isSuccess());
+        setProperty(pureExecResult, "successful", success);
+
+        if (javaExecResult.isSuccess())
+        {
+            CoreInstance convertedResult = buildJavaValue(javaExecResult.getResult());
+            setProperty(pureExecResult, "returnValue", convertedResult);
+        }
+        else
+        {
+            Throwable error = javaExecResult.getError();
+            if (error != null)
+            {
+                StringWriter stringWriter = new StringWriter();
+                try (PrintWriter printWriter = new PrintWriter(stringWriter))
+                {
+                    error.printStackTrace(printWriter);
+                }
+                CoreInstance errorMessage = newStringCoreInstance(stringWriter.toString());
+                setProperty(pureExecResult, "error", errorMessage);
+            }
+        }
+
+        return pureExecResult;
+    }
+
+    CoreInstance buildCompileAndExecuteResult(CompilationResult javaCompResult, ExecutionResult javaExecResult)
+    {
+        CoreInstance pureCompAndExecResult = newCoreInstance(COMP_AND_EXEC_RESULT_CLASS);
+
+        CoreInstance pureCompResult = buildCompilationResult(javaCompResult);
+        setProperty(pureCompAndExecResult, "compilationResult", pureCompResult);
+
+        if (javaExecResult != null)
+        {
+            CoreInstance pureExecResult = buildExecutionResult(javaExecResult);
+            setProperty(pureCompAndExecResult, "executionResult", pureExecResult);
+        }
+        return pureCompAndExecResult;
+    }
+
+    CoreInstance buildJavaValue(Object object)
+    {
+        if (object == null)
+        {
+            return buildJavaNull();
+        }
+
+        Class<?> objectClass = object.getClass();
+
+        if (objectClass.isArray())
+        {
+            return buildJavaArray(object);
+        }
+
+        if (objectClass.isPrimitive())
+        {
+            return buildJavaPrimitive(objectClass, object);
+        }
+
+        if (objectClass.isEnum())
+        {
+            return buildJavaEnum((Enum<?>) object);
+        }
+
+        if (object instanceof Map)
+        {
+            return buildJavaMap((Map<?, ?>) object);
+        }
+
+        if (object instanceof Iterable)
+        {
+            return buildJavaIterable((Iterable<?>) object);
+        }
+
+        return buildJavaOtherObject(object);
+    }
+
+    private CoreInstance buildJavaNull()
+    {
+        return newCoreInstance("null", JAVA_NULL_CLASS);
+    }
+
+    private CoreInstance buildJavaArray(Object array)
+    {
+        Class<?> componentType = array.getClass().getComponentType();
+
+        int length = Array.getLength(array);
+        MutableList<CoreInstance> values = Lists.mutable.ofInitialCapacity(length);
+        for (int i = 0; i < length; i++)
+        {
+            Object javaValue = Array.get(array, i);
+            CoreInstance convertedValue = componentType.isPrimitive() ? buildJavaPrimitive(componentType, javaValue) : buildJavaValue(javaValue);
+            values.add(convertedValue);
+        }
+        CoreInstance instance = newCoreInstance(JAVA_ARRAY_CLASS);
+        setProperty(instance, "componentType", componentType.getName());
+        setProperty(instance, M3Properties.values, values);
+        return instance;
+    }
+
+    private CoreInstance buildJavaPrimitive(Class<?> primitiveType, Object value)
+    {
+        CoreInstance instance = newCoreInstance(JAVA_PRIMITIVE_CLASS);
+        setProperty(instance, M3Properties.type, primitiveType.getName());
+        setProperty(instance, M3Properties.value, value.toString());
+        return instance;
+    }
+
+    private CoreInstance buildJavaEnum(Enum<?> enumValue)
+    {
+        CoreInstance instance = newCoreInstance(JAVA_ENUM_CLASS);
+        setProperty(instance, M3Properties._class, enumValue.getDeclaringClass().getName());
+        setProperty(instance, M3Properties.name, enumValue.name());
+        return instance;
+    }
+
+    private CoreInstance buildJavaMap(Map<?, ?> map)
+    {
+        MutableList<CoreInstance> keyValuePairs = Lists.mutable.ofInitialCapacity(map.size());
+        map.forEach((key, value) ->
+        {
+            CoreInstance convertedKey = buildJavaValue(key);
+            CoreInstance convertedValue = buildJavaValue(value);
+
+            CoreInstance pair = newCoreInstance(M3Paths.Pair);
+            setProperty(pair, M3Properties.first, convertedKey);
+            setProperty(pair, M3Properties.second, convertedValue);
+            keyValuePairs.add(pair);
+        });
+        CoreInstance instance = newCoreInstance(JAVA_MAP_CLASS);
+        setProperty(instance, M3Properties._class, map.getClass().getName());
+        setProperty(instance, "keyValuePairs", keyValuePairs);
+        return instance;
+    }
+
+    private CoreInstance buildJavaIterable(Iterable<?> iterable)
+    {
+        MutableList<CoreInstance> values = Iterate.collect(iterable, this::buildJavaValue, Lists.mutable.empty());
+        CoreInstance instance = newCoreInstance(JAVA_ITERABLE_CLASS);
+        setProperty(instance, M3Properties._class, iterable.getClass().getName());
+        setProperty(instance, M3Properties.values, values);
+        return instance;
+    }
+
+    private CoreInstance buildJavaOtherObject(Object object)
+    {
+        CoreInstance instance = newCoreInstance(JAVA_OBJECT_CLASS);
+        setProperty(instance, M3Properties._class, object.getClass().getName());
+        setProperty(instance, "string", object.toString());
+        return instance;
+    }
+
+    private void setProperty(CoreInstance instance, String property, String value)
+    {
+        setProperty(instance, property, newStringCoreInstance(value));
+    }
+
+    private void setProperty(CoreInstance instance, String property, CoreInstance value)
+    {
+        Instance.setValueForProperty(instance, property, value, this.processorSupport);
+    }
+
+    private void setProperty(CoreInstance instance, String property, ListIterable<? extends CoreInstance> values)
+    {
+        Instance.setValuesForProperty(instance, property, values, this.processorSupport);
+    }
+
+    private CoreInstance newBooleanCoreInstance(boolean value)
+    {
+        return newCoreInstance(Boolean.toString(value), M3Paths.Boolean);
+    }
+
+    private CoreInstance newStringCoreInstance(String string)
+    {
+        return newCoreInstance(string, M3Paths.String);
+    }
+
+    private CoreInstance newCoreInstance(String typeName)
+    {
+        return newCoreInstance(null, typeName);
+    }
+
+    private CoreInstance newCoreInstance(String name, String typeName)
+    {
+        return this.processorSupport.newCoreInstance(name, typeName, null);
+    }
+}

--- a/legend-engine-xt-java-runtime-compiler/src/main/resources/core_external_language_java_compiler/compiler.pure
+++ b/legend-engine-xt-java-runtime-compiler/src/main/resources/core_external_language_java_compiler/compiler.pure
@@ -36,6 +36,80 @@ Class meta::external::language::java::compiler::ExecutionResult
 {
     successful : Boolean[1];
     error : String[0..1];
+    returnValue : JavaValue[0..1];
+}
+
+Class meta::external::language::java::compiler::JavaValue
+{
+}
+
+Class meta::external::language::java::compiler::JavaNull extends JavaValue
+{
+   <<equality.Key>> key:Nil[0];
+   toString()
+   {
+       'null'
+   }:String[1];
+}
+
+Class meta::external::language::java::compiler::JavaPrimitive extends JavaValue
+{
+    <<equality.Key>> type : String[1];
+    <<equality.Key>> value : String[1];
+    toString()
+    {
+        '(' + $this.type + ') ' + $this.value
+    }:String[1];
+}
+
+Class meta::external::language::java::compiler::JavaArray extends JavaValue
+{
+    <<equality.Key>> componentType : String[1];
+    <<equality.Key>> values : JavaValue[*];
+    toString()
+    {
+        $this.values->map(v | $v->toString())->joinStrings('<' + $this.componentType + '[] [', ', ', ']>')
+    }:String[1];
+}
+
+Class meta::external::language::java::compiler::JavaEnum extends JavaValue
+{
+    <<equality.Key>> class : String[1];
+    <<equality.Key>> name : String[1];
+    toString()
+    {
+        $this.class + '.' + $this.name
+    }:String[1];
+}
+
+Class meta::external::language::java::compiler::JavaIterable extends JavaValue
+{
+    <<equality.Key>> class : String[1];
+    <<equality.Key>> values : JavaValue[*];
+    toString()
+    {
+        $this.values->map(v | $v->toString())->joinStrings('<' + $this.class + ' [', ', ', ']>')
+    }:String[1];
+}
+
+Class meta::external::language::java::compiler::JavaMap extends JavaValue
+{
+    <<equality.Key>> class : String[1];
+    <<equality.Key>> keyValuePairs : Pair<JavaValue, JavaValue>[*];
+    toString()
+    {
+        $this.keyValuePairs->map(p | $p.first->toString() + ' : ' + $p.second->toString())->joinStrings('<' + $this.class + ' {', ', ', '}>')
+    }:String[1];
+}
+
+Class meta::external::language::java::compiler::JavaObject extends JavaValue
+{
+    <<equality.Key>> class : String[1];
+    <<equality.Key>> string : String[1];
+    toString()
+    {
+        '<' + $this.class + ' ' + $this.string + '>'
+    }:String[1];
 }
 
 Class meta::external::language::java::compiler::CompileAndExecuteResult

--- a/legend-engine-xt-java-runtime-compiler/src/main/resources/core_external_language_java_compiler/compiler.pure
+++ b/legend-engine-xt-java-runtime-compiler/src/main/resources/core_external_language_java_compiler/compiler.pure
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import meta::external::language::java::compiler::*;
+import meta::external::language::java::factory::*;
 import meta::external::language::java::serialization::*;
 
 Class meta::external::language::java::compiler::CompilationConfiguration
@@ -127,12 +128,12 @@ Class meta::external::language::java::compiler::JavaSource
 
 function meta::external::language::java::compiler::compileJava(classes:meta::external::language::java::metamodel::Class[*], config:CompilationConfiguration[0..1]):meta::external::language::java::compiler::CompilationResult[1]
 {
-    compileJava($classes->map(c | ^JavaSource(package=$c.package->packageToString(), name=$c.simpleName, content=$c->classToString())), $config);
+    compileJava($classes->map(c | ^JavaSource(package=$c.package->packageToString(), name=$c.simpleName, content=$c->inferImports()->classToString())), $config);
 }
 
 function meta::external::language::java::compiler::compileAndExecuteJava(classes:meta::external::language::java::metamodel::Class[*], compConfig:CompilationConfiguration[0..1], execConfig:ExecutionConfiguration[1]):CompileAndExecuteResult[1]
 {
-    compileAndExecuteJava($classes->map(c | ^JavaSource(package=$c.package->packageToString(), name=$c.simpleName, content=$c->classToString())), $compConfig, $execConfig);
+    compileAndExecuteJava($classes->map(c | ^JavaSource(package=$c.package->packageToString(), name=$c.simpleName, content=$c->inferImports()->classToString())), $compConfig, $execConfig);
 }
 
 native function meta::external::language::java::compiler::compileJava(classes:JavaSource[*], config:CompilationConfiguration[0..1]):meta::external::language::java::compiler::CompilationResult[1];

--- a/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/AbstractTestCompileAndExecuteJava.java
+++ b/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/AbstractTestCompileAndExecuteJava.java
@@ -16,12 +16,12 @@ package org.finos.legend.engine.external.language.java.runtime.compiler;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.exception.PureAssertFailException;
 import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
@@ -54,7 +54,8 @@ public abstract class AbstractTestCompileAndExecuteJava extends AbstractPureTest
                 "let emptyResult = compileAndExecuteJava([]->cast(@JavaSource), [], ^ExecutionConfiguration(class='not.a.real.Cls', method='none'));",
                 "assert($emptyResult.compilationResult.successful, |'expected successful compilation');",
                 "assert(!$emptyResult.executionResult->toOne().successful, |'expected failed execution');",
-                "assert($emptyResult.executionResult.error->toOne()->startsWith('java.lang.ClassNotFoundException: not.a.real.Cls'), |'unexpected error: ' + $emptyResult.executionResult.error->toOne());");
+                "assert($emptyResult.executionResult.error->toOne()->startsWith('java.lang.ClassNotFoundException: not.a.real.Cls'), |'unexpected error: ' + $emptyResult.executionResult.error->toOne());",
+                "assert($emptyResult.executionResult.returnValue->isEmpty(), |'unexpected returnValue: ' + $emptyResult.executionResult.returnValue->toOne()->toString());");
     }
 
     @Test
@@ -68,7 +69,7 @@ public abstract class AbstractTestCompileAndExecuteJava extends AbstractPureTest
         compileAndExecute(
                 "let invalidResult = compileJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + invalidJavaCode + "'), []);",
                 "assert(false == $invalidResult.successful, |'expected unsuccessful compilation');",
-                "let expectedErrors = ['/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:14:13" + lineSep + "cannot assign a value to final variable name', '/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:14:21" + lineSep + "incompatible types: java.lang.Integer cannot be converted to java.lang.String'];",
+                "let expectedErrors = ['/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:28:13" + lineSep + "cannot assign a value to final variable name', '/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:28:21" + lineSep + "incompatible types: java.lang.Integer cannot be converted to java.lang.String'];",
                 "assert($expectedErrors == $invalidResult.errors, |'expected: ' + $expectedErrors->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']') + '\\nactual: ' + $invalidResult.errors->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']'));");
     }
 
@@ -83,7 +84,7 @@ public abstract class AbstractTestCompileAndExecuteJava extends AbstractPureTest
         compileAndExecute(
                 "let invalidResult = compileAndExecuteJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + invalidJavaCode + "'), [], ^ExecutionConfiguration(class='" + SourceCodeHelper.INVALID_CLASS + "', method='main'));",
                 "assert(false == $invalidResult.compilationResult.successful, |'expected unsuccessful compilation');",
-                "let expectedErrors = ['/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:14:13" + lineSep + "cannot assign a value to final variable name', '/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:14:21" + lineSep + "incompatible types: java.lang.Integer cannot be converted to java.lang.String'];",
+                "let expectedErrors = ['/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:28:13" + lineSep + "cannot assign a value to final variable name', '/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java:28:21" + lineSep + "incompatible types: java.lang.Integer cannot be converted to java.lang.String'];",
                 "assert($expectedErrors == $invalidResult.compilationResult.errors, |'expected: ' + $expectedErrors->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']') + '\\nactual: ' + $invalidResult.compilationResult.errors->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']'));",
                 "assert($invalidResult.executionResult->isEmpty(), |'expected empty execution result, got: ' + $invalidResult.executionResult->toOne()->toString());");
     }
@@ -103,7 +104,7 @@ public abstract class AbstractTestCompileAndExecuteJava extends AbstractPureTest
     }
 
     @Test
-    public void testCompileAndExecuteValidJavaExecuteSuccess()
+    public void testCompileAndExecuteValidJavaExecuteSuccess_Void()
     {
         String validJavaCode = loadSourceCodeEscaped(SourceCodeHelper.VALID_CLASS);
         int lastDot = SourceCodeHelper.VALID_CLASS.lastIndexOf('.');
@@ -115,7 +116,137 @@ public abstract class AbstractTestCompileAndExecuteJava extends AbstractPureTest
                 "assert($validResult.compilationResult.errors->isEmpty(), |$validResult.compilationResult.errors->joinStrings('expected no errors, got: \\'', '\\', \\'', '\\''));",
                 "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
                 "assert($validResult.executionResult->toOne().successful, |'expected successful execution');",
-                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());");
+                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue == ^JavaNull(), |'unexpected return value, got: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
+    }
+
+    @Test
+    public void testCompileAndExecuteValidJavaExecuteSuccess_String()
+    {
+        String validJavaCode = loadSourceCodeEscaped(SourceCodeHelper.VALID_CLASS);
+        int lastDot = SourceCodeHelper.VALID_CLASS.lastIndexOf('.');
+        String packageName = SourceCodeHelper.VALID_CLASS.substring(0, lastDot);
+        String className = SourceCodeHelper.VALID_CLASS.substring(lastDot + 1);
+        compileAndExecute(
+                "let validResult = compileAndExecuteJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + validJavaCode + "'), [], ^ExecutionConfiguration(class='" + SourceCodeHelper.VALID_CLASS + "', method='succeedReturnString'));",
+                "assert($validResult.compilationResult.successful, |'expected successful compilation');",
+                "assert($validResult.compilationResult.errors->isEmpty(), |$validResult.compilationResult.errors->joinStrings('expected no errors, got: \\'', '\\', \\'', '\\''));",
+                "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
+                "assert($validResult.executionResult->toOne().successful, |'expected successful execution');",
+                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue == ^JavaObject(class='java.lang.String', string='the quick brown fox jumps over the lazy dog'), |'unexpected return value, got: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
+    }
+
+    @Test
+    public void testCompileAndExecuteValidJavaExecuteSuccess_Integer()
+    {
+        String validJavaCode = loadSourceCodeEscaped(SourceCodeHelper.VALID_CLASS);
+        int lastDot = SourceCodeHelper.VALID_CLASS.lastIndexOf('.');
+        String packageName = SourceCodeHelper.VALID_CLASS.substring(0, lastDot);
+        String className = SourceCodeHelper.VALID_CLASS.substring(lastDot + 1);
+        compileAndExecute(
+                "let validResult = compileAndExecuteJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + validJavaCode + "'), [], ^ExecutionConfiguration(class='" + SourceCodeHelper.VALID_CLASS + "', method='succeedReturnInt'));",
+                "assert($validResult.compilationResult.successful, |'expected successful compilation');",
+                "assert($validResult.compilationResult.errors->isEmpty(), |$validResult.compilationResult.errors->joinStrings('expected no errors, got: \\'', '\\', \\'', '\\''));",
+                "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
+                "assert($validResult.executionResult->toOne().successful, |'expected successful execution');",
+                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue == ^JavaObject(class='java.lang.Integer', string='4'), |'unexpected return value, got: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
+    }
+
+    @Test
+    public void testCompileAndExecuteValidJavaExecuteSuccess_StringArray()
+    {
+        String validJavaCode = loadSourceCodeEscaped(SourceCodeHelper.VALID_CLASS);
+        int lastDot = SourceCodeHelper.VALID_CLASS.lastIndexOf('.');
+        String packageName = SourceCodeHelper.VALID_CLASS.substring(0, lastDot);
+        String className = SourceCodeHelper.VALID_CLASS.substring(lastDot + 1);
+        compileAndExecute(
+                "let validResult = compileAndExecuteJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + validJavaCode + "'), [], ^ExecutionConfiguration(class='" + SourceCodeHelper.VALID_CLASS + "', method='succeedReturnArray'));",
+                "assert($validResult.compilationResult.successful, |'expected successful compilation');",
+                "assert($validResult.compilationResult.errors->isEmpty(), |$validResult.compilationResult.errors->joinStrings('expected no errors, got: \\'', '\\', \\'', '\\''));",
+                "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
+                "assert($validResult.executionResult->toOne().successful, |'expected successful execution');",
+                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue == ^JavaArray(componentType='java.lang.String', values=[^JavaObject(class='java.lang.String', string='the quick'), ^JavaObject(class='java.lang.String', string='brown fox'), ^JavaObject(class='java.lang.String', string='jumps over'), ^JavaObject(class='java.lang.String', string='the lazy dog')]), |'unexpected return value, got: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
+    }
+
+    @Test
+    public void testCompileAndExecuteValidJavaExecuteSuccess_IntArray()
+    {
+        String validJavaCode = loadSourceCodeEscaped(SourceCodeHelper.VALID_CLASS);
+        int lastDot = SourceCodeHelper.VALID_CLASS.lastIndexOf('.');
+        String packageName = SourceCodeHelper.VALID_CLASS.substring(0, lastDot);
+        String className = SourceCodeHelper.VALID_CLASS.substring(lastDot + 1);
+        compileAndExecute(
+                "let validResult = compileAndExecuteJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + validJavaCode + "'), [], ^ExecutionConfiguration(class='" + SourceCodeHelper.VALID_CLASS + "', method='succeedReturnIntArray'));",
+                "assert($validResult.compilationResult.successful, |'expected successful compilation');",
+                "assert($validResult.compilationResult.errors->isEmpty(), |$validResult.compilationResult.errors->joinStrings('expected no errors, got: \\'', '\\', \\'', '\\''));",
+                "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
+                "assert($validResult.executionResult->toOne().successful, |'expected successful execution');",
+                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue == ^JavaArray(componentType='int', values=[^JavaPrimitive(type='int', value='9'), ^JavaPrimitive(type='int', value='9'), ^JavaPrimitive(type='int', value='10'), ^JavaPrimitive(type='int', value='12')]), |'unexpected return value, got: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
+    }
+
+    @Test
+    public void testCompileAndExecuteValidJavaExecuteSuccess_StringList()
+    {
+        String validJavaCode = loadSourceCodeEscaped(SourceCodeHelper.VALID_CLASS);
+        int lastDot = SourceCodeHelper.VALID_CLASS.lastIndexOf('.');
+        String packageName = SourceCodeHelper.VALID_CLASS.substring(0, lastDot);
+        String className = SourceCodeHelper.VALID_CLASS.substring(lastDot + 1);
+        compileAndExecute(
+                "let validResult = compileAndExecuteJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + validJavaCode + "'), [], ^ExecutionConfiguration(class='" + SourceCodeHelper.VALID_CLASS + "', method='succeedReturnList'));",
+                "assert($validResult.compilationResult.successful, |'expected successful compilation');",
+                "assert($validResult.compilationResult.errors->isEmpty(), |$validResult.compilationResult.errors->joinStrings('expected no errors, got: \\'', '\\', \\'', '\\''));",
+                "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
+                "assert($validResult.executionResult->toOne().successful, |'expected successful execution');",
+                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue == ^JavaIterable(class='java.util.Arrays$ArrayList', values=[^JavaObject(class='java.lang.String', string='the quick'), ^JavaObject(class='java.lang.String', string='brown fox'), ^JavaObject(class='java.lang.String', string='jumps over'), ^JavaObject(class='java.lang.String', string='the lazy dog')]), |'unexpected return value, got: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
+    }
+
+    @Test
+    public void testCompileAndExecuteValidJavaExecuteSuccess_Map()
+    {
+        String validJavaCode = loadSourceCodeEscaped(SourceCodeHelper.VALID_CLASS);
+        int lastDot = SourceCodeHelper.VALID_CLASS.lastIndexOf('.');
+        String packageName = SourceCodeHelper.VALID_CLASS.substring(0, lastDot);
+        String className = SourceCodeHelper.VALID_CLASS.substring(lastDot + 1);
+        compileAndExecute(
+                "let validResult = compileAndExecuteJava(^JavaSource(package='" + packageName + "', name='" + className + "', content='" + validJavaCode + "'), [], ^ExecutionConfiguration(class='" + SourceCodeHelper.VALID_CLASS + "', method='succeedReturnMap'));",
+                "assert($validResult.compilationResult.successful, |'expected successful compilation');",
+                "assert($validResult.compilationResult.errors->isEmpty(), |$validResult.compilationResult.errors->joinStrings('expected no errors, got: \\'', '\\', \\'', '\\''));",
+                "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
+                "assert($validResult.executionResult->toOne().successful, |'expected successful execution');",
+                "assert($validResult.executionResult->toOne().error->isEmpty(), |'expected no execution error, got: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue == ^JavaMap(class='java.util.HashMap', keyValuePairs=[",
+                "    pair(^JavaObject(class='java.lang.Character', string='a'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='36')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='b'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='10')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='c'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='7')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='d'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='40')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='e'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='2'), ^JavaObject(class='java.lang.Integer', string='28'), ^JavaObject(class='java.lang.Integer', string='33')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='f'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='16')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='g'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='42')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='h'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='1'), ^JavaObject(class='java.lang.Integer', string='32')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='i'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='6')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='j'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='20')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='k'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='8')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='l'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='35')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='m'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='22')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='n'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='14')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='o'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='12'), ^JavaObject(class='java.lang.Integer', string='17'), ^JavaObject(class='java.lang.Integer', string='26'), ^JavaObject(class='java.lang.Integer', string='41')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='p'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='23')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='q'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='4')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='r'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='11'), ^JavaObject(class='java.lang.Integer', string='29')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='s'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='24')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='t'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='0'), ^JavaObject(class='java.lang.Integer', string='31')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='u'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='5'), ^JavaObject(class='java.lang.Integer', string='21')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='v'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='27')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='w'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='13')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='x'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='18')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='y'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='38')])),",
+                "    pair(^JavaObject(class='java.lang.Character', string='z'), ^JavaIterable(class='java.util.ArrayList', values=[^JavaObject(class='java.lang.Integer', string='37')]))",
+                "]), |'unexpected return value, got: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
     }
 
     @Test
@@ -132,7 +263,8 @@ public abstract class AbstractTestCompileAndExecuteJava extends AbstractPureTest
                 "assert(!$validResult.executionResult->isEmpty(), |'expected non-empty execution result');",
                 "assert(!$validResult.executionResult->toOne().successful, |'expected unsuccessful execution');",
                 "assert(!$validResult.executionResult->toOne().error->isEmpty(), |'expected an execution error');",
-                "assert($validResult.executionResult->toOne().error->toOne()->contains('Caused by: java.lang.RuntimeException: Oh no! A failure!'), |'expected an execution error');");
+                "assert($validResult.executionResult->toOne().error->toOne()->contains('Caused by: java.lang.RuntimeException: Oh no! A failure!'), |'unexpected execution error: ' + $validResult.executionResult->toOne().error->toOne());",
+                "assert($validResult.executionResult->toOne().returnValue->isEmpty(), |'unexpected execution return value: ' + $validResult.executionResult->toOne().returnValue->toOne()->toString());");
     }
 
     private void compileAndExecute(String... lines)

--- a/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/compiled/TestCompileAndExecuteJavaCompiled.java
+++ b/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/compiled/TestCompileAndExecuteJavaCompiled.java
@@ -15,7 +15,6 @@
 package org.finos.legend.engine.external.language.java.runtime.compiler.compiled;
 
 import org.finos.legend.engine.external.language.java.runtime.compiler.AbstractTestCompileAndExecuteJava;
-import org.finos.legend.pure.generated.CoreJavaModelFactoryRegistry;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.junit.BeforeClass;
 

--- a/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/shared/TestCompileAndExecuteJava.java
+++ b/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/shared/TestCompileAndExecuteJava.java
@@ -15,12 +15,16 @@
 package org.finos.legend.engine.external.language.java.runtime.compiler.shared;
 
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.external.language.java.runtime.compiler.SourceCodeHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,7 +42,7 @@ public class TestCompileAndExecuteJava
 
         JavaFileObject sourceCode = SourceCodeHelper.loadSourceCode(SourceCodeHelper.VALID_CLASS);
         CompilationResult result = CompileAndExecuteJava.compile(Collections.singletonList(sourceCode), Collections.emptyList());
-        Assert.assertTrue(result.isSuccess());
+        Assert.assertTrue(result.getErrorMessages().makeString("\n"), result.isSuccess());
         Assert.assertEquals(Collections.emptyList(), result.getDiagnostics());
         Assert.assertEquals(Collections.emptyList(), result.getErrorMessages());
         ClassLoader classLoader = result.getClassLoader();
@@ -62,8 +66,8 @@ public class TestCompileAndExecuteJava
         Assert.assertEquals(Collections.singleton(sourceCode), Iterate.collect(diagnostics, Diagnostic::getSource, Sets.mutable.empty()));
 
         String separator = System.lineSeparator();
-        String expectedMessage1 = sourceCode.getName() + ":14:13" + separator + "cannot assign a value to final variable name";
-        String expectedMessage2 = sourceCode.getName() + ":14:21" + separator + "incompatible types: java.lang.Integer cannot be converted to java.lang.String";
+        String expectedMessage1 = sourceCode.getName() + ":28:13" + separator + "cannot assign a value to final variable name";
+        String expectedMessage2 = sourceCode.getName() + ":28:21" + separator + "incompatible types: java.lang.Integer cannot be converted to java.lang.String";
         Assert.assertEquals(Arrays.asList(expectedMessage1, expectedMessage2), result.getErrorMessages());
     }
 
@@ -74,10 +78,68 @@ public class TestCompileAndExecuteJava
         JavaFileObject sourceCode = SourceCodeHelper.loadSourceCode(validClassName);
         CompilationResult compResult = CompileAndExecuteJava.compile(Collections.singletonList(sourceCode), Collections.emptyList());
 
-        ExecutionResult execResult = CompileAndExecuteJava.execute(compResult, validClassName, "succeed");
-        Assert.assertTrue(execResult.isSuccess());
-        Assert.assertEquals("the quick brown fox jumps over the lazy dog", execResult.getResult());
-        Assert.assertNull(execResult.getError());
+        testExecuteSuccess(null, compResult, validClassName, "succeed");
+        testExecuteSuccess("the quick brown fox jumps over the lazy dog", compResult, validClassName, "succeedReturnString");
+        testExecuteSuccess(4, compResult, validClassName, "succeedReturnInt");
+        testExecuteSuccess(new String[]{"the quick", "brown fox", "jumps over", "the lazy dog"}, compResult, validClassName, "succeedReturnArray");
+        testExecuteSuccess(new int[]{9, 9, 10, 12}, compResult, validClassName, "succeedReturnIntArray");
+        testExecuteSuccess(Lists.mutable.with("the quick", "brown fox", "jumps over", "the lazy dog"), compResult, validClassName, "succeedReturnList");
+        MutableMap<Character, List<Integer>> expectedMap = Maps.mutable.<Character, List<Integer>>empty()
+                .withKeyValue('a', Lists.mutable.with(36))
+                .withKeyValue('b', Lists.mutable.with(10))
+                .withKeyValue('c', Lists.mutable.with(7))
+                .withKeyValue('d', Lists.mutable.with(40))
+                .withKeyValue('e', Lists.mutable.with(2, 28, 33))
+                .withKeyValue('f', Lists.mutable.with(16))
+                .withKeyValue('g', Lists.mutable.with(42))
+                .withKeyValue('h', Lists.mutable.with(1, 32))
+                .withKeyValue('i', Lists.mutable.with(6))
+                .withKeyValue('j', Lists.mutable.with(20))
+                .withKeyValue('k', Lists.mutable.with(8))
+                .withKeyValue('l', Lists.mutable.with(35))
+                .withKeyValue('m', Lists.mutable.with(22))
+                .withKeyValue('n', Lists.mutable.with(14))
+                .withKeyValue('o', Lists.mutable.with(12, 17, 26, 41))
+                .withKeyValue('p', Lists.mutable.with(23))
+                .withKeyValue('q', Lists.mutable.with(4))
+                .withKeyValue('r', Lists.mutable.with(11, 29))
+                .withKeyValue('s', Lists.mutable.with(24))
+                .withKeyValue('t', Lists.mutable.with(0, 31))
+                .withKeyValue('u', Lists.mutable.with(5, 21))
+                .withKeyValue('v', Lists.mutable.with(27))
+                .withKeyValue('w', Lists.mutable.with(13))
+                .withKeyValue('x', Lists.mutable.with(18))
+                .withKeyValue('y', Lists.mutable.with(38))
+                .withKeyValue('z', Lists.mutable.with(37));
+        testExecuteSuccess(expectedMap, compResult, validClassName, "succeedReturnMap");
+    }
+
+    private void testExecuteSuccess(Object expectedResult, CompilationResult compResult, String className, String methodName)
+    {
+        String failureMessage = className + "." + methodName;
+        ExecutionResult execResult = CompileAndExecuteJava.execute(compResult, className, methodName);
+        Assert.assertTrue(failureMessage, execResult.isSuccess());
+        Assert.assertNull(failureMessage, execResult.getError());
+        Object actualResult = execResult.getResult();
+        if ((expectedResult == null) || !expectedResult.getClass().isArray() || !actualResult.getClass().isArray())
+        {
+            Assert.assertEquals(failureMessage, expectedResult, actualResult);
+        }
+        else
+        {
+            Assert.assertEquals(failureMessage, arrayToList(expectedResult), arrayToList(actualResult));
+        }
+    }
+
+    private MutableList<Object> arrayToList(Object array)
+    {
+        int length = Array.getLength(array);
+        MutableList<Object> result = Lists.mutable.ofInitialCapacity(length);
+        for (int i = 0; i < length; i++)
+        {
+            result.add(Array.get(array, i));
+        }
+        return result;
     }
 
     @Test

--- a/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/shared/TestPureResultBuilder.java
+++ b/legend-engine-xt-java-runtime-compiler/src/test/java/org/finos/legend/engine/external/language/java/runtime/compiler/shared/TestPureResultBuilder.java
@@ -1,0 +1,298 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.external.language.java.runtime.compiler.shared;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.PrimitiveType;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import javax.lang.model.SourceVersion;
+
+public class TestPureResultBuilder extends AbstractPureTestWithCoreCompiled
+{
+    private static PureResultBuilder resultBuilder;
+
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(new FunctionExecutionInterpreted(), getCodeStorage(), getFactoryRegistryOverride(), getOptions(), getExtra());
+        runtime.loadAndCompileSystem();
+        resultBuilder = new PureResultBuilder(processorSupport);
+    }
+
+    protected static MutableCodeStorage getCodeStorage()
+    {
+        CodeRepositorySet repositories = CodeRepositorySet.newBuilder()
+                .withCodeRepositories(CodeRepositoryProviderHelper.findCodeRepositories(true))
+                .build()
+                .subset("core_external_language_java_compiler");
+
+        return PureCodeStorage.createCodeStorage(null, repositories.getRepositories());
+    }
+
+    @Test
+    public void testBuildJavaNull()
+    {
+        CoreInstance instance = resultBuilder.buildJavaValue(null);
+        assertClassifierPath("meta::external::language::java::compiler::JavaNull", instance);
+    }
+
+    @Test
+    public void testBuildJavaEnum()
+    {
+        testBuildJavaEnum(SourceVersion.RELEASE_0);
+        testBuildJavaEnum(SourceVersion.RELEASE_7);
+        testBuildJavaEnum(SourceVersion.RELEASE_8);
+    }
+
+    private void testBuildJavaEnum(Enum<?> javaEnum)
+    {
+        CoreInstance instance = resultBuilder.buildJavaValue(javaEnum);
+        assertClassifierPath("meta::external::language::java::compiler::JavaEnum", instance);
+        Assert.assertEquals(javaEnum.getDeclaringClass().getName(), getStringPropertyValue(instance, "class"));
+        Assert.assertEquals(javaEnum.name(), getStringPropertyValue(instance, "name"));
+    }
+
+    @Test
+    public void testBuildJavaArray()
+    {
+        testBuildJavaArray(new int[] {1, 2, 3, 4, Integer.MIN_VALUE, Integer.MAX_VALUE});
+        testBuildJavaArray(new long[] {1L, 2L, 3L, 4L, Long.MIN_VALUE, Long.MAX_VALUE});
+        testBuildJavaArray(new byte[] {1, 2, 3, 4, Byte.MIN_VALUE, Byte.MAX_VALUE});
+        testBuildJavaArray(new short[] {1, 2, 3, 4, Short.MIN_VALUE, Short.MAX_VALUE});
+        testBuildJavaArray(new char[] {'1', '2', 'a', 'b', Character.MIN_VALUE, Character.MAX_VALUE});
+        testBuildJavaArray(new float[] {1.0f, 2.0f, 3.0f, 4.0f, Float.MIN_VALUE, Float.MAX_VALUE});
+        testBuildJavaArray(new double[] {1.0, 2.0, 3.0, 4.0, Double.MIN_VALUE, Double.MAX_VALUE});
+        testBuildJavaArray(new boolean[] {true, false});
+        testBuildJavaArray(new Object[]{});
+        testBuildJavaArray(new Object[]{null, "a", "b", 3L, 4, new Object[]{5, 6L, "b"}});
+        testBuildJavaArray(new String[]{"the", "quick", "brown", null, "fox"});
+    }
+
+    private void testBuildJavaArray(Object array)
+    {
+        CoreInstance instance = resultBuilder.buildJavaValue(array);
+        assertClassifierPath("meta::external::language::java::compiler::JavaArray", instance);
+        Assert.assertEquals(array.getClass().getComponentType().getName(), getStringPropertyValue(instance, "componentType"));
+        assertCoreInstancesEqual(buildArrayExpectedValues(array), getPropertyValues(instance, "values"));
+    }
+
+    private MutableList<CoreInstance> buildArrayExpectedValues(Object array)
+    {
+        Class<?> componentType = array.getClass().getComponentType();
+        int length = Array.getLength(array);
+        MutableList<CoreInstance> results = Lists.mutable.ofInitialCapacity(length);
+        for (int i = 0; i < length; i++)
+        {
+            Object object = Array.get(array, i);
+            CoreInstance instance;
+            if (componentType.isPrimitive())
+            {
+                instance = processorSupport.newCoreInstance(null, "meta::external::language::java::compiler::JavaPrimitive", null);
+                Instance.setValueForProperty(instance, "type", processorSupport.newCoreInstance(componentType.getName(), M3Paths.String, null), processorSupport);
+                Instance.setValueForProperty(instance, "value", processorSupport.newCoreInstance(object.toString(), M3Paths.String, null), processorSupport);
+            }
+            else
+            {
+                instance = resultBuilder.buildJavaValue(object);
+            }
+            results.add(instance);
+        }
+        return results;
+    }
+
+    @Test
+    public void testBuildJavaIterable()
+    {
+        testBuildJavaIterable(Collections.emptyList());
+        testBuildJavaIterable(Lists.immutable.empty());
+        testBuildJavaIterable(Lists.mutable.empty());
+        testBuildJavaIterable(new ArrayList<>());
+        testBuildJavaIterable(Lists.mutable.with("a", "b", "c", null, 1, 2, 3, null));
+
+        testBuildJavaIterable(Collections.emptySet());
+        testBuildJavaIterable(Sets.immutable.empty());
+        testBuildJavaIterable(new HashSet<>());
+        testBuildJavaIterable(Sets.mutable.with("a", "B", "c", null, 1, 2, 3, null));
+    }
+
+    private void testBuildJavaIterable(Iterable<?> iterable)
+    {
+        CoreInstance instance = resultBuilder.buildJavaValue(iterable);
+        assertClassifierPath("meta::external::language::java::compiler::JavaIterable", instance);
+        Assert.assertEquals(iterable.getClass().getName(), getStringPropertyValue(instance, "class"));
+        assertCoreInstancesEqual(Iterate.collect(iterable, resultBuilder::buildJavaValue, Lists.mutable.empty()), getPropertyValues(instance, "values"));
+    }
+
+    @Test
+    public void testBuildJavaMap()
+    {
+        testBuildJavaMap(Collections.emptyMap());
+        testBuildJavaMap(new HashMap<>());
+        testBuildJavaMap(Maps.immutable.empty().castToMap());
+        testBuildJavaMap(Maps.mutable.with("one", 1, "two", 2));
+        testBuildJavaMap(Maps.mutable.with("one", Lists.mutable.with(1, 2, 3, 4), "two", 5, "three", Sets.mutable.with(6, 7, 8)));
+    }
+
+    private void testBuildJavaMap(Map<?, ?> map)
+    {
+        CoreInstance instance = resultBuilder.buildJavaValue(map);
+        assertClassifierPath("meta::external::language::java::compiler::JavaMap", instance);
+        Assert.assertEquals(map.getClass().getName(), getStringPropertyValue(instance, "class"));
+
+        MutableList<CoreInstance> expectedKeyValues = Lists.mutable.ofInitialCapacity(map.size());
+        map.forEach((key, value) ->
+        {
+            CoreInstance convertedKey = resultBuilder.buildJavaValue(key);
+            CoreInstance convertedValue = resultBuilder.buildJavaValue(value);
+            CoreInstance pair = processorSupport.newCoreInstance(null, M3Paths.Pair, null);
+            Instance.setValueForProperty(pair, M3Properties.first, convertedKey, processorSupport);
+            Instance.setValueForProperty(pair, M3Properties.second, convertedValue, processorSupport);
+            expectedKeyValues.add(pair);
+        });
+        assertCoreInstancesEqual(expectedKeyValues, getPropertyValues(instance, "keyValuePairs"));
+    }
+
+    @Test
+    public void testBuildJavaOtherObject()
+    {
+        testBuildJavaOtherObject("the quick brown fox");
+        testBuildJavaOtherObject(123);
+        testBuildJavaOtherObject(123L);
+        testBuildJavaOtherObject(123.0f);
+        testBuildJavaOtherObject(123.0d);
+        testBuildJavaOtherObject(Boolean.TRUE);
+        testBuildJavaOtherObject(Boolean.FALSE);
+        testBuildJavaOtherObject('\n');
+        testBuildJavaOtherObject(new Object()
+        {
+           @Override
+           public String toString()
+           {
+               return "expected string";
+           }
+        });
+    }
+
+    private void testBuildJavaOtherObject(Object object)
+    {
+        CoreInstance instance = resultBuilder.buildJavaValue(object);
+        assertClassifierPath("meta::external::language::java::compiler::JavaObject", instance);
+        Assert.assertEquals(object.getClass().getName(), getStringPropertyValue(instance, "class"));
+        Assert.assertEquals(object.toString(), getStringPropertyValue(instance, "string"));
+    }
+
+    private static void assertClassifierPath(String expected, CoreInstance instance)
+    {
+        CoreInstance classifier = instance.getClassifier();
+        Assert.assertNotNull(expected, classifier);
+        String path = PackageableElement.getUserPathForPackageableElement(classifier);
+        Assert.assertEquals(expected, path);
+    }
+
+    private static void assertCoreInstancesEqual(ListIterable<? extends CoreInstance> expected, ListIterable<? extends CoreInstance> actual)
+    {
+        Assert.assertEquals(expected.collect(TestPureResultBuilder::printCoreInstance), actual.collect(TestPureResultBuilder::printCoreInstance));
+    }
+
+    private static void assertCoreInstanceEquals(CoreInstance expected, CoreInstance actual)
+    {
+        Assert.assertEquals(printCoreInstance(expected), printCoreInstance(actual));
+    }
+
+    private static String printCoreInstance(CoreInstance instance)
+    {
+        return printCoreInstance(new StringBuilder(), instance).toString();
+    }
+
+    private static StringBuilder printCoreInstance(StringBuilder builder, CoreInstance instance)
+    {
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement)
+        {
+            return PackageableElement.writeUserPathForPackageableElement(builder, instance);
+        }
+
+        CoreInstance classifier = instance.getClassifier();
+        PackageableElement.writeUserPathForPackageableElement(builder.append('<'), classifier);
+        if (classifier instanceof PrimitiveType)
+        {
+            builder.append(' ').append(instance.getName());
+        }
+        else
+        {
+            instance.getKeys().toSortedList().forEach(key ->
+            {
+                if (!M3Properties.classifierGenericType.equals(key))
+                {
+                    ListIterable<? extends CoreInstance> values = instance.getValueForMetaPropertyToMany(key);
+                    if (values.notEmpty())
+                    {
+                        builder.append(' ').append(key).append('=');
+                        if (values.size() == 1)
+                        {
+                            printCoreInstance(values.get(0));
+                        }
+                        else
+                        {
+                            values.forEachWithIndex((v, i) -> printCoreInstance(builder.append((i == 0) ? "[" : ", "), v));
+                            builder.append(']');
+                        }
+                    }
+                }
+            });
+        }
+        return builder.append('>');
+    }
+
+    private static String getStringPropertyValue(CoreInstance instance, String property)
+    {
+        return PrimitiveUtilities.getStringValue(getPropertyValue(instance, property));
+    }
+
+    private static CoreInstance getPropertyValue(CoreInstance instance, String property)
+    {
+        return instance.getValueForMetaPropertyToOne(property);
+    }
+
+    private static ListIterable<? extends CoreInstance> getPropertyValues(CoreInstance instance, String property)
+    {
+        return instance.getValueForMetaPropertyToMany(property);
+    }
+}

--- a/legend-engine-xt-java-runtime-compiler/src/test/resources/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java
+++ b/legend-engine-xt-java-runtime-compiler/src/test/resources/org/finos/legend/engine/external/language/java/runtime/compiler/shared/InvalidJavaClass.java
@@ -1,3 +1,17 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package org.finos.legend.engine.external.language.java.runtime.compiler.shared;
 
 public class InvalidJavaClass

--- a/legend-engine-xt-java-runtime-compiler/src/test/resources/org/finos/legend/engine/external/language/java/runtime/compiler/shared/ValidJavaClass.java
+++ b/legend-engine-xt-java-runtime-compiler/src/test/resources/org/finos/legend/engine/external/language/java/runtime/compiler/shared/ValidJavaClass.java
@@ -1,4 +1,24 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package org.finos.legend.engine.external.language.java.runtime.compiler.shared;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ValidJavaClass
 {
@@ -14,10 +34,76 @@ public class ValidJavaClass
         return this.source.replaceAll("\\R", " ");
     }
 
-    public static String succeed()
+    public String[] splitLines()
+    {
+        return this.source.split("\\R");
+    }
+
+    public int countLines()
+    {
+        return splitLines().length;
+    }
+
+    public int[] lineLengths()
+    {
+        String[] lines = splitLines();
+        int[] lengths = new int[lines.length];
+        for (int i = 0; i < lines.length; i++)
+        {
+            lengths[i] = lines[i].length();
+        }
+        return lengths;
+    }
+
+    public static void succeed()
+    {
+        String source = "the quick\r\nbrown fox\njumps over\rthe lazy dog";
+        new ValidJavaClass(source).replaceNewlines();
+    }
+
+    public static String succeedReturnString()
     {
         String source = "the quick\r\nbrown fox\njumps over\rthe lazy dog";
         return new ValidJavaClass(source).replaceNewlines();
+    }
+
+    public static int succeedReturnInt()
+    {
+        String source = "the quick\r\nbrown fox\njumps over\rthe lazy dog";
+        return new ValidJavaClass(source).countLines();
+    }
+
+    public static String[] succeedReturnArray()
+    {
+        String source = "the quick\r\nbrown fox\njumps over\rthe lazy dog";
+        return new ValidJavaClass(source).splitLines();
+    }
+
+    public static int[] succeedReturnIntArray()
+    {
+        String source = "the quick\r\nbrown fox\njumps over\rthe lazy dog";
+        return new ValidJavaClass(source).lineLengths();
+    }
+
+    public static List<Object> succeedReturnList()
+    {
+        return Arrays.asList(succeedReturnArray());
+    }
+
+    public static Map<Character, List<Integer>> succeedReturnMap()
+    {
+        String source = "the quick\r\nbrown fox\njumps over\rthe lazy dog";
+        String converted = new ValidJavaClass(source).replaceNewlines();
+        Map<Character, List<Integer>> map = new HashMap<>();
+        for (int i = 0; i < converted.length(); i++)
+        {
+            char c = converted.charAt(i);
+            if (!Character.isWhitespace(c))
+            {
+                map.computeIfAbsent(c, x -> new ArrayList<>()).add(i);
+            }
+        }
+        return map;
     }
 
     public static String fail()


### PR DESCRIPTION
#### What type of PR is this?

Enhancement

#### What does this PR do / why is it needed ?

Adds the Java return value to meta::external::language::java::compiler::ExecutionResult, which is returned by compileAndExecuteJava. It is included if and only if the execution completes successfully. Note that executing a void method will result in a return value of Java null.

#### Does this PR introduce a user-facing change?

It adds an optional additional value to the return value of a native function.
