### PR TITLE
Fix firstDayOfQuarter dynafunc for memsql

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/memSql/memSqlExtension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/memSql/memSqlExtension.pure
@@ -81,7 +81,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memSq
     dynaFnToSql('decodeBase64',           $allStates,            ^ToSql(format='cast(from_base64(%s) as char)')),
     dynaFnToSql('encodeBase64',           $allStates,            ^ToSql(format='cast(to_base64(%s) as char)')),
     dynaFnToSql('firstDayOfMonth',        $allStates,            ^ToSql(format='subdate(%s, INTERVAL dayofmonth(%s) - 1 DAY) ', transform={p:String[1] | $p->repeat(2)})),
-    dynaFnToSql('firstDayOfQuarter',      $allStates,            ^ToSql(format='adddate(subdate(%s, INTERVAL dayofyear(%s) - 1 DAY), INTERVAL (quarter(date(%s) -1)) QUARTER)', transform={p:String[1] | $p->repeat(3)})),
+    dynaFnToSql('firstDayOfQuarter',      $allStates,            ^ToSql(format='adddate(subdate(%s, INTERVAL dayofyear(%s) - 1 DAY), INTERVAL (quarter(date(%s)) -1) QUARTER)', transform={p:String[1] | $p->repeat(3)})),
     dynaFnToSql('firstDayOfThisMonth',    $allStates,            ^ToSql(format='subdate(curdate(), INTERVAL dayofmonth(current_date()) - 1 DAY) ')),
     dynaFnToSql('firstDayOfThisQuarter',  $allStates,            ^ToSql(format='adddate(subdate(curdate(), INTERVAL dayofyear(current_date()) - 1 DAY), INTERVAL (quarter(curdate()) -1) QUARTER)')),
     dynaFnToSql('firstDayOfThisYear',     $allStates,            ^ToSql(format='subdate(curdate(), INTERVAL dayofyear(current_date()) - 1 DAY)')),

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
@@ -1229,7 +1229,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testToSqlG
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testToSqlGenerationFirstDayOfQuarter_MemSQL():Boolean[1]
 {
-   testToSqlGenerationFirstDayOfQuarter(DatabaseType.MemSQL, 'select adddate(subdate(`root`.tradeDate, INTERVAL dayofyear(`root`.tradeDate) - 1 DAY), INTERVAL (quarter(date(`root`.tradeDate) -1)) QUARTER) as `date` from tradeTable as `root`');
+   testToSqlGenerationFirstDayOfQuarter(DatabaseType.MemSQL, 'select adddate(subdate(`root`.tradeDate, INTERVAL dayofyear(`root`.tradeDate) - 1 DAY), INTERVAL (quarter(date(`root`.tradeDate)) -1) QUARTER) as `date` from tradeTable as `root`');
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testToSqlGenerationFirstDayOfQuarter_Sybase():Boolean[1]


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
`firstDayOfQuarter()` function currently returns incorrect values when used on a MemSql runtime.
This PR fixes the dyna function to generate the correct sql
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
