### PR TITLE
Persistence validation fix

### DIFF
--- a/legend-engine-xt-persistence-cloud-grammar/pom.xml
+++ b/legend-engine-xt-persistence-cloud-grammar/pom.xml
@@ -164,6 +164,11 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/legend-engine-xt-persistence-grammar/pom.xml
+++ b/legend-engine-xt-persistence-grammar/pom.xml
@@ -132,6 +132,11 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-dsl-service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-generation</artifactId>
+        </dependency>
+
         <!-- ENGINE -->
 
         <!-- ANTLR -->

--- a/legend-engine-xt-persistence-grammar/pom.xml
+++ b/legend-engine-xt-persistence-grammar/pom.xml
@@ -170,6 +170,11 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
+++ b/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.finos.legend.pure.generated.core_persistence_persistence_validation.Root_meta_pure_persistence_validation_validate_T_1__ValidationRuleSet_1__ValidationResult_1_;
+import static org.finos.legend.pure.generated.core_persistence_persistence_validations_rules.Root_meta_pure_persistence_validation_commonRules_Extension_MANY__ValidationRuleSet_1_;
 import static org.finos.legend.pure.generated.core_persistence_persistence_validations_rules.Root_meta_pure_persistence_validation_commonRules__ValidationRuleSet_1_;
 
 public class PersistenceCompilerExtension implements IPersistenceCompilerExtension
@@ -118,7 +119,7 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                             Root_meta_pure_persistence_metamodel_PersistenceContext purePersistenceContext = (Root_meta_pure_persistence_metamodel_PersistenceContext) context.pureModel.getOrCreatePackage(persistenceContext._package)._children().detect(c -> persistenceContext.name.equals(c._name()));
 
                             // execute common validations
-                            Root_meta_pure_persistence_validation_ValidationRuleSet<? extends Root_meta_pure_persistence_metamodel_PersistenceContext> pureValidationRuleSet = Root_meta_pure_persistence_validation_commonRules__ValidationRuleSet_1_(context.getExecutionSupport());
+                            Root_meta_pure_persistence_validation_ValidationRuleSet<? extends Root_meta_pure_persistence_metamodel_PersistenceContext> pureValidationRuleSet = Root_meta_pure_persistence_validation_commonRules_Extension_MANY__ValidationRuleSet_1_(Lists.immutable.empty(), context.getExecutionSupport());
                             Root_meta_pure_persistence_validation_ValidationResult pureValidationResult = Root_meta_pure_persistence_validation_validate_T_1__ValidationRuleSet_1__ValidationResult_1_(purePersistenceContext, pureValidationRuleSet, context.getExecutionSupport());
                             if (pureValidationResult.invalid(context.getExecutionSupport()))
                             {

--- a/legend-engine-xt-persistence-pure/src/main/resources/core_persistence/persistence/validations_rules.pure
+++ b/legend-engine-xt-persistence-pure/src/main/resources/core_persistence/persistence/validations_rules.pure
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import meta::external::shared::format::*;
 import meta::legend::service::metamodel::*;
 
 import meta::pure::executionPlan::*;
@@ -27,15 +26,13 @@ import meta::pure::persistence::metamodel::persister::*;
 import meta::pure::persistence::metamodel::persister::targetshape::*;
 import meta::pure::persistence::validation::*;
 
-import meta::relational::extension::*;
-
-function meta::pure::persistence::validation::commonRules(): ValidationRuleSet<PersistenceContext>[1]
+function meta::pure::persistence::validation::commonRules(extensions: Extension[*]): ValidationRuleSet<PersistenceContext>[1]
 {
   ^ValidationRuleSet<PersistenceContext>(
     name = 'Common',
     rules = [
       c: PersistenceContext[1] | validateTarget($c.persistence.persister->cast(@BatchPersister).targetShape),
-      c: PersistenceContext[1] | validateServiceAndTarget($c.persistence.service, $c.persistence.persister->cast(@BatchPersister).targetShape)
+      c: PersistenceContext[1] | validateServiceAndTarget($c.persistence.service, $c.persistence.persister->cast(@BatchPersister).targetShape, $extensions)
     ]
   );
 }
@@ -56,46 +53,46 @@ function meta::pure::persistence::validation::validateTarget(target: TargetShape
  * service + target validations
  **********/
 
-function meta::pure::persistence::validation::validateServiceAndTarget(service: Service[1], target: TargetShape[1]): ValidationResult[1]
+function meta::pure::persistence::validation::validateServiceAndTarget(service: Service[1], target: TargetShape[1], extensions: Extension[*]): ValidationResult[1]
 {
   $service.execution->match([
     se: PureSingleExecution[1] | $target->match([
-      f: FlatTarget[1] | validateSingleExecutionServiceAndFlatTarget($service, $se, $f),
-      mf: MultiFlatTarget[1] | validateSingleExecutionServiceAndMultiFlatTarget($service, $se, $mf),
+      f: FlatTarget[1] | validateSingleExecutionServiceAndFlatTarget($service, $se, $f, $extensions),
+      mf: MultiFlatTarget[1] | validateSingleExecutionServiceAndMultiFlatTarget($service, $se, $mf, $extensions),
       any: Any[1] | failure('Unknown target shape')
     ]),
     me: PureMultiExecution[1] | $target->match([
-      f: FlatTarget[1] | validateMultiExecutionServiceAndFlatTarget($service, $me, $f),
-      mf: MultiFlatTarget[1] | validateMultiExecutionServiceAndMultiFlatTarget($service, $me, $mf),
+      f: FlatTarget[1] | validateMultiExecutionServiceAndFlatTarget($service, $me, $f, $extensions),
+      mf: MultiFlatTarget[1] | validateMultiExecutionServiceAndMultiFlatTarget($service, $me, $mf, $extensions),
       any: Any[1] | failure('Unknown target shape')
     ]),
     any: Any[1] | failure('Unknown service execution')
   ]);
 }
 
-function meta::pure::persistence::validation::validateSingleExecutionServiceAndFlatTarget(service: Service[1], execution: PureSingleExecution[1], target: FlatTarget[1]): ValidationResult[1]
+function meta::pure::persistence::validation::validateSingleExecutionServiceAndFlatTarget(service: Service[1], execution: PureSingleExecution[1], target: FlatTarget[1], extensions: Extension[*]): ValidationResult[1]
 {
-  let classification = $execution->classify();
+  let classification = $execution->classify($extensions);
   if ($classification->instanceOf(TdsExecutionClassification) || $classification->instanceOf(FlatGraphFetchSerialize),
     | success(),
     | failure('Flat target requires a service that returns a TDS or ends with a "graphFetch()->serialize()" expression that has only primitive properties off the root node'));
 }
 
-function meta::pure::persistence::validation::validateSingleExecutionServiceAndMultiFlatTarget(service: Service[1], execution: PureSingleExecution[1], target: MultiFlatTarget[1]): ValidationResult[1]
+function meta::pure::persistence::validation::validateSingleExecutionServiceAndMultiFlatTarget(service: Service[1], execution: PureSingleExecution[1], target: MultiFlatTarget[1], extensions: Extension[*]): ValidationResult[1]
 {
-  let classification = $execution->classify();
+  let classification = $execution->classify($extensions);
   if ($classification->instanceOf(OneLevelGraphFetchSerialize),
     | success(),
     | failure('Multi flat target requires a service that ends with a "graphFetch()->serialize()" expression that has 1) only complex properties off the root node and 2) only primitive properties off nodes at depth 1'));
 }
 
-function meta::pure::persistence::validation::validateMultiExecutionServiceAndFlatTarget(service: Service[1], execution: PureMultiExecution[1], target: FlatTarget[1]): ValidationResult[1]
+function meta::pure::persistence::validation::validateMultiExecutionServiceAndFlatTarget(service: Service[1], execution: PureMultiExecution[1], target: FlatTarget[1], extensions: Extension[*]): ValidationResult[1]
 {
   //TODO: ledav -- implement flat validations
   success();
 }
 
-function meta::pure::persistence::validation::validateMultiExecutionServiceAndMultiFlatTarget(service: Service[1], execution: PureMultiExecution[1], target: MultiFlatTarget[1]): ValidationResult[1]
+function meta::pure::persistence::validation::validateMultiExecutionServiceAndMultiFlatTarget(service: Service[1], execution: PureMultiExecution[1], target: MultiFlatTarget[1], extensions: Extension[*]): ValidationResult[1]
 {
   //TODO: ledav -- implement multi flat validations
   success();
@@ -135,13 +132,13 @@ Class meta::pure::persistence::validation::OtherExecutionClassification extends 
 {
 }
 
-function meta::pure::persistence::validation::classify(execution: PureSingleExecution[1]): ExecutionClassification[1]
+function meta::pure::persistence::validation::classify(execution: PureSingleExecution[1], extensions: Extension[*]): ExecutionClassification[1]
 {
   assert($execution->cast(@PureSingleExecution).mapping->isNotEmpty() && $execution->cast(@PureSingleExecution).runtime->isNotEmpty(),'Please provide mapping and runtime as part of execution');
   $execution.func.expressionSequence->evaluateAndDeactivate()->last()->match([
     fe: FunctionExpression[1] | if ($fe.func == meta::pure::graphFetch::execution::serialize_T_MANY__RootGraphFetchTree_1__String_1_,
       | classifyFunctionExpression($execution.func, $fe),
-      | let plan = executionPlan($execution.func, $execution.mapping->toOne(), $execution.runtime->toOne(), extensions());
+      | let plan = executionPlan($execution.func, $execution.mapping->toOne(), $execution.runtime->toOne(), $extensions);
         $plan.rootExecutionNode.resultType->match([
           tds: TDSResultType[1] |
             let columnByName = $tds.tdsColumns->map(c | pair($c.name, $c))->newMap();
@@ -180,13 +177,4 @@ function <<access.private>> meta::pure::persistence::validation::validRootGraphF
 function <<access.private>> meta::pure::persistence::validation::validLeafGraphFetchProperty(property: PropertyGraphFetchTree[1]): Boolean[1]
 {
   $property.isPrimitive() && $property.alias->isEmpty() && $property.parameters->isEmpty() && $property.subType->isEmpty();
-}
-
-/**********
- * utility functions
- **********/
-
-function meta::pure::persistence::validation::extensions(): Extension[*]
-{
-  defaultExtensions()->add(externalFormatExtension())->concatenate(relationalExtensions());
 }

--- a/legend-engine-xt-persistence-pure/src/main/resources/core_persistence/test/validation_rules_test.pure
+++ b/legend-engine-xt-persistence-pure/src/main/resources/core_persistence/test/validation_rules_test.pure
@@ -32,7 +32,7 @@ function <<test.Test>> meta::pure::persistence::test::validateTarget_tdsService_
 function <<test.Test>> meta::pure::persistence::test::validateServiceAndTarget_tdsService_flatPersistence(): Boolean[1]
 {
   let persistence = TdsServiceWithFlatPersistence();
-  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape);
+  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape, extensions());
   assert($result.valid());
 }
 
@@ -46,7 +46,7 @@ function <<test.Test>> meta::pure::persistence::test::validateTarget_tdsService_
 function <<test.Test>> meta::pure::persistence::test::validateServiceAndTarget_tdsService_multiFlatPersistence(): Boolean[1]
 {
   let persistence = TdsServiceWithMultiFlatPersistence();
-  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape);
+  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape, extensions());
   assert($result.invalid());
   assertEq('Multi flat target requires a service that ends with a "graphFetch()->serialize()" expression that has 1) only complex properties off the root node and 2) only primitive properties off nodes at depth 1', $result.reasons->at(0));
 }
@@ -65,7 +65,7 @@ function <<test.Test>> meta::pure::persistence::test::validateTarget_flatM2mServ
 function <<test.Test>> meta::pure::persistence::test::validateServiceAndTarget_flatM2mService_flatPersistence(): Boolean[1]
 {
   let persistence = FlatM2mServiceWithFlatPersistence();
-  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape);
+  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape, extensions());
   assert($result.valid());
 }
 
@@ -79,7 +79,7 @@ function <<test.Test>> meta::pure::persistence::test::validateTarget_flatM2mServ
 function <<test.Test>> meta::pure::persistence::test::validateServiceAndTarget_flatM2mService_multiFlatPersistence(): Boolean[1]
 {
   let persistence = FlatM2mServiceWithMultiFlatPersistence();
-  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape);
+  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape, extensions());
   assert($result.invalid());
   assertEq('Multi flat target requires a service that ends with a "graphFetch()->serialize()" expression that has 1) only complex properties off the root node and 2) only primitive properties off nodes at depth 1', $result.reasons->at(0));
 }
@@ -98,7 +98,7 @@ function <<test.Test>> meta::pure::persistence::test::validateTarget_nestedM2mSe
 function <<test.Test>> meta::pure::persistence::test::validateServiceAndTarget_nestedM2mService_flatPersistence(): Boolean[1]
 {
   let persistence = NestedM2mServiceWithFlatPersistence();
-  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape);
+  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape, extensions());
   assert($result.invalid());
   assertEq('Flat target requires a service that returns a TDS or ends with a "graphFetch()->serialize()" expression that has only primitive properties off the root node', $result.reasons->at(0));
 }
@@ -113,7 +113,7 @@ function <<test.Test>> meta::pure::persistence::test::validateTarget_nestedM2mSe
 function <<test.Test>> meta::pure::persistence::test::validateServiceAndTarget_nestedM2mService_multiFlatPersistence(): Boolean[1]
 {
   let persistence = NestedM2mServiceWithMultiFlatPersistence();
-  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape);
+  let result = validateServiceAndTarget($persistence.service, $persistence.persister->cast(@BatchPersister).targetShape, extensions());
   assert($result.valid());
 }
 
@@ -245,6 +245,7 @@ function meta::pure::persistence::test::RelationalConnection(): Connection[1]
 
 ###Pure
 import meta::legend::service::metamodel::*;
+
 import meta::pure::mapping::*;
 import meta::pure::persistence::metamodel::*;
 import meta::pure::persistence::metamodel::notifier::*;
@@ -542,7 +543,11 @@ Mapping meta::pure::persistence::test::NestedM2mMapping
 )
 
 ###Pure
+import meta::external::shared::format::*;
+
 import meta::legend::service::metamodel::*;
+
+import meta::pure::extension::*;
 import meta::pure::graphFetch::execution::*;
 import meta::pure::mapping::*;
 import meta::pure::mapping::modelToModel::*;
@@ -558,6 +563,8 @@ import meta::pure::persistence::metamodel::persister::targetshape::*;
 import meta::pure::persistence::metamodel::trigger::*;
 import meta::pure::runtime::*;
 import meta::pure::test::assertion::*;
+
+import meta::relational::extension::*;
 
 function meta::pure::persistence::test::NestedM2mRuntime(): Runtime[1]
 {
@@ -704,4 +711,9 @@ function meta::pure::persistence::test::NestedM2mServiceWithMultiFlatPersistence
     ),
     notifier = ^Notifier(notifyees = [])
   );
+}
+
+function meta::pure::persistence::validation::extensions(): Extension[*]
+{
+  defaultExtensions()->add(externalFormatExtension())->concatenate(relationalExtensions());
 }


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
Persistence validation generates an execution plan as a workaround to examine the return type of TDS services.

This PR ensures all plan generation extensions are passed through when this execution plan is generated. 

#### Which issue(s) this PR fixes:
None.

#### Other notes for reviewers:
None.

#### Does this PR introduce a user-facing change?
No.
