### PR TITLE
json schema feature updates to enable polymorphism

### DIFF
--- a/legend-engine-external-format-jsonSchema/src/main/java/org/finos/legend/engine/external/format/jsonSchema/schema/generations/JSONSchemaConfig.java
+++ b/legend-engine-external-format-jsonSchema/src/main/java/org/finos/legend/engine/external/format/jsonSchema/schema/generations/JSONSchemaConfig.java
@@ -39,7 +39,8 @@ public class JSONSchemaConfig extends GenerationConfiguration
     public String schemaSpecification;
     @JsonProperty(value = "createSchemaCollection")
     public Boolean createSchemaCollection;
-
+    @JsonProperty(value = "generateAnyOfSubType")
+    public Boolean generateAnyOfSubType;
 
     public Root_meta_json_schema_generation_JSONSchemaConfig process(PureModel pureModel)
     {
@@ -81,6 +82,11 @@ public class JSONSchemaConfig extends GenerationConfiguration
         if (createSchemaCollection != null)
         {
             generationConfiguration._createSchemaCollection(createSchemaCollection);
+        }
+
+        if (generateAnyOfSubType != null)
+        {
+            generationConfiguration._generateAnyOfSubType(generateAnyOfSubType);
         }
 
         return generationConfiguration;

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/fromJSONSchema.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/fromJSONSchema.pure
@@ -36,13 +36,14 @@ Class meta::json::schema::fromSchema::SchemaInput
 }
 
 function meta::json::schema::fromSchema::JSONSchemaToPure(schemas:SchemaInput[*]):PackageableElement[*]
-{
+{ 
    let processed = $schemas->map(s|$s->processSchema(false));  
-   let subSchemas = $processed->map(s|$s->extractSubSchemas()); 
+   let subSchemas = $processed->map(s|$s->extractSubSchemas($processed)); 
+
+
    let allSchemas = $processed->concatenate($subSchemas)->filter(s|$s.schemaType!=SchemaType.collection);
    let processedWithSuperType = $allSchemas->JSONSchemaSuperTypes();
    let prefix = if($schemas.pathPrefix->first()->isEmpty(),| 'generated',|$schemas.pathPrefix->at(0));
-   
    let extendedProfile =    $processedWithSuperType.extendedTags->distinct()->createProfile($prefix);
    let pathSchemas = $processedWithSuperType->map(s | pair($s.fileName->refToFullPath([]),$s);)->newMap();
    $pathSchemas->values()->map(s | let parsedFileName =  $s.fileName->refToFullPath([]);  
@@ -98,9 +99,9 @@ function <<access.private>> meta::json::schema::fromSchema::deReferenceElement(e
     
 }
 
-function <<access.private>> meta::json::schema::fromSchema::extractSubSchemas(schema:ProcessedSchema[1]):ProcessedSchema[*]
-{   
-   
+function <<access.private>> meta::json::schema::fromSchema::extractSubSchemas(schema:ProcessedSchema[1],allSchemas:ProcessedSchema[*]):ProcessedSchema[*]
+{  
+  
    $schema.embeddedSchemas->cast(@JSONObject).keyValuePairs->map(kv | let fileName=if($schema.pathPrefix->isEmpty(),
                                                                                                |'',
                                                                                                |if($kv.key.value->contains('::'),
@@ -110,7 +111,11 @@ function <<access.private>> meta::json::schema::fromSchema::extractSubSchemas(sc
                                                                                                   )
                                                                                                );
                                                                     let final=  $fileName  +$kv.key.value->refToFullPath([]);
-                                                                   processSchema($final,$kv.value->cast(@JSONObject) ,[]  ,true);
+
+                                                                   if($final->in($allSchemas.fileName->map(f|'/'+$f)),
+                                                                        |[],
+                                                                        |processSchema($final,$kv.value->cast(@JSONObject) ,[]  ,true);
+                                                                    );    
                                                       );
 }
 
@@ -141,10 +146,10 @@ function <<access.private>> meta::json::schema::fromSchema::processSchema(schema
 
 function <<access.private>> meta::json::schema::fromSchema::processSchema(fileName:String[1],parsedSchema:JSONObject[1],prefix:String[0..1],embedded:Boolean[1]):ProcessedSchema[1]
 {
-   
+
    let allOf=  $parsedSchema.keyValuePairs->getValueForKey('allOf');
   
-   
+
    let updatedSchema = if($allOf->isNotEmpty() && $allOf->toOne()->instanceOf(JSONArray) && $allOf->toOne()->cast(@JSONArray)->extractObjectFromColletion()->isNotEmpty(),
                               |   let allOfWithoutObject=  $allOf->toOne()->cast(@JSONArray).values->filter(v|$v->instanceOf(JSONObject))->cast(@JSONObject)->filter(v|!$v->JSONSchemaIsObject());  
                                   let updatedSchema =  $allOf->toOne()->cast(@JSONArray)->extractObjectFromColletion()->toOne();
@@ -177,7 +182,7 @@ function <<access.private>> meta::json::schema::fromSchema::processSchema(fileNa
                            |$refs->map(r|$r->cast(@JSONString).value->refToFullPath($fileName));,
                            |[]);,
                        | [] );
-                               
+
     let subTypeRefs =  if($parsedSchema.keyValuePairs->getValueForKey('anyOf')->isNotEmpty(),
                            |$parsedSchema.keyValuePairs->getValueForKey('anyOf'),
                            | if($parsedSchema.keyValuePairs->getValueForKey('oneOf')->isNotEmpty(),
@@ -192,7 +197,6 @@ function <<access.private>> meta::json::schema::fromSchema::processSchema(fileNa
    let properties = $updatedSchema.keyValuePairs->getValueForKey('properties');
 
    let extendedTags = $updatedSchema->getExtendedTags('')->distinct();
-   
 
    ^ProcessedSchema( fileName=$fileName,
                      pathPrefix=if($embedded,|[],|$prefix),
@@ -279,7 +283,7 @@ function <<access.private>> meta::json::schema::fromSchema::typeValues(schema:JS
 
 function <<access.private>> meta::json::schema::fromSchema::JSONSchemaSuperTypes(schemas:ProcessedSchema[*]):ProcessedSchema[*]
 {
-   $schemas->map(s  |   let rootTypes = $s->getRootSuperTypes($schemas,[]); 
+   $schemas->map(s  |   let rootTypes = $s->getRootSuperTypes($schemas,[]);  
                     ^$s(rootSuperTypes=$rootTypes );
               
               );
@@ -796,13 +800,14 @@ function meta::json::schema::fromSchema::typeFullPath(fileName:String[1],pathPre
 
 
 function <<access.private>> meta::json::schema::fromSchema::JSONSchemaToClass(fileName:String[1],processedSchema:ProcessedSchema[1],pathSchemas:Map<String,ProcessedSchema>[1],pathPrefix:String[0..1],extendedProfile:Profile[0..1], strict:Boolean[1]):Class<Any>[1]
-{
+  { 
+
     let parsed = $processedSchema.parsedSchema;
     let javaType = $parsed.keyValuePairs->getValueForKey('javaType')->cast(@JSONString).value->first();
 
     let noadditionalProps = $parsed.keyValuePairs->getValueForKey('additionalProperties')->cast(@JSONBoolean).value->first();
     let properties = $parsed.keyValuePairs->getValueForKey('properties')->cast(@JSONObject).keyValuePairs;
-    
+
     let discriminatorPropertyName = if($parsed.keyValuePairs->getValueForKey('discriminator')->isNotEmpty(),
                                          | let property = $parsed.keyValuePairs->getValueForKey('discriminator')->cast(@JSONObject).keyValuePairs->getValueForKey('propertyName');
                                            if($property->isNotEmpty(),
@@ -923,7 +928,6 @@ function <<access.private>> meta::json::schema::fromSchema::JSONSchemaToProperty
      
    
     let typeValue = $propertyKVP->getValueForKey('type')->cast(@JSONString).value;
-
     let propertyObject = $property->propertyObject($ownerClass,$strict);
      
     let ref = if($propertyAllOf->isNotEmpty(),
@@ -1130,6 +1134,7 @@ function <<access.private>> meta::json::schema::fromSchema::getTypesFromFragment
 function <<access.private>> meta::json::schema::fromSchema::refToPath(ref:String[1],parentPath:String[1],pathSchemas:Map<String,ProcessedSchema>[1],pathPrefix:String[0..1]):Type[1]
 { 
    let fullPath = $ref->refToFullPath($parentPath); 
+
    let schemaForPath= $pathSchemas->get($fullPath);
    if($schemaForPath->isEmpty(),
       |Any,

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/jsonSchema.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/jsonSchema.pure
@@ -58,7 +58,7 @@ Class meta::json::schema::generation::JSONSchemaConfig extends GenerationConfigu
 {
   {doc.doc='Generate JSON schema constraints from class constraints, unsupported functions will not generate'}useConstraints:Boolean[0..1];  //defaults false
   {doc.doc='Include related types in a definitions element on the schema, ignored if generating openAPI'}  includeAllRelatedTypes:Boolean[0..1];  // defaults true - if true , dependencies generate to definitions elements
-  {doc.doc='If true,An additional schema will be generated that can be used as a collection of subTypes' }generateAnyOfSubType:Boolean[0..1];  // defaults true - if true , SupertTypes generate an additional anyOf for all the subTypes.
+  {doc.doc='If true,An additional schema will be generated that can be used as a collection of subTypes' }generateAnyOfSubType:Boolean[0..1];  // defaults false - if true , SuperTypes generate an additional anyOf for all the subTypes.
   {doc.doc='If true, constraint functions generate as schema files, if false constraint function content is in-lined with the parent schema' }generateConstraintFunctionSchemas:Boolean[0..1];  // defaults false - if true , functions generate seperate schemas.
   {doc.doc='The specification which your schema should be compatible with' }schemaSpecification:JSONSchemaSpecification[0..1];
   {doc.doc='Generate a components or definitions collection, if true, only one file will generate with a collection of related elements in scope for execution and there will be no root element in the schema' }createSchemaCollection:Boolean[0..1];
@@ -73,7 +73,7 @@ Class <<access.protected>> meta::json::schema::JSONSchemaConfigInternal
    includeAllRelatedTypes:Boolean[1];  // defaults true - if true , dependencies generate to definitions elements
    useDefinitions:Boolean[1];  //defaults to value of includeAllRelatedTypes - used for second pass
    rootLevel:Boolean[1];//indicates if we are on first pass of generation
-   generateAnyOfSubType:Boolean[1];  // defaults true - if true , SupertTypes generate a oneOF for all the subTypes.
+   generateAnyOfSubType:Boolean[1];  // defaults false - if true , SupertTypes generate a oneOF for all the subTypes.
    generateConstraintFunctionSchemas:Boolean[1];
    rootElement:Any[0..1]; //root element for correct reletiveReferences
    schemaSpecification:JSONSchemaSpecification[1];
@@ -81,6 +81,8 @@ Class <<access.protected>> meta::json::schema::JSONSchemaConfigInternal
    fileType:String[1];
    createSchemaCollection:Boolean[1]; //defaults false, if true all elements generate as a single collection
    generateMilestoneProperties:Boolean[1];  //defaults false - If true - the auto-gen milestoned properties will be included on generated schemas
+   anyOfMember:Boolean[1];  //Indicates if we are generating an object inside an anyOf
+
 }
 
 
@@ -89,6 +91,7 @@ meta::json::schema::generation::JSONSchemaSpecification
 {
    OPEN_API_V3_0_3,
    JSON_SCHEMA_DRAFT_07,
+   JSON_SCHEMA_2019_09,
    OPEN_API_V3_0_3_YAML,
    OPEN_API_V3_0_3_YAML_PLAIN
 }
@@ -205,7 +208,7 @@ function <<access.private>> meta::json::schema::generation::defaultConfig():JSON
 
 function <<Generation.Configuration>> meta::json::schema::generation::describeConfiguration():GenerationParameter[*]
 {
-   meta::pure::generation::describeConfiguration(JSONSchemaConfig,meta::json::schema::generation::defaultConfig__JSONSchemaConfig_1_,[])->filter(p|!$p.name->in(['generateAnyOfSubType','generateMilestoneProperties']));
+   meta::pure::generation::describeConfiguration(JSONSchemaConfig,meta::json::schema::generation::defaultConfig__JSONSchemaConfig_1_,[])->filter(p|!$p.name->in(['generateMilestoneProperties']));
 
 
 
@@ -236,12 +239,13 @@ function <<access.private>> meta::json::schema::defaultInternalConfig() : JSONSc
                              includeAllRelatedTypes = true,
                              useDefinitions = true,
                              rootLevel = true,
-                             generateAnyOfSubType=true,
+                             generateAnyOfSubType=false,
                              generateConstraintFunctionSchemas= false,
                              schemaSpecification = JSONSchemaSpecification.JSON_SCHEMA_DRAFT_07,
                              fileType='json',
                              createSchemaCollection = false,
-                             generateMilestoneProperties = false
+                             generateMilestoneProperties = false,
+                             anyOfMember = false
                               )
   }
 
@@ -249,13 +253,12 @@ function <<access.protected>> meta::json::schema::externalToInternalConfig(confi
   if($config->isEmpty() ,
       | defaultInternalConfig(),
       | let useConstraints = if($config.useConstraints->isEmpty(),|false,|$config.useConstraints->toOne());
-        let generateAnyOfSubType = if($config.generateAnyOfSubType->isEmpty(),|true,|$config.generateAnyOfSubType->toOne());
+        let generateAnyOfSubType = if($config.generateAnyOfSubType->isEmpty(),|false,|$config.generateAnyOfSubType->toOne());
         let generateConstraintFunctionSchemas = if($config.generateConstraintFunctionSchemas->isEmpty(),|false,|$config.generateConstraintFunctionSchemas->toOne());
         let schemaSpecification =   if($config.schemaSpecification->isEmpty(),|JSONSchemaSpecification.JSON_SCHEMA_DRAFT_07,|$config.schemaSpecification->toOne());
         let fileType =   if($config.schemaSpecification->isEmpty(),|'json',|if($config.schemaSpecification->toOne()->meta::json::schema::isYAML() ,|'yaml',|'json'));
         let includeAllRelatedTypes = if($schemaSpecification->isOpenAPI(),|false,|if($config.includeAllRelatedTypes->isEmpty(),|true,| $config.includeAllRelatedTypes->toOne()));  
         let generateMilestoneProperties = if($config.generateMilestoneProperties->isEmpty(),|false,|$config.generateMilestoneProperties->toOne());
-
         let createSchemaCollection =   if($config.createSchemaCollection->isEmpty(),|false,|$config.createSchemaCollection->toOne());
       ^JSONSchemaConfigInternal(useConstraints =$useConstraints,
                                    includeAllRelatedTypes = $includeAllRelatedTypes,
@@ -267,8 +270,8 @@ function <<access.protected>> meta::json::schema::externalToInternalConfig(confi
                                    scopeElements = $config.allPackageScopeElements(),
                                    fileType = $fileType ,
                                    createSchemaCollection = $createSchemaCollection,
-                                   generateMilestoneProperties = $generateMilestoneProperties
-
+                                   generateMilestoneProperties = $generateMilestoneProperties,
+                                   anyOfMember = false
                                      );
      );
 
@@ -309,9 +312,28 @@ function <<access.protected>> meta::json::schema::toJSONSchema( type:Type[1], ro
    let javaInterfaces = $type->javaInterfaceReference();
 
    let schemaType = if($type->instanceOf(Class),|newJSONKeyStringValue( 'type', 'object'),|[]);
-   let initialKeys =  $type -> schema($config.schemaSpecification)->concatenate(  $type -> title());
+   let initialKeys =  $type -> schema($config.schemaSpecification)->concatenate( if($config.anyOfMember,|[],| $type -> title()));
 
-    let propertyKeys = if( $type->isEnum(),
+   //let allOf = if($type->instanceOf(Class),|$type->cast(@Class<Any>)->allOfGeneralizations($config),|[]);
+   let properties  =   meta::json::schema::schemaProperties($type,$root,$config);
+
+  let schema = newJSONObject(  [ $initialKeys  ]
+                                          ->concatenate($type -> elementTags($config))
+                                          ->concatenate($javaType)
+                                          ->concatenate($javaInterfaces)
+                                          -> concatenate($properties.key)
+                                          );
+
+
+^JsonSchemaGenerationResult(schema = $schema, message = $properties.message );
+}
+
+
+function meta::json::schema::schemaProperties(type:Type[1], root:Type[0..1], config:JSONSchemaConfigInternal[1]):JsonSchemaKeyValueMessage[1]
+{
+   let schemaType = if($type->instanceOf(Class),|newJSONKeyStringValue( 'type', 'object'),|[]);
+
+   let properties  =    if( $type->isEnum(),
                              |   let default = $type->cast(@ElementWithTaggedValues)->value4Tag('defaultValue',JSONSchemaGeneration);
                                  let defaultTag = $default->first()->toJSONRepresentation('default',[]);
                                 ^JsonSchemaKeyValueMessage(key=$type->cast(@Enumeration<Any>)->enum()->concatenate($defaultTag)->concatenate( newJSONKeyStringValue( 'type', 'string')->addNullType($type,$config)));,
@@ -323,39 +345,34 @@ function <<access.protected>> meta::json::schema::toJSONSchema( type:Type[1], ro
 
                                let rootClass = $root->cast(@Class<Any>);
                                let required = $class->required($config);
-                               let properties = properties( $class,$rootClass,$constraints,$constraintsNoRef,$config);
-                               let res = $class->allOfGeneralizations($config)
+                               let properties =  if( $config.generateAnyOfSubType && !$config.anyOfMember && !$config.rootLevel,
+                                                               |  [],
+                                                               |  properties( $class,$rootClass,$constraints,$constraintsNoRef,$config));
+
+                                let anyOf = if( $config.generateAnyOfSubType && !$config.anyOfMember ,
+                                                               |$class-> meta::json::schema::specializationsAnyOf($rootClass,$config),
+                                                               | []);
+
+
+
+                               let res =  if($config.generateAnyOfSubType && $config.anyOfMember,|[],|$class->allOfGeneralizations($config))
+                                              ->concatenate( if($config.anyOfMember,|$class->title(),|[]))
                                               ->concatenate( $schemaType)
-                                               ->concatenate(if($properties.key.value->cast(@JSONObject).keyValuePairs->isEmpty(),|[],|$properties.key) )
+                                              ->concatenate(if($properties.key.value->cast(@JSONObject).keyValuePairs->isEmpty()  ,|[],|$properties.key) )
+                                              ->concatenate($anyOf.key)
                                               ->concatenate(if($type->hasStereotype('noAdditionalProperties',JSONSchemaGeneration),
                                                                   |additionalProperties(false),
                                                                   |[] )
-                                                             )->concatenate($class->addDiscriminator($config));
-                               let newRes = if ($required->isEmpty(), | $res, | $res->concatenate($required));
-                               ^JsonSchemaKeyValueMessage(key =if ($config.includeAllRelatedTypes && $config.rootLevel ,
-                                                                 | $newRes->concatenate($class->definitions($rootClass,$config)),
-                                                                 | $newRes),
+                                                             )->concatenate($class->addDiscriminator($config))->concatenate(  $required);
+
+                               ^JsonSchemaKeyValueMessage(key =if ($config.includeAllRelatedTypes && $config.rootLevel,
+                                                                 | $res->concatenate($class->definitions($class,$config)),
+                                                                 | $res),
                                                       message=$constraints.generationMessage->concatenate($properties.message));
-                           );
 
-
-
-
-
-
-   let schema =  newJSONObject(
-        [ $initialKeys
-        ]
-         ->concatenate($type -> elementTags($config))
-         ->concatenate($javaType)
-         ->concatenate($javaInterfaces)
-         -> concatenate($propertyKeys.key)
-                     );
-
-
-
-^JsonSchemaGenerationResult(schema = $schema, message = $propertyKeys.message );
+);
 }
+
 
 
 function meta::json::schema::createObjectProperty( class:Class<Any>[1] ) : JSONKeyValue[1]
@@ -387,6 +404,12 @@ function meta::json::schema::additionalProperties( hasAdditionalProperties:Boole
 {
    newJSONKeyValue('additionalProperties', ^JSONBoolean( value = $hasAdditionalProperties ) );
 }
+
+function meta::json::schema::unevaluatedProperties( ) : JSONKeyValue[1]
+{
+   newJSONKeyValue('unevaluatedProperties', ^JSONBoolean( value = false ) );
+}
+
 
 function meta::json::schema::enum( type:Enumeration<Any>[1] ) : JSONKeyValue[1]
 {
@@ -446,7 +469,6 @@ function <<access.protected>> meta::json::schema::isRef(pairs:JSONKeyValue[*] ) 
 
 function <<access.private>> meta::json::schema::calculateJSONRef( element:PackageableElement[1], root:Any[0..1],useDefinitions:Boolean[1],referenceParent:Any[0..1], config:JSONSchemaConfigInternal[1] ) : String[1]
 {
-
    if(  ( !$root->isEmpty() ) && $element == $root,
                       | '#',
                       | if($useDefinitions || $referenceParent->isEmpty() || $config.createSchemaCollection,
@@ -493,7 +515,7 @@ function <<access.private>> meta::json::schema::JSONRefPrefix(config:JSONSchemaC
 {
      if($config->isOpenAPI(),
         |'#/components/schemas/' ,
-        |'#/definitions/');
+        |'#/'+ $config->definitionsKey() +'/');
 
 
 }
@@ -577,8 +599,17 @@ function <<access.private>> meta::json::schema::schema( element:PackageableEleme
 {
   if($schema==JSONSchemaSpecification.JSON_SCHEMA_DRAFT_07,
      |   newJSONKeyStringValue( '$schema', 'http://json-schema.org/draft-07/schema#' );,
-     |[]
+     |if($schema==JSONSchemaSpecification.JSON_SCHEMA_2019_09,
+         |newJSONKeyStringValue( '$schema', 'http://json-schema.org/draft/2019-09/schema' ),
+        |[])
+
    );
+
+}
+
+function <<access.private>> meta::json::schema::supportsUnevaluatedProperties( schema:JSONSchemaSpecification[1])  : Boolean[1]
+{
+   $schema == JSONSchemaSpecification.JSON_SCHEMA_2019_09;
 
 }
 
@@ -758,7 +789,7 @@ function <<access.private>> meta::json::schema::allReferencedElements( element:P
                             let myPropertyElements =  $allNonPrimitivePropertiesOfClass->map( p |
                                                                       if( !$p->isClass(),
                                                                           | [],
-                                                                          | $p->cast(@Class<Any>).specializations->map( class | $class.specific->cast(@Class<Any>) )
+                                                                          |   $p->cast(@Class<Any>)->meta::pure::functions::meta::getLeafTypes()->cast(@Class<Any>)
                                                                       );
                                                       )
                                                       -> concatenate( $allNonPrimitivePropertiesOfClass );
@@ -781,7 +812,7 @@ function <<access.private>> meta::json::schema::allReferencedElements( element:P
 
 
 
-function <<access.private>> meta::json::schema::allFunctionElements(any:Any[1], seen:PackageableElement[*],config:JSONSchemaConfigInternal[0..1]):Function<Any>[*]
+function <<access.private>> meta::json::schema::allFunctionElements(any:Any[1], seen:Any[*],config:JSONSchemaConfigInternal[0..1]):Function<Any>[*]
 {
    $any->match([
       {
@@ -790,7 +821,7 @@ function <<access.private>> meta::json::schema::allFunctionElements(any:Any[1], 
          if($sfe.func->in($seen) || $sfe.func->instanceOf(Property),
             | [],
             |  let newElements = if($sfe.func->isWithinPackage(meta) &&!$sfe.func->meta::alloy::isMetaAlloyTestDependencyForGeneration(),|[];,|$sfe.func);
-               $newElements->concatenate($sfe.parametersValues->evaluateAndDeactivate()->map(p| $p->allFunctionElements($seen->concatenate($newElements)->cast(@PackageableElement),$config);));
+               $newElements->concatenate($sfe.parametersValues->evaluateAndDeactivate()->map(p| $p->allFunctionElements($seen->concatenate($newElements),$config);));
          );
       },
       lam:LambdaFunction<Any>[1]      | $lam.expressionSequence->evaluateAndDeactivate()->map(vs| $vs->allFunctionElements($seen,$config)),
@@ -814,18 +845,20 @@ function <<access.private>> meta::json::schema::createObjectProperty( class:Clas
             ),
         | if( size( $specializations ) == 1,
               | $specializations->toOne()->newJsonRef($root,$useDefinitions,$propertyOwner,$config),
-              |
-                 let specialisedObjectRefs = $specializations->map(
-                          specialisedClass |
-                          newJSONObject( $specialisedClass->newJsonRef($root,$useDefinitions,$propertyOwner,$config) ) );
+              |  if(  $config.generateAnyOfSubType,
+                         | $class->newJsonRef($root,$useDefinitions,$propertyOwner,$config),
+                         | let specialisedObjectRefs = $specializations->map(
+                                    specialisedClass |
+                                    newJSONObject( $specialisedClass->newJsonRef($root,$useDefinitions,$propertyOwner,$config) ) );
 
 
                  newJSONKeyValue('oneOf', ^JSONArray( values = $specialisedObjectRefs ) );
-          )
-     );
-
-     $objProperty;
+             )
+           );
+      );
+     
 }
+
 
 function <<access.private>> meta::json::schema::generalizations( class:Class<Any>[1], keyName:String[1],config:JSONSchemaConfigInternal[1] ) : JSONKeyValue[0..1]
 {
@@ -1055,9 +1088,13 @@ function <<access.private>> meta::json::schema::properties( class:Class<Any>[1],
 
 function <<access.private>> meta::json::schema::inscopeProperties( class:Class<Any>[1], config:JSONSchemaConfigInternal[1]) : Property<Nil,Any|*>[*]
 {
+   let classProps = if($config.anyOfMember,
+                      |$class->meta::pure::functions::meta::hierarchicalProperties(),
+                      |$class.properties);
+
    if($config.generateMilestoneProperties,
-      | $class.properties->concatenate($class.propertiesFromAssociations)->filter(p|$p.owner->in($config.scopeElements)),
-      |  $class.properties->concatenate($class.propertiesFromAssociations->concatenate($class.originalMilestonedProperties)->filter(p|$p.owner->in($config.scopeElements)))->filter(p|!$p->meta::pure::milestoning::hasGeneratedMilestoningPropertyStereotype());
+      | $classProps->concatenate($class.propertiesFromAssociations)->filter(p|$p.owner->in($config.scopeElements)),
+      |  $classProps->concatenate($class.propertiesFromAssociations->concatenate($class.originalMilestonedProperties)->filter(p|$p.owner->in($config.scopeElements)))->filter(p|!$p->meta::pure::milestoning::hasGeneratedMilestoningPropertyStereotype());
       );
 
 }
@@ -1092,16 +1129,46 @@ function meta::json::schema::definitions( class:Class<Any>[1], root:Class<Any>[0
       definitions($class,$root,defaultInternalConfig());
 }
 
+
+
+
+function <<access.private>> meta::json::schema::specializationsAnyOf( class:Class<Any>[1],  root:Class<Any>[0..1], config:JSONSchemaConfigInternal[1] ) : JsonSchemaKeyValueMessage[0..1]
+{
+     let  newConfig = ^$config(anyOfMember=true, rootLevel=false);
+     let unevalulated = if($config.schemaSpecification->supportsUnevaluatedProperties(),| unevaluatedProperties(),|[]);
+
+     let specializations = $class->findAllSpecializations()->concatenate($class)->map(s |
+         if (!$s->isAnyClass(),
+         |   let schema = newJSONObject( $s->meta::json::schema::schemaProperties($root,$newConfig).key->concatenate($unevalulated));,
+         | []
+       );
+
+   );
+
+  let r =  if( $specializations->isEmpty(),
+       | [],
+       |    ^JsonSchemaKeyValueMessage(key =newJSONKeyValue( 'anyOf', ^JSONArray( values = $specializations )))
+
+
+   );
+}
+
 function  <<access.private>> meta::json::schema::definitions( class:Class<Any>[1], root:Class<Any>[0..1], config:JSONSchemaConfigInternal[1] ) : JSONKeyValue[0..1]
 {
    let updatedConfig = ^$config(rootLevel=false);
    let values = $class->allReferencedElements($config)->sortBy(e|$e->elementToPath())->map( p | newJSONKeyValue( $p->elementToPath(), $p->match([t:Type[1]|$t->toJSONSchema($root,$updatedConfig).schema,
                                                                                                                                            f:ConcreteFunctionDefinition<Any>[1] | $f->toJSONSchemaFromFunctionDefinition($updatedConfig).constraint->toOne()]))) ;
+  let definitionsKey =meta::json::schema::definitionsKey($config);
 
   if( $values->isEmpty(),
      | [],
-     | newJSONKeyValue( 'definitions', newJSONObject( $values ) )
+     | newJSONKeyValue( $definitionsKey , newJSONObject( $values ) )
   );
+}
+
+function  <<access.private>> meta::json::schema::definitionsKey( config:JSONSchemaConfigInternal[1] ) : String[1]
+{
+   if($config.schemaSpecification==JSONSchemaSpecification.JSON_SCHEMA_2019_09,|'$defs',|'definitions' );
 }
 
 function <<access.private>> meta::json::schema::createArrayProperty( property:Property<Nil,Any|*>[1],root:Class<Any>[0..1],constraintHasType:Boolean[1], constraint:JSONObject[*],constraintHasRef:Boolean[1],config: JSONSchemaConfigInternal[1] ) : JSONKeyValue[1]
@@ -1231,7 +1298,7 @@ function <<access.private>> meta::json::schema::schemaCollection(elements:Packag
 
     let collection =  if($config->isOpenAPI(),
                         | newJSONKeyValue('components',newJSONObject(newJSONKeyValue('schemas',newJSONObject($generatedSchemas.key)))),
-                        | newJSONKeyValue('definitions',newJSONObject($generatedSchemas.key)));
+                        | newJSONKeyValue($config->definitionsKey(),newJSONObject($generatedSchemas.key)));
 
    ^JsonSchemaGenerationResult(schema = newJSONObject($collection), message =$generatedSchemas.message);
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/sharedSchema.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/sharedSchema.pure
@@ -107,6 +107,34 @@ Class <<temporal.bitemporal>>  meta::json::schema::tests::BiTemporalFirm
 
 }
 
+Class  meta::json::schema::tests::Car extends meta::json::schema::tests::WheeledVehicle
+{
+   driver:String[1]; 
+
+}
+Class  meta::json::schema::tests::Truck extends meta::json::schema::tests::WheeledVehicle
+{
+   weight:Integer[1]; 
+
+}
+
+
+Class  meta::json::schema::tests::WheeledVehicle extends meta::json::schema::tests::Vehicle
+{
+   wheels:Integer[1]; 
+
+}
+Class  meta::json::schema::tests::Vehicle
+{
+   id:Integer[1]; 
+   similarVehiciles:meta::json::schema::tests::Vehicle[*];
+   
+}
+
+Class  meta::json::schema::tests::Road
+{
+   vehicles:meta::json::schema::tests::Vehicle[*]; 
+ }
 
 function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.start='v1_20_0'}  meta::json::schema::tests::roundTrip::typeInclusionForConstraintFunctions():Boolean[1]
 {
@@ -150,9 +178,8 @@ function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.sta
   let fileMap = [schemaInput('/ClassWithFunctionReferences.json', $jsonschemaclass,$prefix),
                    schemaInput('/functionWithStringType.json', $jsonschemafunc,$prefix)]; 
   let generatedClassFromJSON =  $fileMap->JSONSchemaToPure()->filter(p|$p.name=='ClassWithFunctionReferences')->toOne();
-
   assert(jsonEquivalent(meta::json::schema::tests::ClassWithFunctionReferences->toSerializer()->parseJSON(),$generatedClassFromJSON->toOne()->toSerializer()->parseJSON()));
-      testfromJSONSchema(meta::json::schema::tests::ClassWithFunctionReferences,$generatedClassFromJSON);
+  testfromJSONSchema(meta::json::schema::tests::ClassWithFunctionReferences,$generatedClassFromJSON);
 
 }
 
@@ -160,11 +187,11 @@ function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.sta
 
 function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.start='v1_20_0'}  meta::json::schema::tests::roundTrip::testCustomProfile():Boolean[1]
 {
-   
+
   let generatedJSONFromClassOpenAPI = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::ClassWithCustomProfiles,meta::json::schema::tests::profile],
                                                          useConstraints = true ,includeAllRelatedTypes=false,generateConstraintFunctionSchemas=true,schemaSpecification=JSONSchemaSpecification.OPEN_API_V3_0_3 ));
-  
-   
+
+
    let jsonSchemaOpenAPI  = ' {\n' +
         '  "x-customStereoType1": true,\n' +
         '  "description": "A simple description",\n' +
@@ -193,23 +220,23 @@ function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.sta
         '}';
           assert(jsonEquivalent($jsonSchemaOpenAPI->parseJSON(),$generatedJSONFromClassOpenAPI.content->toOne()->parseJSON()));
 
-   
-   
-      
+
+
+
     let prefix = 'meta::json::schema::tests';
-    let fileMap = [schemaInput('/ClassWithCustomProfiles.json', $jsonSchemaOpenAPI,$prefix)]; 
-    let generatedClassFromJSON =  $fileMap->JSONSchemaToPure(); 
+    let fileMap = [schemaInput('/ClassWithCustomProfiles.json', $jsonSchemaOpenAPI,$prefix)];
+    let generatedClassFromJSON =  $fileMap->JSONSchemaToPure();
      //should return  a Profile the schemas
-   
+
    let generatedClassOpenAPI  = $generatedClassFromJSON->filter(p|$p.name=='ClassWithCustomProfiles')->toOne();
    let generatedProfileOpenAPI  = $generatedClassFromJSON->filter(p|$p.name=='GeneratedProfile')->toOne();
    testfromJSONSchema(meta::json::schema::tests::ClassWithCustomProfiles,$generatedClassFromJSON);
     testfromJSONSchema(meta::json::schema::tests::profile::GeneratedProfile,$generatedClassFromJSON);
-  
-      
+
+
    let generatedJSONFromClassDraft07 = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::ClassWithCustomProfiles,meta::json::schema::tests::profile],
                                                          useConstraints = true ,includeAllRelatedTypes=false,generateConstraintFunctionSchemas=true ));
-   
+
    let jsonSchemaDraft07  = ' {\n' +
         '  "customStereoType1": true,\n' +
         '  "description": "A simple description",\n' +
@@ -237,24 +264,24 @@ function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.sta
         '  },\n' +
         '  "customTag1": 10\n' +
         '}';
-   
+
    assert(jsonEquivalent($jsonSchemaDraft07->parseJSON(),$generatedJSONFromClassDraft07.content->toOne()->parseJSON()));
-  let fileMapDraft07 = [schemaInput('/ClassWithCustomProfiles.json', $jsonSchemaDraft07,$prefix)]; 
-  let generatedClassFromJSONDraft07 =  $fileMapDraft07->JSONSchemaToPure(); 
+  let fileMapDraft07 = [schemaInput('/ClassWithCustomProfiles.json', $jsonSchemaDraft07,$prefix)];
+  let generatedClassFromJSONDraft07 =  $fileMapDraft07->JSONSchemaToPure();
   let generatedClassDraft07  = $generatedClassFromJSON->filter(p|$p.name=='ClassWithCustomProfiles')->toOne();
   let generatedProfileDraft07  = $generatedClassFromJSON->filter(p|$p.name=='GeneratedProfile')->toOne();
 
    testfromJSONSchema(meta::json::schema::tests::ClassWithCustomProfiles,$generatedClassFromJSON);
    testfromJSONSchema(meta::json::schema::tests::profile::GeneratedProfile,$generatedClassFromJSON);
 
-   
+
 }
 
 function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.start='v1_20_0'}  meta::json::schema::tests::roundTrip::testforceFunctionToObject():Boolean[1]
 {
-   
+
      let generatedJSONFromElement = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::functionForcedToObject_Any_$0_1$__Boolean_1_],
-                                                          useConstraints = true ,includeAllRelatedTypes=false,generateConstraintFunctionSchemas=true ));  
+                                                          useConstraints = true ,includeAllRelatedTypes=false,generateConstraintFunctionSchemas=true ));
    let jsonSchema  = '{' +
 '  "anyOf": [' +
 '    {' +
@@ -269,18 +296,18 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
 '  "$schema": "http:\/\/json-schema.org\/draft-07\/schema#",' +
 '  "description": "Generate an object tag where there typically would not be any"' +
 '}';
-  
+
    assert(jsonEquivalent($jsonSchema->parseJSON(),$generatedJSONFromElement.content->toOne()->parseJSON()));
     let prefix = 'meta::json::schema::tests';
-    let fileMap = [schemaInput('/functionForcedToObject.json', $jsonSchema,$prefix)]; 
-    let generatedElementFromJSON =  $fileMap->JSONSchemaToPure(); 
+    let fileMap = [schemaInput('/functionForcedToObject.json', $jsonSchema,$prefix)];
+    let generatedElementFromJSON =  $fileMap->JSONSchemaToPure();
    testfromJSONSchema(meta::json::schema::tests::functionForcedToObject_Any_$0_1$__Boolean_1_,$generatedElementFromJSON);
 }
 
 function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.start='v1_20_0'}  meta::json::schema::tests::roundTrip::testinLineFunctions():Boolean[1]
 {
      let generatedJSONFromElement = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[ meta::json::schema::tests::ClassWithInLineFunctions],
-                                                          useConstraints = true ,includeAllRelatedTypes=false,generateConstraintFunctionSchemas=true ));  
+                                                          useConstraints = true ,includeAllRelatedTypes=false,generateConstraintFunctionSchemas=true ));
    let jsonSchema  = '{' +
                      '  "$schema": "http:\/\/json-schema.org\/draft-07\/schema#",' +
                      '  "title": "meta::json::schema::tests::ClassWithInLineFunctions",' +
@@ -334,13 +361,13 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
                      '"integer"' +
                      '  ]' +
                      '}' ;
-    
+
 
 
    assert(jsonEquivalent($jsonSchema->parseJSON(),$generatedJSONFromElement.content->toOne()->parseJSON()));
    let prefix = 'meta::json::schema::tests';
-   let fileMap = [schemaInput('/ClassWithInLineFunctions.json', $jsonSchema,$prefix)]; 
-   let generatedElementFromJSON =  $fileMap->JSONSchemaToPure(); 
+   let fileMap = [schemaInput('/ClassWithInLineFunctions.json', $jsonSchema,$prefix)];
+   let generatedElementFromJSON =  $fileMap->JSONSchemaToPure();
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::ClassWithInLineFunctions,$generatedElementFromJSON);
 
 }
@@ -454,14 +481,14 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
 {
      let collectWithNoRelatedTypes = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[ meta::json::schema::tests::SimpleClass,meta::json::schema::tests::ClassWithFunctionReferences],
                                                           useConstraints = true ,includeAllRelatedTypes=false,generateConstraintFunctionSchemas=true,createSchemaCollection=true ));
-  
+
       let collectWithRelatedTypes = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[ meta::json::schema::tests::SimpleClass,meta::json::schema::tests::ClassWithFunctionReferences],
-                                                          useConstraints = true ,includeAllRelatedTypes=true,generateConstraintFunctionSchemas=true,createSchemaCollection=true )); 
- 
+                                                          useConstraints = true ,includeAllRelatedTypes=true,generateConstraintFunctionSchemas=true,createSchemaCollection=true ));
+
       let collectOpenAPI = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[ meta::json::schema::tests::SimpleClass,meta::json::schema::tests::ClassWithFunctionReferences],
-                                                          useConstraints = true ,includeAllRelatedTypes=true,generateConstraintFunctionSchemas=true,createSchemaCollection=true,schemaSpecification=JSONSchemaSpecification.OPEN_API_V3_0_3 )); 
+                                                          useConstraints = true ,includeAllRelatedTypes=true,generateConstraintFunctionSchemas=true,createSchemaCollection=true,schemaSpecification=JSONSchemaSpecification.OPEN_API_V3_0_3 ));
       let collectOpenAPIYAML = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[ meta::json::schema::tests::SimpleClass,meta::json::schema::tests::ClassWithFunctionReferences],
-                                                          useConstraints = true ,includeAllRelatedTypes=true,generateConstraintFunctionSchemas=true,createSchemaCollection=true,schemaSpecification=JSONSchemaSpecification.OPEN_API_V3_0_3_YAML )); 
+                                                          useConstraints = true ,includeAllRelatedTypes=true,generateConstraintFunctionSchemas=true,createSchemaCollection=true,schemaSpecification=JSONSchemaSpecification.OPEN_API_V3_0_3_YAML ));
       let expectedOpenAPIYAML = 'components: \n' +
                                  '  schemas: \n' +
                                  '    meta::json::schema::tests::ClassWithFunctionReferences: \n' +
@@ -499,9 +526,9 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
                                  '    meta::json::schema::tests::functionWithStringType: \n' +
                                  '      pattern: "test"\n' +
                                  '      type: "string"';
-   
-   
-   
+
+
+
 
     let expectedOPenAPI = '{' +
                         '  "components":   {' +
@@ -561,9 +588,9 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
                         '    }' +
                         '  }' +
                         '}' ;
-  
-   
-  
+
+
+
    let expectedStandardJSONSchema= '{' +
                                        '  "definitions":   {' +
                                        '    "meta::json::schema::tests::ClassWithFunctionReferences":     {' +
@@ -623,8 +650,8 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
                                        '    }' +
                                        '  }' +
                                        '}';
-   
-   
+
+
       let ImportedCollectionNoPath= '{' +
                                        '  "definitions":   {' +
                                        '    "ClassWithFunctionReferences":     {' +
@@ -703,7 +730,6 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
    assert($OpenAPINoPaths->size()==4);
    assert($mergedPaths->size()==4);
 
-   meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::ClassWithFunctionReferences,$standardSchema);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::functionWithStringType_String_$0_1$__Boolean_1_,$standardSchema);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::SimpleClass2,$standardSchema);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::SimpleClass,$standardSchema);
@@ -719,11 +745,12 @@ function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.st
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::functionWithStringType_String_$0_1$__Boolean_1_,$OpenAPINoPaths);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::SimpleClass2,$OpenAPINoPaths);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::SimpleClass,$OpenAPINoPaths);
-   
+
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::ClassWithFunctionReferences,$mergedPaths);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::functionWithStringType_String_$0_1$__Boolean_1_,$mergedPaths);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::SimpleClass2,$mergedPaths);
    meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::SimpleClass,$mergedPaths);
+   meta::json::schema::fromSchema::tests::testfromJSONSchema(meta::json::schema::tests::ClassWithFunctionReferences,$standardSchema,true);
 
 }
 
@@ -778,13 +805,13 @@ function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.sta
 
 function <<test.Test>>   { meta::pure::executionPlan::profiles::serverVersion.start='v1_20_0'}  meta::json::schema::tests::roundTrip::testMilestoneAnnotation():Boolean[1]
 {
-   
-   let generatedJSONFromElement = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::BiTemporalPerson],
-                                                          includeAllRelatedTypes=true ));  
 
-   
+   let generatedJSONFromElement = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::BiTemporalPerson],
+                                                          includeAllRelatedTypes=true ));
+
+
    let generatedJSONFromElementWithMilestone = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::BiTemporalPerson],
-                                                          includeAllRelatedTypes=false,generateMilestoneProperties=true ));  
+                                                          includeAllRelatedTypes=false,generateMilestoneProperties=true ));
 
 
    let jsonSchema  =         '{\n' +
@@ -862,4 +889,595 @@ let jsonSchemaWithMilestone = '        {\n' +
    assert(jsonEquivalent($jsonSchemaWithMilestone->parseJSON(),$generatedJSONFromElementWithMilestone.content->toOne()->parseJSON()));
 
    assert(jsonEquivalent($jsonSchema->parseJSON(),$generatedJSONFromElement.content->toOne()->parseJSON()));
+}
+
+
+
+function <<test.Test>>  { meta::pure::executionPlan::profiles::serverVersion.start='v1_20_0'}  meta::json::schema::tests::roundTrip::testInheritenceOptions():Boolean[1]
+{
+
+
+  let includeAny2019 = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::Car],
+                                                         generateAnyOfSubType=true, schemaSpecification=JSONSchemaSpecification.JSON_SCHEMA_2019_09 ));
+
+  let includeAny07 = generateJsonSchemaFromPureWithScope(^JSONSchemaConfig(scopeElements=[meta::json::schema::tests::Car],
+                                                         generateAnyOfSubType=true, schemaSpecification=JSONSchemaSpecification.JSON_SCHEMA_DRAFT_07 ));
+
+  let includeAny2019Exepected  = '{\n' +
+                                '  "$schema": "http:\/\/json-schema.org\/draft\/2019-09\/schema",\n' +
+                                '  "title": "meta::json::schema::tests::Car",\n' +
+                                '  "allOf": [\n' +
+                                '    {\n' +
+                                '      "$ref": "#\/$defs\/meta::json::schema::tests::WheeledVehicle"\n' +
+                                '    }\n' +
+                                '  ],\n' +
+                                '  "type": "object",\n' +
+                                '  "properties":   {\n' +
+                                '    "driver":     {\n' +
+                                '      "type": "string"\n' +
+                                '    }\n' +
+                                '  },\n' +
+                                '  "anyOf": [\n' +
+                                '    {\n' +
+                                '      "title": "meta::json::schema::tests::Car",\n' +
+                                '      "type": "object",\n' +
+                                '      "properties":       {\n' +
+                                '        "driver":         {\n' +
+                                '          "type": "string"\n' +
+                                '        },\n' +
+                                '        "wheels":         {\n' +
+                                '          "type": "integer"\n' +
+                                '        },\n' +
+                                '        "id":         {\n' +
+                                '          "type": "integer"\n' +
+                                '        },\n' +
+                                '        "similarVehiciles":         {\n' +
+                                '          "type": "array",\n' +
+                                '          "items":           {\n' +
+                                '            "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '          }\n' +
+                                '        }\n' +
+                                '      },\n' +
+                                '      "required": [\n' +
+                                '"driver",\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '      ],\n' +
+                                '      "unevaluatedProperties": false\n' +
+                                '    }\n' +
+                                '  ],\n' +
+                                '  "required": [\n' +
+                                '"driver"\n' +
+                                '  ],\n' +
+                                '  "$defs":   {\n' +
+                                '    "meta::json::schema::tests::Truck":     {\n' +
+                                '      "$schema": "http:\/\/json-schema.org\/draft\/2019-09\/schema",\n' +
+                                '      "title": "meta::json::schema::tests::Truck",\n' +
+                                '      "allOf": [\n' +
+                                '        {\n' +
+                                '          "$ref": "#\/$defs\/meta::json::schema::tests::WheeledVehicle"\n' +
+                                '        }\n' +
+                                '      ],\n' +
+                                '      "type": "object",\n' +
+                                '      "anyOf": [\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::Truck",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "weight":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "wheels":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"weight",\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        }\n' +
+                                '      ],\n' +
+                                '      "required": [\n' +
+                                '"weight"\n' +
+                                '      ]\n' +
+                                '    },\n' +
+                                '    "meta::json::schema::tests::Vehicle":     {\n' +
+                                '      "$schema": "http:\/\/json-schema.org\/draft\/2019-09\/schema",\n' +
+                                '      "title": "meta::json::schema::tests::Vehicle",\n' +
+                                '      "type": "object",\n' +
+                                '      "anyOf": [\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::WheeledVehicle",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "wheels":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        },\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::Car",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "driver":             {\n' +
+                                '              "type": "string"\n' +
+                                '            },\n' +
+                                '            "wheels":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"driver",\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        },\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::Truck",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "weight":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "wheels":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"weight",\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        },\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::Vehicle",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        }\n' +
+                                '      ],\n' +
+                                '      "required": [\n' +
+                                '"id"\n' +
+                                '      ]\n' +
+                                '    },\n' +
+                                '    "meta::json::schema::tests::WheeledVehicle":     {\n' +
+                                '      "$schema": "http:\/\/json-schema.org\/draft\/2019-09\/schema",\n' +
+                                '      "title": "meta::json::schema::tests::WheeledVehicle",\n' +
+                                '      "allOf": [\n' +
+                                '        {\n' +
+                                '          "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '        }\n' +
+                                '      ],\n' +
+                                '      "type": "object",\n' +
+                                '      "anyOf": [\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::Car",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "driver":             {\n' +
+                                '              "type": "string"\n' +
+                                '            },\n' +
+                                '            "wheels":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"driver",\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        },\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::Truck",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "weight":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "wheels":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"weight",\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        },\n' +
+                                '        {\n' +
+                                '          "title": "meta::json::schema::tests::WheeledVehicle",\n' +
+                                '          "type": "object",\n' +
+                                '          "properties":           {\n' +
+                                '            "wheels":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "id":             {\n' +
+                                '              "type": "integer"\n' +
+                                '            },\n' +
+                                '            "similarVehiciles":             {\n' +
+                                '              "type": "array",\n' +
+                                '              "items":               {\n' +
+                                '                "$ref": "#\/$defs\/meta::json::schema::tests::Vehicle"\n' +
+                                '              }\n' +
+                                '            }\n' +
+                                '          },\n' +
+                                '          "required": [\n' +
+                                '"wheels",\n' +
+                                '"id"\n' +
+                                '          ],\n' +
+                                '          "unevaluatedProperties": false\n' +
+                                '        }\n' +
+                                '      ],\n' +
+                                '      "required": [\n' +
+                                '"wheels"\n' +
+                                '      ]\n' +
+                                '    }\n' +
+                                '  }\n' +
+                                '}';
+
+
+                        let includeAny07expected = '{\n' +
+                                                    '  "$schema": "http:\/\/json-schema.org\/draft-07\/schema#",\n' +
+                                                    '  "title": "meta::json::schema::tests::Car",\n' +
+                                                    '  "allOf": [\n' +
+                                                    '    {\n' +
+                                                    '      "$ref": "#\/definitions\/meta::json::schema::tests::WheeledVehicle"\n' +
+                                                    '    }\n' +
+                                                    '  ],\n' +
+                                                    '  "type": "object",\n' +
+                                                    '  "properties":   {\n' +
+                                                    '    "driver":     {\n' +
+                                                    '      "type": "string"\n' +
+                                                    '    }\n' +
+                                                    '  },\n' +
+                                                    '  "anyOf": [\n' +
+                                                    '    {\n' +
+                                                    '      "title": "meta::json::schema::tests::Car",\n' +
+                                                    '      "type": "object",\n' +
+                                                    '      "properties":       {\n' +
+                                                    '        "driver":         {\n' +
+                                                    '          "type": "string"\n' +
+                                                    '        },\n' +
+                                                    '        "wheels":         {\n' +
+                                                    '          "type": "integer"\n' +
+                                                    '        },\n' +
+                                                    '        "id":         {\n' +
+                                                    '          "type": "integer"\n' +
+                                                    '        },\n' +
+                                                    '        "similarVehiciles":         {\n' +
+                                                    '          "type": "array",\n' +
+                                                    '          "items":           {\n' +
+                                                    '            "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '          }\n' +
+                                                    '        }\n' +
+                                                    '      },\n' +
+                                                    '      "required": [\n' +
+                                                    '"driver",\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '      ]\n' +
+                                                    '    }\n' +
+                                                    '  ],\n' +
+                                                    '  "required": [\n' +
+                                                    '"driver"\n' +
+                                                    '  ],\n' +
+                                                    '  "definitions":   {\n' +
+                                                    '    "meta::json::schema::tests::Truck":     {\n' +
+                                                    '      "$schema": "http:\/\/json-schema.org\/draft-07\/schema#",\n' +
+                                                    '      "title": "meta::json::schema::tests::Truck",\n' +
+                                                    '      "allOf": [\n' +
+                                                    '        {\n' +
+                                                    '          "$ref": "#\/definitions\/meta::json::schema::tests::WheeledVehicle"\n' +
+                                                    '        }\n' +
+                                                    '      ],\n' +
+                                                    '      "type": "object",\n' +
+                                                    '      "anyOf": [\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::Truck",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "weight":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "wheels":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"weight",\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        }\n' +
+                                                    '      ],\n' +
+                                                    '      "required": [\n' +
+                                                    '"weight"\n' +
+                                                    '      ]\n' +
+                                                    '    },\n' +
+                                                    '    "meta::json::schema::tests::Vehicle":     {\n' +
+                                                    '      "$schema": "http:\/\/json-schema.org\/draft-07\/schema#",\n' +
+                                                    '      "title": "meta::json::schema::tests::Vehicle",\n' +
+                                                    '      "type": "object",\n' +
+                                                    '      "anyOf": [\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::WheeledVehicle",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "wheels":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        },\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::Car",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "driver":             {\n' +
+                                                    '              "type": "string"\n' +
+                                                    '            },\n' +
+                                                    '            "wheels":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"driver",\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        },\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::Truck",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "weight":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "wheels":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"weight",\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        },\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::Vehicle",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        }\n' +
+                                                    '      ],\n' +
+                                                    '      "required": [\n' +
+                                                    '"id"\n' +
+                                                    '      ]\n' +
+                                                    '    },\n' +
+                                                    '    "meta::json::schema::tests::WheeledVehicle":     {\n' +
+                                                    '      "$schema": "http:\/\/json-schema.org\/draft-07\/schema#",\n' +
+                                                    '      "title": "meta::json::schema::tests::WheeledVehicle",\n' +
+                                                    '      "allOf": [\n' +
+                                                    '        {\n' +
+                                                    '          "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '        }\n' +
+                                                    '      ],\n' +
+                                                    '      "type": "object",\n' +
+                                                    '      "anyOf": [\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::Car",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "driver":             {\n' +
+                                                    '              "type": "string"\n' +
+                                                    '            },\n' +
+                                                    '            "wheels":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"driver",\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        },\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::Truck",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "weight":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "wheels":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"weight",\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        },\n' +
+                                                    '        {\n' +
+                                                    '          "title": "meta::json::schema::tests::WheeledVehicle",\n' +
+                                                    '          "type": "object",\n' +
+                                                    '          "properties":           {\n' +
+                                                    '            "wheels":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "id":             {\n' +
+                                                    '              "type": "integer"\n' +
+                                                    '            },\n' +
+                                                    '            "similarVehiciles":             {\n' +
+                                                    '              "type": "array",\n' +
+                                                    '              "items":               {\n' +
+                                                    '                "$ref": "#\/definitions\/meta::json::schema::tests::Vehicle"\n' +
+                                                    '              }\n' +
+                                                    '            }\n' +
+                                                    '          },\n' +
+                                                    '          "required": [\n' +
+                                                    '"wheels",\n' +
+                                                    '"id"\n' +
+                                                    '          ]\n' +
+                                                    '        }\n' +
+                                                    '      ],\n' +
+                                                    '      "required": [\n' +
+                                                    '"wheels"\n' +
+                                                    '      ]\n' +
+                                                    '    }\n' +
+                                                    '  }\n' +
+                                                    '}';
+
+
+      assert(jsonEquivalent($includeAny2019Exepected->parseJSON(),$includeAny2019.content->toOne()->parseJSON()));
+      assert(jsonEquivalent($includeAny07expected->parseJSON(),$includeAny07.content->toOne()->parseJSON()));
+
+   
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testToJsonSchema.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testToJsonSchema.pure
@@ -262,14 +262,15 @@ Class
   meta::json::schema::tests::constraints::ClassWithConstraints
 [
    simple: $this.simple->constraintFunctionSimpleNumber(),
-   complex: $this.complex->constraintFunctionComplex() && $this.complex->makeString()->isNoShorterThan(4),
+   complex: $this.complex->constraintFunctionComplex() && $this.complex->makeString()->isNoShorterThan(4) ,
   duplicateConstraint: $this.duplicateConstraint->toOne() ->instanceOf(String),
    inLine : $this.inLine->toOne()->instanceOf(String) || $this.inLine->toOne()->instanceOf(Number),
    constant: $this.constant=='constantValue',
    number:( ($this.number>10) && ($this.number < 15)) || (( $this.number >= 0 )&& ( $this.number <=2)),
    dateOrString: if( $this.dateOrString->isNotEmpty(),| $this.dateOrString->toOne()->instanceOf(String) || $this.dateOrString->toOne()->instanceOf(StrictDate),|true),
     manyString:    $this.manyString->forAll(v |$v->isNoShorterThan(4) && $v->isNoLongerThan(10) && $v->constraintRegEXFn())  && $this.manyString->isDistinct() ,
-   uuid: $this.uuidProperty->isUUID()
+   uuid: $this.uuidProperty->isUUID(),
+   ignore:  $this.ignoredQualifiedProperty('ignore Me')->isNoShorterThan(4)
 ]
 {
    constant:String[0..1];
@@ -288,7 +289,7 @@ Class
    <<meta::json::schema::JSONSchemaTypeExtension.array>> forcedArrayOptional:String[0..1];
   <<meta::json::schema::JSONSchemaTypeExtension.array>> forcedArrayRequired:String[0..1];
   <<meta::json::schema::JSONSchemaTypeExtension.object>> objectType : meta::pure::metamodel::type::Any[0..1];
-
+  ignoredQualifiedProperty(r:String[1]) {$r}:String[1];
 
 }
 


### PR DESCRIPTION
#### What type of PR is this?
 Improvement

#### What does this PR do / why is it needed ?
Add support for generating json schemas that include all subtypes of a specific class on an anyOF collection so that the schema successfully passes validation for more then one subtype match an instance of data


