### PR TITLE
External Format Contract Refactor

### DIFF
--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/external/shared/format/model/ExternalFormatExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/external/shared/format/model/ExternalFormatExtension.java
@@ -24,7 +24,6 @@ import org.finos.legend.engine.shared.core.operational.errorManagement.EngineExc
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_ExternalFormatContract;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_binding_Binding;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_binding_validation_BindingDetail;
-import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaDetail;
 
 import java.util.List;
 
@@ -36,7 +35,7 @@ import java.util.List;
  * will represent the semantically checked and canonicalized data model (for example inclusions maybe
  * inlined and references reconciled).
  */
-public interface ExternalFormatExtension<Metamodel extends Root_meta_external_shared_format_metamodel_SchemaDetail>
+public interface ExternalFormatExtension<Metamodel>
 {
     /**
      * Returns the contract for this external format written in PURE

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/external/shared/format/model/transformation/fromModel/ExternalFormatSchemaGenerationExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/external/shared/format/model/transformation/fromModel/ExternalFormatSchemaGenerationExtension.java
@@ -22,7 +22,6 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ModelUnit;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_ExternalFormatFromPureDescriptor;
-import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaDetail;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaSet;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_transformation_fromPure_ModelToSchemaConfiguration;
 import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationParameter;
@@ -39,7 +38,7 @@ import org.finos.legend.pure.generated.core_pure_generation_generations;
  * is also necessary to define the translation from pure model to schema set (via externalFormatFromPureDescriptor)
  * in externalFormatContract modelled in pure.
  */
-public interface ExternalFormatSchemaGenerationExtension<Metamodel extends Root_meta_external_shared_format_metamodel_SchemaDetail, SchemaGenConfig extends ModelToSchemaConfiguration> extends ExternalFormatExtension<Metamodel>
+public interface ExternalFormatSchemaGenerationExtension<Metamodel, SchemaGenConfig extends ModelToSchemaConfiguration> extends ExternalFormatExtension<Metamodel>
 {
     /**
      * Called to compile an external format ModelToSchemaConfiguration.

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/external/shared/format/model/transformation/toModel/ExternalFormatModelGenerationExtension.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/external/shared/format/model/transformation/toModel/ExternalFormatModelGenerationExtension.java
@@ -20,7 +20,6 @@ import org.finos.legend.engine.external.shared.format.model.ExternalFormatExtens
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_ExternalFormatToPureDescriptor;
-import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaDetail;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaSet;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_transformation_toPure_SchemaToModelConfiguration;
 import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationParameter;
@@ -37,7 +36,7 @@ import java.util.List;
  * is also necessary to define the translation from schema set to pure model (via externalFormatToPureDescriptor)
  * in externalFormatContract modelled in pure.
  */
-public interface ExternalFormatModelGenerationExtension<Metamodel extends Root_meta_external_shared_format_metamodel_SchemaDetail, ModelGenConfig extends SchemaToModelConfiguration> extends ExternalFormatExtension<Metamodel>
+public interface ExternalFormatModelGenerationExtension<Metamodel, ModelGenConfig extends SchemaToModelConfiguration> extends ExternalFormatExtension<Metamodel>
 {
     /**
      * Called to compile an external format SchemaToModelConfiguration.

--- a/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SchemaSetCompiler.java
+++ b/legend-engine-external-shared-format-model/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SchemaSetCompiler.java
@@ -27,7 +27,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.externa
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.externalFormat.ExternalFormatSchemaSet;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_Schema;
-import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaDetail;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaSet;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_SchemaSet_Impl;
 import org.finos.legend.pure.generated.Root_meta_external_shared_format_metamodel_Schema_Impl;
@@ -113,7 +112,7 @@ public class SchemaSetCompiler
         {
             try
             {
-                Root_meta_external_shared_format_metamodel_SchemaDetail detail = schemaExtension.compileSchema(new SchemaCompileContext(srcSchema, srcSchemaSet, context));
+                Object detail = schemaExtension.compileSchema(new SchemaCompileContext(srcSchema, srcSchemaSet, context));
                 Root_meta_external_shared_format_metamodel_Schema schema = new Root_meta_external_shared_format_metamodel_Schema_Impl("", null, context.pureModel.getClass("meta::external::shared::format::metamodel::Schema"))
                         ._id(srcSchema.id)
                         ._location(srcSchema.location)

--- a/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/external/shared/format/model/transformation/toModel/TestExampleSchemaToModelGeneration.java
+++ b/legend-engine-external-shared-format-model/src/test/java/org/finos/legend/engine/external/shared/format/model/transformation/toModel/TestExampleSchemaToModelGeneration.java
@@ -30,7 +30,7 @@ public class TestExampleSchemaToModelGeneration extends SchemaToModelGenerationT
         PureModelContextData model = generateModel(schemaCode, config());
 
         String expected = ">>>meta::external::shared::format::transformation::tests::ExampleSchema\n" +
-                "Class meta::external::shared::format::transformation::tests::ExampleSchema extends meta::external::shared::format::metamodel::SchemaDetail\n" +
+                "Class meta::external::shared::format::transformation::tests::ExampleSchema extends meta::pure::metamodel::type::Any\n" +
                 "{\n" +
                 "}\n";
         Assert.assertEquals(modelTextsFromString(expected), modelTextsFromContextData(model));
@@ -46,7 +46,7 @@ public class TestExampleSchemaToModelGeneration extends SchemaToModelGenerationT
         PureModelContextData model = generateModel(schemaCode, config(), true, "test::gen::TargetBinding");
 
         String expected = ">>>meta::external::shared::format::transformation::tests::ExampleSchema\n" +
-                "Class meta::external::shared::format::transformation::tests::ExampleSchema extends meta::external::shared::format::metamodel::SchemaDetail\n" +
+                "Class meta::external::shared::format::transformation::tests::ExampleSchema extends meta::pure::metamodel::type::Any\n" +
                 "{\n" +
                 "}\n";
         Assert.assertEquals(modelTextsFromString(expected), modelTextsFromContextData(model));

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/executionPlan/executionPlan_generation.pure
@@ -110,7 +110,7 @@ function <<access.private>> meta::external::shared::format::executionPlan::exter
                                                                                                                 v:VariableExpression[1] | $inScopeVars->get($v.name).values,
                                                                                                                 i:InstanceValue[1]      | $i.values
                                                                                                              ])->cast(@Binding)->toOne();
-                                                                let sourceTree = $extensions.availableExternalFormats->getExternalFormatContractForContentType($binding.contentType).sourceRecordTree;
+                                                                let sourceTree = $extensions.availableExternalFormats->getExternalFormatContractForContentType($binding.contentType).sourceRecordSerializeTree;
                                                                 assert($sourceTree->isNotEmpty(), | 'Source Tree not defined for contentType - ' + $binding.contentType);
                                                                 checked($valueTree, #{Defect {id, externalId, message, enforcementLevel, ruleType, ruleDefinerPath, path { propertyName, index }}}#, $sourceTree->toOne());
                                ]), 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/externalFormat/externalFormatContract.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/externalFormat/externalFormatContract.pure
@@ -29,28 +29,34 @@ import meta::pure::model::unit::*;
 
 Class meta::external::shared::format::ExternalFormatContract<T>
 [
-  externalFormatMetamodelType : checkSuperType($this.externalFormatMetamodel, SchemaDetail)
+  sourceRecordSerializeTreeProvidedForCheckedResult
+  (
+    ~function: !$this.internalizeReturnsChecked || $this.sourceRecordSerializeTree->isNotEmpty()
+    ~enforcementLevel: Error
+    ~message: 'External Format needs to provide serialized tree structure for its source record, if it returns checked result for internalize'
+  )   
 ]
 {
-   id                               : String[1];   
-   contentTypes                     : String[*];
-   
-   externalFormatMetamodel          : Class<T>[1];
+  id                               : String[1];   
+  contentTypes                     : String[*];
+  
+  externalFormatMetamodel          : Class<T>[1];
 
-   externalFormatToPureDescriptor   : ExternalFormatToPureDescriptor<SchemaToModelConfiguration>[0..1];
-   externalFormatFromPureDescriptor : ExternalFormatFromPureDescriptor<ModelToSchemaConfiguration>[0..1];
-   externalFormatBindingValidator   : Function<{Binding[1] -> BindingDetail[1]}>[0..1];
-   validateBinding(binding:Binding[1])
-   {
-      if($this.externalFormatBindingValidator->isEmpty(),
-         | fail('External Format - ' + $this.id + ' does not support binding validation');@BindingDetail;,
-         | $this.externalFormatBindingValidator->toOne()->eval($binding););
-   }:BindingDetail[1];
+  externalFormatToPureDescriptor   : ExternalFormatToPureDescriptor<SchemaToModelConfiguration>[0..1];
+  externalFormatFromPureDescriptor : ExternalFormatFromPureDescriptor<ModelToSchemaConfiguration>[0..1];
+  externalFormatBindingValidator   : Function<{Binding[1] -> BindingDetail[1]}>[0..1];
+  validateBinding(binding:Binding[1])
+  {
+    if($this.externalFormatBindingValidator->isEmpty(),
+        | fail('External Format - ' + $this.id + ' does not support binding validation');@BindingDetail;,
+        | $this.externalFormatBindingValidator->toOne()->eval($binding););
+  }:BindingDetail[1];
 
-   externalizeConfig                : Class<ExternalFormatExternalizeConfig>[0..1];
-   internalizeConfig                : Class<ExternalFormatInternalizeConfig>[0..1];
-   
-   sourceRecordTree                 : RootGraphFetchTree<Any>[0..1];
+  externalizeConfig                : Class<ExternalFormatExternalizeConfig>[0..1];
+  internalizeConfig                : Class<ExternalFormatInternalizeConfig>[0..1];
+
+  internalizeReturnsChecked        : Boolean[1] = false;              // By default we assume external format would NOT wrap internalize response into checked structure
+  sourceRecordSerializeTree        : RootGraphFetchTree<Any>[0..1];   // If external Format choses to return checked wrapped response for internalize, it needs to provide serialized representation of its source record metamodel
 }
 
 Class meta::external::shared::format::ExternalFormatToPureDescriptor<U>

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/schemaSet/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/schemaSet/metamodel.pure
@@ -23,7 +23,7 @@ Class meta::external::shared::format::metamodel::Schema
 {
    id         : String[0..1];
    location   : String[0..1];
-   detail     : SchemaDetail[1];
+   detail     : Any[1];
 }
 
 Association meta::external::shared::format::metamodel::SchemaSetMembers
@@ -31,8 +31,3 @@ Association meta::external::shared::format::metamodel::SchemaSetMembers
    set        : SchemaSet[1];
    schemas    : Schema[*];
 }
-
-Class meta::external::shared::format::metamodel::SchemaDetail
-{
-}
-

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/schemaSet/metamodel_diagram.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/schemaSet/metamodel_diagram.pure
@@ -24,30 +24,4 @@ Diagram meta::external::shared::format::metamodel::MetamodelDiagram(width=0.0, h
         attributeTypesVisible=true,
         color=#FFFFCC,
         lineWidth=1.0)
-
-    TypeView cview_3(
-        type=meta::external::shared::format::metamodel::SchemaDetail,
-        position=(1297.00000, 528.00000),
-        width=98.70313,
-        height=30.00000,
-        stereotypesVisible=true,
-        attributesVisible=true,
-        attributeStereotypesVisible=true,
-        attributeTypesVisible=true,
-        color=#FFFFCC,
-        lineWidth=1.0)
-
-    PropertyView pview_0(
-        property=meta::external::shared::format::metamodel::Schema.detail,
-        source=cview_2,
-        target=cview_3
-,        points=[(1342.43994,417.00000),(1346.35156,543.00000)],
-        label='',
-        propertyPosition=(0.0,0.0),
-        multiplicityPosition=(0.0,0.0),
-        color=#000000,
-        lineWidth=-1.0,
-        stereotypesVisible=true,
-        nameVisible=true,
-        lineStyle=SIMPLE)
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/transformation/tests/externalFormatContract.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/binding/transformation/tests/externalFormatContract.pure
@@ -40,7 +40,7 @@ function meta::external::shared::format::transformation::tests::exampleFormatCon
 }
 
 // Example Schema Metamodel
-Class meta::external::shared::format::transformation::tests::ExampleSchema extends SchemaDetail
+Class meta::external::shared::format::transformation::tests::ExampleSchema
 {
 
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/extensions/extension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/extensions/extension.pure
@@ -36,7 +36,7 @@ Class meta::pure::extension::Extension
 
   // External Format Extension ----------------------------------------------------------------
   // TODO: We should change this package to better align with our strategy to have binding as core feature
-  availableExternalFormats : meta::external::shared::format::ExternalFormatContract<meta::external::shared::format::metamodel::SchemaDetail>[*];
+  availableExternalFormats : meta::external::shared::format::ExternalFormatContract<Any>[*];
   // ---------------------------------------------------------------- External Format Extension
 
   // Feature Extension ------------------------------------------------------------------------

--- a/legend-engine-xt-flatdata-pure/src/main/resources/core_external_format_flatdata/externalFormatContract.pure
+++ b/legend-engine-xt-flatdata-pure/src/main/resources/core_external_format_flatdata/externalFormatContract.pure
@@ -39,7 +39,8 @@ function meta::external::format::flatdata::contract::flatDataFormatContract(): E
       externalFormatFromPureDescriptor = flatDataFromPureDescriptor(),
       externalFormatBindingValidator   = bindDetails_Binding_1__BindingDetail_1_,
 
-      sourceRecordTree                 = #{RawFlatData {number, lineNumber, record, recordValues {address, rawValue}}}#
+      internalizeReturnsChecked        = true,
+      sourceRecordSerializeTree        = #{RawFlatData {number, lineNumber, record, recordValues {address, rawValue}}}#
    )
 }
 

--- a/legend-engine-xt-flatdata-pure/src/main/resources/core_external_format_flatdata/metamodel/metamodel.pure
+++ b/legend-engine-xt-flatdata-pure/src/main/resources/core_external_format_flatdata/metamodel/metamodel.pure
@@ -78,7 +78,7 @@ Class <<meta::pure::profiles::typemodifiers.abstract>> meta::external::format::f
 {
 }
 
-Class meta::external::format::flatdata::metamodel::FlatData extends meta::external::shared::format::metamodel::SchemaDetail
+Class meta::external::format::flatdata::metamodel::FlatData
 {
    constraints: meta::pure::metamodel::constraint::Constraint[*];
    sections   : FlatDataSection[*];

--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/sdl/fromPure_sdl.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/sdl/fromPure_sdl.pure
@@ -4,7 +4,7 @@ import meta::external::query::graphQL::metamodel::sdl::executable::*;
 import meta::pure::model::unit::*;
 
 
-Class meta::external::query::graphQL::metamodel::sdl::GraphQLSDLContainer extends meta::external::shared::format::metamodel::SchemaDetail
+Class meta::external::query::graphQL::metamodel::sdl::GraphQLSDLContainer
 {
   document : meta::external::query::graphQL::metamodel::sdl::Document[1];
 }

--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/toPure_introspection.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/toPure_introspection.pure
@@ -10,7 +10,7 @@ import meta::external::shared::format::binding::toPure::*;
 import meta::external::shared::format::transformation::toPure::*;
 import meta::pure::model::unit::*;
 
-Class meta::external::query::graphQL::binding::toPure::introspection::GraphQLIntrospectionContainer extends meta::external::shared::format::metamodel::SchemaDetail
+Class meta::external::query::graphQL::binding::toPure::introspection::GraphQLIntrospectionContainer
 {
   schema : meta::external::query::graphQL::metamodel::introspection::__Schema[1];
 }

--- a/legend-engine-xt-haskell-pure/src/main/resources/core_external_language_haskell/transformation.pure
+++ b/legend-engine-xt-haskell-pure/src/main/resources/core_external_language_haskell/transformation.pure
@@ -6,7 +6,7 @@ import meta::external::language::haskell::transformation::fromPure::*;
 import meta::external::language::haskell::format::*;
 import meta::external::shared::format::transformation::fromPure::*;
 
-Class meta::external::language::haskell::format::HaskellSchema extends meta::external::shared::format::metamodel::SchemaDetail
+Class meta::external::language::haskell::format::HaskellSchema
 {
   module : meta::external::language::haskell::metamodel::HaskellModule[1];
 }

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/binding/shared.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/binding/shared.pure
@@ -92,7 +92,7 @@ function meta::external::shared::format::executionPlan::platformBinding::legendJ
 
    let class                               = $node.resultType->cast(@ClassResultType).type->cast(@meta::pure::metamodel::type::Class<Any>);
    let simpleType                          = ^SimpleJavaType(pureType=$class, javaType=$conventions->className($class));
-   let sourceRecordTree                    = $externalFormatContract.sourceRecordTree->toOne();
+   let sourceRecordTree                    = $externalFormatContract.sourceRecordSerializeTree->toOne();
    let returnType                          = if($node.checked, | ^CheckedJavaType(checkedOf=$simpleType, source=^SimpleJavaType(pureType=$sourceRecordTree.class, javaType=$conventions->className($sourceRecordTree.class))), | $simpleType);
    let bindingDetail                       = if($externalFormatContract.externalFormatBindingValidator->isNotEmpty(), 
                                                 | $externalFormatContract.externalFormatBindingValidator->toOne()->eval($node.binding),

--- a/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/externalFormatContract.pure
+++ b/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/externalFormatContract.pure
@@ -42,7 +42,9 @@ function meta::external::format::json::contract::jsonSchemaFormatContract(): Ext
       externalFormatBindingValidator   = bindDetails_Binding_1__BindingDetail_1_,
 
       internalizeConfig                = JsonSchemaInternalizeConfig,
-      sourceRecordTree                 = #{JsonDataRecord {number, record}}#
+
+      internalizeReturnsChecked        = true,
+      sourceRecordSerializeTree        = #{JsonDataRecord {number, record}}#
    )
 }
 

--- a/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/metamodel/metamodel.pure
+++ b/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/metamodel/metamodel.pure
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //TODO: Currently this metamodel is hacky and would be improved upon in successive commits
-Class meta::external::format::json::metamodel::JsonSchema extends meta::external::shared::format::metamodel::SchemaDetail
+Class meta::external::format::json::metamodel::JsonSchema
 {
    content : String[1];  
 }

--- a/legend-engine-xt-protobuf-pure/src/main/resources/core_external_format_protobuf/metamodel/metamodel.pure
+++ b/legend-engine-xt-protobuf-pure/src/main/resources/core_external_format_protobuf/metamodel/metamodel.pure
@@ -19,7 +19,7 @@ Enum meta::external::format::protobuf::metamodel::Syntax
    proto2,proto3
 }
 
-Class meta::external::format::protobuf::metamodel::ProtobufSchema extends meta::external::shared::format::metamodel::SchemaDetail
+Class meta::external::format::protobuf::metamodel::ProtobufSchema
 {
   fileName : String[1];
   file : ProtoFile[1];  

--- a/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/externalFormatContract.pure
+++ b/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/externalFormatContract.pure
@@ -35,7 +35,8 @@ function meta::external::format::xml::contract::xsdFormatContract(): ExternalFor
 
       externalFormatToPureDescriptor   = xsdToPureDescriptor(),
 
-      sourceRecordTree                 = #{XmlDataRecord {number, record}}#
+      internalizeReturnsChecked        = true, 
+      sourceRecordSerializeTree        = #{XmlDataRecord {number, record}}#
    )
 }
 

--- a/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/metamodel/metamodel.pure
+++ b/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/metamodel/metamodel.pure
@@ -277,7 +277,7 @@ Class meta::external::format::xml::metamodel::xsd::XsdRestriction extends meta::
   particle       : meta::external::format::xml::metamodel::xsd::XsdParticle[0..1];
 }
 
-Class meta::external::format::xml::metamodel::xsd::XsdSchema extends meta::external::format::xml::metamodel::xsd::XsdAnnotated, meta::external::shared::format::metamodel::SchemaDetail
+Class meta::external::format::xml::metamodel::xsd::XsdSchema extends meta::external::format::xml::metamodel::xsd::XsdAnnotated
 {
   targetNamespace      : String[0..1];
   items                : meta::external::format::xml::metamodel::xsd::XsdObject[*];


### PR DESCRIPTION
#### What type of PR is this?
Improvement

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
External Format Contract Refactor, this PR brings in 2 changes
- Deleting `SchemaDetail`: Currently we are enforcing each external format to define a schema metamodel which should extend SchemaDetail. With this change, we are removing this so that external format developers don't have to know the internals of the platform to model their schema metamodel. In essence, we are relaxing this in order to make integration more smooth.
- Changing ExternalFormatContract: We are replacing property `sourceRecordTree` with properties `internalizeReturnsChecked` & `sourceRecordSerializeTree`. Again checked is an internal platform concern and in the happy path, external format developers should not have to worry about it. Moving forward if a developer wants to provide record-level lineage and defect reporting they can integrate with the checked framework by providing `sourceRecordSerializeTree` and setting `internalizeReturnsChecked` as `true`

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:
No
#### Does this PR introduce a user-facing change?
<!--
-->
