### PR TITLE
Databricks serverless endpoint (enabling integration testing)

### DIFF
--- a/.github/workflows/database-databricks-integration-test.yml
+++ b/.github/workflows/database-databricks-integration-test.yml
@@ -20,8 +20,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   DATABRICKS_API_TOKEN: ${{ secrets.DATABRICKS_API_TOKEN }}
-  DATABRICKS_WORKSPACE: https://dbc-f0687849-717f.cloud.databricks.com
-  DATABRICKS_CLUSTERID: 0228-234110-ve0xbrtk
 
 on:
   schedule:

--- a/legend-engine-xt-relationalStore-executionPlan-connection-tests/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/ExternalIntegration_TestConnectionAcquisitionWithFlowProvider_Databricks.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection-tests/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/ExternalIntegration_TestConnectionAcquisitionWithFlowProvider_Databricks.java
@@ -33,14 +33,12 @@ import javax.security.auth.Subject;
 import java.sql.Connection;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.ResourceBundle;
 
 import static org.junit.Assert.assertTrue;
 
 public class ExternalIntegration_TestConnectionAcquisitionWithFlowProvider_Databricks extends org.finos.legend.engine.plan.execution.stores.relational.connection.test.DbSpecificTests
 {
     private ConnectionManagerSelector connectionManagerSelector;
-    private static final ResourceBundle env = ResourceBundle.getBundle("environment");
 
     // To make test work, please enable environment variable DATABRICKS_API_TOKEN with a valid API token
 
@@ -88,7 +86,7 @@ public class ExternalIntegration_TestConnectionAcquisitionWithFlowProvider_Datab
         dsSpecs.hostname = "dbc-f0687849-717f.cloud.databricks.com";
         dsSpecs.port = "443";
         dsSpecs.protocol = "https";
-        dsSpecs.httpPath = "sql/protocolv1/o/448477574000404/0228-234110-ve0xbrtk";
+        dsSpecs.httpPath = "/sql/1.0/warehouses/c56852187940e5a3";
         ApiTokenAuthenticationStrategy authSpec = new ApiTokenAuthenticationStrategy();
         authSpec.apiToken = "DATABRICKS_API_TOKEN";
         return new RelationalDatabaseConnection(dsSpecs, authSpec, DatabaseType.Databricks);

--- a/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/ApiTokenAuthenticationStrategy.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/ApiTokenAuthenticationStrategy.java
@@ -61,7 +61,6 @@ public class ApiTokenAuthenticationStrategy extends AuthenticationStrategy
     {
         ApiTokenCredential apiTokenCredential = this.resolveCredential(properties, this.apiToken);
         Properties connectionProperties = new Properties();
-        connectionProperties.putAll(properties);
         connectionProperties.put("PWD", apiTokenCredential.getApiToken());
         return Tuples.pair(url, connectionProperties);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <hikaricp.version>4.0.3</hikaricp.version>
         <h2.version>1.4.200</h2.version>
         <snowflake.version>3.13.5</snowflake.version>
-        <databricks.version>2.6.25</databricks.version>
+        <databricks.version>2.6.27</databricks.version>
         <redshiftJDBC.version>2.0.0.3</redshiftJDBC.version>
         <postgres.version>9.4.1208.jre7</postgres.version>
 


### PR DESCRIPTION
- Databricks SQL warehouse do not support extra properties in JDBC connection
- Enable integration tests by using serverless endpoints

#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

Although databricks JDBC connection works for standard (all purpose) clusters, we may need to execute queries against [SQL warehouse](https://www.databricks.com/product/databricks-sql), specifically designed for SQL compute. The latter does not accept additional properties in JDBC connection URLs, hence changes in [ApiTokenAuthenticationStrategy.java](legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/ApiTokenAuthenticationStrategy.java)

By moving to SQL compute, we benefit from serverless offering so that compute is always on (boot time < 5sec), allowing integration tests.

#### Other notes for reviewers:

`N/A`

#### Does this PR introduce a user-facing change?

`N/A`


