### PR TITLE
Update Snowflake/Postgres workflows to upload test results as Github artifacts

### DIFF
--- a/.github/workflows/database-postgresql-integration-test.yml
+++ b/.github/workflows/database-postgresql-integration-test.yml
@@ -72,3 +72,15 @@ jobs:
           MAVEN_OPTS: -Xmx4g
         run :
           mvn -pl legend-engine-xt-relationalStore-executionPlan-connection-tests  -Dtest="ExternalIntegration*Postgres*" test
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: legend-engine-test-reports/surefire-reports-aggregate/*.xml
+      - name: Upload CI Event
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: event-file
+          path: ${{ github.event_path }}

--- a/.github/workflows/database-postgresql-sql-generation-integration-test.yml
+++ b/.github/workflows/database-postgresql-sql-generation-integration-test.yml
@@ -85,3 +85,15 @@ jobs:
           name: ${{github.workflow}}
           path: sql_test_summary.txt
           retention-days: 1
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: legend-engine-test-reports/surefire-reports-aggregate/*.xml
+      - name: Upload CI Event
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: event-file
+          path: ${{ github.event_path }}

--- a/.github/workflows/database-snowflake-integration-test.yml
+++ b/.github/workflows/database-snowflake-integration-test.yml
@@ -72,3 +72,15 @@ jobs:
         run: |
           mvn -pl legend-engine-xt-relationalStore-executionPlan-connection  -Dtest="ExternalIntegration*Snowflake*" test
           mvn -pl legend-engine-xt-relationalStore-executionPlan-connection-tests  -Dtest="ExternalIntegration*Snowflake*" test
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: legend-engine-test-reports/surefire-reports-aggregate/*.xml
+      - name: Upload CI Event
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: event-file
+          path: ${{ github.event_path }}

--- a/.github/workflows/database-snowflake-sql-generation-integration-test.yml
+++ b/.github/workflows/database-snowflake-sql-generation-integration-test.yml
@@ -86,3 +86,15 @@ jobs:
           name: ${{github.workflow}}
           path: sql_test_summary.txt
           retention-days: 1
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: legend-engine-test-reports/surefire-reports-aggregate/*.xml
+      - name: Upload CI Event
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: event-file
+          path: ${{ github.event_path }}


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

Publishes test results from the Snowflake/Postgres  workflows to Github actions.
This is so that other workflow actions can download these results (artifacts) and assemble reports etc. 

We are already doing this in a couple of places -
https://github.com/finos/legend-engine/blob/master/.github/workflows/test-result.yml 
https://github.com/finos/legend-engine/blob/master/.github/workflows/summarize-sql-generation-integration-tests.yml 

This PR publishes the full/raw Junit output instead of a summary. 

Once we get the report generation working for Snowflake/Postgres, we can roll out to the other database workflows and also cleanup other summary artifacts that the workflows are currently publishing.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
<!--
-->
