### PR TITLE
Update GraphQL API endpoints with user/group workspace parameters.

### DIFF
--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
@@ -29,7 +29,6 @@ import org.finos.legend.engine.language.graphQL.grammar.from.GraphQLGrammarParse
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.modelManager.ModelManager;
 import org.finos.legend.engine.language.pure.modelManager.sdlc.configuration.MetaDataServerConfiguration;
-import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.protocol.graphQL.metamodel.Document;
 import org.finos.legend.engine.protocol.graphQL.metamodel.ExecutableDocument;
 import org.finos.legend.engine.protocol.pure.PureClientVersions;
@@ -68,7 +67,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ServiceLoader;
 import java.util.function.Function;
 
 import static org.finos.legend.engine.shared.core.operational.http.InflateInterceptor.APPLICATION_ZLIB;
@@ -121,17 +119,44 @@ public class GraphQLDebug extends GraphQL
         )).build();
     }
 
+    @Deprecated
     @POST
-    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using metadata from SDLC project")
+    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using metadata from SDLC project",  notes = "DEPRECATED - Use the generateGraphFetch APIs that include 'workspace' or 'groupWorkspace' as path parameters")
     @Path("generateGraphFetch/dev/{projectId}/{workspaceId}/query/{queryClassPath}")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
     public Response generateGraphFetchDev(@Context HttpServletRequest request, @PathParam("workspaceId") String workspaceId, @PathParam("projectId") String projectId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
+        return this.generateGraphFetchDevImpl(request, workspaceId, false, queryClassPath, queryClassPath, query, pm);
+    }
+
+    @POST
+    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using metadata from SDLC project (user workspace)")
+    @Path("generateGraphFetch/dev/{projectId}/{workspaceId}/query/{queryClassPath}")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response generateGraphFetchDevWithUserWorkspace(@Context HttpServletRequest request, @PathParam("workspaceId") String workspaceId, @PathParam("projectId") String projectId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    {
+        return this.generateGraphFetchDevImpl(request, workspaceId, false, projectId, queryClassPath, query, pm);
+    }
+
+
+    @POST
+    @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using metadata from SDLC project (group workspace)")
+    @Path("generateGraphFetch/dev/{projectId}/groupWorkspace/{workspaceId}/query/{queryClassPath}")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response generateGraphFetchDevWithGroupWorkspace(@Context HttpServletRequest request, @PathParam("workspaceId") String workspaceId, @PathParam("projectId") String projectId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
+    {
+        return this.generateGraphFetchDevImpl(request, workspaceId, true, projectId, queryClassPath, query, pm);
+    }
+
+    private Response generateGraphFetchDevImpl(HttpServletRequest request, String workspaceId, boolean isGroupWorkspace, String projectId, String queryClassPath, Query query, ProfileManager<CommonProfile> pm)
+    {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         try (Scope scope = GlobalTracer.get().buildSpan("GraphQL: Generate Graph Fetch").startActive(true))
         {
-            return this.generateGraphFetch(queryClassPath, query, loadSDLCProjectModel(profiles, request, projectId, workspaceId, false));
+            return this.generateGraphFetch(queryClassPath, query, loadSDLCProjectModel(profiles, request, projectId, workspaceId, isGroupWorkspace));
         }
         catch (Exception ex)
         {

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/debug/GraphQLDebug.java
@@ -127,12 +127,12 @@ public class GraphQLDebug extends GraphQL
     @Produces(MediaType.APPLICATION_JSON)
     public Response generateGraphFetchDev(@Context HttpServletRequest request, @PathParam("workspaceId") String workspaceId, @PathParam("projectId") String projectId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return this.generateGraphFetchDevImpl(request, workspaceId, false, queryClassPath, queryClassPath, query, pm);
+        return this.generateGraphFetchDevWithUserWorkspace(request, workspaceId, projectId, queryClassPath, query, pm);
     }
 
     @POST
     @ApiOperation(value = "Generate Pure graphFetch(s) from a graphQL query using metadata from SDLC project (user workspace)")
-    @Path("generateGraphFetch/dev/{projectId}/{workspaceId}/query/{queryClassPath}")
+    @Path("generateGraphFetch/dev/{projectId}/workspace/{workspaceId}/query/{queryClassPath}")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
     public Response generateGraphFetchDevWithUserWorkspace(@Context HttpServletRequest request, @PathParam("workspaceId") String workspaceId, @PathParam("projectId") String projectId, @PathParam("queryClassPath") String queryClassPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
@@ -155,7 +155,7 @@ public class GraphQLExecute extends GraphQL
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     public Response generatePlansDev(@Context HttpServletRequest request, @PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return this.generatePlansDevWithWorkspaceImpl(request, projectId, workspaceId, false, queryClassPath, mappingPath, query, pm);
+        return this.generatePlansDevWithUserWorkspace(request, projectId, workspaceId, queryClassPath, mappingPath, query, pm);
     }
 
     @POST
@@ -275,7 +275,7 @@ public class GraphQLExecute extends GraphQL
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     public Response executeDev(@Context HttpServletRequest request, @PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("queryClassPath") String queryClassPath, @PathParam("mappingPath") String mappingPath, @PathParam("runtimePath") String runtimePath, Query query, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
     {
-        return this.executeDevImpl(request, projectId, workspaceId, false, queryClassPath, mappingPath, runtimePath, query, pm);
+        return this.executeDevWithUserWorkspace(request, projectId, workspaceId, queryClassPath, mappingPath, runtimePath, query, pm);
     }
 
     @POST


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

This PR allows users to use the dev GraphQL endpoints with both user and group SDLC workspaces. 
Previously, the code only supported user workspaces (isGroupWorkspace was hardcoded to false). 

Now there are 2 new API endpoints 
```
/workspace/{wsId}
/groupWorkspace/{wsId}
```
that are routed to the appropriate SDLC APIs to load models. 

In addition, the previous API is being deprecated and will be removed in the next release of engine.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes. New APIs are being introduced.  Existing APIs have been deprecated but not deleted. 
<!--
-->
