### PR TITLE
Include 'extractFromSemiStructured' in dynafunction testing

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuiteCompletenessTests.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuiteCompletenessTests.pure
@@ -7,7 +7,7 @@ function <<test.Test>> meta::relational::tests::testSuite::ensureEveryDynaFnIsTe
     meta::relational::tests::dbSpecificTests::sqlQueryTests::selectSubClauses::aggregationDynaFns
   ];
   let testedDynaFnNames = $packagesContainingDynaFnTests.children->filter(c| $c->instanceOf(Package)).name;
-  let testingIgnoredDynaFnNames = ['add', 'averageRank', 'case', 'convertDate', 'convertDateTime', 'convertVarchar128', 'dayOfWeek', 'decodeBase64', 'denseRank', 'distinct', 'divide', 'encodeBase64', 'exists', 'group', 'if', 'isAlphaNumeric', 'isDistinct', 'isNumeric', 'minus', 'not', 'objectReferenceIn', 'parseDate', 'parseDecimal', 'parseFloat', 'parseInteger', 'parseJson', 'percentile', 'plus', 'rank', 'rowNumber', 'sub', 'times', 'toOne', 'toString', 'extractFromSemiStructured'];
+  let testingIgnoredDynaFnNames = ['add', 'averageRank', 'case', 'convertDate', 'convertDateTime', 'convertVarchar128', 'dayOfWeek', 'decodeBase64', 'denseRank', 'distinct', 'divide', 'encodeBase64', 'exists', 'group', 'if', 'isAlphaNumeric', 'isDistinct', 'isNumeric', 'minus', 'not', 'objectReferenceIn', 'parseDate', 'parseDecimal', 'parseFloat', 'parseInteger', 'parseJson', 'percentile', 'plus', 'rank', 'rowNumber', 'sub', 'times', 'toOne', 'toString'];
   let incorrectlyMarkedDynaFnNames = $testingIgnoredDynaFnNames->filter(n| $n->in($testedDynaFnNames));
   assert($incorrectlyMarkedDynaFnNames->isEmpty(), |'dyna fns ' + $incorrectlyMarkedDynaFnNames->makeString('[', ', ', ']') + ' are incorrectly marked as ignored even though they are tested in sqlQueryToString/testSuite');
   let untestedDynaFnNames = $dynaFnNames->filter(d| !$d->in($testedDynaFnNames) && !$d->in($testingIgnoredDynaFnNames));


### PR DESCRIPTION
#### What type of PR is this?

Improvement

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

This PR reinstates the testing of the 'extractFromSemiStructured' dynafunction.

The function has been implemented for H2 and Snowflake but does not have tests in the database specific test suite. (See PR #1411).

In addition, the function has been removed from the testsuite for all the databases. 

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No.

<!--
-->
