### PR TITLE
Add logic for returning default incoming credential in CredentialProvider

### DIFF
--- a/legend-engine-xt-authentication-implementation-core/src/main/java/org/finos/legend/authentication/credentialprovider/CredentialProvider.java
+++ b/legend-engine-xt-authentication-implementation-core/src/main/java/org/finos/legend/authentication/credentialprovider/CredentialProvider.java
@@ -129,13 +129,19 @@ public abstract class CredentialProvider<SPEC extends AuthenticationSpecificatio
 
     protected Credential makeCredential(AuthenticationSpecification specification, Identity identity, Class<? extends Credential> outputCredentialType) throws Exception
     {
+        ImmutableSet<? extends Class<? extends Credential>> identityCredentialTypes = FastList.newList(identity.getCredentials()).collect(credential -> credential.getClass()).toSet().toImmutable();
+
+        if (identityCredentialTypes.contains(outputCredentialType))
+        {
+           return identity.getCredential(outputCredentialType).get();
+        }
+
         if (this.intermediationRules.isEmpty())
         {
             String message = String.format("Cannot make credential for configuration of type '%s'. No intermediation rules have been configured", specification.getClass());
             throw new UnsupportedOperationException(message);
         }
 
-        ImmutableSet<? extends Class<? extends Credential>> identityCredentialTypes = FastList.newList(identity.getCredentials()).collect(credential -> credential.getClass()).toSet().toImmutable();
         Optional<IntermediationRule> matchingRuleHolder = this.findMatchingRule(specification, identityCredentialTypes, outputCredentialType);
         if (!matchingRuleHolder.isPresent())
         {

--- a/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestDefaultCredentialCreation.java
+++ b/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestDefaultCredentialCreation.java
@@ -1,3 +1,17 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.finos.legend.authentication;
 
 import org.finos.legend.authentication.credentialprovider.impl.ApikeyCredentialProvider;

--- a/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestDefaultCredentialCreation.java
+++ b/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestDefaultCredentialCreation.java
@@ -1,0 +1,32 @@
+package org.finos.legend.authentication;
+
+import org.finos.legend.authentication.credentialprovider.impl.ApikeyCredentialProvider;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.ApiKeyAuthenticationSpecification;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.shared.core.identity.credential.ApiTokenCredential;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestDefaultCredentialCreation
+{
+    private Identity identity;
+
+    @Before
+    public void setup()
+    {
+        this.identity = new Identity("alice", new ApiTokenCredential("value1"));
+    }
+
+    @Test
+    public void testProviderWithDefaultIncomingCredential() throws Exception
+    {
+        ApikeyCredentialProvider credentialProvider = new ApikeyCredentialProvider();
+        ApiTokenCredential credential = credentialProvider.makeCredential(new ApiKeyAuthenticationSpecification(), identity);
+
+        assertTrue(credential instanceof ApiTokenCredential);
+        assertEquals("value1", credential.getApiToken());
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?

If the incoming credential type is same as output credential type, we can directly return the incoming credential. There is no need to look for intermediation rules. It will reduce the effort to add default intermediation rules for every authentication spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
