### PR TITLE
Persistence Component: Fix for empty table check SQL for snowflake

### DIFF
--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/LogicalPlanFactory.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/LogicalPlanFactory.java
@@ -44,10 +44,10 @@ public class LogicalPlanFactory
 
     public static LogicalPlan getLogicalPlanForIsDatasetEmpty(Dataset dataset)
     {
-        Function count = FunctionImpl.builder().functionName(FunctionName.COUNT).addValue(All.INSTANCE).alias(IS_TABLE_NON_EMPTY).build();
+        Function countAllRows = FunctionImpl.builder().functionName(FunctionName.COUNT).addValue(All.INSTANCE).alias(IS_TABLE_NON_EMPTY).build();
         Selection selectWithLimit = Selection.builder().source(dataset).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).limit(1).alias(TABLE_ALIAS).build();
         return LogicalPlan.builder()
-            .addOps(Selection.builder().addFields(count).source(selectWithLimit).build())
+            .addOps(Selection.builder().addFields(countAllRows).source(selectWithLimit).build())
             .build();
     }
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/LogicalPlanFactory.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/LogicalPlanFactory.java
@@ -15,8 +15,6 @@
 package org.finos.legend.engine.persistence.components.logicalplan;
 
 import org.finos.legend.engine.persistence.components.common.Datasets;
-import org.finos.legend.engine.persistence.components.logicalplan.conditions.Condition;
-import org.finos.legend.engine.persistence.components.logicalplan.conditions.Exists;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.CsvExternalDatasetReference;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Dataset;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Selection;
@@ -28,6 +26,7 @@ import org.finos.legend.engine.persistence.components.logicalplan.values.Functio
 import org.finos.legend.engine.persistence.components.logicalplan.values.FunctionImpl;
 import org.finos.legend.engine.persistence.components.logicalplan.values.FunctionName;
 import org.finos.legend.engine.persistence.components.logicalplan.values.NumericalValue;
+import org.finos.legend.engine.persistence.components.logicalplan.values.All;
 import org.finos.legend.engine.persistence.components.logicalplan.values.StringValue;
 import org.finos.legend.engine.persistence.components.logicalplan.values.TabularValues;
 import org.finos.legend.engine.persistence.components.logicalplan.values.Value;
@@ -41,14 +40,14 @@ public class LogicalPlanFactory
 {
     public static final String IS_TABLE_NON_EMPTY = "isTableNonEmpty";
     public static final String TABLE_IS_NON_EMPTY = "1";
+    public static final String TABLE_ALIAS = "X";
 
     public static LogicalPlan getLogicalPlanForIsDatasetEmpty(Dataset dataset)
     {
-        Condition exists = Exists.of(Selection.builder().source(dataset).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).build());
-        Function count = FunctionImpl.builder().functionName(FunctionName.COUNT).addValue(NumericalValue.of(1L)).alias(IS_TABLE_NON_EMPTY).build();
-
+        Function count = FunctionImpl.builder().functionName(FunctionName.COUNT).addValue(All.INSTANCE).alias(IS_TABLE_NON_EMPTY).build();
+        Selection selectWithLimit = Selection.builder().source(dataset).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).limit(1).alias(TABLE_ALIAS).build();
         return LogicalPlan.builder()
-            .addOps(Selection.builder().condition(exists).addFields(count).build())
+            .addOps(Selection.builder().addFields(count).source(selectWithLimit).build())
             .build();
     }
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/SelectionAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/SelectionAbstract.java
@@ -47,6 +47,8 @@ public interface SelectionAbstract extends Dataset, Operation
 
     Optional<String> alias();
 
+    Optional<Integer> limit();
+
     @Derived
     default DatasetReference datasetReference()
     {

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/SelectionVisitor.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/SelectionVisitor.java
@@ -49,6 +49,11 @@ public class SelectionVisitor implements LogicalPlanVisitor<Selection>
             selectStatement.setSelectItemsSize((long) current.fields().size());
         }
 
+        if (current.limit().isPresent())
+        {
+            selectStatement.setLimit(current.limit().get());
+        }
+
         current.condition().ifPresent(logicalPlanNodeList::add);
         current.groupByFields().ifPresent(logicalPlanNodeList::addAll);
         current.quantifier().ifPresent(logicalPlanNodeList::add);

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/logicalplan/operations/SelectTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/logicalplan/operations/SelectTest.java
@@ -1,0 +1,54 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.logicalplan.operations;
+
+import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlan;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetDefinition;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.Selection;
+import org.finos.legend.engine.persistence.components.relational.SqlPlan;
+import org.finos.legend.engine.persistence.components.relational.ansi.AnsiSqlSink;
+import org.finos.legend.engine.persistence.components.relational.transformer.RelationalTransformer;
+import org.finos.legend.engine.persistence.components.util.LogicalPlanUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.finos.legend.engine.persistence.components.logicalplan.operations.BaseTestUtils.schemaWithAllColumns;
+
+public class SelectTest
+{
+
+    @Test
+    public void testSelectTable()
+    {
+        DatasetDefinition dataset = DatasetDefinition.builder()
+                .database("my_db")
+                .group("my_schema")
+                .name("my_table")
+                .alias("my_alias")
+                .schema(schemaWithAllColumns)
+                .build();
+
+        RelationalTransformer transformer = new RelationalTransformer(AnsiSqlSink.get());
+        Selection selectWithLimit = Selection.builder().source(dataset).addAllFields(LogicalPlanUtils.ALL_COLUMNS()).limit(1).build();
+        LogicalPlan logicalPlan = LogicalPlan.builder().addOps(selectWithLimit).build();
+        SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
+        List<String> list = physicalPlan.getSqlList();
+
+        String expectedSelectQuery = "SELECT * FROM \"my_db\".\"my_schema\".\"my_table\" as my_alias LIMIT 1";
+        Assertions.assertEquals(expectedSelectQuery, list.get(0));
+    }
+}

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/util/LogicalPlanFactoryTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/util/LogicalPlanFactoryTest.java
@@ -1,0 +1,53 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.util;
+
+import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlan;
+import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlanFactory;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetDefinition;
+import org.finos.legend.engine.persistence.components.relational.SqlPlan;
+import org.finos.legend.engine.persistence.components.relational.ansi.AnsiSqlSink;
+import org.finos.legend.engine.persistence.components.relational.transformer.RelationalTransformer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.finos.legend.engine.persistence.components.logicalplan.operations.BaseTestUtils.schemaWithAllColumns;
+
+public class LogicalPlanFactoryTest
+{
+
+    @Test
+    public void testSelectTable()
+    {
+        DatasetDefinition dataset = DatasetDefinition.builder()
+                .database("my_db")
+                .group("my_schema")
+                .name("my_table")
+                .alias("my_alias")
+                .schema(schemaWithAllColumns)
+                .build();
+
+        RelationalTransformer transformer = new RelationalTransformer(AnsiSqlSink.get());
+        LogicalPlan logicalPlan = LogicalPlanFactory.getLogicalPlanForIsDatasetEmpty(dataset);
+        SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
+        List<String> list = physicalPlan.getSqlList();
+
+        String expectedQuery = "SELECT COUNT(*) as \"isTableNonEmpty\" FROM (SELECT * FROM \"my_db\".\"my_schema\".\"my_table\" as my_alias LIMIT 1) as X";
+        Assertions.assertEquals(expectedQuery, list.get(0));
+    }
+
+}

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalIngestorAbstract.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalIngestorAbstract.java
@@ -181,11 +181,6 @@ public abstract class RelationalIngestorAbstract
         {
             resourcesBuilder.stagingDataSetEmpty(datasetEmpty(updatedDatasets.stagingDataset(), transformer, executor));
         }
-        // Validate if main dataset schema matches the actual table
-        if (executor.datasetExists(updatedDatasets.mainDataset()))
-        {
-            validateMainDatasetSchema(updatedDatasets.mainDataset(), executor);
-        }
 
         // generate sql plans
         RelationalGenerator generator = RelationalGenerator.builder()

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/common/Clause.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/common/Clause.java
@@ -49,7 +49,8 @@ public enum Clause
     CASE("CASE"),
     WHEN("WHEN"),
     ELSE("ELSE"),
-    END("END");
+    END("END"),
+    LIMIT("LIMIT");
 
     private final String clause;
 

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/statements/SelectStatement.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/statements/SelectStatement.java
@@ -72,6 +72,7 @@ public class SelectStatement extends SelectExpression implements DMLStatement
     [ GROUP BY clause ]
     [ HAVING clause ]
     [ ORDER BY clause ]
+    [ limit clause ]
     [ result offset clause ]
     [ fetch first clause ]
      */

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/statements/SelectStatement.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/statements/SelectStatement.java
@@ -45,6 +45,7 @@ public class SelectStatement extends SelectExpression implements DMLStatement
     private final List<TableLike> tables;
     private Condition condition;
     private final List<Value> groupByFields;
+    private Integer limit;
 
     public SelectStatement()
     {
@@ -128,6 +129,15 @@ public class SelectStatement extends SelectExpression implements DMLStatement
             }
         }
 
+        // Add limit clause
+        if (limit != null)
+        {
+            builder.append(WHITE_SPACE);
+            builder.append(Clause.LIMIT.get());
+            builder.append(WHITE_SPACE);
+            builder.append(limit);
+        }
+
         if (getAlias() != null)
         {
             builder.append(CLOSING_PARENTHESIS);
@@ -199,5 +209,10 @@ public class SelectStatement extends SelectExpression implements DMLStatement
     public void setSelectItemsSize(Long selectItemsSize)
     {
         this.selectItemsSize = selectItemsSize;
+    }
+
+    public void setLimit(int limit)
+    {
+        this.limit = limit;
     }
 }

--- a/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/SelectExpressionTest.java
+++ b/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/test/java/org/finos/legend/engine/persistence/components/relational/sqldom/schemaops/SelectExpressionTest.java
@@ -64,20 +64,21 @@ class SelectExpressionTest
     }
 
     @Test
-    void genSqlForSimpleSelectStar()
+    void genSqlForSimpleSelectStarWithLimit()
     {
         Table table = new Table("mydb", null, "mytable", null, BaseTest.QUOTE_IDENTIFIER);
 
-        SelectExpression selectExpression =
+        SelectStatement selectStatement =
             new SelectStatement(
                 null,
                 Collections.singletonList(new All(BaseTest.QUOTE_IDENTIFIER)),
                 Collections.singletonList(table),
                 null,
                 Collections.emptyList());
+        selectStatement.setLimit(10);
 
-        String sql1 = BaseTest.genSqlIgnoringErrors(selectExpression);
-        String expected = "SELECT * FROM \"mydb\".\"mytable\"";
+        String sql1 = BaseTest.genSqlIgnoringErrors(selectStatement);
+        String expected = "SELECT * FROM \"mydb\".\"mytable\" LIMIT 10";
         assertEquals(expected, sql1);
     }
 


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
Bug fix for SQL that checks if the table is empty.

#### Which issue(s) this PR fixes:
Bug fix for SQL that checks if the table is empty.
The old sql was not compliant with Snowflake
Rewrote the SQL that is now compliant with Snowflake and added related tests.
#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
NO
