### PR TITLE
Preeval - handle constants in AggregateValue automaps

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
@@ -232,29 +232,29 @@ function <<access.private>> meta::pure::router::preeval::prevalInternal(item : A
 
                         },
                         {av : meta::pure::tds::AggregateValue<Any,Any>[1]|
-                            let mapFn = $av.mapFn->evaluateAndDeactivate();
-                            let aggFn = $av.aggregateFn->evaluateAndDeactivate();
+                              let mapFn = $av.mapFn->evaluateAndDeactivate();
+                              let aggFn = $av.aggregateFn->evaluateAndDeactivate();
 
-                            let newFuncWrapper_map = prevalInternal($mapFn, ^$state(inScopeTypeParams = ^Map<String, GenericType>(), inScopeVars = $mapFn->openVariableValues()), $extensions);
-                            let newFuncWrapper_agg = prevalInternal($aggFn, ^$state(inScopeTypeParams = ^Map<String, GenericType>(), inScopeVars = $aggFn->openVariableValues()), $extensions);
+                              let newFuncWrapper_map = prevalNestedFunctionDefinition($mapFn, $state, $extensions);
+                              let newFuncWrapper_agg = prevalNestedFunctionDefinition($aggFn, $state, $extensions);
 
                             if(![$newFuncWrapper_map, $newFuncWrapper_agg]->anyModified(),
                               | ^PrevalWrapper<Any>(value = $av, canPreval = true, modified = false),
                               | ^PrevalWrapper<Any>(value = ^$av(mapFn = $newFuncWrapper_map.value->cast($mapFn), aggregateFn = $newFuncWrapper_agg.value->cast($aggFn)), canPreval = true, modified = true);
-                            );
+                              );
                         },   
                         {av : meta::pure::functions::collection::AggregateValue<Any,Any,Any>[1]|
-                            let mapFn = $av.mapFn->evaluateAndDeactivate();
-                            let aggFn = $av.aggregateFn->evaluateAndDeactivate();
+                              let mapFn = $av.mapFn->evaluateAndDeactivate();
+                              let aggFn = $av.aggregateFn->evaluateAndDeactivate();
+                              
+                              let newFuncWrapper_map = prevalNestedFunctionDefinition($mapFn, $state, $extensions);
+                              let newFuncWrapper_agg = prevalNestedFunctionDefinition($aggFn, $state, $extensions);
 
-                            let newFuncWrapper_map = prevalInternal($mapFn, ^$state(inScopeTypeParams = ^Map<String, GenericType>(), inScopeVars = $mapFn->openVariableValues()), $extensions);
-                            let newFuncWrapper_agg = prevalInternal($aggFn, ^$state(inScopeTypeParams = ^Map<String, GenericType>(), inScopeVars = $aggFn->openVariableValues()), $extensions);
-
-                            if(![$newFuncWrapper_map, $newFuncWrapper_agg]->anyModified(),
-                                | ^PrevalWrapper<Any>(value = $av, canPreval = true, modified = false),
-                                | ^PrevalWrapper<Any>(value = ^$av(mapFn = $newFuncWrapper_map.value->cast($mapFn), aggregateFn = $newFuncWrapper_agg.value->cast($aggFn)), canPreval = true, modified = true);
-                            );
-                        },                              
+                              if(![$newFuncWrapper_map, $newFuncWrapper_agg]->anyModified(),
+                                  | ^PrevalWrapper<Any>(value = $av, canPreval = true, modified = false),
+                                  | ^PrevalWrapper<Any>(value = ^$av(mapFn = $newFuncWrapper_map.value->cast($mapFn), aggregateFn = $newFuncWrapper_agg.value->cast($aggFn)), canPreval = true, modified = true);
+                                  );
+                        },                             
                         {r: meta::pure::graphFetch::RootGraphFetchTree<Any>[1] | ^PrevalWrapper<Any>(value = $r, canPreval = true, modified = false);},
                         {b: meta::external::shared::format::binding::Binding[1] | ^PrevalWrapper<Any>(value = $b, canPreval = true, modified = false);},
                         {a : Any[1]|
@@ -265,6 +265,22 @@ function <<access.private>> meta::pure::router::preeval::prevalInternal(item : A
 
   $state->printDebugWithDepth(|'Returning ' + $newItem.value->type()->makeString() + ' ' + $newItem.value->match([iv:InstanceValue[1]|$iv.values->map(x|$x->type())->makeString(), sfe:SimpleFunctionExpression[1]|'(' + $sfe.func->elementToPath() + ')', ve : VariableExpression[1]|'(' + $ve.name + ')', a:Any[*]|'']) + ' ' + $newItem.toString());
   $newItem;
+}
+
+function <<access.private>> meta::pure::router::preeval::prevalNestedFunctionDefinition(f:FunctionDefinition<Any>[1], state : meta::pure::router::preeval::State[1], extensions:Extension[*]):PrevalWrapper<Any>[1]
+{
+  $f->match([
+    l:LambdaFunction<Any>[1] | prevalNestedLambda($l, $state, $extensions),
+    fn:FunctionDefinition<Any>[1] | prevalInternal($fn, ^$state(inScopeTypeParams = ^Map<String, GenericType>(), inScopeVars = $fn->openVariableValues()), $extensions);
+  ]);
+}
+
+function <<access.private>> meta::pure::router::preeval::prevalNestedLambda(lambda:LambdaFunction<Any>[1], state : meta::pure::router::preeval::State[1], extensions:Extension[*]):PrevalWrapper<Any>[1]
+{
+  let fnArgNames = $lambda->functionType().parameters.name;
+  let fnOpenVariables = $lambda->openVariableValues()->putAll($state.inScopeVars->keyValues()->filter(kv | !$kv.first->in($fnArgNames))->newMap());
+
+  prevalInternal($lambda, ^$state(inScopeTypeParams = ^Map<String, GenericType>(), inScopeVars = $fnOpenVariables), $extensions);
 }
 
 function <<access.private>> meta::pure::router::preeval::prevalFunctionDefinition(fd : FunctionDefinition<Any>[1], origState : meta::pure::router::preeval::State[1], extensions:Extension[*]):PrevalWrapper<Any>[1]

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
@@ -1160,6 +1160,49 @@ function <<test.Test>> meta::pure::router::preeval::tests::testPrerouting_mapped
   assertRoundTrip($input, $expected);
 }
 
+function <<test.Test>> meta::pure::router::preeval::tests::testPrerouting_constantInAgg():Boolean[1]
+{   
+  let lambda = {|
+    let businessDate = %2023-01-01;
+    let x = 'a';
+    meta::pure::router::preeval::tests::Position.all($businessDate)->groupBy(
+      [],
+      agg(x|$x.client($businessDate).name + 'b', y|$y->count()),
+      'ID Count'
+    );
+  };
+
+  //we re-write the lambda to inline an AggregateValue with businessDate variable
+  let aggregateValue = ^meta::pure::functions::collection::AggregateValue<meta::pure::router::preeval::tests::Position, String, Integer>(mapFn={x:meta::pure::router::preeval::tests::Position[1] | $x.client(%2023-01-01).name + $x->toString()},aggregateFn={y:String[*] | $y->count()});
+
+  let expressionSequence = $lambda.expressionSequence->evaluateAndDeactivate();
+  let groupBy = $expressionSequence->at(2)->cast(@SimpleFunctionExpression);
+
+  let mapFn = $aggregateValue.mapFn;
+  let mapFnExpressionSequnce = $mapFn.expressionSequence->evaluateAndDeactivate()->cast(@SimpleFunctionExpression)->toOne();
+
+  let plus = $mapFnExpressionSequnce.parametersValues->at(0)->cast(@InstanceValue);
+  let plusParams = $plus.values;
+  let plusLeft = $plusParams->at(0)->cast(@SimpleFunctionExpression);
+  let client = $plusLeft.parametersValues->at(0)->cast(@SimpleFunctionExpression);
+  let newClient = ^$client(parametersValues = [$client.parametersValues->at(0), ^VariableExpression(name='businessDate',genericType=^GenericType(rawType = StrictDate),multiplicity=PureOne)]);
+
+  let newPlusLeft = ^$plusLeft(parametersValues = $newClient);
+  let newPlus = ^$plus(values = [$newPlusLeft,$plus.values->at(1)]);
+
+  let newAggregateValue = ^$aggregateValue(mapFn = ^$mapFn(expressionSequence = ^$mapFnExpressionSequnce(parametersValues = [$newPlus])));
+  let newAggregateValueInstance = ^InstanceValue(genericType=^GenericType(rawType = meta::pure::functions::collection::AggregateValue),multiplicity=PureOne, values = $newAggregateValue);
+  let newGroupBy = ^$groupBy(parametersValues = [$groupBy.parametersValues->at(0), $groupBy.parametersValues->at(1), $newAggregateValueInstance, $groupBy.parametersValues->at(3)]);
+  let newLambda = ^$lambda(expressionSequence = [$expressionSequence->at(0), $expressionSequence->at(1), $newGroupBy]);
+
+ 
+  let expected = {|
+    meta::pure::router::preeval::tests::Position.all(%2023-01-01)->groupBy([], ^meta::pure::functions::collection::AggregateValue<meta::pure::router::preeval::tests::Position, String, Integer>(mapFn={x:meta::pure::router::preeval::tests::Position[1] | $x.client(%2023-01-01).name + $x->toString()},aggregateFn={y:String[*]|$y->count()}), ['ID Count'])
+  };
+
+    assertRoundTrip($newLambda, $expected);
+}
+
 function <<test.Test>> meta::pure::router::preeval::tests::testPrerouting_castEmptyCollection():Boolean[1]
 {
   let input = {b:Integer[*]|$b->uniqueValueOnly()};
@@ -1239,6 +1282,7 @@ function <<test.Test>> meta::pure::router::preeval::tests::testPreroutingRemoveU
 
   assertRoundTrip($input, $expected);
 }
+
 
 function meta::pure::router::preeval::tests::myStopFunction(b: Integer[1]) : Integer[1]
 {


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
Fixes an issue in preval in the case where AggregateValue uses in scope constant variables within an automap, in the map or agg functions.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
