### PR TITLE
User friendly error for slice, drop and limit/take parameters

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -2383,9 +2383,12 @@ function meta::relational::functions::pureToSqlQuery::processSlice(f:FunctionExp
    let mainQuery = processValueSpecification($f.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
    let mainSelect = $mainQuery.select;
 
-   let fromRow = processValueSpecification($f.parametersValues->at(1), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->at(0)->cast(@Literal);
-   let toRow = processValueSpecification($f.parametersValues->at(2), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->at(0)->cast(@Literal);
-
+   let param1 = processValueSpecification($f.parametersValues->at(1), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->at(0);
+   assert($param1->instanceOf(Literal),'Only literals are supported inside the slice function, you are passing a ' + $param1->type()->toString());
+   let fromRow = $param1->cast(@Literal);
+   let param2 = processValueSpecification($f.parametersValues->at(2), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->at(0);
+   assert($param2->instanceOf(Literal),'Only literals are supported inside the slice function, you are passing a ' + $param2->type()->toString());
+   let toRow = $param2->cast(@Literal); 
    let processedSelect = ^$mainSelect (
                   fromRow = if ($fromRow.value->instanceOf(Integer) && $fromRow.value->cast(@Integer) == 0, |[], |$fromRow),
                   toRow = $toRow
@@ -2421,8 +2424,9 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::isolate
 function meta::relational::functions::pureToSqlQuery::processTake(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
    let mainQuery = processValueSpecification($f.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
-   let limitValue = processValueSpecification($f.parametersValues->at(1), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->toOne()->cast(@Literal);
-
+   let param1 = processValueSpecification($f.parametersValues->at(1), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->toOne();
+   assert($param1->instanceOf(Literal),'Only literals are supported inside the take/limit function, you are passing a ' + $param1->type()->toString());
+   let limitValue = $param1->cast(@Literal);
    let mainSelect = $mainQuery.select;
 
    let limitSize = if($limitValue->instanceOf(SQLNull),
@@ -2721,8 +2725,9 @@ function meta::relational::functions::pureToSqlQuery::processDrop(f:FunctionExpr
    let mainQuery = processValueSpecification($f.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
    let mainSelect = $mainQuery.select;
 
-   let fromValue = processValueSpecification($f.parametersValues->at(1), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->at(0)->cast(@Literal);//.value->cast(@Integer);
-
+   let param1 = processValueSpecification($f.parametersValues->at(1), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor).select.columns->at(0);//.value->cast(@Integer);
+   assert($param1->instanceOf(Literal),'Only literals are supported inside the drop function, you are passing a ' + $param1->type()->toString());
+   let fromValue = $param1->cast(@Literal);
    let processedSelect = ^$mainSelect(fromRow = $fromValue)->isolateSubSelectIfNotLastOperation($f, $state.functionExpressionStack, $extensions);
 
    ^$mainQuery(


### PR DESCRIPTION
#### What type of PR is this?
Improvement in errors
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Currently upon using a dyna function inside slice, drop and limit/take we get a cast exception. This MR introduces user friendly errors.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
yes, message displayed on a specific error
