### PR TITLE
Optimizing Connection Data setup for MultiExecution Services

### DIFF
--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
@@ -154,7 +154,7 @@ public class ServiceTestRunner implements TestRunner
         MutableSet<String> allValidEnvIdsInTestSuite = Sets.mutable.empty();
         List<AtomicTest> testsForEachValidEnv = Lists.mutable.empty();
 
-        for (AtomicTest test: suite.tests)
+        for (AtomicTest test: atomicTestsInScope)
         {
             if(((ServiceTest) test).keys.isEmpty())
             {
@@ -170,8 +170,8 @@ public class ServiceTestRunner implements TestRunner
         {
             for (KeyedExecutionParameter param : allValidEnvInTestSuite)
             {
-                testsForEachValidEnv = suite.tests.stream().filter(test -> ((ServiceTest) test).keys.contains(param.key)).collect(Collectors.toList());
 
+                testsForEachValidEnv = atomicTestsInScope.stream().filter(test -> ((ServiceTest) test).keys.contains(param.key) || ((ServiceTest) test).keys.isEmpty()).collect(Collectors.toList());
                 for (AtomicTest test: testsForEachValidEnv)
                 {
                     PureSingleExecution pureSingleExecution = new PureSingleExecution();

--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
@@ -156,9 +156,9 @@ public class ServiceTestRunner implements TestRunner
 
         for (AtomicTest test: atomicTestsInScope)
         {
-            if(((ServiceTest) test).keys.isEmpty())
+            if (((ServiceTest) test).keys.isEmpty())
             {
-                allValidEnvIdsInTestSuite.addAll(((PureMultiExecution) service.execution).executionParameters.stream().map( x -> x.key).collect(Collectors.toList()));
+                allValidEnvIdsInTestSuite.addAll(((PureMultiExecution) service.execution).executionParameters.stream().map(x -> x.key).collect(Collectors.toList()));
             }
             else
             {
@@ -195,7 +195,7 @@ public class ServiceTestRunner implements TestRunner
         }
         finally
         {
-            for(Pair<Runtime, List<Closeable>> runtimeWIthCloseablePair: runtimeWithKeyMap.values())
+            for (Pair<Runtime, List<Closeable>> runtimeWIthCloseablePair: runtimeWithKeyMap.values())
             {
                 if (runtimeWIthCloseablePair != null)
                 {

--- a/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
+++ b/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
@@ -21,7 +21,10 @@ import io.opentracing.util.GlobalTracer;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -130,7 +133,7 @@ public class ServiceTestRunner implements TestRunner
             }
             if (((PureMultiExecution) service.execution).executionParameters != null && !((PureMultiExecution) service.execution).executionParameters.isEmpty())
             {
-                return executeMutiExecutionParametersTestSuite(atomicTestIds, pureModel, data, routerExtensions, planTransformers, service, suite, testResultsByTestId, atomicTestsInScope);
+                return executeMultiExecutionParametersTestSuite(atomicTestIds, pureModel, data, routerExtensions, planTransformers, service, suite, testResultsByTestId, atomicTestsInScope);
             }
             return executeMultiExecutionEnvironmentTestSuite((PureMultiExecution) service.execution, suite, atomicTestIds, pureModel, data, routerExtensions, planTransformers, testResultsByTestId);
         }
@@ -144,31 +147,71 @@ public class ServiceTestRunner implements TestRunner
         }
     }
 
-    private List<TestResult> executeMutiExecutionParametersTestSuite(List<String> atomicTestIds, PureModel pureModel, PureModelContextData data, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions, MutableList<PlanTransformer> planTransformers, Service service, ServiceTestSuite suite, Map<String, MultiExecutionServiceTestResult> testResultsByTestId, List<AtomicTest> atomicTestsInScope)
+    private List<TestResult> executeMultiExecutionParametersTestSuite(List<String> atomicTestIds, PureModel pureModel, PureModelContextData data, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions, MutableList<PlanTransformer> planTransformers, Service service, ServiceTestSuite suite, Map<String, MultiExecutionServiceTestResult> testResultsByTestId, List<AtomicTest> atomicTestsInScope)
     {
-        for  (AtomicTest test : atomicTestsInScope)
+        Pair<Runtime,List<Closeable>> runtimeWithCloseables = null;
+        MutableMap<String, Pair<Runtime, List<Closeable>>> runtimeWithKeyMap = Maps.mutable.empty();
+        MutableSet<String> allValidEnvIdsInTestSuite = Sets.mutable.empty();
+        List<AtomicTest> testsForEachValidEnv = Lists.mutable.empty();
+
+        for (AtomicTest test: suite.tests)
         {
-            List<KeyedExecutionParameter> allValidKeys = new ArrayList<>();
-            List<String> allKeys = ((ServiceTest) test).keys;
-            if (allKeys.isEmpty())
+            if(((ServiceTest) test).keys.isEmpty())
             {
-                allValidKeys.addAll(((PureMultiExecution) service.execution).executionParameters);
+                allValidEnvIdsInTestSuite.addAll(((PureMultiExecution) service.execution).executionParameters.stream().map( x -> x.key).collect(Collectors.toList()));
             }
             else
             {
-                allValidKeys = ((PureMultiExecution) service.execution).executionParameters.stream().filter(s -> allKeys.contains(s.key)).collect(Collectors.toList());
+                allValidEnvIdsInTestSuite.addAll(((ServiceTest) test).keys);
             }
-            allValidKeys.forEach(param ->
+        }
+        List<KeyedExecutionParameter> allValidEnvInTestSuite = ((PureMultiExecution) service.execution).executionParameters.stream().filter(s -> allValidEnvIdsInTestSuite.contains(s.key)).collect(Collectors.toList());
+        try
+        {
+            for (KeyedExecutionParameter param : allValidEnvInTestSuite)
             {
-                PureSingleExecution pureSingleExecution = new PureSingleExecution();
-                pureSingleExecution.func = ((PureMultiExecution) service.execution).func;
-                pureSingleExecution.mapping = param.mapping;
-                pureSingleExecution.runtime = param.runtime;
-                pureSingleExecution.executionOptions = param.executionOptions;
+                testsForEachValidEnv = suite.tests.stream().filter(test -> ((ServiceTest) test).keys.contains(param.key)).collect(Collectors.toList());
 
-                List<TestResult> testResultsForKey = executeSingleExecutionTestSuite(pureSingleExecution, suite, Collections.singletonList(test.id), pureModel, data, routerExtensions, planTransformers);
-                testResultsByTestId.get(test.id).addTestResult(param.key, testResultsForKey.get(0));
-            });
+                for (AtomicTest test: testsForEachValidEnv)
+                {
+                    PureSingleExecution pureSingleExecution = new PureSingleExecution();
+                    pureSingleExecution.func = ((PureMultiExecution) service.execution).func;
+                    pureSingleExecution.mapping = param.mapping;
+                    if (runtimeWithKeyMap.containsKey(param.key))
+                    {
+                        pureSingleExecution.runtime = runtimeWithKeyMap.get(param.key).getOne();
+                    }
+                    else
+                    {
+                        runtimeWithCloseables = TestRuntimeBuilder.getTestRuntimeAndClosableResources(param.runtime, suite.testData, data);
+                        runtimeWithKeyMap.put(param.key, runtimeWithCloseables);
+                        pureSingleExecution.runtime = runtimeWithCloseables.getOne();
+                    }
+                    pureSingleExecution.executionOptions = param.executionOptions;
+                    List<TestResult> testResultsForKey = executeSingleExecutionTestSuite(pureSingleExecution, suite, Collections.singletonList(test.id), pureModel, data, routerExtensions, planTransformers);
+                    testResultsByTestId.get(test.id).addTestResult(param.key, testResultsForKey.get(0));
+                }
+            }
+        }
+        finally
+        {
+            for(Pair<Runtime, List<Closeable>> runtimeWIthCloseablePair: runtimeWithKeyMap.values())
+            {
+                if (runtimeWIthCloseablePair != null)
+                {
+                    runtimeWIthCloseablePair.getTwo().forEach(closeable ->
+                    {
+                        try
+                        {
+                            closeable.close();
+                        }
+                        catch (IOException e)
+                        {
+                            LOGGER.warn("Exception occurred closing closeable resource" + e);
+                        }
+                    });
+                }
+            }
         }
         return new ArrayList<>(testResultsByTestId.values());
     }

--- a/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
+++ b/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
@@ -2833,7 +2833,7 @@ public class TestServiceTestSuite
     @Test
     public void testServiceTestKeysWithOptimizedWorkflow()
     {
-        List<TestResult> MultiKeyTestResult = executeServiceTest("testable/service/", "serviceGrammarModel.pure", "serviceGrammarWithOptimizedWorkflow.pure", "testModelStoreTestSuites::service::DocM2MService");
+        List<TestResult> MultiKeyTestResult = executeServiceTest("testable/service/", "serviceGrammarModel.pure", "serviceGrammarTestWithOptimizedWorkflow.pure", "testModelStoreTestSuites::service::DocM2MService");
         Assert.assertEquals(3, MultiKeyTestResult.size());
         Assert.assertTrue(MultiKeyTestResult.get(0) instanceof MultiExecutionServiceTestResult);
         Assert.assertEquals("testModelStoreTestSuites::service::DocM2MService", MultiKeyTestResult.get(0).testable);

--- a/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
+++ b/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
@@ -2831,6 +2831,48 @@ public class TestServiceTestSuite
     }
 
     @Test
+    public void testServiceTestKeysWithOptimizedWorkflow()
+    {
+        List<TestResult> MultiKeyTestResult = executeServiceTest("testable/service/", "serviceGrammarModel.pure", "serviceGrammarWithOptimizedWorkflow.pure", "testModelStoreTestSuites::service::DocM2MService");
+        Assert.assertEquals(3, MultiKeyTestResult.size());
+        Assert.assertTrue(MultiKeyTestResult.get(0) instanceof MultiExecutionServiceTestResult);
+        Assert.assertEquals("testModelStoreTestSuites::service::DocM2MService", MultiKeyTestResult.get(0).testable);
+        Assert.assertEquals("testSuite1", MultiKeyTestResult.get(0).testSuiteId);
+        Assert.assertEquals("test1", MultiKeyTestResult.get(0).atomicTestId);
+
+        Map<String, TestResult> KeysInScopeTestResults = ((MultiExecutionServiceTestResult) MultiKeyTestResult.get(0)).getKeyIndexedTestResults();
+        KeysInScopeTestResults.forEach((key, value) ->
+        {
+            Assert.assertTrue(value instanceof TestExecuted);
+            Assert.assertSame(((TestExecuted) value).testExecutionStatus, TestExecutionStatus.PASS);
+            Assert.assertEquals("testModelStoreTestSuites::service::DocM2MService", value.testable);
+            Assert.assertEquals("testSuite1", value.testSuiteId);
+            Assert.assertEquals("test1", value.atomicTestId);
+
+        });
+
+        Map<String, TestResult> KeysInScopeTestResults2 = ((MultiExecutionServiceTestResult) MultiKeyTestResult.get(1)).getKeyIndexedTestResults();
+        KeysInScopeTestResults2.forEach((key, value) ->
+        {
+            Assert.assertTrue(value instanceof TestExecuted);
+            Assert.assertSame(((TestExecuted) value).testExecutionStatus, TestExecutionStatus.PASS);
+            Assert.assertEquals("testModelStoreTestSuites::service::DocM2MService", value.testable);
+            Assert.assertEquals("testSuite1", value.testSuiteId);
+            Assert.assertEquals("test2", value.atomicTestId);
+        });
+
+        Map<String, TestResult> KeysInScopeTestResults3 = ((MultiExecutionServiceTestResult) MultiKeyTestResult.get(2)).getKeyIndexedTestResults();
+        KeysInScopeTestResults3.forEach((key, value) ->
+        {
+            Assert.assertTrue(value instanceof TestExecuted);
+            Assert.assertSame(((TestExecuted) value).testExecutionStatus, TestExecutionStatus.PASS);
+            Assert.assertEquals("testModelStoreTestSuites::service::DocM2MService", value.testable);
+            Assert.assertEquals("testSuite1", value.testSuiteId);
+            Assert.assertEquals("test3", value.atomicTestId);
+        });
+    }
+
+    @Test
     public void testServiceTestKeysWithParametersWithMultipleTestBlocks()
     {
         List<TestResult> MultiKeyTestResult = executeServiceTest("testable/service/","serviceGrammarModel.pure","serviceGrammarWithTestKeysAndParameters.pure", "testModelStoreTestSuites::service::DocM2MService");

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
@@ -1,0 +1,136 @@
+###Service
+Service testModelStoreTestSuites::service::DocM2MService3
+{
+  pattern: '/testModelStoreTestSuites/service';
+  owners:
+  [
+    'dummy',
+    'dummy1'
+  ];
+  documentation: 'Service to test refiner flow';
+  autoActivateUpdates: true;
+  execution: Multi
+  {
+    query: |testModelStoreTestSuites::model::Doc.all()->graphFetchChecked(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#)->serialize(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#);
+    key: 'env';
+    executions['QA1']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
+    }
+    executions['QA4']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime2;
+    }
+    executions['UAT']:
+    {
+      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime3;
+    }
+  }
+  testSuites:
+  [
+    testSuite1:
+    {
+      data:
+      [
+        connections:
+        [
+          connection_2:
+            Reference
+            #{
+              testServiceStoreTestSuites::TestData2
+            }#
+        ]
+      ]
+      tests:
+      [
+        test1:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'UAT'
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 18\\",\\"firmId\\":22,\\"ceoId\\":49,\\"addressId\\":88,\\"employees\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 2\\",\\"age\\":14,\\"id\\":52,\\"addressId\\":83,\\"firmId\\":73}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 4\\",\\"age\\":98,\\"id\\":87,\\"addressId\\":46,\\"firmId\\":26}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 88,\n        "ceoId" : 49,\n        "firmId" : 22,\n        "legalName" : "legalName 18"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 46,\n        "age" : 98,\n        "firmId" : 26,\n        "firstName" : "firstName 69",\n        "id" : 87,\n        "lastName" : "lastName 4"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 88,\n      "firmId" : 22,\n      "legalName" : "legalName 18x",\n      "ceoId" : 49\n    },\n    "person_tbl" : {\n      "addressId" : 46,\n      "age" : 98,\n      "firmId" : 26,\n      "firstName" : "firstName 69",\n      "id" : 87,\n      "lastName" : "lastName 4"\n    }\n  }\n}';
+                  }#;
+              }#
+          ]
+        },
+        test2:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'UAT'
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 18\\",\\"firmId\\":22,\\"ceoId\\":49,\\"addressId\\":88,\\"employees\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 2\\",\\"age\\":14,\\"id\\":52,\\"addressId\\":83,\\"firmId\\":73}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 4\\",\\"age\\":98,\\"id\\":87,\\"addressId\\":46,\\"firmId\\":26}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 88,\n        "ceoId" : 49,\n        "firmId" : 22,\n        "legalName" : "legalName 18"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 46,\n        "age" : 98,\n        "firmId" : 26,\n        "firstName" : "firstName 69",\n        "id" : 87,\n        "lastName" : "lastName 4"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 88,\n      "firmId" : 22,\n      "legalName" : "legalName 18x",\n      "ceoId" : 49\n    },\n    "person_tbl" : {\n      "addressId" : 46,\n      "age" : 98,\n      "firmId" : 26,\n      "firstName" : "firstName 69",\n      "id" : 87,\n      "lastName" : "lastName 4"\n    }\n  }\n}';
+                  }#;
+              }#
+          ]
+        },
+        test2:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'UAT'
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 18\\",\\"firmId\\":22,\\"ceoId\\":49,\\"addressId\\":88,\\"employees\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 2\\",\\"age\\":14,\\"id\\":52,\\"addressId\\":83,\\"firmId\\":73}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 4\\",\\"age\\":98,\\"id\\":87,\\"addressId\\":46,\\"firmId\\":26}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 88,\n        "ceoId" : 49,\n        "firmId" : 22,\n        "legalName" : "legalName 18"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 46,\n        "age" : 98,\n        "firmId" : 26,\n        "firstName" : "firstName 69",\n        "id" : 87,\n        "lastName" : "lastName 4"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 88,\n      "firmId" : 22,\n      "legalName" : "legalName 18x",\n      "ceoId" : 49\n    },\n    "person_tbl" : {\n      "addressId" : 46,\n      "age" : 98,\n      "firmId" : 26,\n      "firstName" : "firstName 69",\n      "id" : 87,\n      "lastName" : "lastName 4"\n    }\n  }\n}';
+                  }#;
+              }#
+          ]
+        },
+        test3:
+        {
+          serializationFormat: PURE;
+          keys:
+          [
+            'QA', 'UAT'
+          ];
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 18\\",\\"firmId\\":22,\\"ceoId\\":49,\\"addressId\\":88,\\"employees\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 2\\",\\"age\\":14,\\"id\\":52,\\"addressId\\":83,\\"firmId\\":73}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 4\\",\\"age\\":98,\\"id\\":87,\\"addressId\\":46,\\"firmId\\":26}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 88,\n        "ceoId" : 49,\n        "firmId" : 22,\n        "legalName" : "legalName 18"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 46,\n        "age" : 98,\n        "firmId" : 26,\n        "firstName" : "firstName 69",\n        "id" : 87,\n        "lastName" : "lastName 4"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 88,\n      "firmId" : 22,\n      "legalName" : "legalName 18x",\n      "ceoId" : 49\n    },\n    "person_tbl" : {\n      "addressId" : 46,\n      "age" : 98,\n      "firmId" : 26,\n      "firstName" : "firstName 69",\n      "id" : 87,\n      "lastName" : "lastName 4"\n    }\n  }\n}';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
@@ -114,7 +114,7 @@ Service testModelStoreTestSuites::service::DocM2MService3
           serializationFormat: PURE;
           keys:
           [
-            'QA', 'UAT'
+            'QA','UAT'
           ];
           asserts:
           [

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
@@ -88,27 +88,6 @@ Service testModelStoreTestSuites::service::DocM2MService3
               }#
           ]
         },
-        test2:
-        {
-          serializationFormat: PURE;
-          keys:
-          [
-            'UAT'
-          ];
-          asserts:
-          [
-            assert1:
-              EqualToJson
-              #{
-                expected :
-                  ExternalFormat
-                  #{
-                    contentType: 'application/json';
-                    data: '{\n  "defects" : [ ],\n  "source" : {\n    "defects" : [ ],\n    "source" : {\n      "number" : 1,\n      "record" : "{\\"sFirm_tbl\\":{\\"legalName\\":\\"legalName 18\\",\\"firmId\\":22,\\"ceoId\\":49,\\"addressId\\":88,\\"employees\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 2\\",\\"age\\":14,\\"id\\":52,\\"addressId\\":83,\\"firmId\\":73}},\\"sPerson_tbl\\":{\\"firstName\\":\\"firstName 69\\",\\"lastName\\":\\"lastName 4\\",\\"age\\":98,\\"id\\":87,\\"addressId\\":46,\\"firmId\\":26}}"\n    },\n    "value" : {\n      "sFirm_tbl" : {\n        "addressId" : 88,\n        "ceoId" : 49,\n        "firmId" : 22,\n        "legalName" : "legalName 18"\n      },\n      "sPerson_tbl" : {\n        "addressId" : 46,\n        "age" : 98,\n        "firmId" : 26,\n        "firstName" : "firstName 69",\n        "id" : 87,\n        "lastName" : "lastName 4"\n      }\n    }\n  },\n  "value" : {\n    "firm_tbl" : {\n      "addressId" : 88,\n      "firmId" : 22,\n      "legalName" : "legalName 18x",\n      "ceoId" : 49\n    },\n    "person_tbl" : {\n      "addressId" : 46,\n      "age" : 98,\n      "firmId" : 26,\n      "firstName" : "firstName 69",\n      "id" : 87,\n      "lastName" : "lastName 4"\n    }\n  }\n}';
-                  }#;
-              }#
-          ]
-        },
         test3:
         {
           serializationFormat: PURE;

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarTestWithOptimizedWorkflow.pure
@@ -1,7 +1,7 @@
 ###Service
-Service testModelStoreTestSuites::service::DocM2MService3
+Service testModelStoreTestSuites::service::DocM2MService
 {
-  pattern: '/testModelStoreTestSuites/service';
+  pattern: '/testModelStoreTestSuites/service/{param}';
   owners:
   [
     'dummy',
@@ -11,22 +11,17 @@ Service testModelStoreTestSuites::service::DocM2MService3
   autoActivateUpdates: true;
   execution: Multi
   {
-    query: |testModelStoreTestSuites::model::Doc.all()->graphFetchChecked(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#)->serialize(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#);
+    query: {param:String[1]|testModelStoreTestSuites::model::Doc.all()->graphFetchChecked(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#)->serialize(#{testModelStoreTestSuites::model::Doc{firm_tbl{addressId,firmId,legalName,ceoId},person_tbl{addressId,age,firmId,firstName,id,lastName}}}#)};
     key: 'env';
-    executions['QA1']:
+    executions['QA']:
     {
       mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
       runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
     }
-    executions['QA4']:
-    {
-      mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
-      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime2;
-    }
     executions['UAT']:
     {
       mapping: testModelStoreTestSuites::mapping::DocM2MMapping;
-      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime3;
+      runtime: testModelStoreTestSuites::runtime::DocM2MRuntime;
     }
   }
   testSuites:
@@ -37,6 +32,11 @@ Service testModelStoreTestSuites::service::DocM2MService3
       [
         connections:
         [
+          connection_1:
+            Reference
+            #{
+              testServiceStoreTestSuites::TestData
+            }#,
           connection_2:
             Reference
             #{
@@ -51,8 +51,12 @@ Service testModelStoreTestSuites::service::DocM2MService3
           serializationFormat: PURE;
           keys:
           [
-            'UAT'
+            'QA'
           ];
+          parameters:
+          [
+            param = 'dummy firstName'
+          ]
           asserts:
           [
             assert1:
@@ -74,6 +78,10 @@ Service testModelStoreTestSuites::service::DocM2MService3
           [
             'UAT'
           ];
+          parameters:
+          [
+            param = 'firstName 69'
+          ]
           asserts:
           [
             assert1:
@@ -88,13 +96,17 @@ Service testModelStoreTestSuites::service::DocM2MService3
               }#
           ]
         },
-        test3:
+       test3:
         {
           serializationFormat: PURE;
           keys:
           [
             'QA','UAT'
           ];
+          parameters:
+          [
+            param = 'firstName 69'
+          ]
           asserts:
           [
             assert1:


### PR DESCRIPTION

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
--> Improvement 

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> Changing the instances of connection set up and closeable for execution parameters by limiting their setup and close to 1 per test suite. Previously, a multi exec service with 3 execution parameters and 3 test cases (that is running against all keys), would setup the same runtime 3 times per test suite, which caused latency in build for users. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # Build time issues, code optimization for multiexecution services.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> No, but they should be able to experience shorter build times 
