### PR TITLE
Bump version of legend-engine-xt-analytics-search-generation-* modules

### DIFF
--- a/legend-engine-xt-analytics-search-generation/pom.xml
+++ b/legend-engine-xt-analytics-search-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.2.1-SNAPSHOT</version>
+        <version>4.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xt-analytics-search-pure/pom.xml
+++ b/legend-engine-xt-analytics-search-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.2.1-SNAPSHOT</version>
+        <version>4.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Bumps version of legend-engine-xt-analytics-search-generation-* modules to match rest of project.
https://github.com/finos/legend-engine/pull/1465 contained new modules but was merged after a new development iteration began.

#### Which issue(s) this PR fixes:
N/A

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
