### PR TITLE
Update authentication APIs

### DIFF
--- a/legend-engine-executionPlan-execution/pom.xml
+++ b/legend-engine-executionPlan-execution/pom.xml
@@ -110,6 +110,11 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-dependencies</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-authentication-implementation-core</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- PAC4J -->

--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/identity/credential/PlaintextCredential.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/identity/credential/PlaintextCredential.java
@@ -1,0 +1,55 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.shared.core.identity.credential;
+
+import org.finos.legend.engine.shared.core.identity.Credential;
+
+import java.util.Objects;
+
+public class PlaintextCredential implements Credential
+{
+    private final String value;
+
+    public PlaintextCredential(String value)
+    {
+        this.value = value;
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        PlaintextCredential that = (PlaintextCredential) o;
+        return value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(value);
+    }
+}

--- a/legend-engine-xt-authentication-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/authentication/compiler/toPureGraph/HelperAuthenticationBuilder.java
+++ b/legend-engine-xt-authentication-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/authentication/compiler/toPureGraph/HelperAuthenticationBuilder.java
@@ -18,6 +18,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.ApiKeyAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.AuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.AuthenticationSpecificationVisitor;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.PlaintextAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.EncryptedPrivateKeyPairAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.GCPWIFWithAWSIdPAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.UserPasswordAuthenticationSpecification;
@@ -77,6 +78,12 @@ public class HelperAuthenticationBuilder
 
         @Override
         public Root_meta_pure_runtime_connection_authentication_AuthenticationSpecification visit(GCPWIFWithAWSIdPAuthenticationSpecification gcpwifWithAWSIdPAuthenticationSpecification)
+        {
+            throw new UnsupportedOperationException("TODO - epsstan");
+        }
+
+        @Override
+        public Root_meta_pure_runtime_connection_authentication_AuthenticationSpecification visit(PlaintextAuthenticationSpecification authenticationSpecification)
         {
             throw new UnsupportedOperationException("TODO - epsstan");
         }

--- a/legend-engine-xt-authentication-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/authentication/grammar/to/AuthenticationSpecificationComposer.java
+++ b/legend-engine-xt-authentication-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/authentication/grammar/to/AuthenticationSpecificationComposer.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.language.pure.dsl.authentication.grammar.to;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.ApiKeyAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.AuthenticationSpecificationVisitor;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.PlaintextAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.EncryptedPrivateKeyPairAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.GCPWIFWithAWSIdPAuthenticationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.UserPasswordAuthenticationSpecification;
@@ -87,6 +88,12 @@ public class AuthenticationSpecificationComposer implements AuthenticationSpecif
                 getTabString(indentLevel + 1) + "idP: " + this.renderGCPWIFWithAWSIdPIdP(authenticationSpecification.idPConfiguration, indentLevel + 1, context) + "\n" +
                 getTabString(indentLevel + 1) + "workload: " + this.renderGCPWIFWithAWSIdPWorkload(authenticationSpecification.workloadConfiguration, indentLevel + 1, context) + "\n" +
                 getTabString(indentLevel) + "}\n";
+    }
+
+    @Override
+    public String visit(PlaintextAuthenticationSpecification authenticationSpecification)
+    {
+        throw new UnsupportedOperationException("TODO");
     }
 
     private String renderGCPWIFWithAWSIdPWorkload(GCPWIFWithAWSIdPAuthenticationSpecification.WorkloadConfiguration workloadConfiguration, int indentLevel, PureGrammarComposerContext context)

--- a/legend-engine-xt-authentication-implementation-core/src/main/java/org/finos/legend/authentication/credentialprovider/CredentialProviderProvider.java
+++ b/legend-engine-xt-authentication-implementation-core/src/main/java/org/finos/legend/authentication/credentialprovider/CredentialProviderProvider.java
@@ -19,8 +19,11 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
+import org.finos.legend.authentication.credentialprovider.impl.PlainTextCredentialProvider;
 import org.finos.legend.authentication.intermediationrule.IntermediationRule;
 import org.finos.legend.authentication.intermediationrule.IntermediationRuleProvider;
+import org.finos.legend.authentication.vault.CredentialVaultProvider;
+import org.finos.legend.authentication.vault.impl.SystemPropertiesCredentialVault;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.AuthenticationSpecification;
 import org.finos.legend.engine.shared.core.identity.Credential;
 
@@ -108,6 +111,14 @@ public class CredentialProviderProvider
     public static Builder builder()
     {
         return new Builder();
+    }
+
+    public static Builder defaultBuilder()
+    {
+        Builder builder = new Builder();
+        CredentialVaultProvider credentialVaultProvider = CredentialVaultProvider.builder().with(new SystemPropertiesCredentialVault()).build();
+        PlainTextCredentialProvider plainTextCredentialProvider = new PlainTextCredentialProvider(credentialVaultProvider);
+        return builder.with(plainTextCredentialProvider);
     }
 
     public static class Builder

--- a/legend-engine-xt-authentication-implementation-core/src/main/java/org/finos/legend/authentication/credentialprovider/impl/PlainTextCredentialProvider.java
+++ b/legend-engine-xt-authentication-implementation-core/src/main/java/org/finos/legend/authentication/credentialprovider/impl/PlainTextCredentialProvider.java
@@ -1,0 +1,45 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.authentication.credentialprovider.impl;
+
+import org.finos.legend.authentication.credentialprovider.CredentialProvider;
+import org.finos.legend.authentication.vault.CredentialVault;
+import org.finos.legend.authentication.vault.CredentialVaultProvider;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.PlaintextAuthenticationSpecification;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.shared.core.identity.credential.PlaintextCredential;
+
+public class PlainTextCredentialProvider extends CredentialProvider<PlaintextAuthenticationSpecification, PlaintextCredential>
+{
+    private CredentialVaultProvider credentialVaultProvider;
+
+    public PlainTextCredentialProvider()
+    {
+
+    }
+
+    public PlainTextCredentialProvider(CredentialVaultProvider credentialVaultProvider)
+    {
+        this.credentialVaultProvider = credentialVaultProvider;
+    }
+
+    @Override
+    public PlaintextCredential makeCredential(PlaintextAuthenticationSpecification authenticationSpecification, Identity identity) throws Exception
+    {
+        CredentialVault credentialVault = this.credentialVaultProvider.getVault(authenticationSpecification.plaintextValue);
+        String rawSecret = credentialVault.lookupSecret(authenticationSpecification.plaintextValue, identity);
+        return new PlaintextCredential(rawSecret);
+    }
+}

--- a/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestCredentialCreation_Plaintext.java
+++ b/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestCredentialCreation_Plaintext.java
@@ -1,0 +1,75 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.authentication;
+
+import org.finos.legend.authentication.credentialprovider.impl.PlainTextCredentialProvider;
+import org.finos.legend.authentication.vault.CredentialVaultProvider;
+import org.finos.legend.authentication.vault.impl.SystemPropertiesCredentialVault;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.PlaintextAuthenticationSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.SystemPropertiesSecret;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.shared.core.identity.credential.AnonymousCredential;
+import org.finos.legend.engine.shared.core.identity.credential.PlaintextCredential;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestCredentialCreation_Plaintext
+{
+    private Identity identity;
+
+    private CredentialVaultProvider credentialVaultProvider;
+
+    @Before
+    public void setup()
+    {
+        this.identity = new Identity("alice", new AnonymousCredential());
+
+        System.setProperty("my.property1", "value1");
+        this.credentialVaultProvider = CredentialVaultProvider.builder().with(new SystemPropertiesCredentialVault()).build();
+    }
+
+    @After
+    public void clear()
+    {
+        System.clearProperty("my.property1");
+    }
+
+    @Test
+    public void makeCredentialFromSystemProperties() throws Exception
+    {
+        PlainTextCredentialProvider credentialProvider = new PlainTextCredentialProvider(credentialVaultProvider);
+        PlaintextAuthenticationSpecification authenticationSpecification = new PlaintextAuthenticationSpecification(new SystemPropertiesSecret("my.property1"));
+        PlaintextCredential credential = credentialProvider.makeCredential(authenticationSpecification, identity);
+        assertEquals("value1", credential.getValue());
+    }
+
+    @Test
+    public void credentialNotFoundInSystemProperties() throws Exception
+    {
+        try
+        {
+            PlainTextCredentialProvider credentialProvider = new PlainTextCredentialProvider(credentialVaultProvider);
+            PlaintextAuthenticationSpecification authenticationSpecification = new PlaintextAuthenticationSpecification(new SystemPropertiesSecret("my.property2"));
+            credentialProvider.makeCredential(authenticationSpecification, identity);
+        }
+        catch (RuntimeException e)
+        {
+            assertEquals("Secret not found in system properties. System property name=my.property2", e.getMessage());
+        }
+    }
+}

--- a/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestCredentialProviderProviderDefaults.java
+++ b/legend-engine-xt-authentication-implementation-core/src/test/java/org/finos/legend/authentication/TestCredentialProviderProviderDefaults.java
@@ -1,0 +1,63 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.authentication;
+
+import org.finos.legend.authentication.credentialprovider.CredentialBuilder;
+import org.finos.legend.authentication.credentialprovider.CredentialProviderProvider;
+import org.finos.legend.authentication.credentialprovider.impl.ApikeyCredentialProvider;
+import org.finos.legend.authentication.credentialprovider.impl.PrivateKeyCredentialProvider;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification.PlaintextAuthenticationSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.SystemPropertiesSecret;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.shared.core.identity.credential.AnonymousCredential;
+import org.finos.legend.engine.shared.core.identity.credential.PlaintextCredential;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestCredentialProviderProviderDefaults
+{
+    private Identity identity;
+
+    @Before
+    public void setup()
+    {
+        this.identity = new Identity("alice", new AnonymousCredential());
+        System.setProperty("my.property1", "value1");
+    }
+
+    @Test
+    public void defaultProviderProviderCanLoadFromSystemProperties() throws Exception
+    {
+        CredentialProviderProvider credentialProviderProvider = CredentialProviderProvider.defaultBuilder().build();
+
+        assertEquals(1, credentialProviderProvider.getConfiguredCredentialProviders().size());
+
+        PlaintextCredential credential = (PlaintextCredential) CredentialBuilder.makeCredential(credentialProviderProvider, new PlaintextAuthenticationSpecification(new SystemPropertiesSecret("my.property1")), identity);
+        assertEquals("value1", credential.getValue());
+    }
+
+    @Test
+    public void defaultProviderProviderCanBeEnrichedWithProviders()
+    {
+        CredentialProviderProvider credentialProviderProvider = CredentialProviderProvider.defaultBuilder()
+                .with(new PrivateKeyCredentialProvider())
+                .with(new ApikeyCredentialProvider())
+                .build();
+
+        assertEquals(3, credentialProviderProvider.getConfiguredCredentialProviders().size());
+    }
+}

--- a/legend-engine-xt-authentication-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/authentication/specification/PlaintextAuthenticationSpecification.java
+++ b/legend-engine-xt-authentication-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/authentication/specification/PlaintextAuthenticationSpecification.java
@@ -14,15 +14,24 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.specification;
 
-public interface AuthenticationSpecificationVisitor<T>
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.CredentialVaultSecret;
+
+public class PlaintextAuthenticationSpecification extends AuthenticationSpecification
 {
-    T visit(ApiKeyAuthenticationSpecification authenticationSpecification);
+    public CredentialVaultSecret plaintextValue;
 
-    T visit(UserPasswordAuthenticationSpecification authenticationSpecification);
+    public PlaintextAuthenticationSpecification()
+    {
+    }
 
-    T visit(EncryptedPrivateKeyPairAuthenticationSpecification authenticationSpecification);
+    public PlaintextAuthenticationSpecification(CredentialVaultSecret plaintextValue)
+    {
+        this.plaintextValue = plaintextValue;
+    }
 
-    T visit(GCPWIFWithAWSIdPAuthenticationSpecification authenticationSpecification);
-
-    T visit(PlaintextAuthenticationSpecification authenticationSpecification);
+    @Override
+    public <T> T accept(AuthenticationSpecificationVisitor<T> visitor)
+    {
+        return visitor.visit(this);
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
This PR adds the following features/APIs.

1/ `PlaintextCredential` that can be loaded from a `CredentialVault`

This credential (composes a single String) and is different from `PlaintextUserPasswordCredential` which composes a user and password String.

2/ `PlaintextCredentialProvider`

A `CredentialProvider` that simply looks up a `PlaintextCredential` from a `CredentialVault` using a `PlaintextAuthenticationSpecification`

Note : This provider does not make use of any rules as it does not require any business logic. 

See TestCredentialCreation_Plaintext.java

3/ PlanExecutor wired with a `CredentialProviderProvider`

The PlanExecutor now carries a `CredentialProviderProvider`.  Code that constructs a `PlanExecutor` can inject a `CredentialProviderProvider` via  `newPlanExecutor(CredentialProviderProvider credentialProviderProvider, StoreExecutor... storeExecutors)`

In addition, the `PlanExecutor` exposes a convenience method `makeCredential(a, i)`

4/ Default `CredentialProviderProvider`

A convenience method to construct a `CredentialProviderProvider`  with defaults has been added. 
The default behavior includes a `CredentialProvider` that can provide `PlaintextCredential`s.

See TestCredentialProviderProviderDefaults.java 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
<!--
-->
