### PR TITLE
Preval - simplify filter with constant boolean return

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
@@ -675,7 +675,37 @@ function <<access.private>> meta::pure::router::preeval::prevalGenericSimpleFunc
                                   openVars = [],
                                   modified = true
                                 );
-                            })
+                            }),
+                            pair(
+                              {theSfe:SimpleFunctionExpression[1] | isFilterFunctionReturningConstant($theSfe, false)},
+                              {theSfe:SimpleFunctionExpression[1] |
+                                $state->printDebugWithDepth(|'Handling filter which returns false: ' + $newSfe.func->elementToPath());
+                                let r = ^InstanceValue(
+                                          genericType = ^GenericType(rawType = Nil),
+                                          multiplicity = PureZero
+                                        )->evaluateAndDeactivate();
+
+                                ^PrevalWrapper<InstanceValue>(
+                                  value = $r,
+                                  canPreval = true,
+                                  openVars = [],
+                                  modified = true
+                                );
+                              }
+                            ),
+                            pair(
+                              {theSfe:SimpleFunctionExpression[1] | isFilterFunctionReturningConstant($theSfe, true)},
+                              {theSfe:SimpleFunctionExpression[1] |
+                                $state->printDebugWithDepth(|'Handling filter which returns true: ' + $newSfe.func->elementToPath());
+
+                                ^PrevalWrapper<ValueSpecification>(
+                                  value = $theSfe.parametersValues->at(0),
+                                  canPreval = true,
+                                  openVars = [],
+                                  modified = true
+                                );
+                              }
+                            )
                         ]);
 
                     let handler = $handlers->filter(p|$p.first->eval($newSfe))->first();
@@ -712,6 +742,17 @@ function <<access.private>> meta::pure::router::preeval::prevalGenericSimpleFunc
           );
       );
   );
+}
+
+function <<access.public>> meta::pure::router::preeval::isFilterFunctionReturningConstant(sfe:SimpleFunctionExpression[1], value:Boolean[1]) : Boolean[1]
+{
+  let isFilter = $sfe.func == filter_T_MANY__Function_1__T_MANY_;
+
+  if ($isFilter,
+    |
+      let es = $sfe.parametersValues->last()->cast(@InstanceValue).values->cast(@LambdaFunction<Any>).expressionSequence->evaluateAndDeactivate();
+      $es->last()->toOne()->instanceOf(InstanceValue) && $es->last()->toOne()->cast(@InstanceValue).values == $value;,
+    | false);
 }
 
 // ====================================================================================================================================================================

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
@@ -1299,6 +1299,77 @@ function <<test.Test>> meta::pure::router::preeval::tests::testAdditionalStopFun
   assertRoundTrip($input, $input, myStopFunction_Integer_1__Integer_1_, [], noDebug());
 }
 
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | false).id};
+
+  let expected = {a:OrganizationalEntity[1]| []};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseSimplification2():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | 1 == 2).id};
+
+  let expected = {o:OrganizationalEntity[1]| []};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseConstantSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| let bool = false; let date = %2023-01-01; $o.positions($date)->filter(p | $bool).id;};
+
+  let expected = {o:OrganizationalEntity[1]| []};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseSimplificationReturnType():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | false).id;};
+  let result = $input->preval([]);
+
+  assertEquals(Integer, $result->functionReturnType().rawType);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterTrueSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | false; true;).id};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01).id};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterTrueSimplification2():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | 1 == 1).id};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01).id};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterTrueConstantSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| let bool = true; let date = %2023-01-01; $o.positions($date)->filter(p | $bool).id;};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01).id};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterNoSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | $p.id == 1).id};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | $p.id == 1).id};
+
+  assertRoundTrip($input, $expected);
+}
+
 function meta::pure::router::preeval::tests::getTestRuntimeWithModelConnection(sourceClass:Class<Any>[1], inputs:Any[*]):Runtime[1]
 {
   // Need element as string to allow roundtrip to pass. When using ^ModelStore(), preeval evaluates it to a instance, however expected as it as a new function

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/serialization/toPureGrammar.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/serialization/toPureGrammar.pure
@@ -50,7 +50,7 @@ function meta::pure::metamodel::serialization::grammar::printValueSpecification(
                 ]
              )
 }
-function <<access.private>> meta::pure::metamodel::serialization::grammar::removeAutomap(v:ValueSpecification[0..1]):ValueSpecification[1]
+function <<access.private>> meta::pure::metamodel::serialization::grammar::removeAutomap(v:ValueSpecification[1]):ValueSpecification[1]
 
 {
    $v->match([fe:FunctionExpression[1] | if($fe.functionName=='map' 


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?
Simplifies $x->filter(f | false) to []
Simplifies $x->filter(f | true) to $x

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
