### PR TITLE
Preval - simplify filter with constant boolean return

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
@@ -675,7 +675,40 @@ function <<access.private>> meta::pure::router::preeval::prevalGenericSimpleFunc
                                   openVars = [],
                                   modified = true
                                 );
-                            })
+                            }),
+                            pair(
+                              {theSfe:SimpleFunctionExpression[1] | 
+                                //TODO getAll check is only needed as router does not route FunctionDefinition wth constant result.
+                                isFilterFunctionReturningConstant($theSfe, false) && !isGetAll($theSfe.parametersValues->at(0))},
+                              {theSfe:SimpleFunctionExpression[1] |
+                                $state->printDebugWithDepth(|'Handling filter which returns false: ' + $newSfe.func->elementToPath());
+    
+                                let r = ^InstanceValue(
+                                          genericType = ^GenericType(rawType = Nil),
+                                          multiplicity = PureZero
+                                        )->evaluateAndDeactivate();                          
+    
+                                ^PrevalWrapper<InstanceValue>(
+                                  value = $r,
+                                  canPreval = true,
+                                  openVars = [],
+                                  modified = true
+                                );  
+                              }
+                            ),
+                            pair(
+                              {theSfe:SimpleFunctionExpression[1] | isFilterFunctionReturningConstant($theSfe, true)},
+                              {theSfe:SimpleFunctionExpression[1] |
+                                $state->printDebugWithDepth(|'Handling filter which returns true: ' + $newSfe.func->elementToPath());                        
+    
+                                ^PrevalWrapper<ValueSpecification>(
+                                  value = $theSfe.parametersValues->at(0),
+                                  canPreval = true,
+                                  openVars = [],
+                                  modified = true
+                                );
+                              }
+                            )                                                            
                         ]);
 
                     let handler = $handlers->filter(p|$p.first->eval($newSfe))->first();
@@ -712,6 +745,25 @@ function <<access.private>> meta::pure::router::preeval::prevalGenericSimpleFunc
           );
       );
   );
+}
+
+function meta::pure::router::preeval::isGetAll(v:ValueSpecification[0..1]):Boolean[1]
+{
+  $v->match([
+    s:SimpleFunctionExpression[1] | meta::pure::router::routing::isGetAllFunction($s.func) || $s.parametersValues->first()->isGetAll(),
+    a:Any[*] | false;
+  ]);
+}
+
+function <<access.public>> meta::pure::router::preeval::isFilterFunctionReturningConstant(sfe:SimpleFunctionExpression[1], value:Boolean[1]) : Boolean[1]
+{
+  let isFilter = $sfe.func == filter_T_MANY__Function_1__T_MANY_;
+  
+  if ($isFilter, 
+    | 
+      let es = $sfe.parametersValues->last()->cast(@InstanceValue).values->cast(@LambdaFunction<Any>).expressionSequence->evaluateAndDeactivate();
+      $es->last()->toOne()->instanceOf(InstanceValue) && $es->last()->toOne()->cast(@InstanceValue).values == $value;,
+    | false);
 }
 
 // ====================================================================================================================================================================

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
@@ -1299,6 +1299,86 @@ function <<test.Test>> meta::pure::router::preeval::tests::testAdditionalStopFun
   assertRoundTrip($input, $input, myStopFunction_Integer_1__Integer_1_, [], noDebug());
 }
 
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | false).id};
+
+  let expected = {a:OrganizationalEntity[1]| []};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseSimplificationAll():Boolean[1]
+{
+  let input = {s:String[0..1]| OrganizationalEntity.all(%2023-01-01)->filter(c | 1 == 2)->project(c | $c.name, 'name')};
+
+  let expected = {s:String[0..1]| OrganizationalEntity.all(%2023-01-01)->filter(c | false)->project(c | $c.name, 'name')};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseSimplification2():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | 1 == 2).id};
+
+  let expected = {o:OrganizationalEntity[1]| []};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseConstantSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| let bool = false; let date = %2023-01-01; $o.positions($date)->filter(p | $bool).id;};
+
+  let expected = {o:OrganizationalEntity[1]| []};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterFalseSimplificationReturnType():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | false).id;};
+  let result = $input->preval([]);
+  
+  assertEquals(Integer, $result->functionReturnType().rawType);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterTrueSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | false; true;).id};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01).id};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterTrueSimplification2():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | 1 == 1).id};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01).id};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterTrueConstantSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| let bool = true; let date = %2023-01-01; $o.positions($date)->filter(p | $bool).id;};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01).id};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testFilterNoSimplification():Boolean[1]
+{
+  let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | $p.id == true).id};
+
+  let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | $p.id == true).id};
+
+  assertRoundTrip($input, $expected);
+}
+
 function meta::pure::router::preeval::tests::getTestRuntimeWithModelConnection(sourceClass:Class<Any>[1], inputs:Any[*]):Runtime[1]
 {
   // Need element as string to allow roundtrip to pass. When using ^ModelStore(), preeval evaluates it to a instance, however expected as it as a new function

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -314,7 +314,7 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
         let routedValueSpecForReturnClass = 
             if($returnClass->isEmpty(), 
                 | [], 
-                | if($f == getAll_Class_1__T_MANY_ || $f == getAllVersions_Class_1__T_MANY_ || $f == getAll_Class_1__Date_1__T_MANY_ || $f == getAll_Class_1__Date_1__Date_1__T_MANY_ || $f == getAllVersionsInRange_Class_1__Date_1__Date_1__T_MANY_ || $f == getAllForEachDate_Class_1__Date_MANY__T_MANY_,
+                | if(isGetAllFunction($f),
                     |$routed->filter(v|let ta = $v.value.genericType.typeArguments;
                                        $ta->isNotEmpty() && $ta->at(0).rawType->toOne()->_subTypeOf($returnClass->toOne());),
                     |$newSet->filter(v|if ($v.value.genericType.rawType == Property || $v.value.genericType.rawType == Path,
@@ -367,7 +367,7 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                     print(if($debug.debug,|$debug.space+'~>NQS) ('+$lastSecondPass.routingStrategy.toString()+') '+$possiblyWrapperd->evaluateAndDeactivate()->asString()+'\n',|''));
                     let shouldBeRouted = if($f == letFunction_String_1__T_m__T_m_,
                                             |false,
-                                            |$lastSecondPass.shouldBeRouted || $f == getAll_Class_1__T_MANY_ || $f == getAllVersions_Class_1__T_MANY_ || $f==getAll_Class_1__Date_1__T_MANY_ || $f==getAll_Class_1__Date_1__Date_1__T_MANY_ || $f == getAllVersionsInRange_Class_1__Date_1__Date_1__T_MANY_ || $f == getAllForEachDate_Class_1__Date_MANY__T_MANY_);
+                                            |$lastSecondPass.shouldBeRouted || isGetAllFunction($f));
                     ^$lastSecondPass(shouldBeRouted = $shouldBeRouted, value=$possiblyWrapperd, pathPrefix=$state.pathPrefix);,
                   | let newVars = $fullRes->mapVariables(newMap([]->cast(@Pair<VariableExpression, ValueSpecification>), VariableExpression->classPropertyByName('name')->cast(@Property<VariableExpression,String|1>)),$inScopeVars);
                     assert($f->cast(@FunctionDefinition<Any>).expressionSequence->size() <= 1, | 'Function ' +$f->cast(@FunctionDefinition<Any>)->elementToPath() + ' is not yet supported as functions with more than one expression can not be routed');
@@ -562,6 +562,11 @@ function meta::pure::router::routing::varToString(a:Any[1]):String[1]
               k:KeyExpression[1]|'',
               a:Any[1] | $a->toString()
             ])
+}
+
+function meta::pure::router::routing::isGetAllFunction(f:Function<Any>[1]):Boolean[1]
+{
+  $f == getAll_Class_1__T_MANY_ || $f == getAllVersions_Class_1__T_MANY_ || $f == getAll_Class_1__Date_1__T_MANY_ || $f == getAll_Class_1__Date_1__Date_1__T_MANY_ || $f == getAllVersionsInRange_Class_1__Date_1__Date_1__T_MANY_ || $f == getAllForEachDate_Class_1__Date_MANY__T_MANY_
 }
 
 function meta::pure::router::routing::shouldStop(f:Function<Any>[1], extensions:meta::pure::extension::Extension[*]):Boolean[1]


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?
Simplifies $x->filter(f | false) to []
Simplifies $x->filter(f | true) to $x

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
