### PR TITLE
Improve prohibited function logic by using a map

### DIFF
--- a/legend-engine-pure-runtime-execution/src/test/java/org/finos/legend/engine/pure/runtime/execution/LegendExecuteTest.java
+++ b/legend-engine-pure-runtime-execution/src/test/java/org/finos/legend/engine/pure/runtime/execution/LegendExecuteTest.java
@@ -161,7 +161,7 @@ public class LegendExecuteTest
     }
 
     @Test
-    public void tesStringVariable()
+    public void testStringVariable()
     {
         String toExecute = "{pref: String[1], suf:String[1]|\n" +
                 "  let tree = #{test::Types{string, 'prefixed': string($pref, $suf)}}#;\n" +

--- a/legend-engine-xt-javaGeneration-pure/pom.xml
+++ b/legend-engine-xt-javaGeneration-pure/pom.xml
@@ -136,6 +136,10 @@
 
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-engine-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
+++ b/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
@@ -1111,7 +1111,7 @@ function meta::external::language::java::transform::registerLibrary(conventions:
 
 function meta::external::language::java::transform::defaultProhibitedFunctions(extraProhibitedFunctions : Function<Any>[*]): Function<{Conventions[1],Function<Any>[1]->Boolean[1]}>[1]
 {
-   let functionsBlacklist = [
+   let prohibitedFunctions = [
       // Instances
       copy_T_1__String_1__KeyExpression_MANY__T_1_,
       copy_T_1__String_1__T_1_,
@@ -1179,9 +1179,7 @@ function meta::external::language::java::transform::defaultProhibitedFunctions(e
       meta::json::fromJson_String_1__Class_1__JSONDeserializationConfig_1__T_1_,
       meta::json::parseJSON_String_1__JSONElement_1_,
       meta::json::toJsonBeta_Any_MANY__JSONSerializationConfig_1__String_1_
-
-      
-   ]->concatenate($extraProhibitedFunctions);
+   ]->concatenate($extraProhibitedFunctions)->map(f | pair($f, true))->newMap();
 
    let manipulatesPackagesBlacklist = [
       'meta::pure::codestore',
@@ -1222,24 +1220,18 @@ function meta::external::language::java::transform::defaultProhibitedFunctions(e
      'meta::pure::mapping::modelToModel::test'
    ];
 
-   {conventions:Conventions[1],func:Function<Any>[1]|
-      $func->match([
-         {nf:NativeFunction<Any>[1]     | $func->in($functionsBlacklist);},
-         {fd:FunctionDefinition<Any>[1] |
-            if($func->in($functionsBlacklist),
-               | true,
-               {|
-                  let funcType = $func->evaluateAndDeactivate()->functionType();
-                  let types    = $funcType.returnType.rawType->concatenate($funcType.parameters.genericType.rawType);
-                  let usesPkgs = $types->filter(t| !$t->in($manipulatesTypesWhitelist) && $t->instanceOf(PackageableElement))->cast(@PackageableElement).package->filter(p | !$excludeTestPackages->exists(b|$p->elementToPath()->startsWith($b)));
-                  $usesPkgs->exists({p|
-                     let name = $p->elementToPath();
-                     $manipulatesPackagesBlacklist->exists(b|$name->startsWith($b));
-                  });
-               }
-            );
-         }
-      ]);
+   {conventions:Conventions[1], func:Function<Any>[1] | $prohibitedFunctions->getIfAbsentPutWithKey($func, f |
+      if($f->instanceOf(NativeFunction),
+         | false,
+         | let funcType = $f->evaluateAndDeactivate()->functionType();
+           let types    = $funcType.returnType.rawType->concatenate($funcType.parameters.genericType.rawType);
+           let usesPkgs = $types->filter(t | $t->instanceOf(PackageableElement) && !$t->in($manipulatesTypesWhitelist))
+                                ->map(t | $t->cast(@PackageableElement).package)
+                                ->map(p | $p->elementToPath())
+                                ->filter(p | !$excludeTestPackages->exists(b | $p->startsWith($b)));
+           $usesPkgs->exists(p | $manipulatesPackagesBlacklist->exists(b | $p->startsWith($b)));
+         )
+      )->toOne()
    };
 }
 


### PR DESCRIPTION
#### What type of PR is this?

Performance improvement

#### What does this PR do / why is it needed ?

This replaces list lookup with map lookup in the prohibited function logic in Java generation. This is a performance improvement in Java generation, which should particularly help plan generation where Java code is generated.

#### Does this PR introduce a user-facing change?

No