### PR TITLE
fix javadoc and cleanup build order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,15 @@ jobs:
         env:
           DOCKER_USERNAME: finos
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        # NOTE: here we publish snapshot to a staging Maven registry
+        # some registry like Maven Central requires javadoc, but for now we
+        # don't need to, if we do, call javadoc:jar goal instead of javadoc:javadoc
+        # as the latter binds to generate-sources which runs before compile phase
+        # and can cause problem with some code generators
+        # See https://github.com/finos/legend-engine/pull/924
         run: |
-         mvn -B -e -DXss4m -DXX:MaxRAMPercentage=90.0 -DskipTests=true javadoc:javadoc deploy -P docker-snapshot
-         mvn -B -e -DXss4m -DXX:MaxRAMPercentage=10.0 surefire:test -DargLine="-XX:MaxRAMPercentage=80.0"
+          mvn -B -e -DXss4m -DXX:MaxRAMPercentage=90.0 -DskipTests=true deploy -P docker-snapshot
+          mvn -B -e -DXss4m -DXX:MaxRAMPercentage=10.0 surefire:test -DargLine="-XX:MaxRAMPercentage=80.0"
 
       - name: Upload Test Results
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,6 @@
         <module>legend-engine-xt-authentication-implementation-gcp-federation</module>
         <module>legend-engine-xt-authentication-experimental</module>
 
-        <module>legend-engine-test-reports</module>
-
         <module>legend-engine-xt-graphQL-grammar</module>
         <module>legend-engine-xt-graphQL-grammar-integration</module>
         <module>legend-engine-xt-graphQL-compiler</module>
@@ -227,11 +225,6 @@
         <module>legend-engine-shared-javaCompiler</module>
         <module>legend-engine-services-model</module>
         <module>legend-engine-services-model-api</module>
-        <module>legend-engine-server</module>
-        <module>legend-engine-test-server-shared</module>
-        <module>legend-engine-server-integration-tests</module>
-        <module>legend-engine-extensions-collection-execution</module>
-        <module>legend-engine-extensions-collection-generation</module>
         <module>legend-engine-testable</module>
         <module>legend-engine-executionPlan-execution-authorizer</module>
         <module>legend-engine-xt-relationalStore-executionPlan-authorizer</module>
@@ -259,6 +252,15 @@
         <module>legend-engine-xt-nonrelationalStore-mongodb-grammar</module>
         <module>legend-engine-xt-nonrelationalStore-mongodb-protocol</module>
         <module>legend-engine-xt-nonrelationalStore-mongodb-grammar-integration</module>
+
+        <!-- NOTE: Do not change the ordering of this block, we want to build these modules last -->
+        <module>legend-engine-test-reports</module>
+        <module>legend-engine-server</module>
+        <module>legend-engine-test-server-shared</module>
+        <module>legend-engine-server-integration-tests</module>
+        <module>legend-engine-extensions-collection-execution</module>
+        <module>legend-engine-extensions-collection-generation</module>
+        <!-- NOTE: Do not change the ordering of this block, we want to build these modules last -->
     </modules>
 
     <properties>


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

`javadoc` must not be triggered in default branch build as it will fail if we don't call `compile` beforehand due to code generators like `Immutables` which is currently used in persistence code. As such, we will not call it for now.

Also, for the build order, make sure we build all XT modules before engine server and collections modules.
