### PR TITLE
Persist createAt, lastUpateAt timestamp info for a query

### DIFF
--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
@@ -28,6 +28,7 @@ import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.application.query.model.Query;
 import org.finos.legend.engine.application.query.model.QueryEvent;
+import org.finos.legend.engine.application.query.model.QueryProjectCoordinates;
 import org.finos.legend.engine.application.query.model.QuerySearchSpecification;
 import org.finos.legend.engine.application.query.model.QueryStoreStats;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.StereotypePtr;
@@ -38,9 +39,13 @@ import org.finos.legend.engine.shared.core.vault.Vault;
 import javax.lang.model.SourceVersion;
 import javax.ws.rs.core.Response;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import static com.mongodb.client.model.Sorts.descending;
 
 public class QueryStoreManager
 {
@@ -99,6 +104,8 @@ public class QueryStoreManager
         query.runtime = document.getString("runtime");
         query.content = document.getString("content");
         query.owner = document.getString("owner");
+        query.lastUpdateAt = document.getLong("lastUpdateAt");
+        query.createdAt = document.getLong("createdAt");
         if (document.get("taggedValues") != null)
         {
             query.taggedValues = ListIterate.collect(document.getList("taggedValues", Document.class), _doc ->
@@ -188,10 +195,7 @@ public class QueryStoreManager
         // TODO: we can potentially create a pattern check for version
     }
 
-    public List<Query> getQueries(
-            QuerySearchSpecification searchSpecification,
-            String currentUser
-    )
+    public List<Query> getQueries(QuerySearchSpecification searchSpecification, String currentUser)
     {
         List<Bson> filters = new ArrayList<>();
         if (searchSpecification.showCurrentUserQueriesOnly != null && searchSpecification.showCurrentUserQueriesOnly)
@@ -231,9 +235,9 @@ public class QueryStoreManager
                             Filters.and(Filters.eq("stereotypes.profile", stereotype.profile), Filters.eq("stereotypes.value", stereotype.value)))));
         }
         return LazyIterate.collect(this.getQueryCollection()
-                .find(filters.isEmpty() ? EMPTY_FILTER : Filters.and(filters))
+                .find(filters.isEmpty() ? EMPTY_FILTER : Filters.and(filters)).sort(searchSpecification.showLatestQueries != null && searchSpecification.showLatestQueries ? descending("lastUpdateAt") : EMPTY_FILTER)
                 // NOTE: return a light version of the query to save bandwidth
-                .projection(Projections.include("id", "name", "versionId", "groupId", "artifactId", "owner"))
+                .projection(Projections.include("id", "name", "versionId", "groupId", "artifactId", "owner", "createdAt", "lastUpdateAt"))
                 .limit(Math.min(MAX_NUMBER_OF_QUERIES, searchSpecification.limit == null ? Integer.MAX_VALUE : searchSpecification.limit)), QueryStoreManager::documentToQuery).toList();
     }
 
@@ -274,8 +278,12 @@ public class QueryStoreManager
         {
             throw new ApplicationQueryException("Query with ID '" + query.id + "' already existed", Response.Status.BAD_REQUEST);
         }
+        query.createdAt = Instant.now().toEpochMilli();
+        query.lastUpdateAt = query.createdAt;
         this.getQueryCollection().insertOne(queryToDocument(query));
-        this.getQueryEventCollection().insertOne(queryEventToDocument(createEvent(query.id, QueryEvent.QueryEventType.CREATED)));
+        QueryEvent createdEvent = createEvent(query.id, QueryEvent.QueryEventType.CREATED);
+        createdEvent.timestamp = query.createdAt;
+        this.getQueryEventCollection().insertOne(queryEventToDocument(createdEvent));
         return query;
     }
 
@@ -305,8 +313,12 @@ public class QueryStoreManager
             throw new ApplicationQueryException("Only owner can update the query", Response.Status.FORBIDDEN);
         }
         query.owner = currentUser;
+        query.createdAt = currentQuery.createdAt;
+        query.lastUpdateAt = Instant.now().toEpochMilli();
         this.getQueryCollection().findOneAndReplace(Filters.eq("id", queryId), queryToDocument(query));
-        this.getQueryEventCollection().insertOne(queryEventToDocument(createEvent(query.id, QueryEvent.QueryEventType.UPDATED)));
+        QueryEvent updatedEvent = createEvent(query.id, QueryEvent.QueryEventType.UPDATED);
+        updatedEvent.timestamp = query.lastUpdateAt;
+        this.getQueryEventCollection().insertOne(queryEventToDocument(updatedEvent));
         return query;
     }
 

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
@@ -30,11 +30,12 @@ public class Query
     public String mapping;
     public String runtime;
     public String content;
-    // We make it clear that we only allow a single owner
-    public String owner;
-    public Long lastUpdateAt;
+    public Long lastUpdatedAt;
     public Long createdAt;
 
     public List<TaggedValue> taggedValues;
     public List<StereotypePtr> stereotypes;
+
+    // We make it clear that we only allow a single owner
+    public String owner;
 }

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
@@ -32,6 +32,8 @@ public class Query
     public String content;
     // We make it clear that we only allow a single owner
     public String owner;
+    public Long lastUpdateAt;
+    public Long createdAt;
 
     public List<TaggedValue> taggedValues;
     public List<StereotypePtr> stereotypes;

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QuerySearchSpecification.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QuerySearchSpecification.java
@@ -27,4 +27,5 @@ public class QuerySearchSpecification
     public List<StereotypePtr> stereotypes;
     public Integer limit;
     public Boolean showCurrentUserQueriesOnly;
+    public Boolean showLatestQueries;
 }

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QuerySearchSpecification.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QuerySearchSpecification.java
@@ -27,5 +27,8 @@ public class QuerySearchSpecification
     public List<StereotypePtr> stereotypes;
     public Integer limit;
     public Boolean showCurrentUserQueriesOnly;
-    public Boolean showLatestQueries;
+    // TODO: consider doing more complicated filtering/sorting by time
+    // e.g. we can also allow finding queries with `since ... until` for
+    // lastUpdatedAt and createdAt timestamp
+    public Boolean showLatestQueriesFirst;
 }

--- a/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
+++ b/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
@@ -47,7 +47,7 @@ public class TestQueryStoreManager
         public List<StereotypePtr> stereotypes;
         public Integer limit;
         public Boolean showCurrentUserQueriesOnly;
-        public Boolean showLatestQueries;
+        public Boolean showLatestQueriesFirst;
 
         TestQuerySearchSpecificationBuilder withSearchTerm(String searchTerm)
         {
@@ -85,9 +85,9 @@ public class TestQueryStoreManager
             return this;
         }
 
-        TestQuerySearchSpecificationBuilder withShowLatestQueries(Boolean showLatestQueries)
+        TestQuerySearchSpecificationBuilder withshowLatestQueriesFirst(Boolean showLatestQueriesFirst)
         {
-            this.showLatestQueries = showLatestQueries;
+            this.showLatestQueriesFirst = showLatestQueriesFirst;
             return this;
         }
 
@@ -100,7 +100,7 @@ public class TestQueryStoreManager
             searchSpecification.stereotypes = this.stereotypes;
             searchSpecification.limit = this.limit;
             searchSpecification.showCurrentUserQueriesOnly = this.showCurrentUserQueriesOnly;
-            searchSpecification.showLatestQueries = this.showLatestQueries;
+            searchSpecification.showLatestQueriesFirst = this.showLatestQueriesFirst;
             return searchSpecification;
         }
     }
@@ -325,6 +325,8 @@ public class TestQueryStoreManager
         Assert.assertEquals("1", lightQuery.id);
         Assert.assertEquals("query1", lightQuery.name);
         Assert.assertEquals("0.0.0", lightQuery.versionId);
+        Assert.assertNotNull(createdQuery.createdAt);
+        Assert.assertNotNull(createdQuery.lastUpdatedAt);
     }
 
 
@@ -478,6 +480,8 @@ public class TestQueryStoreManager
         Assert.assertEquals("runtime", createdQuery.runtime);
         Assert.assertEquals(0, createdQuery.stereotypes.size());
         Assert.assertEquals(0, createdQuery.taggedValues.size());
+        Assert.assertNotNull(createdQuery.createdAt);
+        Assert.assertEquals(createdQuery.createdAt, createdQuery.lastUpdatedAt);
 
     }
 
@@ -680,17 +684,17 @@ public class TestQueryStoreManager
     }
 
     @Test
-    public void testCreateSimpleQueryContainsTimeStamps() throws Exception
+    public void testCreateSimpleQueryContainsTimestamps() throws Exception
     {
         String currentUser = "testUser";
         Query newQuery = TestQueryBuilder.create("1", "query1", currentUser).build();
         Query createdQuery = queryStoreManager.createQuery(newQuery, currentUser);
-        Assert.assertNotNull(createdQuery.lastUpdateAt);
+        Assert.assertNotNull(createdQuery.lastUpdatedAt);
         Assert.assertNotNull(createdQuery.createdAt);
     }
 
     @Test
-    public void testGetLightQueriesContainTimeStamps() throws Exception
+    public void testGetLightQueriesContainTimestamps() throws Exception
     {
         String currentUser = "testUser";
         Query newQuery = TestQueryBuilder.create("1", "query1", currentUser).withGroupId("test.group").withArtifactId("test-artifact").build();
@@ -698,18 +702,18 @@ public class TestQueryStoreManager
         List<Query> queries = queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().build(), currentUser);
         Assert.assertEquals(1, queries.size());
         Query lightQuery = queries.get(0);
-        Assert.assertNotNull(lightQuery.lastUpdateAt);
+        Assert.assertNotNull(lightQuery.lastUpdatedAt);
         Assert.assertNotNull(lightQuery.createdAt);
     }
 
     @Test
-    public void testGetLightQueriesSortWithLastUpdateAt() throws Exception
+    public void testGetLightQueriesSortWithLastUpdatedAt() throws Exception
     {
         String currentUser = "testUser";
         queryStoreManager.createQuery(TestQueryBuilder.create("1", "query1", currentUser).build(), currentUser);
         queryStoreManager.createQuery(TestQueryBuilder.create("2", "query2", currentUser).build(), currentUser);
         queryStoreManager.updateQuery("2", TestQueryBuilder.create("2", "query", currentUser).build(), currentUser);
-        List<Query> queries = queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withShowLatestQueries(true).build(), currentUser);
+        List<Query> queries = queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withshowLatestQueriesFirst(true).build(), currentUser);
         Query lightQuery = queries.get(0);
         Assert.assertEquals("2", lightQuery.id);
     }

--- a/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
+++ b/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
@@ -47,6 +47,7 @@ public class TestQueryStoreManager
         public List<StereotypePtr> stereotypes;
         public Integer limit;
         public Boolean showCurrentUserQueriesOnly;
+        public Boolean showLatestQueries;
 
         TestQuerySearchSpecificationBuilder withSearchTerm(String searchTerm)
         {
@@ -84,6 +85,12 @@ public class TestQueryStoreManager
             return this;
         }
 
+        TestQuerySearchSpecificationBuilder withShowLatestQueries(Boolean showLatestQueries)
+        {
+            this.showLatestQueries = showLatestQueries;
+            return this;
+        }
+
         QuerySearchSpecification build()
         {
             QuerySearchSpecification searchSpecification = new QuerySearchSpecification();
@@ -93,6 +100,7 @@ public class TestQueryStoreManager
             searchSpecification.stereotypes = this.stereotypes;
             searchSpecification.limit = this.limit;
             searchSpecification.showCurrentUserQueriesOnly = this.showCurrentUserQueriesOnly;
+            searchSpecification.showLatestQueries = this.showLatestQueries;
             return searchSpecification;
         }
     }
@@ -311,20 +319,12 @@ public class TestQueryStoreManager
         queryStoreManager.createQuery(newQuery, currentUser);
         List<Query> queries = queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().build(), currentUser);
         Assert.assertEquals(1, queries.size());
-        Assert.assertEquals("{" +
-            "\"artifactId\":\"test-artifact\"," +
-            "\"content\":null," +
-            "\"description\":null," +
-            "\"groupId\":\"test.group\"," +
-            "\"id\":\"1\"," +
-            "\"mapping\":null," +
-            "\"name\":\"query1\"," +
-            "\"owner\":\"testUser\"," +
-            "\"runtime\":null," +
-            "\"stereotypes\":null," +
-            "\"taggedValues\":null," +
-            "\"versionId\":\"0.0.0\"" +
-            "}", objectMapper.writeValueAsString(queries.get(0)));
+        Query lightQuery = queries.get(0);
+        Assert.assertEquals("test-artifact", lightQuery.artifactId);
+        Assert.assertEquals("test.group", lightQuery.groupId);
+        Assert.assertEquals("1", lightQuery.id);
+        Assert.assertEquals("query1", lightQuery.name);
+        Assert.assertEquals("0.0.0", lightQuery.versionId);
     }
 
 
@@ -467,20 +467,18 @@ public class TestQueryStoreManager
         String currentUser = "testUser";
         Query newQuery = TestQueryBuilder.create("1", "query1", currentUser).build();
         Query createdQuery = queryStoreManager.createQuery(newQuery, currentUser);
-        Assert.assertEquals("{" +
-            "\"artifactId\":\"test-artifact\"," +
-            "\"content\":\"content\"," +
-            "\"description\":\"description\"," +
-            "\"groupId\":\"test.group\"," +
-            "\"id\":\"1\"," +
-            "\"mapping\":\"mapping\"," +
-            "\"name\":\"query1\"," +
-            "\"owner\":\"" + currentUser + "\"," +
-            "\"runtime\":\"runtime\"," +
-            "\"stereotypes\":[]," +
-            "\"taggedValues\":[]," +
-            "\"versionId\":\"0.0.0\"" +
-            "}", objectMapper.writeValueAsString(createdQuery));
+        Assert.assertEquals("test-artifact", createdQuery.artifactId);
+        Assert.assertEquals("test.group", createdQuery.groupId);
+        Assert.assertEquals("1", createdQuery.id);
+        Assert.assertEquals("query1", createdQuery.name);
+        Assert.assertEquals("0.0.0", createdQuery.versionId);
+        Assert.assertEquals("content", createdQuery.content);
+        Assert.assertEquals("description", createdQuery.description);
+        Assert.assertEquals("mapping", createdQuery.mapping);
+        Assert.assertEquals("runtime", createdQuery.runtime);
+        Assert.assertEquals(0, createdQuery.stereotypes.size());
+        Assert.assertEquals(0, createdQuery.taggedValues.size());
+
     }
 
     @Test
@@ -679,5 +677,40 @@ public class TestQueryStoreManager
         QueryEvent event2 = queryStoreManager.getQueryEvents("2", QueryEvent.QueryEventType.CREATED, null, null, null).get(0);
         Assert.assertEquals(3, queryStoreManager.getQueryEvents(null, null, event2.timestamp, null, null).size());
         Assert.assertEquals(4, queryStoreManager.getQueryEvents(null, null, null, event2.timestamp, null).size());
+    }
+
+    @Test
+    public void testCreateSimpleQueryContainsTimeStamps() throws Exception
+    {
+        String currentUser = "testUser";
+        Query newQuery = TestQueryBuilder.create("1", "query1", currentUser).build();
+        Query createdQuery = queryStoreManager.createQuery(newQuery, currentUser);
+        Assert.assertNotNull(createdQuery.lastUpdateAt);
+        Assert.assertNotNull(createdQuery.createdAt);
+    }
+
+    @Test
+    public void testGetLightQueriesContainTimeStamps() throws Exception
+    {
+        String currentUser = "testUser";
+        Query newQuery = TestQueryBuilder.create("1", "query1", currentUser).withGroupId("test.group").withArtifactId("test-artifact").build();
+        queryStoreManager.createQuery(newQuery, currentUser);
+        List<Query> queries = queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().build(), currentUser);
+        Assert.assertEquals(1, queries.size());
+        Query lightQuery = queries.get(0);
+        Assert.assertNotNull(lightQuery.lastUpdateAt);
+        Assert.assertNotNull(lightQuery.createdAt);
+    }
+
+    @Test
+    public void testGetLightQueriesSortWithLastUpdateAt() throws Exception
+    {
+        String currentUser = "testUser";
+        queryStoreManager.createQuery(TestQueryBuilder.create("1", "query1", currentUser).build(), currentUser);
+        queryStoreManager.createQuery(TestQueryBuilder.create("2", "query2", currentUser).build(), currentUser);
+        queryStoreManager.updateQuery("2", TestQueryBuilder.create("2", "query", currentUser).build(), currentUser);
+        List<Query> queries = queryStoreManager.getQueries(new TestQuerySearchSpecificationBuilder().withShowLatestQueries(true).build(), currentUser);
+        Query lightQuery = queries.get(0);
+        Assert.assertEquals("2", lightQuery.id);
     }
 }

--- a/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
+++ b/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
@@ -325,8 +325,14 @@ public class TestQueryStoreManager
         Assert.assertEquals("1", lightQuery.id);
         Assert.assertEquals("query1", lightQuery.name);
         Assert.assertEquals("0.0.0", lightQuery.versionId);
-        Assert.assertNotNull(createdQuery.createdAt);
-        Assert.assertNotNull(createdQuery.lastUpdatedAt);
+        Assert.assertNotNull(lightQuery.createdAt);
+        Assert.assertNotNull(lightQuery.lastUpdatedAt);
+        Assert.assertNull(lightQuery.content);
+        Assert.assertNull(lightQuery.description);
+        Assert.assertNull(lightQuery.mapping);
+        Assert.assertNull(lightQuery.runtime);
+        Assert.assertNull(lightQuery.stereotypes);
+        Assert.assertNull(lightQuery.taggedValues);
     }
 
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
-->

#### What does this PR do / why is it needed ?
 This PR adds a new field `lastUpdateTimeStamp` info for a query 
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
