### PR TITLE
Override default client with authentication for metadata API execution 

### DIFF
--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/SDLCLoader.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 
 import javax.security.auth.Subject;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.opentracing.propagation.Format.Builtin.HTTP_HEADERS;
@@ -64,19 +65,24 @@ public class SDLCLoader implements ModelLoader
     private final Supplier<Subject> subjectProvider;
     private final PureServerLoader pureLoader;
     private final AlloySDLCLoader alloyLoader;
+    private  Function<MutableList<CommonProfile>, CloseableHttpClient> httpClientProvider;
 
     public SDLCLoader(MetaDataServerConfiguration metaDataServerConfiguration, Supplier<Subject> subjectProvider)
     {
-        this.subjectProvider = subjectProvider;
-        this.pureLoader = new PureServerLoader(metaDataServerConfiguration);
-        this.alloyLoader = new AlloySDLCLoader(metaDataServerConfiguration);
+        this(metaDataServerConfiguration, subjectProvider, new PureServerLoader(metaDataServerConfiguration),null);
     }
 
     public SDLCLoader(MetaDataServerConfiguration metaDataServerConfiguration, Supplier<Subject> subjectProvider, PureServerLoader pureLoader)
     {
+         this(metaDataServerConfiguration,subjectProvider,pureLoader,null);
+    }
+
+    public SDLCLoader(MetaDataServerConfiguration metaDataServerConfiguration, Supplier<Subject> subjectProvider, PureServerLoader pureLoader, Function<MutableList<CommonProfile>, CloseableHttpClient> httpClientProvider)
+    {
         this.subjectProvider = subjectProvider;
         this.pureLoader = pureLoader;
         this.alloyLoader = new AlloySDLCLoader(metaDataServerConfiguration);
+        this.httpClientProvider = httpClientProvider;
     }
 
     private Subject getSubject()
@@ -171,7 +177,7 @@ public class SDLCLoader implements ModelLoader
                 try (Scope scope = GlobalTracer.get().buildSpan("Request Alloy Metadata").startActive(true))
                 {
                     AlloySDLC sdlc = (AlloySDLC) context.sdlcInfo;
-                    PureModelContextData loadedProject = this.alloyLoader.loadAlloyProject(pm, sdlc, clientVersion);
+                    PureModelContextData loadedProject = this.alloyLoader.loadAlloyProject(pm, sdlc, clientVersion, this.httpClientProvider);
                     loadedProject.origin.sdlcInfo.packageableElementPointers = sdlc.packageableElementPointers;
                     List<String> missingPaths = this.alloyLoader.checkAllPathsExist(loadedProject, sdlc);
                     if (missingPaths.isEmpty())
@@ -206,8 +212,23 @@ public class SDLCLoader implements ModelLoader
 
     public static PureModelContextData loadMetadataFromHTTPURL(MutableList<CommonProfile> pm, LoggingEventType startEvent, LoggingEventType stopEvent, String url)
     {
+        return loadMetadataFromHTTPURL(pm, startEvent, stopEvent, url, null);
+    }
+
+    public static PureModelContextData loadMetadataFromHTTPURL(MutableList<CommonProfile> pm, LoggingEventType startEvent, LoggingEventType stopEvent, String url, Function<MutableList<CommonProfile>, CloseableHttpClient> httpClientProvider)
+    {
         Scope scope = GlobalTracer.get().scopeManager().active();
-        CloseableHttpClient httpclient = (CloseableHttpClient) HttpClientBuilder.getHttpClient(new BasicCookieStore());
+        CloseableHttpClient httpclient;
+
+        if (httpClientProvider != null)
+        {
+            httpclient = httpClientProvider.apply(pm);
+        }
+        else
+        {
+            httpclient = (CloseableHttpClient) HttpClientBuilder.getHttpClient(new BasicCookieStore());
+        }
+
         long start = System.currentTimeMillis();
 
         LogInfo info = new LogInfo(pm, startEvent, "Requesting metadata");

--- a/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/alloy/AlloySDLCLoader.java
+++ b/legend-engine-language-pure-modelManager-sdlc/src/main/java/org/finos/legend/engine/language/pure/modelManager/sdlc/alloy/AlloySDLCLoader.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.language.pure.modelManager.sdlc.alloy;
 
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.language.pure.modelManager.sdlc.SDLCLoader;
 import org.finos.legend.engine.language.pure.modelManager.sdlc.configuration.MetaDataServerConfiguration;
@@ -25,6 +26,7 @@ import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
 import org.pac4j.core.profile.CommonProfile;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class AlloySDLCLoader
@@ -36,9 +38,9 @@ public class AlloySDLCLoader
         this.metaDataServerConfiguration = metaDataServerConfiguration;
     }
 
-    public PureModelContextData loadAlloyProject(MutableList<CommonProfile> pm, AlloySDLC alloySDLC, String clientVersion)
+    public PureModelContextData loadAlloyProject(MutableList<CommonProfile> pm, AlloySDLC alloySDLC, String clientVersion, Function<MutableList<CommonProfile>, CloseableHttpClient> httpClientProvider)
     {
-        return SDLCLoader.loadMetadataFromHTTPURL(pm, LoggingEventType.METADATA_REQUEST_ALLOY_PROJECT_START, LoggingEventType.METADATA_REQUEST_ALLOY_PROJECT_STOP, getMetaDataApiUrl(pm, alloySDLC, clientVersion));
+        return SDLCLoader.loadMetadataFromHTTPURL(pm, LoggingEventType.METADATA_REQUEST_ALLOY_PROJECT_START, LoggingEventType.METADATA_REQUEST_ALLOY_PROJECT_STOP, getMetaDataApiUrl(pm, alloySDLC, clientVersion), httpClientProvider);
     }
 
     public String getMetaDataApiUrl(MutableList<CommonProfile> pm, AlloySDLC alloySDLC, String clientVersion)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
--> Improvement

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> We want to refactor metadata api execution by allowing a provision for replacing default client with a auth-based client provider.

