### PR TITLE
Use routeFunctionExpression on from to ensure we respect special functions

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
@@ -230,7 +230,7 @@ function  meta::pure::router::store::routing::specializedFunctionExpressionRoute
                                                | getRoutingStrategyFromMappingAndRuntime($fromMapping, $fromRuntime));
                 let newState               = ^$state(routingStrategy = $newRoutingStrategy);
 
-                let processedFunction      = routeFunctionExpressionFunctionDefinition($fe.parametersValues->at(0)->cast(@FunctionExpression).func, $fe.parametersValues->at(0)->cast(@FunctionExpression), $newState, $fromExecutionContext, $vars, $inScopeVars, $extensions, $debug);
+                let processedFunction      = routeFunctionExpression($fe.parametersValues->at(0)->cast(@FunctionExpression), $newState, $fromExecutionContext, $vars, $inScopeVars, $extensions, $debug);
                 let valueSpec              = $processedFunction.value;
                 let wrappedValueSpec       = $valueSpec->evaluateAndDeactivate()->match([
                                                           evs: ExtendedRoutedValueSpecification[1] | $evs,


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Recent changes ended routing the from parameters incorrectly, bypassing specialized functions.  This move to use the routing function that will handle this specialized functions correctly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
