### PR TITLE
ci: add concurrency to build job to save runner minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,13 @@ env:
 
 on: [push, pull_request]
 
+# Cancel running jobs from previous pipelines of the same workflow on PR to save resource when commits are pushed quickly
+# NOTE: we don't want this behavior on default branch
+# See https://stackoverflow.com/a/68422069
+concurrency:
+  group: ${{ github.ref == 'refs/heads/master' && format('ci-default-branch-{0}-{1}', github.sha, github.workflow) || format('ci-pr-{0}-{1}', github.ref, github.workflow) }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

This forces the `Build CI` to run only once at a time per PR to prevent contributors who push a lot of commits within a short period of time wasting CI minutes on our billed large runner - a compromise we can take to reduce operational expense.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
