### PR TITLE
Fix sqlComments avoiding JSON format

### DIFF
--- a/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/execution/TestExecutionPlan.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/execution/TestExecutionPlan.java
@@ -455,8 +455,8 @@ public class TestExecutionPlan extends AlloyTestServer
                 "}";
         SingleExecutionPlan plan = super.buildPlan(TestPlanExecutionForIn.LOGICAL_MODEL + TestPlanExecutionForIn.STORE_MODEL + TestPlanExecutionForIn.MAPPING + TestPlanExecutionForIn.RUNTIME + fetchFunction, null);
         RelationalResult result = (RelationalResult) planExecutor.execute(plan);
-        Assert.assertTrue(((RelationalExecutionActivity) result.activities.get(0)).comment.matches("-- \\{\"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\\}"));
-        Assert.assertTrue(result.executedSQl.matches("-- \\{\"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\\}\nselect \"root\".fullName as \"fullName\" from PERSON as \"root\""));
+        Assert.assertTrue(((RelationalExecutionActivity) result.activities.get(0)).comment.matches("-- \"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\""));
+        Assert.assertTrue(result.executedSQl.matches("-- \"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\nselect \"root\".fullName as \"fullName\" from PERSON as \"root\""));
         String expected = "{\"builder\":{\"_type\":\"tdsBuilder\",\"columns\":[{\"name\":\"fullName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(100)\"}]},\"activities\":[{\"_type\":\"relational\",\"sql\":\"select \\\"root\\\".fullName as \\\"fullName\\\" from PERSON as \\\"root\\\"\"}],\"result\":{\"columns\":[\"fullName\"],\"rows\":[{\"values\":[\"P1\"]},{\"values\":[\"P2\"]}]}}";
         Assert.assertEquals(expected, RelationalResultToJsonDefaultSerializer.removeComment(result.flush(new RelationalResultToJsonDefaultSerializer(result))));
     }
@@ -473,8 +473,8 @@ public class TestExecutionPlan extends AlloyTestServer
         SingleExecutionPlan plan = super.buildPlan(TestPlanExecutionForIn.LOGICAL_MODEL + TestPlanExecutionForIn.STORE_MODEL + TestPlanExecutionForIn.MAPPING + TestPlanExecutionForIn.RUNTIME + fetchFunction, null);
         JsonStreamingResult result = (JsonStreamingResult) planExecutor.execute(plan);
         Result graphFetchResult = ((GraphFetchResult) ((StreamingObjectResult) result.getChildResult()).getChildResult()).getRootResult();
-        Assert.assertTrue(((RelationalExecutionActivity) graphFetchResult.activities.get(0)).comment.matches("-- \\{\"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\\}"));
-        Assert.assertTrue(((SQLExecutionResult) graphFetchResult).getExecutedSql().matches("-- \\{\"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\\}\nselect \"root\".fullName as \"pk_0\", \"root\".fullName as \"fullName\" from PERSON as \"root\""));
+        Assert.assertTrue(((RelationalExecutionActivity) graphFetchResult.activities.get(0)).comment.matches("-- \"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\""));
+        Assert.assertTrue(((SQLExecutionResult) graphFetchResult).getExecutedSql().matches("-- \"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\nselect \"root\".fullName as \"pk_0\", \"root\".fullName as \"fullName\" from PERSON as \"root\""));
         Assert.assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":[{\"fullName\":\"P1\"},{\"fullName\":\"P2\"}]}", result.flush(new JsonStreamToJsonDefaultSerializer(result)));
     }
 

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -2424,7 +2424,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::execution::testSQLComme
 {
    let plan = executionPlan({|Person.all()->project(col(p|$p.firstName, 'firstName'))}, simpleRelationalMapping, meta::relational::tests::testRuntime(), relationalExtensions());
    let sqlComment = $plan.rootExecutionNode->allNodes(relationalExtensions())->filter(node | $node->instanceOf(SQLExecutionNode))->cast(@SQLExecutionNode).sqlComment;
-   assertEquals('-- {"executionTraceID" : "${execID}"}', $sqlComment);
+   assertEquals('-- "executionTraceID" : "${execID}"', $sqlComment);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testSupportStreamFlagGraphFetchSimple():Boolean[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testSimple.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testSimple.pure
@@ -49,7 +49,7 @@ function <<test.Test>> meta::relational::tests::query::simple::testAll():Boolean
 function <<test.Test>> {meta::pure::executionPlan::profiles::serverVersion.start='vX_X_X'} meta::relational::tests::query::simple::testSQLComments():Boolean[1]
 {
    let result = execute(|Person.all(), simpleRelationalMapping, testRuntime(), meta::relational::extension::relationalExtensions());
-   assert($result.activities->at(0)->cast(@RelationalActivity).comment->toOne()->meta::pure::functions::string::matches('-- \\{\"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\\}'));
+   assert($result.activities->at(0)->cast(@RelationalActivity).comment->toOne()->meta::pure::functions::string::matches('-- \"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"'));
 }
 
 function meta::relational::tests::query::simple::getPersonNames( columnList:String[*] ):TabularDataSet[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/defaultPostProcessor.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/defaultPostProcessor.pure
@@ -65,7 +65,7 @@ function meta::relational::mapping::sqlQueryDefaultPostProcessors():meta::pure::
 
 function meta::relational::postProcessor::comments::prependSQLComments(selectSQLQuery:SelectSQLQuery[1], extensions:Extension[*]):Result<SelectSQLQuery|1>[1]
 {
-   ^Result<SelectSQLQuery|1>(values= ^$selectSQLQuery(comment= '-- {"executionTraceID" : "${execID}"}'));
+   ^Result<SelectSQLQuery|1>(values= ^$selectSQLQuery(comment= '-- "executionTraceID" : "${execID}"'));
 }
 
 function meta::relational::postProcessor::generateTempTableSelectSQLQuery(tempTableSchemaName:String[1], tempTableName:String[1], tempTableColumnName: String[1], tempTableColumnType:meta::relational::metamodel::datatype::DataType[1]):SelectSQLQuery[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
@@ -316,7 +316,7 @@ function meta::relational::mapping::execution(store: Database[1], f:FunctionExpr
 
 function meta::relational::mapping::sqlCommentPureExecution(): String[1]
 {
-  '-- {"executionTraceID" : "' + meta::pure::runtime::generateGuid() + '"}';
+  '-- "executionTraceID" : "' + meta::pure::runtime::generateGuid() + '"';
 }
 
 function meta::relational::mapping::executeQuery(sql:String[1], query:SQLQuery[0..1], paths: Pair<String, PathInformation>[*], connection : DatabaseConnection[1], runtime: Runtime[1], class:Type[0..1], ext:RoutedValueSpecification[0..1], m: Mapping[1], sqlGenerationTimeInNanoSecond:Integer[0..1], g_queryTimeOutInSeconds: Integer[0..1], exeCtx:ExecutionContext[1], extensions: Extension[*], debug:DebugContext[1]):Result<Any|*>[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbTestRunner/testRunner.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbTestRunner/testRunner.pure
@@ -61,7 +61,7 @@ function meta::relational::dbTestRunner::runSqlQueryTest(sqlQuery:SQLQuery[1], e
                   let errMsg = 'Result assert failed, expected Values : '+ $expectedStr  +', actual Values : ' + $resStr;
                   
                   assert($areEqual , $errMsg);
-                  assert($res.activities->cast(@RelationalActivity).comment->toOne()->meta::pure::functions::string::matches('-- \\{\"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\\}'));
+                  assert($res.activities->cast(@RelationalActivity).comment->toOne()->meta::pure::functions::string::matches('-- \"executionTraceID\" : \"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"'));
               );
      );
 }
@@ -139,7 +139,7 @@ function meta::relational::dbTestRunner::wrapSQLStringInExecutionPlan(sqlString:
   let sqlExecutionNode = ^RelationalDataTypeInstantiationExecutionNode(
                            resultType=$resultType,
                            executionNodes=^SQLExecutionNode(
-                                sqlComment= '-- {"executionTraceID" : "${execID}"}',
+                                sqlComment= '-- "executionTraceID" : "${execID}"',
                                 sqlQuery=$sqlString ,
                                 connection=$connection , 
                                 resultType=$resultType,


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
To avoid wrapping the comments in { } as Sybase ASE fails to prase this as it is a legacy way to specify a timestamp format

#### Does this PR introduce a user-facing change?
No
