### PR TITLE
Action for handling release failures

### DIFF
--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -1,0 +1,43 @@
+# Copyright 2022 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This action deletes the last two commits made on the master branch and the latest tag
+# This should only be run if a release failed and the remote staging repo has been dropped:
+# [ERROR]  * Dropping failed staging repository with ID "orgfinoslegend-..." ...
+name: Clean repo after failed release
+
+on: [workflow_dispatch]
+
+jobs:
+  clean-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.FINOS_GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "37706051+finos-admin@users.noreply.github.com"
+          git config --global user.name "FINOS Administrator"
+
+      - name: Clean repo
+        run: |
+          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+          git push --delete origin $LATEST_TAG
+          git reset --hard HEAD~2
+          git push --force


### PR DESCRIPTION
#### What type of PR is this?

This PR adds an action for to clean up the repository in case of a release failure

#### What does this PR do / why is it needed ?

The staging process in OSSHR may fail when doing a release and the staging repo could be dropped (in this case we delete the release tag and commits from the master branch and run a new release action)

#### Which issue(s) this PR fixes:

It helps clean up the git repo after a failed release

