### PR TITLE
GraphQL - Nested Qualified Properties in Selection Set

### DIFF
--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/helpers.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/helpers.pure
@@ -1,0 +1,78 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::external::query::graphQL::metamodel::sdl::*;
+import meta::external::query::graphQL::metamodel::sdl::value::*;
+import meta::external::query::graphQL::metamodel::sdl::executable::*;
+import meta::external::query::graphQL::transformation::queryToPure::*;
+import meta::external::query::graphQL::transformation::queryToPure::helpers::*;
+
+function <<access.private>> meta::external::query::graphQL::transformation::queryToPure::helpers::getRootParameters(property: QualifiedProperty<Any>[1],prefix:String[1]): VariableExpression[*]
+{
+  let params = $property.classifierGenericType.typeArguments.rawType->toOne()->cast(@FunctionType).parameters->tail();
+  $params->zip($params->evaluateAndDeactivate().name)->map(p|
+      let rawParam = $p.first;
+      let name = $prefix+$p.second;
+      ^$rawParam(name=$name);
+  );
+}
+
+function <<access.private>> meta::external::query::graphQL::transformation::queryToPure::helpers::getNestedParameters(property: AbstractProperty<Any>[1],prefix:String[1], fieldPathsFromSelectionSet: String[*]): VariableExpression[*]
+{
+  let rootParams = if($property->toOne()->instanceOf(QualifiedProperty) ,
+                    | $property->cast(@QualifiedProperty<Any>)->getRootParameters($prefix),
+                    | []);
+  let nestedParams = $property.genericType.rawType->toOne()->match([
+      p:PrimitiveType[1]    | [],
+      e:Enumeration<Any>[1] | [],
+      c:Class<Any>[1]       | $property.genericType.rawType->toOne()->cast(@Class<Any>)->allProperties()->filter(
+                                x|let pp = $prefix+$x.name->toOne(); $pp->in($fieldPathsFromSelectionSet);
+                              )->map(p|$p->getNestedParameters($prefix+$p.name->toOne()+'_',$fieldPathsFromSelectionSet))
+   ]);
+  $rootParams->concatenate($nestedParams);
+}
+
+function <<access.private>> meta::external::query::graphQL::transformation::queryToPure::helpers::getFieldPathsFromSelectionSet(selection: Selection[*],prefix:String[1],isRoot: Boolean[1]): String[*]
+{
+  $selection->map(s|$s->match(
+    [
+      field : Field[1] | let prefix1 = if($isRoot, |$prefix , |$prefix+$field.name+'_');
+                         $field.name->map(x|$prefix+$x)->concatenate(getFieldPathsFromSelectionSet($field.selectionSet,$prefix1,false));,
+      fragment: FragmentSpread[1] | [];
+    ]
+  ))->fold({p,a:String[*]|$a->concatenate($p)},[]);
+}
+
+function meta::external::query::graphQL::transformation::queryToPure::helpers::getSelectionSet(query:Document[1]): Selection[*]
+{
+  $query.definitions->map(d|
+    $d->match([
+      f : FragmentDefinition[1]| [],
+      o : OperationDefinition[1]| $o.selectionSet;
+    ])
+  );
+}
+
+function meta::external::query::graphQL::transformation::queryToPure::helpers::getUpdatedQualifiedProperty(qualifiedProperty: QualifiedProperty<Any>[1], selectionSet: Selection[*]): QualifiedProperty<Any>[1]
+{
+  let fieldPathsFromSelectionSet = $selectionSet->toOne()->getFieldPathsFromSelectionSet('',true);
+  let newParams = $qualifiedProperty.classifierGenericType.typeArguments.rawType->toOne()->cast(@FunctionType).parameters->first()->concatenate(
+                    $qualifiedProperty->getNestedParameters('', $fieldPathsFromSelectionSet)->cast(@VariableExpression)
+                  );
+  let classifierGenericType = $qualifiedProperty.classifierGenericType->toOne();
+  let typeArguments = $qualifiedProperty.classifierGenericType.typeArguments->toOne();
+  let rawType = $qualifiedProperty.classifierGenericType.typeArguments.rawType->toOne()->cast(@FunctionType);
+  ^$qualifiedProperty(classifierGenericType=^$classifierGenericType(typeArguments=^$typeArguments(rawType=^$rawType(parameters=$newParams))));
+}

--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testHelpers.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testHelpers.pure
@@ -1,0 +1,33 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::external::query::graphQL::metamodel::sdl::executable::*;
+import meta::external::query::graphQL::transformation::queryToPure::*;
+import meta::external::query::graphQL::transformation::introspection::*;
+import meta::external::query::graphQL::transformation::queryToPure::helpers::*;
+
+
+function <<test.Test>> meta::external::query::graphQL::transformation::queryToPure::helpers::testFieldPathsHelper():Boolean[1]
+{
+  let query = meta::legend::compileVS('#GQL{ query { person(firstName: "Abhishoya") { contact(number: "1") { name } firm(id: 1, legalName: "GS") { address(street: "1 Legend Street") { line1 } } } } }#')->cast(@meta::external::query::graphQL::metamodel::sdl::Document);
+  let selectionSet = $query->getSelectionSet();
+  assertEquals(['person', 'contact', 'contact_name', 'firm', 'firm_address', 'firm_address_line1'], $selectionSet->getFieldPathsFromSelectionSet('',true));
+}
+
+function <<test.Test>> meta::external::query::graphQL::transformation::queryToPure::helpers::testFieldPathsHelperWithPrefix():Boolean[1]
+{
+  let query = meta::legend::compileVS('#GQL{ query { person(firstName: "Abhishoya") { firm(id: 1, legalName: "GS") { address(street: "1 Legend Street") { line1 } } } } }#')->cast(@meta::external::query::graphQL::metamodel::sdl::Document);
+  let selectionSet = $query->getSelectionSet();
+  assertEquals(['GQL_person', 'GQL_firm', 'GQL_firm_address', 'GQL_firm_address_line1'], $selectionSet->getFieldPathsFromSelectionSet('GQL_',true));
+}

--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testQueryToGraphFetch.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testQueryToGraphFetch.pure
@@ -271,6 +271,7 @@ Class meta::external::query::graphQL::transformation::queryToPure::tests::model:
 {
   legalName: String[1];
   id: String[1];
+  employeesByFirstName(name: String[1]) {$this.employees->filter(e|$e.firstName == $name)}: Person[*];
 }
 
 Association meta::external::query::graphQL::transformation::queryToPure::tests::model::FIrm_Employee
@@ -294,6 +295,11 @@ Class meta::external::query::graphQL::transformation::queryToPure::tests::model:
   }: Person[*];
 
   personByName(name: String[1]){Person.all()->filter(p|$p.fullName == $name)->first()}: Person[0..1];
+
+  firms()
+  {
+    Firm.all()
+  }: Firm[*];
 }
 
 function <<test.Test>> meta::external::query::graphQL::transformation::queryToPure::tests::testConvertQueryWithOneParamToGraphFetch():Boolean[1]
@@ -332,4 +338,29 @@ function <<test.Test>> meta::external::query::graphQL::transformation::queryToPu
                '        }\n'+
                '    }\n' +
                '}}#', $pureGraphFetch->meta::pure::graphFetch::routing::asString(true));
+}
+
+function <<test.Test>> meta::external::query::graphQL::transformation::queryToPure::tests::testConvertQueryWithNestedFilters():Boolean[1]
+{
+  let graphQLDocument = meta::legend::compileVS('#GQL{ query { firms { employeesByFirstName(firstName: "Abhishoya") { firstName } } } }#')->cast(@meta::external::query::graphQL::metamodel::sdl::Document);
+  let pureGraphFetch = meta::external::query::graphQL::transformation::queryToPure::graphQLExecutableToPure($graphQLDocument, Query);
+  assertEquals('#{meta::external::query::graphQL::transformation::queryToPure::tests::model::Query {\n' +
+               '    firms() {\n' +
+               '        employeesByFirstName($employeesByFirstName_name) {\n' +
+               '            firstName\n'+
+               '        }\n'+
+               '    }\n' +
+               '}}#', $pureGraphFetch->meta::pure::graphFetch::routing::asString(true));
+}
+
+function <<test.Test>> meta::external::query::graphQL::transformation::queryToPure::tests::testFunctionExpressionWithReprocessedVariables():Boolean[1]
+{
+  let graphQLDocument = meta::legend::compileVS('#GQL{ query { firms { employeesByFirstName(firstName: "Abhishoya") { firstName } } } }#')->cast(@meta::external::query::graphQL::metamodel::sdl::Document);
+  let rootUpdated = meta::external::query::graphQL::transformation::queryToPure::getClassWithUpdatedQualifiedProperty($graphQLDocument,Query);
+  
+  let graphFetch = meta::external::query::graphQL::transformation::queryToPure::graphQLExecutableToPure($graphQLDocument, $rootUpdated);
+  
+  let r = $graphFetch->meta::pure::graphFetch::domain::extractDomainTypeClassFromGraphFetchTree(true);
+  assertEquals('firms', $r->at(0).propertyName);
+  assertEquals('employeesByFirstName_name:String[1] | Class Firm.all() -> graphFetch(#{meta::external::query::graphQL::transformation::queryToPure::tests::model::Firm {employeesByFirstName($employeesByFirstName_name) {firstName}}}#) -> serialize(#{meta::external::query::graphQL::transformation::queryToPure::tests::model::Firm {employeesByFirstName($employeesByFirstName_name) {firstName}}}#);', $r->at(0).functionDef->meta::pure::router::printer::asString());
 }

--- a/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/transformation_graphFetch.pure
+++ b/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/transformation_graphFetch.pure
@@ -12,16 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-
-
-
 ###Pure
 import meta::external::query::graphQL::metamodel::sdl::*;
 import meta::external::query::graphQL::metamodel::sdl::value::*;
 import meta::external::query::graphQL::metamodel::sdl::executable::*;
 import meta::external::query::graphQL::transformation::queryToPure::*;
+import meta::external::query::graphQL::transformation::queryToPure::helpers::*;
 import meta::pure::graphFetch::*;
+
+function meta::external::query::graphQL::transformation::queryToPure::getClassWithUpdatedQualifiedProperty(query:Document[1], root: Class<Any>[1]) : Class<Any>[1]
+{
+  let selectionSet = $query->getSelectionSet();
+  assert($selectionSet->size()==1, 'Selection set has more than one root query');
+  $selectionSet->map(s|$s->match(
+    [
+      field : Field[1] |
+                        let property = $root->meta::pure::functions::meta::allProperties()->filter(p|$p.name == $field.name);
+                        assert(!$property->isEmpty(), |'Property "'+$field.name+'" can\'t be found in the type '+$root->elementToPath());
+                        assert($property->toOne()->instanceOf(QualifiedProperty), |'Property "' + $field.name + '" not valid at root');
+                        let updatedProperty = getUpdatedQualifiedProperty($property->toOne()->cast(@QualifiedProperty<Any>), $selectionSet);
+                        let allQualifiedProperties = $root->meta::pure::functions::meta::allProperties()->filter(p|$p.name != $field.name)->concatenate($updatedProperty)->cast(@QualifiedProperty<Any>);
+                        ^$root(qualifiedProperties=$allQualifiedProperties);,
+      fragment: FragmentSpread[1] | $root;
+    ]
+  ))->toOne();
+}
 
 function meta::external::query::graphQL::transformation::queryToPure::graphQLExecutableToPure(query:Document[1], root: Class<Any>[1]) : RootGraphFetchTree<Any>[1]
 {
@@ -29,8 +44,8 @@ function meta::external::query::graphQL::transformation::queryToPure::graphQLExe
   let fragments = $query.definitions->map(d|
     $d->match([
       
-      f : FragmentDefinition[1]| pair($f.name, list($f.selectionSet->transformSelectionToPure($types->filter(c|$c.name == $f.typeCondition)->toOne()->cast(@Class<Any>))));,
-      o : OperationDefinition[1]| pair('__Query', list($o.selectionSet->transformSelectionToPure($root)));
+      f : FragmentDefinition[1]| pair($f.name, list($f.selectionSet->transformSelectionToPure($types->filter(c|$c.name == $f.typeCondition)->toOne()->cast(@Class<Any>),true,'')));,
+      o : OperationDefinition[1]| pair('__Query', list($o.selectionSet->transformSelectionToPure($root,true,'')));
     ])    
   )->newMap();
 
@@ -40,7 +55,6 @@ function meta::external::query::graphQL::transformation::queryToPure::graphQLExe
     subTrees = $fragments->get('__Query')->toOne().values->buildGraphFetchFromIntermediateNodes($fragments)
   );
 }
-
 
 Class <<access.private>> meta::external::query::graphQL::transformation::queryToPure::IntermediateNode
 {
@@ -58,7 +72,7 @@ Class <<access.private>> meta::external::query::graphQL::transformation::queryTo
 }
 
 
-function <<access.private>> meta::external::query::graphQL::transformation::queryToPure::transformSelectionToPure(selection:Selection[*], root:Class<Any>[1]) : meta::external::query::graphQL::transformation::queryToPure::IntermediateNode[*]
+function <<access.private>> meta::external::query::graphQL::transformation::queryToPure::transformSelectionToPure(selection:Selection[*], root:Class<Any>[1],isRoot: Boolean[1],prefix:String[1]) : meta::external::query::graphQL::transformation::queryToPure::IntermediateNode[*]
 {
   $selection->map(s|$s->match(
     [
@@ -70,13 +84,20 @@ function <<access.private>> meta::external::query::graphQL::transformation::quer
                                                     | $property->cast(@QualifiedProperty<Any>).classifierGenericType.typeArguments.rawType->toOne()->cast(@FunctionType).parameters->tail(),
                                                     |  []
                                            );
+                        
+                        let newParams = $params->zip($params->evaluateAndDeactivate().name)->map(p|
+                                          let rawParam = $p.first;
+                                          let name = if($isRoot,|$p.second,|$prefix+$field.name+'_'+$p.second);
+                                          ^$rawParam(name=$name);
+                                        );
+                        
                         ^meta::external::query::graphQL::transformation::queryToPure::IntermediatePropertyNode
                         (
                             propertyFetch = ^PropertyGraphFetchTree
                                           (
                                             property = $property->toOne(),
-                                            parameters = $params),
-                          children = if ($field.selectionSet->isEmpty(),|[],|$field.selectionSet->transformSelectionToPure($property->toOne()->functionReturnType().rawType->cast(@Class<Any>)->toOne()))
+                                            parameters = $newParams),
+                            children = if ($field.selectionSet->isEmpty(),|[],|$field.selectionSet->transformSelectionToPure($property->toOne()->functionReturnType().rawType->cast(@Class<Any>)->toOne(),false,if($isRoot,|'',|$field.name+'_')))
                         );,
       fragmentId : FragmentSpread[1] | ^meta::external::query::graphQL::transformation::queryToPure::IntermediateFragmentNode(name = $fragmentId.name);
     ]
@@ -100,6 +121,7 @@ function <<access.private>> meta::external::query::graphQL::transformation::quer
 
 
 ###Pure
+import meta::pure::runtime::*;
 import meta::external::query::graphQL::transformation::queryToPure::*;
 
 function meta::external::query::graphQL::transformation::queryToPure::getPlansFromGraphQL(
@@ -110,7 +132,10 @@ function meta::external::query::graphQL::transformation::queryToPure::getPlansFr
                                                                           extensions:meta::pure::extension::Extension[*]
                                                                       ):Pair<String, meta::pure::executionPlan::ExecutionPlan>[*]
 {
-  let graphFetch = meta::external::query::graphQL::transformation::queryToPure::graphQLExecutableToPure($query, $cl);
+  let rootUpdated = meta::external::query::graphQL::transformation::queryToPure::getClassWithUpdatedQualifiedProperty($query,$cl);
+  
+  let graphFetch = meta::external::query::graphQL::transformation::queryToPure::graphQLExecutableToPure($query, $rootUpdated);
+
   let res = $graphFetch->meta::pure::graphFetch::domain::extractDomainTypeClassFromGraphFetchTree(true);
   $res->map(r|
               pair(
@@ -133,10 +158,11 @@ function meta::external::query::graphQL::transformation::queryToPure::graphQLExe
                                                                           extensions:meta::pure::extension::Extension[*]
                                                                       ):meta::external::query::graphQL::transformation::queryToPure::NamedExecutionPlan[*]
 {
-  let pureWithParam =  meta::external::query::graphQL::transformation::queryToPure::graphQLExecutableToPure($query, $cl);
-
-
-    let res = $pureWithParam->meta::pure::graphFetch::domain::extractDomainTypeClassFromGraphFetchTree(true);
+  let rootUpdated = meta::external::query::graphQL::transformation::queryToPure::getClassWithUpdatedQualifiedProperty($query,$cl);
+  
+  let pureWithParam =  meta::external::query::graphQL::transformation::queryToPure::graphQLExecutableToPure($query, $rootUpdated);
+  
+  let res = $pureWithParam->meta::pure::graphFetch::domain::extractDomainTypeClassFromGraphFetchTree(true);
 
   $res->map(r|
               ^meta::external::query::graphQL::transformation::queryToPure::NamedExecutionPlan(
@@ -151,6 +177,8 @@ function meta::external::query::graphQL::transformation::queryToPure::graphQLExe
         );
 
 }
+
+
 Class meta::external::query::graphQL::transformation::queryToPure::NamedExecutionPlan
 {
   name : String[1];

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
@@ -105,6 +105,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.finos.legend.engine.query.graphQL.api.execute.GraphQLExecutionHelper.argumentValueToObject;
+import static org.finos.legend.engine.query.graphQL.api.execute.GraphQLExecutionHelper.collectArguments;
 import static org.finos.legend.engine.query.graphQL.api.execute.GraphQLExecutionHelper.extractFieldByName;
 import static org.finos.legend.engine.query.graphQL.api.execute.model.GraphQLCachableVisitorHelper.createCachableGraphQLQuery;
 import static org.finos.legend.engine.shared.core.operational.http.InflateInterceptor.APPLICATION_ZLIB;
@@ -299,13 +300,14 @@ public class GraphQLExecute extends GraphQL
                             try
                             {
                                 Map<String, Result> parameterMap = new HashMap<>();
-                                extractFieldByName(graphQLQuery, p.propertyName).arguments.stream().forEach(a -> parameterMap.put(a.name, new ConstantResult(argumentValueToObject(a.value))));
+//                                extractFieldByName(graphQLQuery, p.propertyName).arguments.stream().forEach(a -> parameterMap.put(a.name, new ConstantResult(argumentValueToObject(a.value))));
+                                collectArguments(graphQLQuery.selectionSet,"",true).forEach(a -> parameterMap.put(a.name, new ConstantResult(argumentValueToObject(a.value))));
 
                                 generator.writeFieldName(p.propertyName);
                                 result = (JsonStreamingResult) planExecutor.execute(p.serializedPlan, parameterMap, null, profiles);
                                 result.getJsonStream().accept(generator);
                             }
-                            catch (IOException e)
+                            catch (Exception e)
                             {
                                 throw new RuntimeException(e);
                             }

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
@@ -300,14 +300,13 @@ public class GraphQLExecute extends GraphQL
                             try
                             {
                                 Map<String, Result> parameterMap = new HashMap<>();
-//                                extractFieldByName(graphQLQuery, p.propertyName).arguments.stream().forEach(a -> parameterMap.put(a.name, new ConstantResult(argumentValueToObject(a.value))));
                                 collectArguments(graphQLQuery.selectionSet,"",true).forEach(a -> parameterMap.put(a.name, new ConstantResult(argumentValueToObject(a.value))));
 
                                 generator.writeFieldName(p.propertyName);
                                 result = (JsonStreamingResult) planExecutor.execute(p.serializedPlan, parameterMap, null, profiles);
                                 result.getJsonStream().accept(generator);
                             }
-                            catch (Exception e)
+                            catch (IOException e)
                             {
                                 throw new RuntimeException(e);
                             }

--- a/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecutionHelper.java
+++ b/legend-engine-xt-graphQL-query/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecutionHelper.java
@@ -14,10 +14,14 @@
 
 package org.finos.legend.engine.query.graphQL.api.execute;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.graphQL.grammar.from.antlr4.GraphQLParser;
+import org.finos.legend.engine.protocol.graphQL.metamodel.executable.Argument;
 import org.finos.legend.engine.protocol.graphQL.metamodel.executable.Field;
 import org.finos.legend.engine.protocol.graphQL.metamodel.executable.FragmentSpread;
 import org.finos.legend.engine.protocol.graphQL.metamodel.executable.InLineFragment;
 import org.finos.legend.engine.protocol.graphQL.metamodel.executable.OperationDefinition;
+import org.finos.legend.engine.protocol.graphQL.metamodel.executable.Selection;
 import org.finos.legend.engine.protocol.graphQL.metamodel.executable.SelectionVisitor;
 
 import org.finos.legend.engine.protocol.graphQL.metamodel.value.BooleanValue;
@@ -126,6 +130,24 @@ public class GraphQLExecutionHelper
             }
         })).collect(Collectors.toList()).get(0);
 
+    }
+
+    public static List<Argument> collectArguments(List<Selection> selectionSet, String prefix, Boolean isRoot)
+    {
+        List<Argument> arguments = Lists.mutable.empty();
+        selectionSet.forEach(selection ->
+        {
+            if (selection instanceof Field)
+            {
+                if (!isRoot)
+                {
+                    ((Field) selection).arguments.forEach(argument -> argument.name = prefix + ((Field) selection).name + '_' + argument.name);
+                }
+                arguments.addAll(((Field) selection).arguments);
+                arguments.addAll(collectArguments(((Field) selection).selectionSet, isRoot ? prefix : prefix + ((Field) selection).name + '_', false));
+            }
+        });
+        return arguments;
     }
 
 }

--- a/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLAPI.java
+++ b/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLAPI.java
@@ -782,13 +782,13 @@ public class TestGraphQLAPI
     {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         Object entity = response.getEntity();
-        if (entity instanceof ExceptionError)
+        if (entity instanceof StreamingOutput)
         {
-            throw new RuntimeException(((ExceptionError) entity).getTrace());
+            StreamingOutput output = (StreamingOutput) response.getEntity();
+            output.write(byteArrayOutputStream);
+            return byteArrayOutputStream.toString("UTF-8");
         }
-        StreamingOutput output = (StreamingOutput) response.getEntity();
-        output.write(byteArrayOutputStream);
-        return byteArrayOutputStream.toString("UTF-8");
+        throw new RuntimeException(((ExceptionError) entity).getMessage());
     }
 
     private static List<ExecutionNode> allChildNodes(ExecutionNode node)

--- a/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLAPI.java
+++ b/legend-engine-xt-graphQL-query/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLAPI.java
@@ -246,43 +246,6 @@ public class TestGraphQLAPI
     }
 
     @Test
-    @Ignore // TODO - Fails as date is not supported as an argument now
-    public void testGraphQLExecuteDevAPI_Milestoning() throws Exception
-    {
-        ModelManager modelManager = new ModelManager(DeploymentMode.TEST);
-        PlanExecutor executor = PlanExecutor.newPlanExecutorWithAvailableStoreExecutors();
-        MutableList<PlanGeneratorExtension> generatorExtensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
-        GraphQLExecute graphQLExecute = new GraphQLExecute(modelManager, executor, metaDataServerConfiguration, (pm) -> generatorExtensions.flatCollect(g -> g.getExtraExtensions(pm)), generatorExtensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers));
-        HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(mockRequest.getCookies()).thenReturn(new Cookie[0]);
-        Query query = new Query();
-        query.query = "query Query {\n" +
-                "  allFirms {\n" +
-                "      legalName,\n" +
-                "      employees {\n" +
-                "        firstName,\n" +
-                "        lastName\n" +
-                "        address(businessDate: \"13-02-2023\", processingDate: \"13-02-2023\"){\n" +
-                "          line1\n" +
-                "        }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }";
-        Response response = graphQLExecute.executeDev(mockRequest, "Project1", "Workspace1", "simple::model::Query", "simple::mapping::Map", "simple::runtime::Runtime", query, null);
-
-        String expected = "{" +
-                "\"data\":{" +
-                "\"allFirms\":[" +
-                "{\"legalName\":\"Firm X\",\"employees\":[{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}]}," +
-                "{\"legalName\":\"Firm A\",\"employees\":[]}," +
-                "{\"legalName\":\"Firm B\",\"employees\":[]}" +
-                "]" +
-                "}" +
-                "}";
-        Assert.assertEquals(expected, responseAsString(response));
-    }
-
-    @Test
     public void testGraphQLExecuteDevAPI_Relational_WithDependencies() throws Exception
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST, new SDLCLoader(metaDataServerConfiguration, null));

--- a/legend-engine-xt-graphQL-query/src/test/resources/org/finos/legend/engine/query/graphQL/api/test/Project1_Workspace1.pure
+++ b/legend-engine-xt-graphQL-query/src/test/resources/org/finos/legend/engine/query/graphQL/api/test/Project1_Workspace1.pure
@@ -48,12 +48,19 @@ Class simple::model::Query
 Class simple::model::Firm
 {
   legalName: String[1];
+  employeesByFirstName(firstName: String[1]) { $this.employees->filter(e|$e.firstName == $firstName) }: simple::model::Person[*];
 }
 
 Class simple::model::Person
 {
   firstName: String[1];
   lastName: String[1];
+  address: Address[1];
+}
+
+Class <<meta::pure::profiles::temporal.bitemporal>> simple::model::Address
+{
+  line1: String[1];
 }
 
 Class <<meta::pure::profiles::temporal.bitemporal>> simple::model::AddressBiTemporal
@@ -130,7 +137,13 @@ Mapping simple::mapping::Map
   {
     firstName: [DB]PERSON_TABLE.FIRST_NAME,
     lastName: [DB]PERSON_TABLE.LAST_NAME,
-    employer: [DB]@PERSON_FIRM
+    employer: [DB]@PERSON_FIRM,
+    address: [DB]@PERSON_ADDRESS
+  }
+
+  Address : Relational
+  {
+    line1: [DB]ADDRESS_TABLE.LINE1
   }
 
   AddressBiTemporal : Relational


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
This PR adds support for passing arguments in nested fields in a GraphQL query. In pure this can be represented by qualified property. 
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:
The issue is of unique variable naming in graph fetch tree, since we only have global variables to a lambda function. Hence, we have some logic to handle this by modifying variable names by prepending them with path.
#### Does this PR introduce a user-facing change?
<!--
-->
