### PR TITLE
setting trust store password

### DIFF
--- a/legend-engine-xt-relationalStore-trino-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/TrinoDatasourceSpecificationRuntime.java
+++ b/legend-engine-xt-relationalStore-trino-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/TrinoDatasourceSpecificationRuntime.java
@@ -85,6 +85,7 @@ public class TrinoDatasourceSpecificationRuntime extends org.finos.legend.engine
                     throw new RuntimeException("No valid SSL trustStorePathVaultReference and trustStorePasswordVaultReference values found for references ");
                 }
                 properties.setProperty(SSL_TRUST_STORE_PATH, createTrinoTempDile(trustStorePathVaultReference, sslTrustStoreValue));
+                properties.setProperty(SSL_TRUST_STORE_PASSWORD, sslTrustStorePassword);
             }
         }
         return properties;


### PR DESCRIPTION
setting trust store password for trino driver properties

#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

It is setting one of the properties - sslTrustStorePassword required for trino jdbc connection

#### Which issue(s) this PR fixes:
This a fix to new change

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
