### PR TITLE
Switch to static filename for SearchDocumentArtifactGenerationExtension

### DIFF
--- a/legend-engine-xt-analytics-search-generation/src/main/java/org/finos/legend/engine/generation/SearchDocumentArtifactGenerationExtension.java
+++ b/legend-engine-xt-analytics-search-generation/src/main/java/org/finos/legend/engine/generation/SearchDocumentArtifactGenerationExtension.java
@@ -16,8 +16,6 @@
 
 package org.finos.legend.engine.generation;
 
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder.getElementFullPath;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -38,6 +36,7 @@ import org.slf4j.Logger;
 public class SearchDocumentArtifactGenerationExtension implements ArtifactGenerationExtension
 {
     public final String ROOT_PATH = "searchDocuments";
+    public static final String FILE_NAME = "SearchDocumentResult.json";
 
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(SearchDocumentArtifactGenerationExtension.class);
 
@@ -56,15 +55,12 @@ public class SearchDocumentArtifactGenerationExtension implements ArtifactGenera
     @Override
     public List<Artifact> generate(PackageableElement element, PureModel pureModel, PureModelContextData data, String clientVersion)
     {
-        String path = getElementFullPath(element, pureModel.getExecutionSupport());
-        String fileName = String.format("%s.json", path);
-
         try
         {
             Root_meta_analytics_search_metamodel_BaseRootDocument document = core_analytics_search_trans.Root_meta_analytics_search_transformation_buildDocument_PackageableElement_1__ProjectCoordinates_1__BaseRootDocument_1_(element, buildProjectCoordinates(data), pureModel.getExecutionSupport());
 
             String stringResult = core_pure_protocol_protocol.Root_meta_alloy_metadataServer_alloyToJSON_Any_1__String_1_(document, pureModel.getExecutionSupport());
-            Artifact output = new Artifact(stringResult, fileName, "json");
+            Artifact output = new Artifact(stringResult, FILE_NAME, "json");
             return Collections.singletonList(output);
         }
         catch (Exception exception)

--- a/legend-engine-xt-analytics-search-generation/src/test/java/org/finos/legend/engine/generation/TestSearchDocumentArtifactGenerationExtension.java
+++ b/legend-engine-xt-analytics-search-generation/src/test/java/org/finos/legend/engine/generation/TestSearchDocumentArtifactGenerationExtension.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.generation;
 
+import static org.finos.legend.engine.generation.SearchDocumentArtifactGenerationExtension.FILE_NAME;
+
 import java.net.URL;
 import java.util.List;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
@@ -68,7 +70,7 @@ public class TestSearchDocumentArtifactGenerationExtension
         Assert.assertEquals(1, outputs.size());
         Artifact searchDocumentResult = outputs.get(0);
         Assert.assertEquals(searchDocumentResult.format, "json");
-        Assert.assertEquals(searchDocumentResult.path, "model::Person.json");
+        Assert.assertEquals(searchDocumentResult.path, FILE_NAME);
         Assert.assertNotNull(searchDocumentResult.content);
         Assert.assertEquals(searchDocumentResult.content, "{\"package\":\"model\",\"name\":\"Person\",\"projectCoordinates\":{\"versionId\":\"UNKNOWN\",\"groupId\":\"UNKNOWN\",\"artifactId\":\"UNKNOWN\"},\"id\":\"model::Person\",\"type\":\"Class\",\"properties\":[\"firstName\",\"lastName\"]}");
     }
@@ -98,7 +100,7 @@ public class TestSearchDocumentArtifactGenerationExtension
         Assert.assertEquals(1, outputs.size());
         Artifact searchDocumentResult = outputs.get(0);
         Assert.assertEquals(searchDocumentResult.format, "json");
-        Assert.assertEquals(searchDocumentResult.path, "model::Person.json");
+        Assert.assertEquals(searchDocumentResult.path, FILE_NAME);
         Assert.assertNotNull(searchDocumentResult.content);
         Assert.assertEquals(searchDocumentResult.content, "{\"package\":\"model\",\"name\":\"Person\",\"projectCoordinates\":{\"versionId\":\"0.0.1-SNAPSHOT\",\"groupId\":\"org.finos.test\",\"artifactId\":\"test-project\"},\"id\":\"model::Person\",\"type\":\"Class\",\"properties\":[\"firstName\",\"lastName\"]}");
     }


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Switch the filename for artifacts generated by SearchDocumentArtifactGenerationExtension to be static rather than using the element's path to avoid scenarios where the filename is too large for the filesystem.

#### Which issue(s) this PR fixes:
N/A

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

