### PR TITLE
Add default value for Trino KerberosDelegation when Delegated Auth Strategy used

### DIFF
--- a/legend-engine-xt-relationalStore-trino-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/TrinoDelegatedKerberosAuthenticationStrategyRuntime.java
+++ b/legend-engine-xt-relationalStore-trino-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/TrinoDelegatedKerberosAuthenticationStrategyRuntime.java
@@ -75,6 +75,7 @@ public class TrinoDelegatedKerberosAuthenticationStrategyRuntime extends org.fin
     {
         properties.setProperty("KerberosRemoteServiceName", this.kerberosRemoteServiceName);
         properties.setProperty("KerberosUseCanonicalHostname", String.valueOf(this.kerberosUseCanonicalHostname));
+        properties.setProperty("KerberosDelegation", "true");
 
         return Tuples.pair(url, properties);
     }

--- a/legend-engine-xt-relationalStore-trino-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/TrinoDatasourceSpecificationRuntime.java
+++ b/legend-engine-xt-relationalStore-trino-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/TrinoDatasourceSpecificationRuntime.java
@@ -40,12 +40,13 @@ public class TrinoDatasourceSpecificationRuntime extends org.finos.legend.engine
     private static final String SSL_TRUST_STORE_PASSWORD = "SSLTrustStorePassword";
     private static final String KERBEROES_REMOTE_SERVICE_NAME = "KerberosRemoteServiceName";
     private static final String KERBEROS_USE_CANONICAL_HOSTNAME = "KerberosUseCanonicalHostname";
+    private static final String KERBEROS_DELEGATION = "KerberosDelegation";
 
     private static final String USER = "user";
     private static final String PASSWORD = "password";
     private final TrinoDatasourceSpecificationKey key;
 
-    public static final List<String> propertiesForDriver = Arrays.asList(CLIENT_TAGS, SSL, SSL_TRUST_STORE_PATH, SSL_TRUST_STORE_PASSWORD, KERBEROES_REMOTE_SERVICE_NAME, KERBEROS_USE_CANONICAL_HOSTNAME, USER, PASSWORD);
+    public static final List<String> propertiesForDriver = Arrays.asList(CLIENT_TAGS, SSL, SSL_TRUST_STORE_PATH, SSL_TRUST_STORE_PASSWORD, KERBEROES_REMOTE_SERVICE_NAME, KERBEROS_USE_CANONICAL_HOSTNAME, KERBEROS_DELEGATION, USER, PASSWORD);
 
     public TrinoDatasourceSpecificationRuntime(TrinoDatasourceSpecificationKey key, DatabaseManager databaseManager, AuthenticationStrategy authenticationStrategy, Properties extraUserProperties)
     {


### PR DESCRIPTION

#### What type of PR is this?
Add default value for Trino KerberosDelegation when Delegated Auth Strategy used


<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
This is required for legend to make use of ContextBasedSubjectProvider from Trino instead of LoginBasedSubjectProvider when delegated Kerberos as the strategy is used,  without this property Auth flow will call LoginBasedSubjectProvider and is expected to throw exception if there is no keyTab or Credential Cache is present.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 
Kerberos error 
Unable to obtain Principal Name for authentication.

#### Other notes for reviewers:
This should've been the default property when Subject.doAs is wrapped to get the TrinoConnection()

#### Does this PR introduce a user-facing change?
No Changes expected
<!--
-->
