### PR TITLE
Fix bug in sourcetree calculation of unions with filters

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -553,12 +553,12 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNode(srcNode
                                                                                                                                                                                                                   |[])),
                                                                                                      |[]));
    let subTrees = $requiredTgtSubTrees->fold({st,n | $n->enrichSourceTreeNodeForProperty($setImplementation, $st, $extensions)}, $srcNode);
-   if($setImplementation.filter->isNotEmpty(),
-      {| 
-         let srcClass = $setImplementation.srcClass->toOne()->cast(@Class<Any>);
-         $subTrees->enrichSourceTreeNodeForExpression($srcClass, $setImplementation.filter.expressionSequence->at(0));
-      },
-      | $subTrees
+   let srcClass = $setImplementation.srcClass->toOne()->cast(@Class<Any>);
+   let srcNodeOwner = $srcNode->typeFromGraphFetchTree();
+
+   if($setImplementation.filter->isNotEmpty() && $srcClass == $srcNodeOwner,
+      | $subTrees->enrichSourceTreeNodeForExpression($srcClass, $setImplementation.filter.expressionSequence->at(0)),
+      | $subTrees   
    );
 }
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
@@ -1607,6 +1607,96 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::SourceToTarg
   }
 )
 
+
+// Union on source classes with same property name, where one element in union has a filter
+###Pure
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionSource
+{
+  a : meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionA[1];
+  b : meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionB[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionA
+{
+  fld : String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionB 
+{
+  fld : String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionTarget 
+{
+  c : meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionC[*];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionC 
+{
+  fld : String[1];
+}
+
+
+function <<meta::pure::profiles::test.Test>> meta::pure::mapping::modelToModel::test::alloy::simple::sourceTreeCalc::simpleUnionWithCommonPropertiesAndSingleFilter() : Boolean[1]
+{
+  let tree = #{meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionTarget { c { fld } }}#;
+  let expectedString = 'UnionSource\n' +
+                        '(\n' +
+                        '  a\n' +
+                        '  (\n' + 
+                        '    fld\n' + 
+                        '  )\n' + 
+                        '  b\n' +
+                        '  (\n' + 
+                        '    fld\n' + 
+                        '  )\n' + 
+                        ')';
+
+  let sourceTree = meta::pure::graphFetch::calculateSourceTree($tree, 
+                                                                meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionMappingWithSingleFilter,
+                                                                meta::pure::extension::defaultExtensions());
+
+  assertEquals($expectedString, $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString());                                                            
+}
+
+
+
+
+###Mapping
+import meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::*;
+
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionMappingWithSingleFilter
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionTarget : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionSource 
+    c[c1] : $src.a ,
+    c[c2] : $src.b 
+
+  }
+
+  *meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionC[c_value] : Operation 
+  {
+    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(c1,c2)
+  }
+
+  meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionC[c1] : Pure 
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionA
+    ~filter $src.fld->isNotEmpty()
+    fld : $src.fld+'_a'
+  }
+
+  meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionC[c2] : Pure 
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionB
+    fld : $src.fld+'_b'
+  }
+
+
+)
+
+
 ###Pure
 import meta::pure::graphFetch::tests::sourceTreeCalc::withFlatteningInTransform::*;
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/simpleObject.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/simpleObject.pure
@@ -801,6 +801,30 @@ meta::pure::mapping::modelToModel::test::alloy::simple::testMappingWithTypeName(
    assert(jsonEquivalent('{"firstName":"Pierre","lastName":"Doe","type":"_S_Person","description":"meta::pure::mapping::modelToModel::test::shared::src::_S_Person"}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
 
+function meta::pure::mapping::modelToModel::test::alloy::simple::testUnionMappingSimilarClassWithFilter() : Boolean[1]
+{
+    let tree = #{meta::pure::mapping::modelToModel::test::shared::dest::UnionTarget {c {fld}}}#;
+  let res = meta::pure::executionPlan::executionPlan(
+      |meta::pure::mapping::modelToModel::test::shared::dest::UnionTarget.all()->meta::pure::graphFetch::execution::graphFetchChecked($tree)->meta::pure::graphFetch::execution::serialize($tree),
+      meta::pure::mapping::modelToModel::test::alloy::M,
+      ^meta::pure::runtime::Runtime(connections = ^meta::pure::mapping::modelToModel::JsonModelConnection(
+                                element=^meta::pure::mapping::modelToModel::ModelStore(),
+                                class=meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionSource,
+                                url='data:application/json,{a : {id : "a"}, { b : { id : "b"}}}'
+                             )
+      ),
+      meta::pure::extension::defaultExtensions()
+   );
+   true;
+  // $res->meta::pure::executionPlan::generatePlatformCode(
+  //   meta::pure::executionPlan::platformBinding::legendJava::legendJavaPlatformBindingId(),
+  //   ^meta::pure::executionPlan::platformBinding::legendJava::LegendJavaPlatformBindingConfig(),
+  //   meta::relational::executionPlan::platformBinding::legendJava::relationalExtensionsWithLegendJavaPlatformBinding())
+  //  ->meta::pure::executionPlan::toString::planToString(meta::pure::extension::defaultExtensions())->println();
+  // meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObjectWithSubTypeNameOnlyTypeReferenceHasDefectsIfMultipleClassesMatch2();
+  // print('ok', 1);
+}
+
 
 ###Pure
 import meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::*;
@@ -938,6 +962,33 @@ Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::Fro
   epochDate: Integer[1];
   d : Date[1];
 }
+
+Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionSource
+{
+  a : meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionA[1];
+  b : meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionB[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionA
+{
+  fld : String[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionB 
+{
+  fld : String[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::shared::dest::UnionTarget 
+{
+  c : meta::pure::mapping::modelToModel::test::shared::dest::UnionC[*];
+}
+
+Class meta::pure::mapping::modelToModel::test::shared::dest::UnionC 
+{
+  fld : String[1];
+}
+
 
 ###Mapping 
 import meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::*;
@@ -1135,4 +1186,33 @@ Mapping meta::pure::mapping::modelToModel::test::alloy::simple::simpleModelMappi
    }
 )
 
+Mapping meta::pure::mapping::modelToModel::test::alloy::M
+(
+  *meta::pure::mapping::modelToModel::test::shared::dest::UnionTarget : Pure
+  {
+    ~src meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionSource 
+    c[c1] : $src.a ,
+    c[c2] : $src.b 
 
+  }
+
+  *meta::pure::mapping::modelToModel::test::shared::dest::UnionC[c_value] : Operation 
+  {
+    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(c1,c2)
+  }
+
+  meta::pure::mapping::modelToModel::test::shared::dest::UnionC[c1] : Pure 
+  {
+    ~src meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionA
+    ~filter $src.fld->isNotEmpty()
+    fld : $src.fld+'_a'
+  }
+
+  meta::pure::mapping::modelToModel::test::shared::dest::UnionC[c2] : Pure 
+  {
+    ~src meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::UnionB
+    fld : $src.fld+'_b'
+  }
+
+
+)


### PR DESCRIPTION
#### What type of PR is this?
Bugfix

#### What does this PR do / why is it needed ?

Fixes sourcetree calculation in certain cases involving union and mapping filters. 
When performing a union on two classes with properties of the same name, if one mapping in the union has a filter then we incorrectly duplicate properties in parts of the source tree


#### Does this PR introduce a user-facing change?
No