### PR TITLE
Move H2 pure to sql now function to localtimestamp

### DIFF
--- a/legend-engine-xt-relationalStore-javaPlatformBinding-pure/src/main/resources/core_relational_java_platform_binding/legendJavaPlatformBinding/executionPlanTest.pure
+++ b/legend-engine-xt-relationalStore-javaPlatformBinding-pure/src/main/resources/core_relational_java_platform_binding/legendJavaPlatformBinding/executionPlanTest.pure
@@ -79,7 +79,7 @@ function <<test.Test>> meta::relational::executionPlan::platformBinding::legendJ
    '    (\n'+
    '      type = TDS[(firstName, String, VARCHAR(200), "")]\n'+
    '      resultColumns = [("firstName", VARCHAR(200))]\n' +
-   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, current_timestamp())\n'+
+   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, localtimestamp())\n'+
    '      connection = TestDatabaseConnection(type = "H2")\n'+
    '    )\n'+
    '  )\n'+
@@ -117,7 +117,7 @@ function <<test.Test>> meta::relational::executionPlan::platformBinding::legendJ
    '    (\n' +
    '      type = TDS[(firstName, String, VARCHAR(200), "")]\n' +
    '      resultColumns = [("firstName", VARCHAR(200))]\n' +
-   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, current_timestamp())\n' +
+   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, localtimestamp())\n' +
    '      connection = TestDatabaseConnection(type = "H2")\n' +
    '    )\n' +
    '  )\n' +
@@ -292,7 +292,7 @@ function <<test.Test>> meta::relational::executionPlan::platformBinding::legendJ
    '    (\n'+
    '      type = TDS[(firstName, String, VARCHAR(200), "")]\n'+
    '      resultColumns = [("firstName", VARCHAR(200))]\n' +
-   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, current_timestamp())\n'+
+   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, localtimestamp())\n'+
    '      connection = TestDatabaseConnection(type = "H2")\n'+
    '    )\n'+
    '  )\n'+
@@ -330,7 +330,7 @@ function <<test.Test>> meta::relational::executionPlan::platformBinding::legendJ
    '    (\n' +
    '      type = TDS[(firstName, String, VARCHAR(200), "")]\n' +
    '      resultColumns = [("firstName", VARCHAR(200))]\n' +
-   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, current_timestamp())\n' +
+   '      sql = select "root".FIRSTNAME as "firstName" from personTable as "root" where \'${x}\' > dateadd(DAY, -1, localtimestamp())\n' +
    '      connection = TestDatabaseConnection(type = "H2")\n' +
    '    )\n' +
    '  )\n' +

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/projection/testDateFilters.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/projection/testDateFilters.pure
@@ -33,7 +33,7 @@ function <<test.Test>> meta::relational::tests::projection::filter::dates::now::
    let query = {|Trade.all()->filter(d | $d.date == now())->project(x | $x.date, 'date')};
 
    let h2Sql = toSQLString($query, simpleRelationalMapping, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select "root".tradeDate as "date" from tradeTable as "root" where "root".tradeDate = current_timestamp()', $h2Sql);
+   assertEquals('select "root".tradeDate as "date" from tradeTable as "root" where "root".tradeDate = localtimestamp()', $h2Sql);
    
    let prestoSql = toSQLString($query, simpleRelationalMapping, meta::relational::runtime::DatabaseType.Presto, meta::relational::extension::relationalExtensions());
    assertEquals('select "root".tradeDate as "date" from tradeTable as "root" where "root".tradeDate = current_timestamp', $prestoSql);

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -796,7 +796,7 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testM
 {
    // Note: Using now in test deliberately to safegaurd change in sql gen flow. Since change depends on variable date hence not asserting on values but sql
    let result = execute(|Product.all(%2015-8-15)->filter(p|$p.orders.orderDate->toOne() < now())->project([p|$p.name],['name']), milestoningmap, testRuntime(), meta::relational::extension::relationalExtensions(), noDebug());
-   assertSameSQL('select "root".name as "name" from ProductTable as "root" left outer join OrderTable as "ordertable_0" on ("ordertable_0".prodFk = "root".id) where "ordertable_0".orderDate < current_timestamp() and "root".from_z <= \'2015-08-15\' and "root".thru_z > \'2015-08-15\'', $result);
+   assertSameSQL('select "root".name as "name" from ProductTable as "root" left outer join OrderTable as "ordertable_0" on ("ordertable_0".prodFk = "root".id) where "ordertable_0".orderDate < localtimestamp() and "root".from_z <= \'2015-08-15\' and "root".thru_z > \'2015-08-15\'', $result);
 }
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testFilterOnView():Boolean[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/tests/testPureToSql.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/tests/testPureToSql.pure
@@ -250,7 +250,7 @@ meta::relational::tests::functions::pureToSqlQuery::simpleFunctionExpressionTran
    let sql_string = $sql->meta::relational::functions::sqlQueryToString::sqlQueryToString(meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
 
 
-   assertEquals('select current_timestamp()', $sql_string);
+   assertEquals('select localtimestamp()', $sql_string);
 }
 
 function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::simpleFunctionExpressionTranslationAdjust() : Boolean[1]
@@ -264,7 +264,7 @@ function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::simpl
    let sql = meta::relational::functions::pureToSqlQuery::toSQLQuery($fe, $mapping, ^Map<String,List<Any>>() , [], noDebug(), meta::relational::extension::relationalExtensions());
    let sql_string = $sql->meta::relational::functions::sqlQueryToString::sqlQueryToString(meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
 
-   assertEquals('select dateadd(MONTH, 1, current_timestamp())', $sql_string);
+   assertEquals('select dateadd(MONTH, 1, localtimestamp())', $sql_string);
 }
 
 function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::addDriverTablePkForProject() : Boolean[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension.pure
@@ -81,7 +81,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::g
     dynaFnToSql('month',                  $allStates,            ^ToSql(format='month(%s)')),
     dynaFnToSql('monthNumber',            $allStates,            ^ToSql(format='month(%s)')),
     dynaFnToSql('mostRecentDayOfWeek',    $allStates,            ^ToSql(format='dateadd(DAY, case when %s - DAY_OF_WEEK(%s) > 0 then %s - DAY_OF_WEEK(%s) - 7 else %s - DAY_OF_WEEK(%s) end, %s)', transform={p:String[1..2] | $p->formatMostRecentH2('current_date()')}, parametersWithinWhenClause = [false, false])),
-    dynaFnToSql('now',                    $allStates,            ^ToSql(format='current_timestamp()')),
+    dynaFnToSql('now',                    $allStates,            ^ToSql(format='localtimestamp()')),
     dynaFnToSql('parseDate',              $allStates,            ^ToSql(format='parsedatetime(%s,%s)')),
     dynaFnToSql('parseDecimal',           $allStates,            ^ToSql(format='cast(%s as decimal)')),
     dynaFnToSql('parseFloat',             $allStates,            ^ToSql(format='cast(%s as float)')),

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testTDSProject.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testTDSProject.pure
@@ -319,7 +319,7 @@ function <<test.Test>> meta::relational::tests::tds::tdsProject::testProjectEnum
    assertEquals('Peter|true,John|true,John|true,Anthony|true,Fabrice|true,Oliver|true,David|true',
       $tds.rows->map(r|$r.values->makeString('|'))->makeString(','));
    
-   assertEquals('select "root".FIRSTNAME as "firstName", dateadd(DAY, 1, current_timestamp()) > current_timestamp() as "tomorrowGreaterThanToday" from personTable as "root"', 
+   assertEquals('select "root".FIRSTNAME as "firstName", dateadd(DAY, 1, localtimestamp()) > localtimestamp() as "tomorrowGreaterThanToday" from personTable as "root"',
       $result->sqlRemoveFormatting());   
 }
 
@@ -345,7 +345,7 @@ function <<test.Test>> meta::relational::tests::tds::tdsProject::testProjectWith
    assertEquals('Peter|true,John|true,John|true,Anthony|true,Fabrice|true,Oliver|true,David|true',
       $tds.rows->map(r|$r.values->makeString('|'))->makeString(','));
    
-   assertEquals('select "root".FIRSTNAME as "firstName", dateadd(DAY, 1, current_timestamp()) > current_timestamp() as "tomorrowGreaterThanToday" from personTable as "root"', 
+   assertEquals('select "root".FIRSTNAME as "firstName", dateadd(DAY, 1, localtimestamp()) > localtimestamp() as "tomorrowGreaterThanToday" from personTable as "root"',
       $result->sqlRemoveFormatting());   
 }
 

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/join/testMappingAssociationToAdvancedJoin.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/join/testMappingAssociationToAdvancedJoin.pure
@@ -117,7 +117,7 @@ function <<test.Test>> meta::relational::tests::mapping::join::testMultipleJoins
    assertSameElements(['Row1', 'Row2', 'Row3'], $result.values.tableProperty);
    assertSameElements(['Row1A', 'Row2A', 'Row3A'], $result.values.propertyTableA);
    assertSameElements(['Row1B', 'Row2B', 'Row3B'], $result.values.propertyTableB);
-   assertSameSQL('select "root".ID as "pk_0", "root".TypeProperty as "tableProperty", "typetablea_0".TypePropertyA as "propertyTableA", "typetableb_0".TypePropertyB as "propertyTableB" from TypeTable as "root" left outer join TypeTableA as "typetablea_0" on ("root".ID = "typetablea_0".ID) left outer join TypeTableB as "typetableb_0" on ("root".ID = "typetableb_0".ID and "typetableb_0".IN_Z <= current_timestamp() and current_timestamp() < "typetableb_0".OUT_Z)', $result);
+   assertSameSQL('select "root".ID as "pk_0", "root".TypeProperty as "tableProperty", "typetablea_0".TypePropertyA as "propertyTableA", "typetableb_0".TypePropertyB as "propertyTableB" from TypeTable as "root" left outer join TypeTableA as "typetablea_0" on ("root".ID = "typetablea_0".ID) left outer join TypeTableB as "typetableb_0" on ("root".ID = "typetableb_0".ID and "typetableb_0".IN_Z <= localtimestamp() and localtimestamp() < "typetableb_0".OUT_Z)', $result);
 }
 
 function <<test.Test>> meta::relational::tests::mapping::join::testMultipleJoinsInPropertyMappingWithDatesInClass():Boolean[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
@@ -489,7 +489,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffYears']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(year,"root".settlementDateTime,current_timestamp()) as "DiffYears" from tradeTable as "root"', $result);
+   assertEquals('select datediff(year,"root".settlementDateTime,localtimestamp()) as "DiffYears" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInYears():Boolean[1]
@@ -529,7 +529,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffMonths']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(month,"root".settlementDateTime,current_timestamp()) as "DiffMonths" from tradeTable as "root"', $result);
+   assertEquals('select datediff(month,"root".settlementDateTime,localtimestamp()) as "DiffMonths" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInMonths():Boolean[1]
@@ -569,7 +569,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffWeeks']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(week,"root".settlementDateTime,current_timestamp()) as "DiffWeeks" from tradeTable as "root"', $result);
+   assertEquals('select datediff(week,"root".settlementDateTime,localtimestamp()) as "DiffWeeks" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInWeeks():Boolean[1]
@@ -609,7 +609,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffDays']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(day,"root".settlementDateTime,current_timestamp()) as "DiffDays" from tradeTable as "root"', $result);
+   assertEquals('select datediff(day,"root".settlementDateTime,localtimestamp()) as "DiffDays" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInDays():Boolean[1]
@@ -649,7 +649,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffHours']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(hour,"root".settlementDateTime,current_timestamp()) as "DiffHours" from tradeTable as "root"', $result);
+   assertEquals('select datediff(hour,"root".settlementDateTime,localtimestamp()) as "DiffHours" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInHours():Boolean[1]
@@ -689,7 +689,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffMinutes']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(minute,"root".settlementDateTime,current_timestamp()) as "DiffMinutes" from tradeTable as "root"', $result);
+   assertEquals('select datediff(minute,"root".settlementDateTime,localtimestamp()) as "DiffMinutes" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInMinutes():Boolean[1]
@@ -729,7 +729,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffSeconds']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(second,"root".settlementDateTime,current_timestamp()) as "DiffSeconds" from tradeTable as "root"', $result);
+   assertEquals('select datediff(second,"root".settlementDateTime,localtimestamp()) as "DiffSeconds" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInSeconds():Boolean[1]
@@ -769,7 +769,7 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenera
                                                   ],
                                                   ['DiffMilliseconds']),
                             simpleRelationalMapping, DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assertEquals('select datediff(millisecond,"root".settlementDateTime,current_timestamp()) as "DiffMilliseconds" from tradeTable as "root"', $result);
+   assertEquals('select datediff(millisecond,"root".settlementDateTime,localtimestamp()) as "DiffMilliseconds" from tradeTable as "root"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testGenerateDateDiffExpressionForPrestoForDifferenceInMilliseconds():Boolean[1]


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

This is required to fully move to H2 in a way that aligns on how legend-pure processes results.  

current_timestamp started to return TIMESTAMP_WITH_TIMEZONE on version 1.4.200.  In legend-pure, this jdbc type is not supported.  To keep behavior as before the upgrade, we need to move to new localtimestamp() function.  

More on H2 changes here: https://github.com/h2database/h2database/pull/1181/files#diff-3feca51e0a32b2066c2b1df4d03d0816267e84a9e6c12b6f7d0ddd3eb54107f6R25

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
