### PR TITLE
Load mongo extensions via PlanGeneratorExtension interface

### DIFF
--- a/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
+++ b/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
@@ -388,6 +388,7 @@ public class TestExtensions
                 .with("core_configuration")
                 .with("core_elasticsearch_seven_metamodel")
                 .with("core_nonrelational_mongodb")
+                .with("core_nonrelational_mongodb_java_platform_binding")
                 ;
     }
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/README.md
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/README.md
@@ -23,7 +23,7 @@
     - Click "Apply"
 - Run MongoTestServerInvoker.java
   - By running this, a dockerized mongo db spins up, and contains the data from this file: src/test/resources/mongoData/person.json
-  - After running the MongoTestServerInvoker, in the console you will see the Running port. You will need to use this port when running the execute
+  - After running the MongoTestServerInvoker, in the console you will see the Running port. You will need to use this port when running the execute function in the welcome.pure
 - Use the welcome.pure pasted on the section below to execute the query. Change the port variable on welcome.pure with the port that the MongoTestServerInvoker generated on the previous step
 
 #### Welcome.pure
@@ -69,9 +69,10 @@
         $personQuery,
         [],
         $executionContext,
-        meta::external::store::mongodb::extension::mongoDBExtensions()->concatenate(meta::external::format::json::extension::jsonSchemaFormatExtension())
-      )->meta::json::parseJSON()->meta::json::toPrettyJSONString();
-      println($result);
+        meta::external::store::mongodb::executionPlan::platformBinding::legendJava::mongoDBLegendJavaPlatformBindingExtensions()
+      );
+      println($result->meta::json::parseJSON()->meta::json::toPrettyJSONString());
+
     }
 </div>
 </div>

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/pom.xml
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/pom.xml
@@ -26,23 +26,25 @@
     <packaging>jar</packaging>
     <name>Legend Engine - XT - Non-Relational Store - MongoDB - Grammar Integration</name>
 
-    <build><plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-                <execution>
-                    <id>dependency-analyze</id>
-                    <configuration>
-                        <!-- The dependency plugin analyzer raises these as false positives -->
-                        <ignoredUnusedDeclaredDependencies>
-                            <dependency>org.finos.legend.pure:legend-pure-runtime-java-engine-compiled</dependency>
-                        </ignoredUnusedDeclaredDependencies>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
-    </plugins></build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dependency-analyze</id>
+                        <configuration>
+                            <!-- The dependency plugin analyzer raises these as false positives -->
+                            <ignoredUnusedDeclaredDependencies>
+                                <dependency>org.finos.legend.pure:legend-pure-runtime-java-engine-compiled</dependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <!-- ENGINE -->
         <dependency>
@@ -75,6 +77,10 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-shared-core</artifactId>
         </dependency>
         <dependency>
@@ -96,6 +102,14 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-code-compiled-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-javaPlatformBinding-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-javaPlatformBinding-pure</artifactId>
         </dependency>
         <!-- ENGINE -->
 

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/pom.xml
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/pom.xml
@@ -103,14 +103,6 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-code-compiled-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-json-javaPlatformBinding-pure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-javaPlatformBinding-pure</artifactId>
-        </dependency>
         <!-- ENGINE -->
 
         <!-- Pure -->

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/plan/MongoDBPlanGeneratorExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/plan/MongoDBPlanGeneratorExtension.java
@@ -15,13 +15,14 @@
 package org.finos.legend.engine.language.pure.grammar.integration.plan;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.list.mutable.FastList;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
-import org.finos.legend.pure.generated.core_nonrelational_mongodb_extensions_extensions;
+import org.finos.legend.pure.generated.core_external_format_json_java_platform_binding_legendJavaPlatformBinding_descriptor;
+import org.finos.legend.pure.generated.core_nonrelational_mongodb_java_platform_binding_mongodbStoreLegendJavaPlatformBindingExtension;
 
 public class MongoDBPlanGeneratorExtension implements PlanGeneratorExtension
 {
@@ -34,9 +35,18 @@ public class MongoDBPlanGeneratorExtension implements PlanGeneratorExtension
     @Override
     public RichIterable<? extends Root_meta_pure_extension_Extension> getExtraExtensions(PureModel pureModel)
     {
-        return Lists.fixedSize.of(
-                core_nonrelational_mongodb_extensions_extensions.Root_meta_external_store_mongodb_extension_mongoDBExtensions_String_1__Extension_1_("mongoDB", pureModel.getExecutionSupport())
-        );
+        return
+                core_nonrelational_mongodb_java_platform_binding_mongodbStoreLegendJavaPlatformBindingExtension.Root_meta_external_store_mongodb_executionPlan_platformBinding_legendJava_mongoDBStoreExtensionsWithLegendJavaPlatformBinding_ExternalFormatLegendJavaPlatformBindingDescriptor_MANY__Extension_MANY_(
+                        FastList.newListWith(core_external_format_json_java_platform_binding_legendJavaPlatformBinding_descriptor.Root_meta_external_format_json_executionPlan_platformBinding_legendJava_jsonSchemaJavaBindingDescriptor__ExternalFormatLegendJavaPlatformBindingDescriptor_1_(pureModel.getExecutionSupport())), pureModel.getExecutionSupport())
+                ;
     }
 }
 
+/*
+public class core_external_format_json_java_platform_binding_legendJavaPlatformBinding_descriptor
+
+meta::external::format::json::executionPlan::platformBinding::legendJava::jsonSchemaJavaBindingDescriptor()
+
+org.finos.legend.pure.generated.Root_meta_external_shared_format_executionPlan_platformBinding_legendJava_ExternalFormatLegendJavaPlatformBindingDescriptor Root_meta_external_format_json_executionPlan_platformBinding_legendJava_jsonSchemaJavaBindingDescriptor__ExternalFormatLegendJavaPlatformBindingDescriptor_1_(final ExecutionSupport es)
+
+*/

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/plan/MongoDBPlanGeneratorExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/plan/MongoDBPlanGeneratorExtension.java
@@ -16,12 +16,10 @@ package org.finos.legend.engine.language.pure.grammar.integration.plan;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
-import org.finos.legend.pure.generated.core_external_format_json_java_platform_binding_legendJavaPlatformBinding_descriptor;
 import org.finos.legend.pure.generated.core_nonrelational_mongodb_java_platform_binding_mongodbStoreLegendJavaPlatformBindingExtension;
 
 public class MongoDBPlanGeneratorExtension implements PlanGeneratorExtension
@@ -35,10 +33,7 @@ public class MongoDBPlanGeneratorExtension implements PlanGeneratorExtension
     @Override
     public RichIterable<? extends Root_meta_pure_extension_Extension> getExtraExtensions(PureModel pureModel)
     {
-        return
-                core_nonrelational_mongodb_java_platform_binding_mongodbStoreLegendJavaPlatformBindingExtension.Root_meta_external_store_mongodb_executionPlan_platformBinding_legendJava_mongoDBStoreExtensionsWithLegendJavaPlatformBinding_ExternalFormatLegendJavaPlatformBindingDescriptor_MANY__Extension_MANY_(
-                        FastList.newListWith(core_external_format_json_java_platform_binding_legendJavaPlatformBinding_descriptor.Root_meta_external_format_json_executionPlan_platformBinding_legendJava_jsonSchemaJavaBindingDescriptor__ExternalFormatLegendJavaPlatformBindingDescriptor_1_(pureModel.getExecutionSupport())), pureModel.getExecutionSupport())
-                ;
+        return core_nonrelational_mongodb_java_platform_binding_mongodbStoreLegendJavaPlatformBindingExtension.Root_meta_external_store_mongodb_executionPlan_platformBinding_legendJava_mongoDBLegendJavaPlatformBindingExtensions__Extension_MANY_(pureModel.getExecutionSupport());
     }
 }
 

--- a/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
@@ -115,15 +115,18 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
    )
 }
 
-function meta::external::store::mongodb::executionPlan::platformBinding::legendJava::mongoDBStoreExtensionsWithLegendJavaPlatformBinding(externalFormatDescriptors: meta::external::shared::format::executionPlan::platformBinding::legendJava::ExternalFormatLegendJavaPlatformBindingDescriptor[*]): Extension[*]
+function meta::external::store::mongodb::executionPlan::platformBinding::legendJava::mongoDBLegendJavaPlatformBindingExtensions(): Extension[*]
 {
-   meta::external::store::mongodb::extension::mongoDBExtensions()->concatenate(
-      meta::pure::executionPlan::platformBinding::platformBindingExtension([
-         meta::pure::executionPlan::platformBinding::legendJava::legendJavaPlatformBinding([
-            meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::inMemoryLegendJavaPlatformBindingExtension(),
-            meta::external::store::mongodb::executionPlan::platformBinding::legendJava::mongoDBStoreLegendJavaPlatformBindingExtension(),
-            meta::external::shared::format::executionPlan::platformBinding::legendJava::bindingLegendJavaPlatformBindingExtension($externalFormatDescriptors)
-         ])
-      ])
-   )
+//Pulls together store extension + PlatformBinding extension to a single method.
+  [
+  meta::external::store::mongodb::extension::mongoDBExtensions('mongoDB'),
+  meta::external::format::json::extension::jsonSchemaFormatExtension(),
+  meta::pure::executionPlan::platformBinding::platformBindingExtension([
+    meta::pure::executionPlan::platformBinding::legendJava::legendJavaPlatformBinding([
+      meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::inMemoryLegendJavaPlatformBindingExtension(),
+      meta::external::store::mongodb::executionPlan::platformBinding::legendJava::mongoDBStoreLegendJavaPlatformBindingExtension(),
+      meta::external::shared::format::executionPlan::platformBinding::legendJava::bindingLegendJavaPlatformBindingExtension(meta::external::format::json::executionPlan::platformBinding::legendJava::jsonSchemaJavaBindingDescriptor())
+    ])
+  ])
+  ]
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/test/testSetup.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/test/testSetup.pure
@@ -225,6 +225,7 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
   let currentBinding = getSimpleBinding();
 
     // Map Fields to properties. create fields that correspond to collection representation
+    /*
     let firstName = ^meta::external::store::mongodb::metamodel::mapping::Field(
           dataType = ^meta::external::store::mongodb::metamodel::StringType(),
           argumentExpression = ^FieldPathExpression(fieldPath='firstName')
@@ -245,7 +246,7 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
     let address = ^meta::external::store::mongodb::metamodel::mapping::Field(
           dataType = ^meta::external::store::mongodb::metamodel::StringType(),
           argumentExpression = ^FieldPathExpression(fieldPath='firm.address'));
-
+    */
        let firmPropMappings = [
         ^meta::external::store::mongodb::metamodel::mapping::MongoDBPropertyMapping(
         property = $firmClass.properties->filter(p | $p.name == 'legalName')->toOne(),
@@ -282,16 +283,16 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
     let personPropMappings = [
       ^meta::external::store::mongodb::metamodel::mapping::MongoDBPropertyMapping(
         property = $domainClass.properties->filter(p | $p.name == 'firstName')->toOne(),
-        sourceSetImplementationId = 'person', targetSetImplementationId = '',
-        field = $firstName),
+        sourceSetImplementationId = 'person', targetSetImplementationId = ''),
+        // field = $firstName),
       ^meta::external::store::mongodb::metamodel::mapping::MongoDBPropertyMapping(
         property = $domainClass.properties->filter(p | $p.name == 'lastName')->toOne(),
-        sourceSetImplementationId = 'person', targetSetImplementationId = '',
-        field = $lastName),
+        sourceSetImplementationId = 'person', targetSetImplementationId = ''),
+        // field = $lastName),
         ^meta::external::store::mongodb::metamodel::mapping::MongoDBPropertyMapping(
         property = $domainClass.properties->filter(p | $p.name == 'age')->toOne(),
-        sourceSetImplementationId = 'person', targetSetImplementationId = '',
-        field = $age),
+        sourceSetImplementationId = 'person', targetSetImplementationId = ''),
+        // field = $age),
         $firmEmbeddedMongoDBSetImplementation
     ];
    

--- a/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/extensions/extensions.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/extensions/extensions.pure
@@ -15,11 +15,6 @@
 import meta::pure::extension::*;
 import meta::external::store::mongodb::extension::*;
 
-function meta::external::store::mongodb::extension::mongoDBExtensions() : meta::pure::extension::Extension[*]
-{
-   [mongoDBExtensions('mongoDB')]
-}
-
 function meta::external::store::mongodb::extension::mongoDBSerializerExtension(version:String[1]):String[1]
 {
   'meta::protocols::pure::'+$version+'::extension::store::mongodb::getMongoDBStoreExtension_String_1__SerializerExtension_1_'


### PR DESCRIPTION
#### What type of PR is this?
Improvement - Part of the fix to avoid adding Mongo-extensions to core-configuration.  The extensions are loaded via PlanGenerator interface

#### What does this PR do / why is it needed ?
Clean up extensions to a single pure function - for ease of use in welcome.pure (development purposes)
