### PR TITLE
In scanProperties, only generate debug string if printing debug info

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/lineage/scanProperties.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/lineage/scanProperties.pure
@@ -132,8 +132,7 @@ function meta::pure::lineage::scanProperties::scanProperties(vs:ValueSpecificati
 
 function <<access.private>> meta::pure::lineage::scanProperties::internal_scanProperties(vs:ValueSpecification[1], processed:Function<Any>[*], vars:Map<String,List<PropertyPathNode>>[1], scanClasses:Boolean[1], debug: meta::pure::tools::DebugContext[1]):Res[0..1]
 {
-  let varsStr= $vars->keys()->map(k| '{' + $k + ' : ' +$vars->get($k)->printPropertyNodeLists('') + '}')->makeString(', ');
-  print(if($debug.debug,|$debug.space+'Context : ' + $varsStr + '\n',|''));
+  print(if($debug.debug,|$vars->keyValues()->map(kv | '{' + $kv.first + ' : ' + $kv.second->printPropertyNodeLists('') + '}')->makeString($debug.space + 'Context : ', ', ', '\n'),|''));
 
    let res = $vs->match([
                fe:FunctionExpression[1] | print(if($debug.debug,|$debug.space+'Processing Function Expression\n',|''));


### PR DESCRIPTION
#### What type of PR is this?

Performance improvement

#### What does this PR do / why is it needed ?

Improve the performance of lineage calculation by only generating the debug string if printing debug info. By side effect, this should improve plan generation time.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

This should reduce lineage calculation time, thereby reducing plan generation time.