### PR TITLE
Updated preeval to eliminate unnecessary toOne/toOneMany

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
@@ -708,7 +708,33 @@ function <<access.private>> meta::pure::router::preeval::prevalGenericSimpleFunc
                                   modified = true
                                 );
                               }
-                            )                                                            
+                            ),
+                            pair(
+                              {theSfe:SimpleFunctionExpression[1] | ($theSfe.func == toOneMany_T_MANY__T_$1_MANY$_) && 
+                                  $theSfe.parametersValues->match([
+                                    vs:ValueSpecification[1]|$vs.multiplicity->isMultiplicityConcrete() && $vs.multiplicity->hasLowerBound()
+                                          && ($vs.multiplicity->getLowerBound() > 0), 
+                                    a:Any[*]|false
+                                  ])},
+                              {theSfe:SimpleFunctionExpression[1] |
+                                $state->printDebugWithDepth(|'Handling toOneMany');                        
+
+                                $newParamWrappers->toOne()->map(pw|^$pw(modified=true));
+                              }
+                            ),
+                            pair(
+                              {theSfe:SimpleFunctionExpression[1] | ($theSfe.func == toOne_T_MANY__T_1_) && 
+                                  $theSfe.parametersValues->match([
+                                    vs:VariableExpression[1]|$vs.multiplicity->isMultiplicityConcrete() 
+                                          && $vs.multiplicity == PureOne, 
+                                    a:Any[*]|false
+                                  ])},
+                              {theSfe:SimpleFunctionExpression[1] |
+                                $state->printDebugWithDepth(|'Handling toOne');                        
+
+                                $newParamWrappers->toOne()->map(pw|^$pw(modified=true));
+                              }                              
+                            )                                                             
                         ]);
 
                     let handler = $handlers->filter(p|$p.first->eval($newSfe))->first();

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
@@ -1054,7 +1054,7 @@ function <<test.Test>> meta::pure::router::preeval::tests::testPrerouting40b():B
 
   let expected = {|
         let x = today();
-        $x->toOne()->toOne();
+        $x;
     };
 
   assertRoundTrip($input, $expected);
@@ -1400,6 +1400,61 @@ function <<test.Test>> meta::pure::router::preeval::tests::testFilterNoSimplific
   let input = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | $p.id == true).id};
 
   let expected = {o:OrganizationalEntity[1]| $o.positions(%2023-01-01)->filter(p | $p.id == true).id};
+
+  assertRoundTrip($input, $expected);
+}
+
+
+function <<test.Test>> meta::pure::router::preeval::tests::testToOneManyElimination1():Boolean[1]
+{
+  let input = {| 'hello'->toOneMany()};
+
+  let expected = {| 'hello'};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testToOneManyElimination2():Boolean[1]
+{
+  let input = {x:String[*]| $x->toOneMany()};
+
+  let expected = $input;
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testToOneManyElimination3():Boolean[1]
+{
+  let input = {x:String[1..*]| $x->toOneMany()};
+
+  let expected = {x:String[1..*]| $x};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testToOneElimination1():Boolean[1]
+{
+  let input = {| 'hello'->toOne()};
+
+  let expected = {| 'hello'};
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testToOneElimination2():Boolean[1]
+{
+  let input = {x:String[*]| $x->toOne()};
+
+  let expected = $input;
+
+  assertRoundTrip($input, $expected);
+}
+
+function <<test.Test>> meta::pure::router::preeval::tests::testToOneElimination3():Boolean[1]
+{
+  let input = {x:String[1]| $x->toOne()};
+
+  let expected = {x:String[1..*]| $x};
 
   assertRoundTrip($input, $expected);
 }


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

eliminate unnecessary toOne/toOneMany from function expression sequences

