### PR TITLE
Compiler validation for element names

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperModelBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperModelBuilder.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
-import java.util.Collections;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.impl.factory.Lists;
@@ -60,6 +59,7 @@ import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
 import org.slf4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -194,7 +194,7 @@ public class HelperModelBuilder
     {
         if (!org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.subsumes(signatureMultiplicity, actualMultiplicity))
         {
-            throw new EngineException(errorStub + " - Multiplicity error: " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(signatureMultiplicity) + " doesn't subsumes " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(actualMultiplicity), errorSourceInformation, EngineErrorType.COMPILATION);
+            throw new EngineException(errorStub + " - Multiplicity error: " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(signatureMultiplicity) + " doesn't subsume " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(actualMultiplicity), errorSourceInformation, EngineErrorType.COMPILATION);
         }
     }
 

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.impl.utility.ListIterate;
@@ -29,13 +30,41 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Function;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Measure;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Profile;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.StereotypePtr;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.TagPtr;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.PackageableRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.SectionIndex;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
-import org.finos.legend.pure.generated.*;
+import org.finos.legend.pure.generated.Root_meta_pure_data_DataElement;
+import org.finos.legend.pure.generated.Root_meta_pure_data_DataElement_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_mapping_Mapping_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_Profile_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_Stereotype_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_Tag_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_extension_TaggedValue_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_function_ConcreteFunctionDefinition_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relationship_Association_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_section_SectionIndex;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_section_SectionIndex_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enum_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Measure_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_generics_GenericType_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_Connection;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_PackageableConnection;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_PackageableConnection_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_PackageableRuntime;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_PackageableRuntime_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_Runtime;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_Runtime_Impl;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Stereotype;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Tag;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.TaggedValue;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
@@ -61,38 +90,28 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     public PackageableElement visit(Profile profile)
     {
         String fullPath = this.context.pureModel.buildPackageString(profile._package, profile.name);
-        final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile targetProfile = new Root_meta_pure_metamodel_extension_Profile_Impl(profile.name, SourceInformationHelper.toM3SourceInformation(profile.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::extension::Profile"));
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile targetProfile = new Root_meta_pure_metamodel_extension_Profile_Impl(profile.name, SourceInformationHelper.toM3SourceInformation(profile.sourceInformation), this.context.pureModel.getClass("meta::pure::metamodel::extension::Profile"));
         this.context.pureModel.profilesIndex.put(fullPath, targetProfile);
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(profile._package);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile res = targetProfile
-                ._name(profile.name)
-                ._p_stereotypes(ListIterate.collect(profile.stereotypes, s -> new Root_meta_pure_metamodel_extension_Stereotype_Impl(s, null, context.pureModel.getClass("meta::pure::metamodel::extension::Stereotype"))._value(s)._profile(targetProfile)))
-                ._p_tags(ListIterate.collect(profile.tags, t -> new Root_meta_pure_metamodel_extension_Tag_Impl(t, null, context.pureModel.getClass("meta::pure::metamodel::extension::Tag"))._value(t)._profile(targetProfile)))
-                ._package(pack);
-        pack._childrenAdd(res);
-        return res;
+        return targetProfile
+                ._p_stereotypes(ListIterate.collect(profile.stereotypes, st -> newStereotype(targetProfile, st)))
+                ._p_tags(ListIterate.collect(profile.tags, t -> newTag(targetProfile, t)));
     }
 
     @Override
     public PackageableElement visit(Enumeration _enum)
     {
         String fullPath = this.context.pureModel.buildPackageString(_enum._package, _enum.name);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration<Object> en = new Root_meta_pure_metamodel_type_Enumeration_Impl<>(_enum.name, null, context.pureModel.getClass("meta::pure::metamodel::type::Enumeration"));
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration<Object> en = new Root_meta_pure_metamodel_type_Enumeration_Impl<>(_enum.name, null, this.context.pureModel.getClass("meta::pure::metamodel::type::Enumeration"));
         this.context.pureModel.typesIndex.put(fullPath, en);
-        final GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(en);
+        GenericType genericType = newGenericType(en);
         this.context.pureModel.typesGenericTypeIndex.put(fullPath, genericType);
-        GenericType classGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getClass("meta::pure::metamodel::type::Enumeration"))._typeArguments(Lists.fixedSize.of(genericType));
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(_enum._package);
-        pack._childrenAdd(en);
-        return en._name(_enum.name)
-                ._classifierGenericType(classGenericType)
-                ._stereotypes(ListIterate.collect(_enum.stereotypes, s -> this.context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
-                ._taggedValues(ListIterate.collect(_enum.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(this.context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.sourceInformation))._value(t.value)))
-                ._package(pack)
+        return en._classifierGenericType(newGenericType(this.context.pureModel.getClass("meta::pure::metamodel::type::Enumeration"), genericType))
+                ._stereotypes(ListIterate.collect(_enum.stereotypes, this::resolveStereotype))
+                ._taggedValues(ListIterate.collect(_enum.taggedValues, this::newTaggedValue))
                 ._values(ListIterate.collect(_enum.values, v -> new Root_meta_pure_metamodel_type_Enum_Impl(v.value, SourceInformationHelper.toM3SourceInformation(_enum.sourceInformation), null)
                         ._classifierGenericType(genericType)
-                        ._stereotypes(ListIterate.collect(v.stereotypes, s -> this.context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
-                        ._taggedValues(ListIterate.collect(v.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(this.context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.sourceInformation))._value(t.value)))
+                        ._stereotypes(ListIterate.collect(v.stereotypes, this::resolveStereotype))
+                        ._taggedValues(ListIterate.collect(v.taggedValues, this::newTaggedValue))
                         ._name(v.value)));
     }
 
@@ -100,40 +119,27 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     public PackageableElement visit(Class _class)
     {
         String fullPath = this.context.pureModel.buildPackageString(_class._package, _class.name);
-        final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> targetClass = new Root_meta_pure_metamodel_type_Class_Impl<>(_class.name, SourceInformationHelper.toM3SourceInformation(_class.sourceInformation), this.context.pureModel.getClass("meta::pure::metamodel::type::Class"));
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> targetClass = new Root_meta_pure_metamodel_type_Class_Impl<>(_class.name, SourceInformationHelper.toM3SourceInformation(_class.sourceInformation), this.context.pureModel.getClass("meta::pure::metamodel::type::Class"));
         this.context.pureModel.typesIndex.put(fullPath, targetClass);
-        final GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(targetClass);
+        GenericType genericType = newGenericType(targetClass);
         this.context.pureModel.typesGenericTypeIndex.put(fullPath, genericType);
-        GenericType classGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::metamodel::type::Class"))._typeArguments(Lists.fixedSize.of(genericType));
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(_class._package);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> res = targetClass
-                ._name(_class.name)
-                ._package(pack)
-                ._classifierGenericType(classGenericType)
-                ._stereotypes(ListIterate.collect(_class.stereotypes, s -> this.context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
-                ._taggedValues(ListIterate.collect(_class.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(this.context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value)));
-        pack._childrenAdd(res);
-        return res;
+        return targetClass._classifierGenericType(newGenericType(this.context.pureModel.getType("meta::pure::metamodel::type::Class"), genericType))
+                ._stereotypes(ListIterate.collect(_class.stereotypes, this::resolveStereotype))
+                ._taggedValues(ListIterate.collect(_class.taggedValues, this::newTaggedValue));
     }
 
     @Override
     public PackageableElement visit(Measure measure)
     {
         String fullPath = this.context.pureModel.buildPackageString(measure._package, measure.name);
-        final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure targetMeasure = new Root_meta_pure_metamodel_type_Measure_Impl(measure.name, SourceInformationHelper.toM3SourceInformation(measure.sourceInformation), null);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure targetMeasure = new Root_meta_pure_metamodel_type_Measure_Impl(measure.name, SourceInformationHelper.toM3SourceInformation(measure.sourceInformation), null);
         this.context.pureModel.typesIndex.put(fullPath, targetMeasure);
-        final GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(targetMeasure);
+        GenericType genericType = newGenericType(targetMeasure);
         this.context.pureModel.typesGenericTypeIndex.put(fullPath, genericType);
-        GenericType measureGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::metamodel::type::Measure"));
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(measure._package);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure res = targetMeasure
-                ._name(measure.name)
-                ._classifierGenericType(measureGenericType)
-                ._package(pack);
-        pack._childrenAdd(res);
+        targetMeasure._classifierGenericType(newGenericType(this.context.pureModel.getType("meta::pure::metamodel::type::Measure")));
         HelperMeasureBuilder.processUnitPackageableElementFirstPass(measure.canonicalUnit, this.context);
-        ListIterate.forEach(measure.nonCanonicalUnits, ncu -> HelperMeasureBuilder.processUnitPackageableElementFirstPass(ncu, this.context));
-        return res;
+        measure.nonCanonicalUnits.forEach(ncu -> HelperMeasureBuilder.processUnitPackageableElementFirstPass(ncu, this.context));
+        return targetMeasure;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -141,10 +147,8 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     public PackageableElement visit(Association srcAssociation)
     {
         String packageString = this.context.pureModel.buildPackageString(srcAssociation._package, srcAssociation.name);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association association = new Root_meta_pure_metamodel_relationship_Association_Impl(srcAssociation.name, null, context.pureModel.getClass("meta::pure::metamodel::relationship::Association"));
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(srcAssociation._package);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association association = new Root_meta_pure_metamodel_relationship_Association_Impl(srcAssociation.name, null, this.context.pureModel.getClass("meta::pure::metamodel::relationship::Association"));
         this.context.pureModel.associationsIndex.put(packageString, association);
-        pack._childrenAdd(association);
 
         if (srcAssociation.properties.size() != 2)
         {
@@ -154,10 +158,12 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class source = this.context.resolveClass(srcAssociation.properties.get(0).type, srcAssociation.properties.get(0).sourceInformation);
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class target = this.context.resolveClass(srcAssociation.properties.get(1).type, srcAssociation.properties.get(1).sourceInformation);
 
-        String property0Ref = this.context.pureModel.addPrefixToTypeReference(HelperModelBuilder.getElementFullPath(source, context.pureModel.getExecutionSupport()));
-        String property1Ref = this.context.pureModel.addPrefixToTypeReference(HelperModelBuilder.getElementFullPath(target, context.pureModel.getExecutionSupport()));
+        String property0Ref = this.context.pureModel.addPrefixToTypeReference(HelperModelBuilder.getElementFullPath(source, this.context.pureModel.getExecutionSupport()));
+        String property1Ref = this.context.pureModel.addPrefixToTypeReference(HelperModelBuilder.getElementFullPath(target, this.context.pureModel.getExecutionSupport()));
 
-        if (org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(source).equals("meta::pure::metamodel::type::Any") || org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(target).equals("meta::pure::metamodel::type::Any"))
+        // TODO generalize this validation to all platform/core types
+        if ("meta::pure::metamodel::type::Any".equals(org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(source)) ||
+                "meta::pure::metamodel::type::Any".equals(org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(target)))
         {
             throw new EngineException("Associations to Any are not allowed. Found in '" + packageString + "'", srcAssociation.sourceInformation, EngineErrorType.COMPILATION);
         }
@@ -178,18 +184,13 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
             org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class cl = this.context.resolveGenericType(p.returnType, p.sourceInformation)._rawType() == source ? target : source;
             return HelperModelBuilder.processQualifiedPropertyFirstPass(this.context, association, org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(cl), ctx).valueOf(p);
         });
-        for (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty<Object> q : qualifiedProperties)
-        {
-            (q._genericType()._rawType() == source ? target : source)._qualifiedPropertiesFromAssociationsAdd(q);
-        }
+        qualifiedProperties.forEach(q -> (q._genericType()._rawType() == source ? target : source)._qualifiedPropertiesFromAssociationsAdd(q));
         ctx.flushVariable("this");
-        return association._name(srcAssociation.name)
-                ._originalMilestonedProperties(ListIterate.collect(srcAssociation.originalMilestonedProperties, HelperModelBuilder.processProperty(this.context, this.context.pureModel.getGenericTypeFromIndex(srcAssociation.properties.get(0).type), association)))
+        return association._originalMilestonedProperties(ListIterate.collect(srcAssociation.originalMilestonedProperties, HelperModelBuilder.processProperty(this.context, this.context.pureModel.getGenericTypeFromIndex(srcAssociation.properties.get(0).type), association)))
                 ._properties(Lists.mutable.with(property1, property2))
                 ._qualifiedProperties(qualifiedProperties)
-                ._stereotypes(ListIterate.collect(srcAssociation.stereotypes, s -> this.context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
-                ._taggedValues(ListIterate.collect(srcAssociation.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(this.context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.sourceInformation))._value(t.value)))
-                ._package(pack);
+                ._stereotypes(ListIterate.collect(srcAssociation.stereotypes, this::resolveStereotype))
+                ._taggedValues(ListIterate.collect(srcAssociation.taggedValues, this::newTaggedValue));
     }
 
     @Override
@@ -199,24 +200,19 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
         String functionSignature = HelperModelBuilder.getSignature(function);
         String functionFullName = this.context.pureModel.buildPackageString(function._package, functionSignature);
         String functionName = this.context.pureModel.buildPackageString(function._package, HelperModelBuilder.getFunctionNameWithoutSignature(function));
-        final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition<?> targetFunc = new Root_meta_pure_metamodel_function_ConcreteFunctionDefinition_Impl<>(functionSignature, SourceInformationHelper.toM3SourceInformation(function.sourceInformation), null);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition<?> targetFunc = new Root_meta_pure_metamodel_function_ConcreteFunctionDefinition_Impl<>(functionSignature, SourceInformationHelper.toM3SourceInformation(function.sourceInformation), null);
         this.context.pureModel.functionsIndex.put(functionFullName, targetFunc);
 
         ProcessingContext ctx = new ProcessingContext("Function '" + functionFullName + "' First Pass");
 
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(function._package);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition<?> res = targetFunc
-                ._name(HelperModelBuilder.getTerseSignature(function)) // function signature here - e.g. isAfterDay_Date_1__Date_1__Boolean_1_
+        targetFunc
                 ._functionName(functionName) // function name to be used in the handler map -> meta::pure::functions::date::isAfterDay
-                ._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::metamodel::function::ConcreteFunctionDefinition"))
-                        ._typeArguments(Lists.fixedSize.of(PureModel.buildFunctionType(ListIterate.collect(function.parameters, p -> (VariableExpression) p.accept(new ValueSpecificationBuilder(this.context, Lists.mutable.empty(), ctx))), this.context.resolveGenericType(function.returnType, function.sourceInformation), this.context.pureModel.getMultiplicity(function.returnMultiplicity), context.pureModel))))
-                ._stereotypes(ListIterate.collect(function.stereotypes, s -> this.context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
-                ._taggedValues(ListIterate.collect(function.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(this.context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.sourceInformation))._value(t.value)))
-                ._package(pack);
-        HelperModelBuilder.processFunctionConstraints(function, this.context, res, ctx);
-        pack._childrenAdd(res);
+                ._classifierGenericType(newGenericType(this.context.pureModel.getType("meta::pure::metamodel::function::ConcreteFunctionDefinition"), PureModel.buildFunctionType(ListIterate.collect(function.parameters, p -> (VariableExpression) p.accept(new ValueSpecificationBuilder(this.context, Lists.mutable.empty(), ctx))), this.context.resolveGenericType(function.returnType, function.sourceInformation), this.context.pureModel.getMultiplicity(function.returnMultiplicity), this.context.pureModel)))
+                ._stereotypes(ListIterate.collect(function.stereotypes, this::resolveStereotype))
+                ._taggedValues(ListIterate.collect(function.taggedValues, this::newTaggedValue));
+        HelperModelBuilder.processFunctionConstraints(function, this.context, targetFunc, ctx);
 
-        this.context.pureModel.handlers.register(new UserDefinedFunctionHandler(this.context.pureModel, functionFullName, res,
+        this.context.pureModel.handlers.register(new UserDefinedFunctionHandler(this.context.pureModel, functionFullName, targetFunc,
                 ps -> new TypeAndMultiplicity(this.context.resolveGenericType(function.returnType, function.sourceInformation), this.context.pureModel.getMultiplicity(function.returnMultiplicity)),
                 ps ->
                 {
@@ -240,37 +236,29 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
                     }
                     return false;
                 }));
-        return res;
+        return targetFunc;
     }
 
     @Override
     public PackageableElement visit(Mapping mapping)
     {
-        final org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping pureMapping = new Root_meta_pure_mapping_Mapping_Impl(mapping.name);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping pureMapping = new Root_meta_pure_mapping_Mapping_Impl(mapping.name);
         this.context.pureModel.mappingsIndex.put(this.context.pureModel.buildPackageString(mapping._package, mapping.name), pureMapping);
-        GenericType mappingGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::mapping::Mapping"));
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(mapping._package);
-        pureMapping._name(mapping.name)
-                ._package(pack)
-                ._classifierGenericType(mappingGenericType);
-        pack._childrenAdd(pureMapping);
+        GenericType mappingGenericType = newGenericType(this.context.pureModel.getType("meta::pure::mapping::Mapping"));
+        pureMapping._classifierGenericType(mappingGenericType);
         return pureMapping;
     }
 
     @Override
     public PackageableElement visit(PackageableRuntime packageableRuntime)
     {
-        Root_meta_pure_runtime_PackageableRuntime metamodel = new Root_meta_pure_runtime_PackageableRuntime_Impl(packageableRuntime.name, null, context.pureModel.getClass("meta::pure::runtime::PackageableRuntime"));
+        Root_meta_pure_runtime_PackageableRuntime metamodel = new Root_meta_pure_runtime_PackageableRuntime_Impl(packageableRuntime.name, null, this.context.pureModel.getClass("meta::pure::runtime::PackageableRuntime"));
         this.context.pureModel.packageableRuntimesIndex.put(this.context.pureModel.buildPackageString(packageableRuntime._package, packageableRuntime.name), metamodel);
-        GenericType packageableRuntimeGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::runtime::PackageableRuntime"));
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(packageableRuntime._package);
-        metamodel._name(packageableRuntime.name)
-                ._package(pack)
-                ._classifierGenericType(packageableRuntimeGenericType);
-        pack._childrenAdd(metamodel);
+        GenericType packageableRuntimeGenericType = newGenericType(this.context.pureModel.getType("meta::pure::runtime::PackageableRuntime"));
+        metamodel._classifierGenericType(packageableRuntimeGenericType);
 
         // NOTE: the whole point of this processing is to put the Pure Runtime in an index
-        Root_meta_pure_runtime_Runtime pureRuntime = new Root_meta_pure_runtime_Runtime_Impl("Root::meta::pure::runtime::Runtime", null,  context.pureModel.getClass("meta::pure::runtime::Runtime"));
+        Root_meta_pure_runtime_Runtime pureRuntime = new Root_meta_pure_runtime_Runtime_Impl("Root::meta::pure::runtime::Runtime", null, this.context.pureModel.getClass("meta::pure::runtime::Runtime"));
         this.context.pureModel.runtimesIndex.put(this.context.pureModel.buildPackageString(packageableRuntime._package, packageableRuntime.name), pureRuntime);
 
         return metamodel;
@@ -279,13 +267,10 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     @Override
     public PackageableElement visit(PackageableConnection packageableConnection)
     {
-        Root_meta_pure_runtime_PackageableConnection metamodel = new Root_meta_pure_runtime_PackageableConnection_Impl(packageableConnection.name, null, context.pureModel.getClass("meta::pure::runtime::PackageableConnection"));
+        Root_meta_pure_runtime_PackageableConnection metamodel = new Root_meta_pure_runtime_PackageableConnection_Impl(packageableConnection.name, null, this.context.pureModel.getClass("meta::pure::runtime::PackageableConnection"));
         this.context.pureModel.packageableConnectionsIndex.put(this.context.pureModel.buildPackageString(packageableConnection._package, packageableConnection.name), metamodel);
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(packageableConnection._package);
-        metamodel._name(packageableConnection.name)._package(pack);
-        pack._childrenAdd(metamodel);
         // NOTE: the whole point of this processing is to put the Pure Connection in an index
-        final Root_meta_pure_runtime_Connection connection = packageableConnection.connectionValue.accept(new ConnectionFirstPassBuilder(this.context));
+        Root_meta_pure_runtime_Connection connection = packageableConnection.connectionValue.accept(new ConnectionFirstPassBuilder(this.context));
         this.context.pureModel.connectionsIndex.put(this.context.pureModel.buildPackageString(packageableConnection._package, packageableConnection.name), connection);
         return metamodel;
     }
@@ -293,9 +278,7 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     @Override
     public PackageableElement visit(SectionIndex sectionIndex)
     {
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(sectionIndex._package);
-        Root_meta_pure_metamodel_section_SectionIndex stub = new Root_meta_pure_metamodel_section_SectionIndex_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::section::SectionIndex"))._package(pack)._name(sectionIndex.name);
-        pack._childrenAdd(stub);
+        Root_meta_pure_metamodel_section_SectionIndex stub = new Root_meta_pure_metamodel_section_SectionIndex_Impl(sectionIndex.name, null, this.context.pureModel.getClass("meta::pure::metamodel::section::SectionIndex"));
         // NOTE: we don't really need to add section index to the PURE graph
         sectionIndex.sections.forEach(section -> section.elements.forEach(elementPath -> this.context.pureModel.sectionsIndex.putIfAbsent(elementPath, section)));
         return stub;
@@ -305,14 +288,61 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
     public PackageableElement visit(DataElement dataElement)
     {
         Root_meta_pure_data_DataElement compiled = new Root_meta_pure_data_DataElement_Impl(dataElement.name);
-        GenericType mappingGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::data::DataElement"));
-        org.finos.legend.pure.m3.coreinstance.Package pack = this.context.pureModel.getOrCreatePackage(dataElement._package);
-        compiled._name(dataElement.name)
-                ._package(pack)
-                ._classifierGenericType(mappingGenericType)
-                ._stereotypes(ListIterate.collect(dataElement.stereotypes, s -> context.resolveStereotype(s.profile, s.value, s.profileSourceInformation, s.sourceInformation)))
-                ._taggedValues(ListIterate.collect(dataElement.taggedValues, t -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(context.resolveTag(t.tag.profile, t.tag.value, t.tag.profileSourceInformation, t.tag.sourceInformation))._value(t.value)));
-        pack._childrenAdd(compiled);
-        return compiled;
+        GenericType mappingGenericType = newGenericType(this.context.pureModel.getType("meta::pure::data::DataElement"));
+        return compiled._classifierGenericType(mappingGenericType)
+                ._stereotypes(ListIterate.collect(dataElement.stereotypes, this::resolveStereotype))
+                ._taggedValues(ListIterate.collect(dataElement.taggedValues, this::newTaggedValue));
+    }
+
+    private GenericType newGenericType(Type rawType)
+    {
+        return new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+                ._rawType(rawType);
+    }
+
+    private GenericType newGenericType(Type rawType, GenericType typeArgument)
+    {
+        return newGenericType(rawType, Lists.fixedSize.with(typeArgument));
+    }
+
+    private GenericType newGenericType(Type rawType, GenericType... typeArguments)
+    {
+        return newGenericType(rawType, Lists.mutable.with(typeArguments));
+    }
+
+    private GenericType newGenericType(Type rawType, RichIterable<? extends GenericType> typeArguments)
+    {
+        return newGenericType(rawType)._typeArguments(typeArguments);
+    }
+
+    private Stereotype newStereotype(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile profile, String name)
+    {
+        return new Root_meta_pure_metamodel_extension_Stereotype_Impl(name, null, this.context.pureModel.getClass("meta::pure::metamodel::extension::Stereotype"))
+                ._value(name)
+                ._profile(profile);
+    }
+
+    private Tag newTag(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile profile, String name)
+    {
+        return new Root_meta_pure_metamodel_extension_Tag_Impl(name, null, this.context.pureModel.getClass("meta::pure::metamodel::extension::Tag"))
+                ._value(name)
+                ._profile(profile);
+    }
+
+    private TaggedValue newTaggedValue(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.TaggedValue taggedValue)
+    {
+        return new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, this.context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))
+                ._tag(resolveTag(taggedValue.tag))
+                ._value(taggedValue.value);
+    }
+
+    private Tag resolveTag(TagPtr tagPointer)
+    {
+        return this.context.resolveTag(tagPointer.profile, tagPointer.value, tagPointer.profileSourceInformation, tagPointer.sourceInformation);
+    }
+
+    private Stereotype resolveStereotype(StereotypePtr stereotypePointer)
+    {
+        return this.context.resolveStereotype(stereotypePointer.profile, stereotypePointer.value, stereotypePointer.profileSourceInformation, stereotypePointer.sourceInformation);
     }
 }

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -520,32 +520,7 @@ public class PureModel implements IPureModel
 
     private org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement processFirstPass(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
     {
-        // Validate source element name
-        String name = element.name;
-        if ((name == null) || name.isEmpty())
-        {
-            throw new EngineException("PackageableElement name may not be null or empty", element.sourceInformation, EngineErrorType.COMPILATION);
-        }
-
-        // First pass
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement result = visitWithErrorHandling(element, new PackageableElementFirstPassBuilder(getContext(element)));
-
-        // Validate and set name
-        if (!name.equals(result.getName()))
-        {
-            throw new EngineException("PackageableElement name '" + name + "' must match CoreInstance name '" + result.getName() + "'", element.sourceInformation, EngineErrorType.COMPILATION);
-        }
-        result._name(name);
-
-        // Validate and set package
-        Package pack = getOrCreatePackage(element._package);
-        if (pack._children().anySatisfy(c -> name.equals(c._name())))
-        {
-            throw new EngineException("An element named '" + name + "' already exists in the package '" + element._package + "'", element.sourceInformation, EngineErrorType.COMPILATION);
-        }
-        result._package(pack);
-        pack._childrenAdd(result);
-        return result;
+        return visitWithErrorHandling(element, new PackageableElementFirstPassBuilder(getContext(element)));
     }
 
     private void processSecondPass(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
@@ -111,7 +112,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
 
 public class PureModel implements IPureModel
 {
@@ -513,9 +513,9 @@ public class PureModel implements IPureModel
         loadOtherElements(pure, p -> p.getPrerequisiteClasses().contains(PackageableConnection.class) || p.getPrerequisiteClasses().contains(PackageableRuntime.class));
     }
 
-    private void loadOtherElements(PureModelContextDataIndex pure, Predicate<Processor> filter)
+    private void loadOtherElements(PureModelContextDataIndex pure, Predicate<? super Processor<?>> filter)
     {
-        this.extensions.sortExtraProcessors(pure.otherElementsByProcessor.keysView(), filter).forEach(p ->
+        this.extensions.sortExtraProcessors(pure.otherElementsByProcessor.keysView().select(filter)).forEach(p ->
         {
             MutableList<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement> elements = pure.otherElementsByProcessor.get(p);
             elements.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -98,7 +98,6 @@ import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSu
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledProcessorSupport;
 import org.finos.legend.pure.runtime.java.compiled.execution.ConsoleCompiled;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtensionLoader;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Pure;
 import org.finos.legend.pure.runtime.java.compiled.metadata.ClassCache;
 import org.finos.legend.pure.runtime.java.compiled.metadata.FunctionCache;
 import org.finos.legend.pure.runtime.java.compiled.metadata.Metadata;
@@ -174,7 +173,7 @@ public class PureModel implements IPureModel
 
         if (classLoader == null)
         {
-            classLoader = Pure.class.getClassLoader();
+            classLoader = Thread.currentThread().getContextClassLoader();
         }
         this.deploymentMode = deploymentMode;
         this.pureModelProcessParameter = pureModelProcessParameter;
@@ -194,7 +193,7 @@ public class PureModel implements IPureModel
                     null,
                     console,
                     new FunctionCache(),
-                    new ClassCache(),
+                    new ClassCache(classLoader),
                     null,
                     Sets.mutable.empty(),
                     CompiledExtensionLoader.extensions()
@@ -232,26 +231,20 @@ public class PureModel implements IPureModel
             PureModelContextDataIndex pureModelContextDataIndex = index(pureModelContextData);
 
             // First pass -> ensure all packageable elements are resolved as early as possible.
-            pureModelContextDataIndex.sectionIndices.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.profiles.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.classes.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.enumerations.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.functions.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.measures.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.runtimes.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            pureModelContextDataIndex.dataElements.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            this.extensions.sortExtraProcessors(pureModelContextDataIndex.stores.keysView()).forEach(p ->
-            {
-                MutableList<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store> stores = pureModelContextDataIndex.stores.get(p);
-                stores.forEach(el -> this.storesIndex.putIfAbsent(this.buildPackageString(el._package, el.name), (Store) visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el)))));
-            });
-            pureModelContextDataIndex.connections.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            this.extensions.sortExtraProcessors(pureModelContextDataIndex.otherElementsByProcessor.keysView()).forEach(p ->
-            {
-                MutableList<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement> elements = pureModelContextDataIndex.otherElementsByProcessor.get(p);
-                elements.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
-            });
+            pureModelContextDataIndex.sectionIndices.forEach(this::processFirstPass);
+            pureModelContextDataIndex.profiles.forEach(this::processFirstPass);
+            pureModelContextDataIndex.classes.forEach(this::processFirstPass);
+            pureModelContextDataIndex.enumerations.forEach(this::processFirstPass);
+            pureModelContextDataIndex.functions.forEach(this::processFirstPass);
+            pureModelContextDataIndex.mappings.forEach(this::processFirstPass);
+            pureModelContextDataIndex.measures.forEach(this::processFirstPass);
+            pureModelContextDataIndex.runtimes.forEach(this::processFirstPass);
+            pureModelContextDataIndex.dataElements.forEach(this::processFirstPass);
+            this.extensions.sortExtraProcessors(pureModelContextDataIndex.stores.keysView())
+                    .forEach(p -> pureModelContextDataIndex.stores.get(p).forEach(store -> this.storesIndex.getIfAbsentPut(buildPackageString(store._package, store.name), () -> (Store) processFirstPass(store))));
+            pureModelContextDataIndex.connections.forEach(this::processFirstPass);
+            this.extensions.sortExtraProcessors(pureModelContextDataIndex.otherElementsByProcessor.keysView())
+                    .forEach(p -> pureModelContextDataIndex.otherElementsByProcessor.get(p).forEach(this::processFirstPass));
 
             this.loadTypes(pureModelContextDataIndex);
             long loadTypesFinished = System.currentTimeMillis();
@@ -323,7 +316,7 @@ public class PureModel implements IPureModel
             f.setAccessible(true);
             f.set(this.root, this.typesIndex.get("Package"));
         }
-        catch (Exception e)
+        catch (ReflectiveOperationException e)
         {
             throw new RuntimeException(e);
         }
@@ -428,11 +421,11 @@ public class PureModel implements IPureModel
 
     private void initializeMultiplicities()
     {
-        this.multiplicitiesIndex.put("zero", (PackageableMultiplicity) executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::PureZero"));
-        this.multiplicitiesIndex.put("one", (PackageableMultiplicity) executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::PureOne"));
-        this.multiplicitiesIndex.put("zeroone", (PackageableMultiplicity) executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::ZeroOne"));
-        this.multiplicitiesIndex.put("onemany", (PackageableMultiplicity) executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::OneMany"));
-        this.multiplicitiesIndex.put("zeromany", (PackageableMultiplicity) executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::ZeroMany"));
+        this.multiplicitiesIndex.put("zero", (PackageableMultiplicity) this.executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::PureZero"));
+        this.multiplicitiesIndex.put("one", (PackageableMultiplicity) this.executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::PureOne"));
+        this.multiplicitiesIndex.put("zeroone", (PackageableMultiplicity) this.executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::ZeroOne"));
+        this.multiplicitiesIndex.put("onemany", (PackageableMultiplicity) this.executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::OneMany"));
+        this.multiplicitiesIndex.put("zeromany", (PackageableMultiplicity) this.executionSupport.getMetadata(M3Paths.PackageableMultiplicity, "Root::meta::pure::metamodel::multiplicity::ZeroMany"));
     }
 
     private void initializePrimitiveTypes()
@@ -451,28 +444,28 @@ public class PureModel implements IPureModel
     private void loadTypes(PureModelContextDataIndex pure)
     {
         // Second pass
-        pure.classes.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
-        pure.measures.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
+        pure.classes.forEach(this::processSecondPass);
+        pure.measures.forEach(this::processSecondPass);
 
         // Process - associations / inheritance
         // Need to move it with the other first pass processes
-        pure.associations.forEach(el -> visitWithErrorHandling(el, new PackageableElementFirstPassBuilder(this.getContext(el))));
+        pure.associations.forEach(this::processFirstPass);
 
         // Third pass - milestoning
-        pure.classes.forEach(el -> visitWithErrorHandling(el, new PackageableElementThirdPassBuilder(this.getContext(el))));
-        pure.associations.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
+        pure.classes.forEach(this::processThirdPass);
+        pure.associations.forEach(this::processSecondPass);
 
         // Fourth pass - qualifiers
-        pure.classes.forEach(el -> visitWithErrorHandling(el, new PackageableElementFourthPassBuilder(this.getContext(el))));
-        pure.enumerations.forEach(el -> visitWithErrorHandling(el, new PackageableElementFourthPassBuilder(this.getContext(el))));
-        pure.associations.forEach(el -> visitWithErrorHandling(el, new PackageableElementThirdPassBuilder(this.getContext(el))));
-        pure.functions.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
+        pure.classes.forEach(this::processFourthPass);
+        pure.enumerations.forEach(this::processFourthPass);
+        pure.associations.forEach(this::processThirdPass);
+        pure.functions.forEach(this::processSecondPass);
     }
 
     private void loadDataElements(PureModelContextDataIndex pure)
     {
         // Second pass
-        pure.dataElements.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
+        pure.dataElements.forEach(this::processSecondPass);
     }
 
     private void loadStores(PureModelContextDataIndex pure)
@@ -480,27 +473,27 @@ public class PureModel implements IPureModel
         this.extensions.sortExtraProcessors(pure.stores.keysView()).forEach(p ->
         {
             MutableList<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store> stores = pure.stores.get(p);
-            stores.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
-            stores.forEach(el -> visitWithErrorHandling(el, new PackageableElementThirdPassBuilder(this.getContext(el))));
-            stores.forEach(el -> visitWithErrorHandling(el, new PackageableElementFourthPassBuilder(this.getContext(el))));
-            stores.forEach(el -> visitWithErrorHandling(el, new PackageableElementFifthPassBuilder(this.getContext(el))));
+            stores.forEach(this::processSecondPass);
+            stores.forEach(this::processThirdPass);
+            stores.forEach(this::processFourthPass);
+            stores.forEach(this::processFifthPass);
         });
     }
 
     public void loadMappings(PureModelContextDataIndex pure)
     {
-        pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
-        pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementThirdPassBuilder(this.getContext(el))));
-        pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementFourthPassBuilder(this.getContext(el))));
-        pure.mappings.forEach(el -> visitWithErrorHandling(el, new PackageableElementFifthPassBuilder(this.getContext(el))));
+        pure.mappings.forEach(this::processSecondPass);
+        pure.mappings.forEach(this::processThirdPass);
+        pure.mappings.forEach(this::processFourthPass);
+        pure.mappings.forEach(this::processFifthPass);
 
     }
 
     public void loadConnectionsAndRuntimes(PureModelContextDataIndex pure)
     {
         // Connections must be loaded before runtimes
-        pure.connections.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
-        pure.runtimes.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
+        pure.connections.forEach(this::processSecondPass);
+        pure.runtimes.forEach(this::processSecondPass);
     }
 
     private void loadOtherElementsPreStores(PureModelContextDataIndex pure)
@@ -518,11 +511,61 @@ public class PureModel implements IPureModel
         this.extensions.sortExtraProcessors(pure.otherElementsByProcessor.keysView().select(filter)).forEach(p ->
         {
             MutableList<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement> elements = pure.otherElementsByProcessor.get(p);
-            elements.forEach(el -> visitWithErrorHandling(el, new PackageableElementSecondPassBuilder(this.getContext(el))));
-            elements.forEach(el -> visitWithErrorHandling(el, new PackageableElementThirdPassBuilder(this.getContext(el))));
-            elements.forEach(el -> visitWithErrorHandling(el, new PackageableElementFourthPassBuilder(this.getContext(el))));
-            elements.forEach(el -> visitWithErrorHandling(el, new PackageableElementFifthPassBuilder(this.getContext(el))));
+            elements.forEach(this::processSecondPass);
+            elements.forEach(this::processThirdPass);
+            elements.forEach(this::processFourthPass);
+            elements.forEach(this::processFifthPass);
         });
+    }
+
+    private org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement processFirstPass(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
+    {
+        // Validate source element name
+        String name = element.name;
+        if ((name == null) || name.isEmpty())
+        {
+            throw new EngineException("PackageableElement name may not be null or empty", element.sourceInformation, EngineErrorType.COMPILATION);
+        }
+
+        // First pass
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement result = visitWithErrorHandling(element, new PackageableElementFirstPassBuilder(getContext(element)));
+
+        // Validate and set name
+        if (!name.equals(result.getName()))
+        {
+            throw new EngineException("PackageableElement name '" + name + "' must match CoreInstance name '" + result.getName() + "'", element.sourceInformation, EngineErrorType.COMPILATION);
+        }
+        result._name(name);
+
+        // Validate and set package
+        Package pack = getOrCreatePackage(element._package);
+        if (pack._children().anySatisfy(c -> name.equals(c._name())))
+        {
+            throw new EngineException("An element named '" + name + "' already exists in the package '" + element._package + "'", element.sourceInformation, EngineErrorType.COMPILATION);
+        }
+        result._package(pack);
+        pack._childrenAdd(result);
+        return result;
+    }
+
+    private void processSecondPass(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
+    {
+        visitWithErrorHandling(element, new PackageableElementSecondPassBuilder(getContext(element)));
+    }
+
+    private void processThirdPass(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
+    {
+        visitWithErrorHandling(element, new PackageableElementThirdPassBuilder(getContext(element)));
+    }
+
+    private void processFourthPass(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
+    {
+        visitWithErrorHandling(element, new PackageableElementFourthPassBuilder(getContext(element)));
+    }
+
+    private void processFifthPass(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
+    {
+        visitWithErrorHandling(element, new PackageableElementFifthPassBuilder(getContext(element)));
     }
 
     private <T> T visitWithErrorHandling(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element, PackageableElementVisitor<T> visitor)
@@ -657,25 +700,25 @@ public class PureModel implements IPureModel
             // Search for system types in the Pure graph
             try
             {
-                type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) executionSupport.getMetadata("meta::pure::metamodel::type::Class", "Root::" + fullPath);
+                type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) this.executionSupport.getMetadata("meta::pure::metamodel::type::Class", "Root::" + fullPath);
             }
             catch (Exception e)
             {
                 try
                 {
-                    type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) executionSupport.getMetadata("meta::pure::metamodel::type::Enumeration", "Root::" + fullPath);
+                    type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) this.executionSupport.getMetadata("meta::pure::metamodel::type::Enumeration", "Root::" + fullPath);
                 }
                 catch (Exception ee)
                 {
                     try
                     {
-                        type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) executionSupport.getMetadata("meta::pure::metamodel::type::Unit", "Root::" + fullPath);
+                        type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) this.executionSupport.getMetadata("meta::pure::metamodel::type::Unit", "Root::" + fullPath);
                     }
                     catch (Exception eee)
                     {
                         try
                         {
-                            type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) executionSupport.getMetadata("meta::pure::metamodel::type::Measure", "Root::" + fullPath);
+                            type = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) this.executionSupport.getMetadata("meta::pure::metamodel::type::Measure", "Root::" + fullPath);
                         }
                         catch (Exception ignored)
                         {
@@ -842,7 +885,7 @@ public class PureModel implements IPureModel
             // Search for system types in the Pure graph
             try
             {
-                association = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association) executionSupport.getMetadata("meta::pure::metamodel::relationship::Association", "Root::" + fullPath);
+                association = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association) this.executionSupport.getMetadata("meta::pure::metamodel::relationship::Association", "Root::" + fullPath);
             }
             catch (Exception ignored)
             {
@@ -877,9 +920,9 @@ public class PureModel implements IPureModel
         {
             try
             {
-                profile = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile) executionSupport.getMetadata("meta::pure::metamodel::extension::Profile", "Root::" + pathWithTypeReference);
+                profile = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile) this.executionSupport.getMetadata("meta::pure::metamodel::extension::Profile", "Root::" + pathWithTypeReference);
             }
-            catch (Exception e)
+            catch (Exception ignore)
             {
                 //Do Nothing
             }

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/Processor.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/Processor.java
@@ -15,10 +15,7 @@
 package org.finos.legend.engine.language.pure.compiler.toPureGraph.extension;
 
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
-import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
-import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
-import org.finos.legend.pure.m3.coreinstance.Package;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -36,18 +33,7 @@ public abstract class Processor<T extends PackageableElement>
 
     public final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement processFirstPass(PackageableElement element, CompileContext context)
     {
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pureElement = processElementFirstPass(castElement(element), context);
-        pureElement._name(element.name);
-
-        Package pack = context.pureModel.getOrCreatePackage(element._package);
-        if (pack._children().anySatisfy(c -> element.name.equals(c._name())))
-        {
-            throw new EngineException("An element named '" + element.name + "' already exists in the package '" + element._package + "'", element.sourceInformation, EngineErrorType.COMPILATION);
-        }
-
-        pureElement._package(pack);
-        pack._childrenAdd(pureElement);
-        return pureElement;
+        return processElementFirstPass(castElement(element), context);
     }
 
     public final void processSecondPass(PackageableElement element, CompileContext context)

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestAggregationAwareCompilationFromGrammar.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestAggregationAwareCompilationFromGrammar.java
@@ -16,14 +16,13 @@ package org.finos.legend.engine.language.pure.compiler.test.fromGrammar;
 
 import org.finos.legend.engine.language.pure.compiler.test.TestCompilationFromGrammar;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.InstanceSetImplementation;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyOwnerImplementationAccessor;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.aggregationAware.AggregationAwareSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.modelToModel.PureInstanceSetImplementation;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Comparator;
 
 public class TestAggregationAwareCompilationFromGrammar extends TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite
 {
@@ -50,11 +49,6 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
                 "{\n" +
                 "  salesDate: test::FiscalCalendar[1];\n" +
                 "  netRevenue: Float[1];\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::math::sum(numbers: Float[*]): Float[1]\n" +
-                "{\n" +
-                "   $numbers->plus()\n" +
                 "}\n" +
                 "\n" +
                 "\n" +
@@ -99,14 +93,7 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
                 "  }\n" +
                 ")\n").getTwo();
 
-        InstanceSetImplementation setImpl = (InstanceSetImplementation) pureModel.getMapping("test::map")._classMappings().toSortedList(new Comparator<SetImplementation>()
-        {
-            @Override
-            public int compare(SetImplementation o1, SetImplementation o2)
-            {
-                return o1._id().compareTo(o2._id());
-            }
-        }).get(0);
+        InstanceSetImplementation setImpl = (InstanceSetImplementation) pureModel.getMapping("test::map")._classMappings().minBy(PropertyOwnerImplementationAccessor::_id);
 
         Assert.assertTrue(setImpl instanceof AggregationAwareSetImplementation);
 
@@ -118,12 +105,12 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
         Assert.assertEquals("a_Main", aggSetImpl._mainSetImplementation()._id());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().size() == 1);
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().size());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification());
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._canAggregate());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._groupByFunctions().size() == 1);
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._aggregateValues().size() == 1);
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._groupByFunctions().size());
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._aggregateValues().size());
 
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._setImplementation() instanceof PureInstanceSetImplementation);
         Assert.assertEquals("a_Aggregate_0", aggSetImpl._aggregateSetImplementations().toList().get(0)._setImplementation()._id());
@@ -158,11 +145,6 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
                 "{\n" +
                 "  salesQtrFirstDate: test::FiscalCalendar[1];\n" +
                 "  netRevenue: Float[1];\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::math::sum(numbers: Float[*]): Float[1]\n" +
-                "{\n" +
-                "   $numbers->plus()\n" +
                 "}\n" +
                 "\n" +
                 "\n" +
@@ -226,14 +208,7 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
                 "  }\n" +
                 ")\n").getTwo();
 
-        InstanceSetImplementation setImpl = (InstanceSetImplementation) pureModel.getMapping("test::map")._classMappings().toSortedList(new Comparator<SetImplementation>()
-        {
-            @Override
-            public int compare(SetImplementation o1, SetImplementation o2)
-            {
-                return o1._id().compareTo(o2._id());
-            }
-        }).get(0);
+        InstanceSetImplementation setImpl = (InstanceSetImplementation) pureModel.getMapping("test::map")._classMappings().minBy(PropertyOwnerImplementationAccessor::_id);
 
         Assert.assertTrue(setImpl instanceof AggregationAwareSetImplementation);
 
@@ -245,20 +220,20 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
         Assert.assertEquals("a_Main", aggSetImpl._mainSetImplementation()._id());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().size() == 2);
+        Assert.assertEquals(2, aggSetImpl._aggregateSetImplementations().size());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification());
         Assert.assertFalse(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._canAggregate());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._groupByFunctions().size() == 2);
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._aggregateValues().size() == 1);
+        Assert.assertEquals(2, aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._groupByFunctions().size());
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._aggregateValues().size());
 
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._setImplementation() instanceof PureInstanceSetImplementation);
         Assert.assertEquals("a_Aggregate_0", aggSetImpl._aggregateSetImplementations().toList().get(0)._setImplementation()._id());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification());
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._canAggregate());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._groupByFunctions().size() == 1);
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._aggregateValues().size() == 1);
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._groupByFunctions().size());
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._aggregateValues().size());
 
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._setImplementation() instanceof PureInstanceSetImplementation);
         Assert.assertEquals("a_Aggregate_1", aggSetImpl._aggregateSetImplementations().toList().get(1)._setImplementation()._id());
@@ -293,11 +268,6 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
                 "{\n" +
                 "  salesQtrFirstDate: test::FiscalCalendar[1];\n" +
                 "  netRevenue: Float[1];\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::math::sum(numbers: Float[*]): Float[1]\n" +
-                "{\n" +
-                "   $numbers->plus()\n" +
                 "}\n" +
                 "\n" +
                 "\n" +
@@ -362,14 +332,7 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
                 "  }\n" +
                 ")\n").getTwo();
 
-        InstanceSetImplementation setImpl = (InstanceSetImplementation) pureModel.getMapping("test::map")._classMappings().toSortedList(new Comparator<SetImplementation>()
-        {
-            @Override
-            public int compare(SetImplementation o1, SetImplementation o2)
-            {
-                return o1._id().compareTo(o2._id());
-            }
-        }).get(0);
+        InstanceSetImplementation setImpl = (InstanceSetImplementation) pureModel.getMapping("test::map")._classMappings().minBy(PropertyOwnerImplementationAccessor::_id);
 
         Assert.assertTrue(setImpl instanceof AggregationAwareSetImplementation);
 
@@ -381,20 +344,20 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
         Assert.assertEquals("a_Main", aggSetImpl._mainSetImplementation()._id());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().size() == 2);
+        Assert.assertEquals(2, aggSetImpl._aggregateSetImplementations().size());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification());
         Assert.assertFalse(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._canAggregate());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._groupByFunctions().size() == 2);
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._aggregateValues().size() == 1);
+        Assert.assertEquals(2, aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._groupByFunctions().size());
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().toList().get(0)._aggregateSpecification()._aggregateValues().size());
 
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(0)._setImplementation() instanceof PureInstanceSetImplementation);
         Assert.assertEquals("a_Aggregate_0", aggSetImpl._aggregateSetImplementations().toList().get(0)._setImplementation()._id());
 
         Assert.assertNotNull(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification());
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._canAggregate());
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._groupByFunctions().size() == 1);
-        Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._aggregateValues().size() == 2);
+        Assert.assertEquals(1, aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._groupByFunctions().size());
+        Assert.assertEquals(2, aggSetImpl._aggregateSetImplementations().toList().get(1)._aggregateSpecification()._aggregateValues().size());
 
         Assert.assertTrue(aggSetImpl._aggregateSetImplementations().toList().get(1)._setImplementation() instanceof PureInstanceSetImplementation);
         Assert.assertEquals("a_Aggregate_1", aggSetImpl._aggregateSetImplementations().toList().get(1)._setImplementation()._id());
@@ -403,480 +366,420 @@ public class TestAggregationAwareCompilationFromGrammar extends TestCompilationF
     @Test
     public void testAggregationAwareMappingErrorInMainSetImplementationTarget()
     {
-        try
-        {
-            test("###Pure\n" +
-                    "Class test::Sales\n" +
-                    "{\n" +
-                    "  id: Integer[1];\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  revenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::FiscalCalendar\n" +
-                    "{\n" +
-                    "  date: Date[1];\n" +
-                    "  fiscalYear: Integer[1];\n" +
-                    "  fiscalMonth: Integer[1];\n" +
-                    "  fiscalQtr: Integer[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::Sales_By_Date\n" +
-                    "{\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  netRevenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "function meta::pure::functions::math::sum(numbers: Float[*]): Float[1]\n" +
-                    "{\n" +
-                    "   $numbers->plus()\n" +
-                    "}\n" +
-                    "\n" +
-                    "\n" +
-                    "###Mapping\n" +
-                    "Mapping test::map\n" +
-                    "(\n" +
-                    "  test::FiscalCalendar[b]: Pure\n" +
-                    "  {\n" +
-                    "    ~src test::FiscalCalendar\n" +
-                    "    date: $src.date,\n" +
-                    "    fiscalYear: $src.fiscalYear,\n" +
-                    "    fiscalMonth: $src.fiscalMonth,\n" +
-                    "    fiscalQtr: $src.fiscalQtr\n" +
-                    "  }\n" +
-                    "  test::Sales[a]: AggregationAware \n" +
-                    "  {\n" +
-                    "    Views: [\n" +
-                    "      (\n" +
-                    "        ~modelOperation: {\n" +
-                    "          ~canAggregate true,\n" +
-                    "          ~groupByFunctions (\n" +
-                    "            $this.salesDate\n" +
-                    "          ),\n" +
-                    "          ~aggregateValues (\n" +
-                    "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
-                    "          )\n" +
-                    "        },\n" +
-                    "        ~aggregateMapping: Pure\n" +
-                    "        {\n" +
-                    "          ~src test::Sales_By_Date\n" +
-                    "          salesDate[b]: $src.salesDate,\n" +
-                    "          revenue: $src.netRevenue\n" +
-                    "        }\n" +
-                    "      )\n" +
-                    "    ],\n" +
-                    "    ~mainMapping: Pure\n" +
-                    "    {\n" +
-                    "      ~src test::Sales\n" +
-                    "      salesDate[b]: $src.salesDate_NonExistent,\n" +
-                    "      revenue: $src.revenue\n" +
-                    "    }\n" +
-                    "  }\n" +
-                    ")\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Can't find property 'salesDate_NonExistent' in class 'test::Sales'", e.getMessage());
-        }
+        EngineException e = Assert.assertThrows(EngineException.class, () -> test("###Pure\n" +
+                "Class test::Sales\n" +
+                "{\n" +
+                "  id: Integer[1];\n" +
+                "  salesDate: test::FiscalCalendar[1];\n" +
+                "  revenue: Float[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::FiscalCalendar\n" +
+                "{\n" +
+                "  date: Date[1];\n" +
+                "  fiscalYear: Integer[1];\n" +
+                "  fiscalMonth: Integer[1];\n" +
+                "  fiscalQtr: Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::Sales_By_Date\n" +
+                "{\n" +
+                "  salesDate: test::FiscalCalendar[1];\n" +
+                "  netRevenue: Float[1];\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping test::map\n" +
+                "(\n" +
+                "  test::FiscalCalendar[b]: Pure\n" +
+                "  {\n" +
+                "    ~src test::FiscalCalendar\n" +
+                "    date: $src.date,\n" +
+                "    fiscalYear: $src.fiscalYear,\n" +
+                "    fiscalMonth: $src.fiscalMonth,\n" +
+                "    fiscalQtr: $src.fiscalQtr\n" +
+                "  }\n" +
+                "  test::Sales[a]: AggregationAware \n" +
+                "  {\n" +
+                "    Views: [\n" +
+                "      (\n" +
+                "        ~modelOperation: {\n" +
+                "          ~canAggregate true,\n" +
+                "          ~groupByFunctions (\n" +
+                "            $this.salesDate\n" +
+                "          ),\n" +
+                "          ~aggregateValues (\n" +
+                "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
+                "          )\n" +
+                "        },\n" +
+                "        ~aggregateMapping: Pure\n" +
+                "        {\n" +
+                "          ~src test::Sales_By_Date\n" +
+                "          salesDate[b]: $src.salesDate,\n" +
+                "          revenue: $src.netRevenue\n" +
+                "        }\n" +
+                "      )\n" +
+                "    ],\n" +
+                "    ~mainMapping: Pure\n" +
+                "    {\n" +
+                "      ~src test::Sales\n" +
+                "      salesDate[b]: $src.salesDate_NonExistent,\n" +
+                "      revenue: $src.revenue\n" +
+                "    }\n" +
+                "  }\n" +
+                ")\n"));
+        Assert.assertEquals("Can't find property 'salesDate_NonExistent' in class 'test::Sales'", e.getMessage());
     }
 
     @Test
     public void testAggregationAwareMappingErrorInMainSetImplementationProperty()
     {
-        try
-        {
-            test("###Pure\n" +
-                    "Class test::Sales\n" +
-                    "{\n" +
-                    "  id: Integer[1];\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  revenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::FiscalCalendar\n" +
-                    "{\n" +
-                    "  date: Date[1];\n" +
-                    "  fiscalYear: Integer[1];\n" +
-                    "  fiscalMonth: Integer[1];\n" +
-                    "  fiscalQtr: Integer[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::Sales_By_Date\n" +
-                    "{\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  netRevenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "function meta::pure::functions::math::sum(numbers: Float[*]): Float[1]\n" +
-                    "{\n" +
-                    "   $numbers->plus()\n" +
-                    "}\n" +
-                    "\n" +
-                    "\n" +
-                    "###Mapping\n" +
-                    "Mapping test::map\n" +
-                    "(\n" +
-                    "  test::FiscalCalendar[b]: Pure\n" +
-                    "  {\n" +
-                    "    ~src test::FiscalCalendar\n" +
-                    "    date: $src.date,\n" +
-                    "    fiscalYear: $src.fiscalYear,\n" +
-                    "    fiscalMonth: $src.fiscalMonth,\n" +
-                    "    fiscalQtr: $src.fiscalQtr\n" +
-                    "  }\n" +
-                    "  test::Sales[a]: AggregationAware \n" +
-                    "  {\n" +
-                    "    Views: [\n" +
-                    "      (\n" +
-                    "        ~modelOperation: {\n" +
-                    "          ~canAggregate true,\n" +
-                    "          ~groupByFunctions (\n" +
-                    "            $this.salesDate\n" +
-                    "          ),\n" +
-                    "          ~aggregateValues (\n" +
-                    "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
-                    "          )\n" +
-                    "        },\n" +
-                    "        ~aggregateMapping: Pure\n" +
-                    "        {\n" +
-                    "          ~src test::Sales_By_Date\n" +
-                    "          salesDate[b]: $src.salesDate,\n" +
-                    "          revenue: $src.netRevenue\n" +
-                    "        }\n" +
-                    "      )\n" +
-                    "    ],\n" +
-                    "    ~mainMapping: Pure\n" +
-                    "    {\n" +
-                    "      ~src test::Sales\n" +
-                    "      salesDate_nonExistent[b]: $src.salesDate,\n" +
-                    "      revenue: $src.revenue\n" +
-                    "    }\n" +
-                    "  }\n" +
-                    ")\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Can't find property 'salesDate_nonExistent' in [Sales, Any]", e.getMessage());
-        }
+        EngineException e = Assert.assertThrows(EngineException.class, () -> test(
+                "###Pure\n" +
+                        "Class test::Sales\n" +
+                        "{\n" +
+                        "  id: Integer[1];\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  revenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::FiscalCalendar\n" +
+                        "{\n" +
+                        "  date: Date[1];\n" +
+                        "  fiscalYear: Integer[1];\n" +
+                        "  fiscalMonth: Integer[1];\n" +
+                        "  fiscalQtr: Integer[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::Sales_By_Date\n" +
+                        "{\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  netRevenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "Mapping test::map\n" +
+                        "(\n" +
+                        "  test::FiscalCalendar[b]: Pure\n" +
+                        "  {\n" +
+                        "    ~src test::FiscalCalendar\n" +
+                        "    date: $src.date,\n" +
+                        "    fiscalYear: $src.fiscalYear,\n" +
+                        "    fiscalMonth: $src.fiscalMonth,\n" +
+                        "    fiscalQtr: $src.fiscalQtr\n" +
+                        "  }\n" +
+                        "  test::Sales[a]: AggregationAware \n" +
+                        "  {\n" +
+                        "    Views: [\n" +
+                        "      (\n" +
+                        "        ~modelOperation: {\n" +
+                        "          ~canAggregate true,\n" +
+                        "          ~groupByFunctions (\n" +
+                        "            $this.salesDate\n" +
+                        "          ),\n" +
+                        "          ~aggregateValues (\n" +
+                        "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
+                        "          )\n" +
+                        "        },\n" +
+                        "        ~aggregateMapping: Pure\n" +
+                        "        {\n" +
+                        "          ~src test::Sales_By_Date\n" +
+                        "          salesDate[b]: $src.salesDate,\n" +
+                        "          revenue: $src.netRevenue\n" +
+                        "        }\n" +
+                        "      )\n" +
+                        "    ],\n" +
+                        "    ~mainMapping: Pure\n" +
+                        "    {\n" +
+                        "      ~src test::Sales\n" +
+                        "      salesDate_nonExistent[b]: $src.salesDate,\n" +
+                        "      revenue: $src.revenue\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        ")\n"));
+        Assert.assertEquals("Can't find property 'salesDate_nonExistent' in [Sales, Any]", e.getMessage());
     }
 
     @Test
     public void testAggregationAwareMappingErrorInAggregateViewTarget()
     {
-        try
-        {
-            test("###Pure\n" +
-                    "Class test::Sales\n" +
-                    "{\n" +
-                    "  id: Integer[1];\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  revenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::FiscalCalendar\n" +
-                    "{\n" +
-                    "  date: Date[1];\n" +
-                    "  fiscalYear: Integer[1];\n" +
-                    "  fiscalMonth: Integer[1];\n" +
-                    "  fiscalQtr: Integer[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::Sales_By_Date\n" +
-                    "{\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  netRevenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "function meta::pure::functions::math::sum(numbers: Float[*]): Float[1]\n" +
-                    "{\n" +
-                    "   $numbers->plus()\n" +
-                    "}\n" +
-                    "\n" +
-                    "\n" +
-                    "###Mapping\n" +
-                    "Mapping test::map\n" +
-                    "(\n" +
-                    "  test::FiscalCalendar[b]: Pure\n" +
-                    "  {\n" +
-                    "    ~src test::FiscalCalendar\n" +
-                    "    date: $src.date,\n" +
-                    "    fiscalYear: $src.fiscalYear,\n" +
-                    "    fiscalMonth: $src.fiscalMonth,\n" +
-                    "    fiscalQtr: $src.fiscalQtr\n" +
-                    "  }\n" +
-                    "  test::Sales[a]: AggregationAware \n" +
-                    "  {\n" +
-                    "    Views: [\n" +
-                    "      (\n" +
-                    "        ~modelOperation: {\n" +
-                    "          ~canAggregate true,\n" +
-                    "          ~groupByFunctions (\n" +
-                    "            $this.salesDate\n" +
-                    "          ),\n" +
-                    "          ~aggregateValues (\n" +
-                    "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
-                    "          )\n" +
-                    "        },\n" +
-                    "        ~aggregateMapping: Pure\n" +
-                    "        {\n" +
-                    "          ~src test::Sales_By_Date\n" +
-                    "          salesDate[b]: $src.salesDate_NonExistent,\n" +
-                    "          revenue: $src.netRevenue\n" +
-                    "        }\n" +
-                    "      )\n" +
-                    "    ],\n" +
-                    "    ~mainMapping: Pure\n" +
-                    "    {\n" +
-                    "      ~src test::Sales\n" +
-                    "      salesDate[b]: $src.salesDate,\n" +
-                    "      revenue: $src.revenue\n" +
-                    "    }\n" +
-                    "  }\n" +
-                    ")\n"
-            );
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Can't find property 'salesDate_NonExistent' in class 'test::Sales_By_Date'", e.getMessage());
-        }
+        EngineException e = Assert.assertThrows(EngineException.class, () -> test(
+                "###Pure\n" +
+                        "Class test::Sales\n" +
+                        "{\n" +
+                        "  id: Integer[1];\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  revenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::FiscalCalendar\n" +
+                        "{\n" +
+                        "  date: Date[1];\n" +
+                        "  fiscalYear: Integer[1];\n" +
+                        "  fiscalMonth: Integer[1];\n" +
+                        "  fiscalQtr: Integer[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::Sales_By_Date\n" +
+                        "{\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  netRevenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "Mapping test::map\n" +
+                        "(\n" +
+                        "  test::FiscalCalendar[b]: Pure\n" +
+                        "  {\n" +
+                        "    ~src test::FiscalCalendar\n" +
+                        "    date: $src.date,\n" +
+                        "    fiscalYear: $src.fiscalYear,\n" +
+                        "    fiscalMonth: $src.fiscalMonth,\n" +
+                        "    fiscalQtr: $src.fiscalQtr\n" +
+                        "  }\n" +
+                        "  test::Sales[a]: AggregationAware \n" +
+                        "  {\n" +
+                        "    Views: [\n" +
+                        "      (\n" +
+                        "        ~modelOperation: {\n" +
+                        "          ~canAggregate true,\n" +
+                        "          ~groupByFunctions (\n" +
+                        "            $this.salesDate\n" +
+                        "          ),\n" +
+                        "          ~aggregateValues (\n" +
+                        "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
+                        "          )\n" +
+                        "        },\n" +
+                        "        ~aggregateMapping: Pure\n" +
+                        "        {\n" +
+                        "          ~src test::Sales_By_Date\n" +
+                        "          salesDate[b]: $src.salesDate_NonExistent,\n" +
+                        "          revenue: $src.netRevenue\n" +
+                        "        }\n" +
+                        "      )\n" +
+                        "    ],\n" +
+                        "    ~mainMapping: Pure\n" +
+                        "    {\n" +
+                        "      ~src test::Sales\n" +
+                        "      salesDate[b]: $src.salesDate,\n" +
+                        "      revenue: $src.revenue\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        ")\n"
+        ));
+        Assert.assertEquals("Can't find property 'salesDate_NonExistent' in class 'test::Sales_By_Date'", e.getMessage());
     }
 
     @Test
     public void testAggregationAwareMappingErrorInAggregateViewProperty()
     {
-        try
-        {
-            test(
-                    "###Pure\n" +
-                            "Class test::Sales\n" +
-                            "{\n" +
-                            "  id: Integer[1];\n" +
-                            "  salesDate: test::FiscalCalendar[1];\n" +
-                            "  revenue: Float[1];\n" +
-                            "}\n" +
-                            "\n" +
-                            "Class test::FiscalCalendar\n" +
-                            "{\n" +
-                            "  date: Date[1];\n" +
-                            "  fiscalYear: Integer[1];\n" +
-                            "  fiscalMonth: Integer[1];\n" +
-                            "  fiscalQtr: Integer[1];\n" +
-                            "}\n" +
-                            "\n" +
-                            "Class test::Sales_By_Date\n" +
-                            "{\n" +
-                            "  salesDate: test::FiscalCalendar[1];\n" +
-                            "  netRevenue: Float[1];\n" +
-                            "}\n" +
-                            "\n" +
-                            "function meta::pure::functions::math::sum(numbers: Float[*]): Float[1]\n" +
-                            "{\n" +
-                            "   $numbers->plus()\n" +
-                            "}\n" +
-                            "\n" +
-                            "\n" +
-                            "###Mapping\n" +
-                            "Mapping test::map\n" +
-                            "(\n" +
-                            "  test::FiscalCalendar[b]: Pure\n" +
-                            "  {\n" +
-                            "    ~src test::FiscalCalendar\n" +
-                            "    date: $src.date,\n" +
-                            "    fiscalYear: $src.fiscalYear,\n" +
-                            "    fiscalMonth: $src.fiscalMonth,\n" +
-                            "    fiscalQtr: $src.fiscalQtr\n" +
-                            "  }\n" +
-                            "  test::Sales[a]: AggregationAware \n" +
-                            "  {\n" +
-                            "    Views: [\n" +
-                            "      (\n" +
-                            "        ~modelOperation: {\n" +
-                            "          ~canAggregate true,\n" +
-                            "          ~groupByFunctions (\n" +
-                            "            $this.salesDate\n" +
-                            "          ),\n" +
-                            "          ~aggregateValues (\n" +
-                            "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
-                            "          )\n" +
-                            "        },\n" +
-                            "        ~aggregateMapping: Pure\n" +
-                            "        {\n" +
-                            "          ~src test::Sales_By_Date\n" +
-                            "          salesDate_NonExistent[b]: $src.salesDate,\n" +
-                            "          revenue: $src.netRevenue\n" +
-                            "        }\n" +
-                            "      )\n" +
-                            "    ],\n" +
-                            "    ~mainMapping: Pure\n" +
-                            "    {\n" +
-                            "      ~src test::Sales\n" +
-                            "      salesDate[b]: $src.salesDate,\n" +
-                            "      revenue: $src.revenue\n" +
-                            "    }\n" +
-                            "  }\n" +
-                            ")\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Can't find property 'salesDate_NonExistent' in [Sales, Any]", e.getMessage());
-        }
+        EngineException e = Assert.assertThrows(EngineException.class, () -> test(
+                "###Pure\n" +
+                        "Class test::Sales\n" +
+                        "{\n" +
+                        "  id: Integer[1];\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  revenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::FiscalCalendar\n" +
+                        "{\n" +
+                        "  date: Date[1];\n" +
+                        "  fiscalYear: Integer[1];\n" +
+                        "  fiscalMonth: Integer[1];\n" +
+                        "  fiscalQtr: Integer[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::Sales_By_Date\n" +
+                        "{\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  netRevenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "Mapping test::map\n" +
+                        "(\n" +
+                        "  test::FiscalCalendar[b]: Pure\n" +
+                        "  {\n" +
+                        "    ~src test::FiscalCalendar\n" +
+                        "    date: $src.date,\n" +
+                        "    fiscalYear: $src.fiscalYear,\n" +
+                        "    fiscalMonth: $src.fiscalMonth,\n" +
+                        "    fiscalQtr: $src.fiscalQtr\n" +
+                        "  }\n" +
+                        "  test::Sales[a]: AggregationAware \n" +
+                        "  {\n" +
+                        "    Views: [\n" +
+                        "      (\n" +
+                        "        ~modelOperation: {\n" +
+                        "          ~canAggregate true,\n" +
+                        "          ~groupByFunctions (\n" +
+                        "            $this.salesDate\n" +
+                        "          ),\n" +
+                        "          ~aggregateValues (\n" +
+                        "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
+                        "          )\n" +
+                        "        },\n" +
+                        "        ~aggregateMapping: Pure\n" +
+                        "        {\n" +
+                        "          ~src test::Sales_By_Date\n" +
+                        "          salesDate_NonExistent[b]: $src.salesDate,\n" +
+                        "          revenue: $src.netRevenue\n" +
+                        "        }\n" +
+                        "      )\n" +
+                        "    ],\n" +
+                        "    ~mainMapping: Pure\n" +
+                        "    {\n" +
+                        "      ~src test::Sales\n" +
+                        "      salesDate[b]: $src.salesDate,\n" +
+                        "      revenue: $src.revenue\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        ")\n"));
+        Assert.assertEquals("Can't find property 'salesDate_NonExistent' in [Sales, Any]", e.getMessage());
     }
 
     @Test
     public void testAggregationAwareMappingErrorInAggregateViewModelOperationGroupByFunction()
     {
-        try
-        {
-            test(
-                    "###Pure\n" +
-                            "Class test::Sales\n" +
-                            "{\n" +
-                            "  id: Integer[1];\n" +
-                            "  salesDate: test::FiscalCalendar[1];\n" +
-                            "  revenue: Float[1];\n" +
-                            "}\n" +
-                            "\n" +
-                            "Class test::FiscalCalendar\n" +
-                            "{\n" +
-                            "  date: Date[1];\n" +
-                            "  fiscalYear: Integer[1];\n" +
-                            "  fiscalMonth: Integer[1];\n" +
-                            "  fiscalQtr: Integer[1];\n" +
-                            "}\n" +
-                            "\n" +
-                            "Class test::Sales_By_Date\n" +
-                            "{\n" +
-                            "  salesDate: test::FiscalCalendar[1];\n" +
-                            "  netRevenue: Float[1];\n" +
-                            "}\n" +
-                            "\n" +
-                            "\n" +
-                            "###Mapping\n" +
-                            "Mapping test::map\n" +
-                            "(\n" +
-                            "  test::FiscalCalendar[b]: Pure\n" +
-                            "  {\n" +
-                            "    ~src test::FiscalCalendar\n" +
-                            "    date: $src.date,\n" +
-                            "    fiscalYear: $src.fiscalYear,\n" +
-                            "    fiscalMonth: $src.fiscalMonth,\n" +
-                            "    fiscalQtr: $src.fiscalQtr\n" +
-                            "  }\n" +
-                            "  test::Sales[a]: AggregationAware \n" +
-                            "  {\n" +
-                            "    Views: [\n" +
-                            "      (\n" +
-                            "        ~modelOperation: {\n" +
-                            "          ~canAggregate true,\n" +
-                            "          ~groupByFunctions (\n" +
-                            "            $this.salesDate_NonExistent\n" +
-                            "          ),\n" +
-                            "          ~aggregateValues (\n" +
-                            "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
-                            "          )\n" +
-                            "        },\n" +
-                            "        ~aggregateMapping: Pure\n" +
-                            "        {\n" +
-                            "          ~src test::Sales_By_Date\n" +
-                            "          salesDate[b]: $src.salesDate,\n" +
-                            "          revenue: $src.netRevenue\n" +
-                            "        }\n" +
-                            "      )\n" +
-                            "    ],\n" +
-                            "    ~mainMapping: Pure\n" +
-                            "    {\n" +
-                            "      ~src test::Sales\n" +
-                            "      salesDate[b]: $src.salesDate,\n" +
-                            "      revenue: $src.revenue\n" +
-                            "    }\n" +
-                            "  }\n" +
-                            ")\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Can't find property 'salesDate_NonExistent' in class 'test::Sales'", e.getMessage());
-        }
+        EngineException e = Assert.assertThrows(EngineException.class, () -> test(
+                "###Pure\n" +
+                        "Class test::Sales\n" +
+                        "{\n" +
+                        "  id: Integer[1];\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  revenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::FiscalCalendar\n" +
+                        "{\n" +
+                        "  date: Date[1];\n" +
+                        "  fiscalYear: Integer[1];\n" +
+                        "  fiscalMonth: Integer[1];\n" +
+                        "  fiscalQtr: Integer[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::Sales_By_Date\n" +
+                        "{\n" +
+                        "  salesDate: test::FiscalCalendar[1];\n" +
+                        "  netRevenue: Float[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "Mapping test::map\n" +
+                        "(\n" +
+                        "  test::FiscalCalendar[b]: Pure\n" +
+                        "  {\n" +
+                        "    ~src test::FiscalCalendar\n" +
+                        "    date: $src.date,\n" +
+                        "    fiscalYear: $src.fiscalYear,\n" +
+                        "    fiscalMonth: $src.fiscalMonth,\n" +
+                        "    fiscalQtr: $src.fiscalQtr\n" +
+                        "  }\n" +
+                        "  test::Sales[a]: AggregationAware \n" +
+                        "  {\n" +
+                        "    Views: [\n" +
+                        "      (\n" +
+                        "        ~modelOperation: {\n" +
+                        "          ~canAggregate true,\n" +
+                        "          ~groupByFunctions (\n" +
+                        "            $this.salesDate_NonExistent\n" +
+                        "          ),\n" +
+                        "          ~aggregateValues (\n" +
+                        "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->sum() )\n" +
+                        "          )\n" +
+                        "        },\n" +
+                        "        ~aggregateMapping: Pure\n" +
+                        "        {\n" +
+                        "          ~src test::Sales_By_Date\n" +
+                        "          salesDate[b]: $src.salesDate,\n" +
+                        "          revenue: $src.netRevenue\n" +
+                        "        }\n" +
+                        "      )\n" +
+                        "    ],\n" +
+                        "    ~mainMapping: Pure\n" +
+                        "    {\n" +
+                        "      ~src test::Sales\n" +
+                        "      salesDate[b]: $src.salesDate,\n" +
+                        "      revenue: $src.revenue\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        ")\n"));
+        Assert.assertEquals("Can't find property 'salesDate_NonExistent' in class 'test::Sales'", e.getMessage());
     }
 
     @Test
     public void testAggregationAwareMappingErrorInAggregateViewModelOperationAggregateFunction()
     {
-        try
-        {
-            test("###Pure\n" +
-                    "Class test::Sales\n" +
-                    "{\n" +
-                    "  id: Integer[1];\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  revenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::FiscalCalendar\n" +
-                    "{\n" +
-                    "  date: Date[1];\n" +
-                    "  fiscalYear: Integer[1];\n" +
-                    "  fiscalMonth: Integer[1];\n" +
-                    "  fiscalQtr: Integer[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class test::Sales_By_Date\n" +
-                    "{\n" +
-                    "  salesDate: test::FiscalCalendar[1];\n" +
-                    "  netRevenue: Float[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "\n" +
-                    "###Mapping\n" +
-                    "Mapping test::map\n" +
-                    "(\n" +
-                    "  test::FiscalCalendar[b]: Pure\n" +
-                    "  {\n" +
-                    "    ~src test::FiscalCalendar\n" +
-                    "    date: $src.date,\n" +
-                    "    fiscalYear: $src.fiscalYear,\n" +
-                    "    fiscalMonth: $src.fiscalMonth,\n" +
-                    "    fiscalQtr: $src.fiscalQtr\n" +
-                    "  }\n" +
-                    "  test::Sales[a]: AggregationAware \n" +
-                    "  {\n" +
-                    "    Views: [\n" +
-                    "      (\n" +
-                    "        ~modelOperation: {\n" +
-                    "          ~canAggregate true,\n" +
-                    "          ~groupByFunctions (\n" +
-                    "            $this.salesDate\n" +
-                    "          ),\n" +
-                    "          ~aggregateValues (\n" +
-                    "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->summation() )\n" +
-                    "          )\n" +
-                    "        },\n" +
-                    "        ~aggregateMapping: Pure\n" +
-                    "        {\n" +
-                    "          ~src test::Sales_By_Date\n" +
-                    "          salesDate[b]: $src.salesDate,\n" +
-                    "          revenue: $src.netRevenue\n" +
-                    "        }\n" +
-                    "      )\n" +
-                    "    ],\n" +
-                    "    ~mainMapping: Pure\n" +
-                    "    {\n" +
-                    "      ~src test::Sales\n" +
-                    "      salesDate[b]: $src.salesDate,\n" +
-                    "      revenue: $src.revenue\n" +
-                    "    }\n" +
-                    "  }\n" +
-                    ")\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Can't resolve the builder for function 'summation' - stack:[Lambda, new lambda, Applying summation]", e.getMessage());
-        }
+        EngineException e = Assert.assertThrows(EngineException.class, () -> test("###Pure\n" +
+                "Class test::Sales\n" +
+                "{\n" +
+                "  id: Integer[1];\n" +
+                "  salesDate: test::FiscalCalendar[1];\n" +
+                "  revenue: Float[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::FiscalCalendar\n" +
+                "{\n" +
+                "  date: Date[1];\n" +
+                "  fiscalYear: Integer[1];\n" +
+                "  fiscalMonth: Integer[1];\n" +
+                "  fiscalQtr: Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::Sales_By_Date\n" +
+                "{\n" +
+                "  salesDate: test::FiscalCalendar[1];\n" +
+                "  netRevenue: Float[1];\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping test::map\n" +
+                "(\n" +
+                "  test::FiscalCalendar[b]: Pure\n" +
+                "  {\n" +
+                "    ~src test::FiscalCalendar\n" +
+                "    date: $src.date,\n" +
+                "    fiscalYear: $src.fiscalYear,\n" +
+                "    fiscalMonth: $src.fiscalMonth,\n" +
+                "    fiscalQtr: $src.fiscalQtr\n" +
+                "  }\n" +
+                "  test::Sales[a]: AggregationAware \n" +
+                "  {\n" +
+                "    Views: [\n" +
+                "      (\n" +
+                "        ~modelOperation: {\n" +
+                "          ~canAggregate true,\n" +
+                "          ~groupByFunctions (\n" +
+                "            $this.salesDate\n" +
+                "          ),\n" +
+                "          ~aggregateValues (\n" +
+                "            ( ~mapFn:$this.revenue , ~aggregateFn: $mapped->summation() )\n" +
+                "          )\n" +
+                "        },\n" +
+                "        ~aggregateMapping: Pure\n" +
+                "        {\n" +
+                "          ~src test::Sales_By_Date\n" +
+                "          salesDate[b]: $src.salesDate,\n" +
+                "          revenue: $src.netRevenue\n" +
+                "        }\n" +
+                "      )\n" +
+                "    ],\n" +
+                "    ~mainMapping: Pure\n" +
+                "    {\n" +
+                "      ~src test::Sales\n" +
+                "      salesDate[b]: $src.salesDate,\n" +
+                "      revenue: $src.revenue\n" +
+                "    }\n" +
+                "  }\n" +
+                ")\n"));
+        Assert.assertEquals("Can't resolve the builder for function 'summation' - stack:[Lambda, new lambda, Applying summation]", e.getMessage());
     }
 
     @Override

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -1422,7 +1422,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "{\n" +
                 "   names : String[*];\n" +
                 "   prop() {$this.names} : String[1];\n" +
-                "}", "COMPILATION error at [4:18-22]: Error in derived property 'A.prop' - Multiplicity error: [1] doesn't subsumes [*]");
+                "}", "COMPILATION error at [4:18-22]: Error in derived property 'A.prop' - Multiplicity error: [1] doesn't subsume [*]");
     }
 
     @Test

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestMappingCompilationFromGrammar.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestMappingCompilationFromGrammar.java
@@ -998,7 +998,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "   {\n" +
                 "       lastName : ['1', '2']\n" +
                 "   }\n" +
-                ")", "COMPILATION error at [7:19-28]: Error in class mapping 'a::mapping' for property 'lastName' - Multiplicity error: [1] doesn't subsumes [2]");
+                ")", "COMPILATION error at [7:19-28]: Error in class mapping 'a::mapping' for property 'lastName' - Multiplicity error: [1] doesn't subsume [2]");
     }
 
     @Test
@@ -2041,7 +2041,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "    lastName: $src.fullName->substring($src.fullName->indexOf(' ') + 1, $src.fullName->length()),\n" +
                 "    firm: $src.firm\n" +
                 "  }\n" +
-                ")\n", "COMPILATION error at [26:16-19]: Error in class mapping 'test::Mapping' for property 'firm' - Multiplicity error: [1] doesn't subsumes [*]");
+                ")\n", "COMPILATION error at [26:16-19]: Error in class mapping 'test::Mapping' for property 'firm' - Multiplicity error: [1] doesn't subsume [*]");
 
         test("###Pure\n" +
                 "Class test::dest::Person\n" +

--- a/legend-engine-language-pure-compiler/src/test/resources/functionExample.json
+++ b/legend-engine-language-pure-compiler/src/test/resources/functionExample.json
@@ -22,7 +22,7 @@
           ]
         }
       ],
-      "name": "func1",
+      "name": "func1__Date_1_",
       "package": "model::domain::test",
       "parameters": [],
       "postConstraints": [],
@@ -58,7 +58,7 @@
           }
         }
       ],
-      "name": "func2",
+      "name": "func2__Date_1_",
       "package": "model::domain::test",
       "parameters": [],
       "postConstraints": [],

--- a/legend-engine-language-pure-compiler/src/test/resources/functionWithLambdaVariable.json
+++ b/legend-engine-language-pure-compiler/src/test/resources/functionWithLambdaVariable.json
@@ -82,7 +82,7 @@
           }
         }
       ],
-      "name": "funcx",
+      "name": "funcx__Any_MANY_",
       "package": "test",
       "parameters": [],
       "postConstraints": [],

--- a/legend-engine-language-pure-compiler/src/test/resources/queryWithPathVariable.json
+++ b/legend-engine-language-pure-compiler/src/test/resources/queryWithPathVariable.json
@@ -354,7 +354,7 @@
           }
         }
       ],
-      "name": "blah",
+      "name": "blah_Person_1__Boolean_1_",
       "package": "test",
       "parameters": [
         {

--- a/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestRuntimeGenerationForServiceTests.java
+++ b/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/test/runner/service/TestRuntimeGenerationForServiceTests.java
@@ -169,7 +169,7 @@ public class TestRuntimeGenerationForServiceTests
                         "\n" +
                         "\n" +
                         "###Runtime\n" +
-                        "Runtime demo::modelChainConnection\n" +
+                        "Runtime demo::modelChainConnection::runtime\n" +
                         "{\n" +
                         "  mappings:\n" +
                         "  [\n" +
@@ -191,9 +191,9 @@ public class TestRuntimeGenerationForServiceTests
         PureModel pureModel = new PureModel(contextData, null, DeploymentMode.TEST);
         Service service = contextData.getElementsOfType(Service.class).get(0);
         EngineRuntime testRuntime = (EngineRuntime) ServiceTestGenerationHelper.buildSingleExecutionTestRuntime((PureSingleExecution) service.execution, (SingleExecutionTest) service.test, contextData, pureModel);
-        Assert.assertEquals(testRuntime.connections.size(), 2);
+        Assert.assertEquals(2, testRuntime.connections.size());
         Assert.assertNotNull(testRuntime.getStoreConnections("ModelStore"));
-        Assert.assertEquals(testRuntime.getStoreConnections("ModelStore").storeConnections.size(), 1);
+        Assert.assertEquals(1, testRuntime.getStoreConnections("ModelStore").storeConnections.size());
         Assert.assertFalse((testRuntime.getStoreConnections("ModelStore").storeConnections.get(0).connection instanceof RelationalDatabaseConnection));
     }
 
@@ -292,6 +292,6 @@ public class TestRuntimeGenerationForServiceTests
         PureModel pureModel = new PureModel(contextData, null, DeploymentMode.TEST);
         Service service = contextData.getElementsOfType(Service.class).get(0);
         EngineRuntime testRuntime = (EngineRuntime) ServiceTestGenerationHelper.buildSingleExecutionTestRuntime((PureSingleExecution) service.execution, (SingleExecutionTest) service.test, contextData, pureModel);
-        Assert.assertEquals(testRuntime.connections.size(), 1);
+        Assert.assertEquals(1, testRuntime.connections.size());
     }
 }

--- a/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
+++ b/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
@@ -19,16 +19,11 @@ import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.test.TestCompilationFromGrammar;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
-
-//import org.finos.legend.pure.generated.*;
 import org.finos.legend.pure.generated.Root_meta_pure_mastery_metamodel_MasterRecordDefinition;
 import org.finos.legend.pure.generated.Root_meta_pure_mastery_metamodel_identity_IdentityResolution;
 import org.finos.legend.pure.generated.Root_meta_pure_mastery_metamodel_identity_ResolutionQuery;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_function_LambdaFunction_Impl;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
-
-import java.util.List;
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -45,7 +40,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "###Mapping\n" +
             "Mapping test::Mapping\n(\n)\n\n\n" +
             "###Connection\n" +
-            "JsonModelConnection test::connection\n" +
+            "JsonModelConnection test::connection::modelConnection\n" +
             "{\n" +
             "  class: test::connection::class;\n" +
             "  url: 'test/connection/url';\n" +
@@ -65,7 +60,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      [\n" +
             "        ModelStore:\n" +
             "        [\n" +
-            "          id1: test::connection\n" +
+            "          id1: test::connection::modelConnection\n" +
             "        ]\n" +
             "      ];\n" +
             "    }#;\n" +
@@ -124,7 +119,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "  recordSources:\n" +
             "  [\n" +
             "    widget-file-single-partition-14: {\n" +
-            "      description: \'Single partition source.\';\n" +
+            "      description: 'Single partition source.';\n" +
             "      status: Development;\n" +
             "      parseService: org::dataeng::ParseWidget;\n" +
             "      transformService: org::dataeng::TransformWidget;\n" +
@@ -132,16 +127,16 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      stagedLoad: false;\n" +
             "      createPermitted: true;\n" +
             "      createBlockedException: false;\n" +
-            "      tags: [\'Refinitive DSP\'];\n" +
+            "      tags: ['Refinitive DSP'];\n" +
             "      partitions:\n" +
             "      [\n" +
             "        partition-1-of-5: {\n" +
-            "          tags: [\'Equity\', \'Global\', \'Full-Universe\'];\n" +
+            "          tags: ['Equity', 'Global', 'Full-Universe'];\n" +
             "        }\n" +
             "      ]\n" +
             "    },\n" +
             "    widget-file-multiple-partition: {\n" +
-            "      description: \'Multiple partition source.\';\n" +
+            "      description: 'Multiple partition source.';\n" +
             "      status: Production;\n" +
             "      parseService: org::dataeng::ParseWidget;\n" +
             "      transformService: org::dataeng::TransformWidget;\n" +
@@ -149,17 +144,17 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      stagedLoad: true;\n" +
             "      createPermitted: false;\n" +
             "      createBlockedException: true;\n" +
-            "      tags: [\'Refinitive DSP Delta Files\'];\n" +
+            "      tags: ['Refinitive DSP Delta Files'];\n" +
             "      partitions:\n" +
             "      [\n" +
             "        ASIA_Equity: {\n" +
-            "          tags: [\'Equity\', \'ASIA\'];\n" +
+            "          tags: ['Equity', 'ASIA'];\n" +
             "        },\n" +
             "        EMEA_Equity: {\n" +
-            "          tags: [\'Equity\', \'EMEA\'];\n" +
+            "          tags: ['Equity', 'EMEA'];\n" +
             "        },\n" +
             "        US_Equity: {\n" +
-            "          tags: [\'Equity\', \'US\'];\n" +
+            "          tags: ['Equity', 'US'];\n" +
             "        }\n" +
             "      ]\n" +
             "    }\n" +
@@ -205,7 +200,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "  recordSources:\n" +
             "  [\n" +
             "    widget-file-single-partition: {\n" +
-            "      description: \'Single partition source.\';\n" +
+            "      description: 'Single partition source.';\n" +
             "      status: Development;\n" +
             "      transformService: org::dataeng::TransformWidget;\n" +
             "      partitions:\n" +
@@ -242,7 +237,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "  recordSources:\n" +
             "  [\n" +
             "    widget-file-single-partition: {\n" +
-            "      description: \'Single partition source.\';\n" +
+            "      description: 'Single partition source.';\n" +
             "      status: Development;\n" +
             "      parseService: org::dataeng::ParseWidget;\n" +
             "      transformService: org::dataeng::TransformWidget;\n" +
@@ -250,11 +245,11 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      stagedLoad: false;\n" +
             "      createPermitted: true;\n" +
             "      createBlockedException: false;\n" +
-            "      tags: [\'Refinitive DSP\'];\n" +
+            "      tags: ['Refinitive DSP'];\n" +
             "      partitions:\n" +
             "      [\n" +
             "        partition-1a: {\n" +
-            "          tags: [\'Equity\'];\n" +
+            "          tags: ['Equity'];\n" +
             "        }\n" +
             "      ]\n" +
             "    }\n" +
@@ -278,7 +273,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
 
         //IdentityResolution
         Root_meta_pure_mastery_metamodel_identity_IdentityResolution idRes = masterRecordDefinition._identityResolution();
-        assert (idRes instanceof Root_meta_pure_mastery_metamodel_identity_IdentityResolution);
+        assertNotNull(idRes);
         assertEquals("Widget", idRes._modelClass()._name());
 
         //Resolution Queries
@@ -363,12 +358,9 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
         assertEquals("Widget", masterRecordDefinition._modelClass()._name());
     }
 
-    private void assertPureLambdas(List list)
+    private void assertPureLambdas(Iterable<?> list)
     {
-        ListIterate.forEach(list, (resQuery) ->
-        {
-            assert (resQuery instanceof Root_meta_pure_metamodel_function_LambdaFunction_Impl);
-        });
+        list.forEach(resQuery -> assertTrue(resQuery instanceof Root_meta_pure_metamodel_function_LambdaFunction_Impl));
     }
 
     @Override

--- a/legend-engine-xt-morphir/pom.xml
+++ b/legend-engine-xt-morphir/pom.xml
@@ -100,10 +100,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
         <!-- JACKSON -->
 
         <!-- OPEN TRACING -->

--- a/legend-engine-xt-morphir/src/test/java/org/finos/legend/engine/external/language/morphir/tests/TestMorphirFileGeneration.java
+++ b/legend-engine-xt-morphir/src/test/java/org/finos/legend/engine/external/language/morphir/tests/TestMorphirFileGeneration.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.external.language.morphir.tests;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.finos.legend.engine.external.language.morphir.extension.MorphirGenerationConfigFromFileGenerationSpecificationBuilder;
 import org.finos.legend.engine.external.language.morphir.model.MorphirGenerationConfig;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -28,40 +27,30 @@ import org.finos.legend.pure.generated.core_external_language_morphir_transforma
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Scanner;
+import java.util.Objects;
 
 public class TestMorphirFileGeneration
 {
     @Test
-    public void testGenerateMorphirRentalExample()
+    public void testGenerateMorphirRentalExample() throws IOException
     {
-        try
-        {
-            PureModelContextData pureModelContextData = getProtocol("simpleFileGeneration.json");
-            PureModel pureModel = new PureModel(pureModelContextData, null, DeploymentMode.TEST);
-            FileGenerationSpecification fileGeneration = pureModelContextData.getElementsOfType(FileGenerationSpecification.class).get(0);
-            MorphirGenerationConfig morphirConfig = MorphirGenerationConfigFromFileGenerationSpecificationBuilder.build(fileGeneration);
-            Root_meta_external_language_morphir_generation_MorphirConfig metaModelConfig = morphirConfig.process(pureModel);
-            List<? extends Root_meta_pure_generation_metamodel_GenerationOutput> outputs = core_external_language_morphir_transformation_integration.Root_meta_external_language_morphir_generation_generateMorphirIRFromPureWithScope_MorphirConfig_1__GenerationOutput_MANY_(metaModelConfig, pureModel.getExecutionSupport()).toList();
-            Assert.assertEquals(outputs.size(), 1);
-        }
-        catch (Exception e)
-        {
-            throw new RuntimeException(e);
-        }
+        PureModelContextData pureModelContextData = getProtocol("org/finos/legend/engine/external/language/morphir/tests/simpleFileGeneration.json");
+        PureModel pureModel = new PureModel(pureModelContextData, null, DeploymentMode.PROD);
+        FileGenerationSpecification fileGeneration = pureModelContextData.getElementsOfType(FileGenerationSpecification.class).get(0);
+        MorphirGenerationConfig morphirConfig = MorphirGenerationConfigFromFileGenerationSpecificationBuilder.build(fileGeneration);
+        Root_meta_external_language_morphir_generation_MorphirConfig metaModelConfig = morphirConfig.process(pureModel);
+        List<? extends Root_meta_pure_generation_metamodel_GenerationOutput> outputs = core_external_language_morphir_transformation_integration.Root_meta_external_language_morphir_generation_generateMorphirIRFromPureWithScope_MorphirConfig_1__GenerationOutput_MANY_(metaModelConfig, pureModel.getExecutionSupport()).toList();
+        Assert.assertEquals(outputs.size(), 1);
     }
 
-    private PureModelContextData getProtocol(String fileName) throws JsonProcessingException
+    private PureModelContextData getProtocol(String fileName) throws IOException
     {
-        return ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(this.getResourceAsString(fileName), PureModelContextData.class);
-    }
-
-    private String getResourceAsString(String fileName)
-    {
-        InputStream inputStream = TestMorphirFileGeneration.class.getResourceAsStream(fileName);
-        Scanner scanner = new Scanner(inputStream, "UTF-8").useDelimiter("\\A");
-        return scanner.hasNext() ? scanner.next() : "";
+        try (InputStream stream = Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)))
+        {
+            return ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(stream, PureModelContextData.class);
+        }
     }
 }

--- a/legend-engine-xt-morphir/src/test/resources/org/finos/legend/engine/external/language/morphir/tests/simpleFileGeneration.json
+++ b/legend-engine-xt-morphir/src/test/resources/org/finos/legend/engine/external/language/morphir/tests/simpleFileGeneration.json
@@ -354,7 +354,7 @@
             }
           }
         ],
-        "name": "rentals",
+        "name": "rentals_Number_1__Number_1__Boolean_1__Number_1_",
         "package": "demo",
         "parameters": [
           {

--- a/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreClassMappingBuilder.java
+++ b/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreClassMappingBuilder.java
@@ -409,7 +409,7 @@ public class HelperServiceStoreClassMappingBuilder
 
         if (!org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.subsumes(parameterMultiplicty, multiplicity))
         {
-            throw new EngineException("Parameter multiplicity is not compatible with transform multiplicity - Multiplicity error: " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(parameterMultiplicty) + " doesn't subsumes " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(multiplicity), sourceInformation, EngineErrorType.COMPILATION);
+            throw new EngineException("Parameter multiplicity is not compatible with transform multiplicity - Multiplicity error: " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(parameterMultiplicty) + " doesn't subsume " + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(multiplicity), sourceInformation, EngineErrorType.COMPILATION);
         }
 
         if (typeReference instanceof Root_meta_external_store_service_metamodel_StringTypeReference)


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What does this PR do / why is it needed ?

This adds a validation in the compiler that checks for three things. First, that each element has a non-null, non-empty name. Second, that the name of Pure element created in the first pass matches the name of the protocol element it was created from. Third, that the name in unique within its package. Violation of any of these results in a compilation error.

In passing, this abstracts out the package creation, setting the package on the new element, and adding the new element as a child of the package.

All existing extensions that were in violation have been fixed. However, this should make it easier to prevent future extensions from being in violation, as it will be easy to detect the problem when compiling in tests.

#### Does this PR introduce a user-facing change?

This should have no immediate effect, as all offending extensions have been fixed. However, if an offending extension were created and deployed, it would result in compilation errors if used. Ideally, though, this would prevent the offending extensions from even making it that far.