### PR TITLE
In typeInfo.pure, reduce calls to elementToPath

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/platformBinding/typeInfo/typeInfo.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/platformBinding/typeInfo/typeInfo.pure
@@ -170,7 +170,7 @@ function meta::pure::executionPlan::platformBinding::typeInfo::allUnitInfos(info
 function meta::pure::executionPlan::platformBinding::typeInfo::forType(info:TypeInfoSet[1], type:Type[1]): TypeInfo[1]
 {
    let forType = $info.typeInfos->filter(ti| $ti.type == $type);
-   assert($forType->size() == 1, 'Type ' + if($forType->isEmpty(), |'missing', |'duplicated') + ': ' + $type->elementToPath());
+   assert($forType->size() == 1, |'Type ' + if($forType->isEmpty(), |'missing', |'duplicated') + ': ' + $type->elementToPath());
    $forType->toOne();
 }
 
@@ -260,19 +260,19 @@ function meta::pure::executionPlan::platformBinding::typeInfo::classDependencies
    let cd = $info
       ->classPropertiesRecursiveWithsubTypes($class, [])
       ->map(p| $p.genericType.rawType)
-      ->removeDuplicates(elementsEquals())
-      ->cast(@Class<Any>);
+      ->cast(@Class<Any>)
+      ->removeDuplicatesBy(classEqualityKey());
 
-   let cdSubTypes = $cd->map(c | $c->getSpecializations())->filter(s |  $info.typeInfos->exists(ti | $ti.type == $s->cast(@Type)));
+   let cdSubTypes = $cd->map(c | $c->getSpecializations())->filter(s | $info.typeInfos->exists(ti | $ti.type == $s));
 
-  if($getClassSubTypes ,
-        |  let classSubtypes = $class->getSpecializations()->filter(s |  $info.typeInfos->exists(ti | $ti.type == $s->cast(@Type)));
+   if($getClassSubTypes,
+        |  let classSubtypes = $class->getSpecializations()->filter(s | $info.typeInfos->exists(ti | $ti.type == $s));
            $cd->concatenate($cdSubTypes)->concatenate($classSubtypes);,
         |  $cd->concatenate($cdSubTypes)
-    )->filter(c| !elementsEquals()->eval($c, $class))
+    )->filter($class->isNotClassFn())
       ->remove(Any)
-      ->removeDuplicates(elementsEquals())
-      ->cast(@Class<Any>);
+      ->cast(@Class<Any>)
+      ->removeDuplicatesBy(classEqualityKey());
 }
 
 function meta::pure::executionPlan::platformBinding::typeInfo::enumDependenciesViaProperties(info:TypeInfoSet[1], class:Class<Any>[1]): Enumeration<Any>[*]
@@ -284,8 +284,8 @@ function meta::pure::executionPlan::platformBinding::typeInfo::enumDependenciesV
       ->concatenate($dependencyProperties)
       ->filter(p| $p.genericType.rawType->toOne()->instanceOf(Enumeration))
       ->map(p| $p.genericType.rawType)
-      ->removeDuplicates(elementsEquals())
-      ->cast(@Enumeration<Any>);
+      ->cast(@Enumeration<Any>)
+      ->removeDuplicatesBy(enumerationEqualityKey());
 }
 
 function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::classPropertiesRecursiveWithsubTypes(info:TypeInfoSet[1], class:Class<Any>[1], visitedClasses:Class<Any>[*]):AbstractProperty<Any>[*]
@@ -296,7 +296,7 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo
          let forThisClass        = $info->allProperties($class)->filter(p| $p.genericType.rawType->toOne()->instanceOf(Class));
          let forThisWithSubtypes = $forThisClass->concatenate($class->getSpecializations()->filter(s |  $info.typeInfos->exists(ti | $ti.type == $s->cast(@Type)))->map(g | $info->allProperties($g)->filter(p| $p.genericType.rawType->toOne()->instanceOf(Class))));
          
-         let forChildren         = $forThisWithSubtypes.genericType.rawType->removeDuplicates(elementsEquals())->cast(@Class<Any>)->map(c| $info->classPropertiesRecursiveWithsubTypes($c, $visitedClasses->concatenate($class)));
+         let forChildren         = $forThisWithSubtypes.genericType.rawType->cast(@Class<Any>)->removeDuplicatesBy(classEqualityKey())->map(c| $info->classPropertiesRecursiveWithsubTypes($c, $visitedClasses->concatenate($class)));
          $forThisWithSubtypes->concatenate($forChildren);
       }
    );
@@ -560,8 +560,9 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo
 
 function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::addOrReplace(info:TypeInfoSet[1], newTypeInfo:TypeInfo[1]): TypeInfoSet[1]
 {
+   let filterFn = $newTypeInfo.type->isNotTypeFn();
    ^$info(
-      typeInfos=$info.typeInfos->filter(ti| !elementsEquals()->eval($ti.type, $newTypeInfo.type))->concatenate($newTypeInfo)
+      typeInfos=$info.typeInfos->filter(ti|$filterFn->eval($ti.type))->concatenate($newTypeInfo)
    );
 }
 
@@ -663,9 +664,9 @@ function  <<access.private>> meta::pure::executionPlan::platformBinding::typeInf
    let generalizations = $class.generalizations->map(g | $g.general->cast(@GenericType).rawType->toOne())->cast(@Class<Any>);
    $generalizations
       ->concatenate($generalizations->map(g| $g->getGeneralizations()))
-      ->filter(c|!elementsEquals()->eval($c, meta::pure::metamodel::type::Any))
-      ->removeDuplicates(elementsEquals())
-      ->cast(@Class<Any>);
+      ->filter(meta::pure::metamodel::type::Any->isNotClassFn())
+      ->cast(@Class<Any>)
+      ->removeDuplicatesBy(classEqualityKey());
 }
 
 function  <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::getSpecializations(class:Type[1]):Class<Any>[*]
@@ -674,15 +675,32 @@ function  <<access.private>> meta::pure::executionPlan::platformBinding::typeInf
   
    $specializations
       ->concatenate($specializations->map(g| $g->getSpecializations()))
-      ->filter(c|!elementsEquals()->eval($c, meta::pure::metamodel::type::Any))
-      ->removeDuplicates(elementsEquals())
-      ->cast(@Class<Any>);
+      ->filter(meta::pure::metamodel::type::Any->isNotClassFn())
+      ->cast(@Class<Any>)
+      ->removeDuplicatesBy(classEqualityKey());
 }
 
 
 // Comparator needed due to Alloy bug in metadata vs other deserialization
 // TODO Verify if this is still needed
-function  <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::elementsEquals():Function<{PackageableElement[1],PackageableElement[1]->Boolean[1]}>[1]
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::classEqualityKey():Function<{Class<Any>[1]->String[1]}>[1]
 {
-   {pe1:PackageableElement[1], pe2:PackageableElement[1] | $pe1->elementToPath() == $pe2->elementToPath()};
+  {c:Class<Any>[1] | $c->elementToPath()}
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::enumerationEqualityKey():Function<{Enumeration<Any>[1]->String[1]}>[1]
+{
+  {e:Enumeration<Any>[1] | $e->elementToPath()}
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::isNotTypeFn(type:Type[1]):Function<{Type[1]->Boolean[1]}>[1]
+{
+   let path = $type->cast(@PackageableElement)->elementToPath();
+   {t:Type[1] | ($type != $t) && ($path != $t->cast(@PackageableElement)->elementToPath())};
+}
+
+function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::isNotClassFn(class:Class<Any>[1]):Function<{Class<Any>[1]->Boolean[1]}>[1]
+{
+   let path = $class->elementToPath();
+   {c:Class<Any>[1] | ($class != $c) && ($path != $c->elementToPath())};
 }


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Improve performance of plan binding by reducing the amount of string concatenation, particularly in calls to elementToPath.

#### Does this PR introduce a user-facing change?

This should result in a modest speed improvement in plan binding.