### PR TITLE
Add default implementations to AuthenticationSpecificationVisitor

### DIFF
--- a/legend-engine-xt-authentication-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/authentication/AuthenticationParserGrammar.g4
+++ b/legend-engine-xt-authentication-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/authentication/AuthenticationParserGrammar.g4
@@ -76,7 +76,7 @@ apiKeyAuthentication :          (
 apiKeyAuthentication_keyName:    API_KEY_AUTHENTICATION_KEY_NAME COLON STRING SEMI_COLON
 ;
 
-apiKeyAuthentication_location:    API_KEY_AUTHENTICATION_LOCATION COLON STRING SEMI_COLON
+apiKeyAuthentication_location:    API_KEY_AUTHENTICATION_LOCATION COLON identifier SEMI_COLON
 ;
 
 apiKeyAuthentication_value:    API_KEY_AUTHENTICATION_VALUE COLON secret_value SEMI_COLON

--- a/legend-engine-xt-authentication-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/authentication/grammar/from/AuthenticationParseTreeWalker.java
+++ b/legend-engine-xt-authentication-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/authentication/grammar/from/AuthenticationParseTreeWalker.java
@@ -104,7 +104,7 @@ public class AuthenticationParseTreeWalker
         authenticationSpecification.sourceInformation = walkerSourceInformation.getSourceInformation(ctx);
 
         AuthenticationParserGrammar.ApiKeyAuthentication_locationContext locationContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.apiKeyAuthentication_location(), "location", authenticationSpecification.getSourceInformation());
-        String location = PureGrammarParserUtility.fromGrammarString(locationContext.STRING().getText(), true);
+        String location = PureGrammarParserUtility.fromIdentifier(locationContext.identifier());
         authenticationSpecification.location = ApiKeyAuthenticationSpecification.Location.valueOf(location.toUpperCase());
 
         AuthenticationParserGrammar.ApiKeyAuthentication_keyNameContext keyNameContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.apiKeyAuthentication_keyName(), "keyName", authenticationSpecification.getSourceInformation());

--- a/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/language/pure/dsl/authentication/grammar/test/TestAuthenticationGrammarParser_AuthenticationTypes.java
+++ b/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/language/pure/dsl/authentication/grammar/test/TestAuthenticationGrammarParser_AuthenticationTypes.java
@@ -73,7 +73,7 @@ public class TestAuthenticationGrammarParser_AuthenticationTypes extends TestGra
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # ApiKey {\n" +
-                "    location: 'header';\n" +
+                "    location: header;\n" +
                 "    keyName: 'key1';\n" +
                 "    value: PropertiesFileSecret\n" +
                 "    {\n" +

--- a/legend-engine-xt-authentication-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/authentication/specification/AuthenticationSpecificationVisitor.java
+++ b/legend-engine-xt-authentication-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/authentication/specification/AuthenticationSpecificationVisitor.java
@@ -16,15 +16,33 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authen
 
 public interface AuthenticationSpecificationVisitor<T>
 {
-    T visit(AuthenticationSpecification catchAll);
+    default T visit(AuthenticationSpecification catchAll)
+    {
+        throw new RuntimeException("Not implemented!");
+    }
 
-    T visit(ApiKeyAuthenticationSpecification authenticationSpecification);
+    default T visit(ApiKeyAuthenticationSpecification authenticationSpecification)
+    {
+        throw new RuntimeException("Not implemented!");
+    }
 
-    T visit(UserPasswordAuthenticationSpecification authenticationSpecification);
+    default T visit(UserPasswordAuthenticationSpecification authenticationSpecification)
+    {
+        throw new RuntimeException("Not implemented!");
+    }
 
-    T visit(EncryptedPrivateKeyPairAuthenticationSpecification authenticationSpecification);
+    default T visit(EncryptedPrivateKeyPairAuthenticationSpecification authenticationSpecification)
+    {
+        throw new RuntimeException("Not implemented!");
+    }
 
-    T visit(GCPWIFWithAWSIdPAuthenticationSpecification authenticationSpecification);
+    default T visit(GCPWIFWithAWSIdPAuthenticationSpecification authenticationSpecification)
+    {
+        throw new RuntimeException("Not implemented!");
+    }
 
-    T visit(KerberosAuthenticationSpecification authenticationSpecification);
+    default T visit(KerberosAuthenticationSpecification authenticationSpecification)
+    {
+        throw new RuntimeException("Not implemented!");
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Add default implementations to AuthenticationSpecificationVisitor
Minor - ApiKey location is an enum and hence not required to be a string

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

Yes, grammar change
