### PR TITLE
Allow Calendar aggregate functions to operate on attributes coming from subclasses

### DIFF
--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/calendarAggregation/calendarAggregationPureToSQL.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/calendarAggregation/calendarAggregationPureToSQL.pure
@@ -22,7 +22,7 @@ import meta::relational::metamodel::join::*;
 import meta::relational::metamodel::operation::*;
 import meta::relational::metamodel::relation::*;
 
-function meta::relational::functions::pureToSqlQuery::calendarAggregations::insertCalendarJoins(dateCol:SelectSQLQuery[1], endDate:StrictDate[1], calendarType:String[1], nodeId:String[1], operation:SelectWithCursor[1], state:State[1], context:DebugContext[1], extensions:Extension[*]):SelectWithCursor[1]
+function meta::relational::functions::pureToSqlQuery::calendarAggregations::insertCalendarJoins(dateColCursor:SelectWithCursor[1], endDate:StrictDate[1], calendarType:String[1], nodeId:String[1], operation:SelectWithCursor[1], state:State[1], context:DebugContext[1], extensions:Extension[*]):SelectWithCursor[1]
 {
   let calendarTableName = $calendarType->cast(@String)+'_Calendar';
   assert(isNotEmpty(table(schema(CalendarDatabase,'LegendCalendarSchema')->toOne(),$calendarTableName)), | 'A new calendar type requires a table in meta::relational::functions::pureToSqlQuery::calendarAggregations::CalendarDatabase store, LegendCalendarSchema schema.');
@@ -38,20 +38,20 @@ function meta::relational::functions::pureToSqlQuery::calendarAggregations::inse
                         );
 
   // define table aliases for each side of the join.
-   let leftAlias  =        $dateCol.data.alias->toOne(); //  left side of the join (user class)
-   let rightAlias = $calendarSelect.data.alias->toOne(); // right side of the join, 'Calendar'
+   let leftAlias  = $dateColCursor.currentTreeNode.alias->toOne(); //  left side of the join (user class)
+   let rightAlias = $calendarSelect.data.alias->toOne();           // right side of the join, 'Calendar'
 
   // define the calendar joins...
   // ... on userClass.dateCol == CalendarTable.date.
   let join    = ^Join(name='calendarJoin'   +$nodeId, aliases=[pair($leftAlias,$rightAlias),pair($rightAlias,$leftAlias)],
           operation=[^DynaFunction(name = 'equal',
-                                   parameters=[ ^TableAliasColumn(alias=$leftAlias , column=$dateCol.columns->cast(@TableAliasColumn).column->toOne()),
+                                   parameters=[ ^TableAliasColumn(alias=$leftAlias , column=$dateColCursor.select.columns->cast(@TableAliasColumn).column->toOne()),
                                                 ^TableAliasColumn(alias=$rightAlias, column=^Column(name = 'date', type = ^meta::relational::metamodel::datatype::Date()) )
                                               ])
                     ]->cast(@Operation)->toOne('First parameter should be one date column.')
     );
 
-  // ... on user.dateCol == CalendarTable.date and CalendarTable.date == $endDate.
+  // ... on userClass.dateCol == CalendarTable.date and CalendarTable.date == $endDate.
   let joinEnd = ^Join(name='calendarEndJoin'+$endDate->toString()+$nodeId, aliases=[pair($leftAlias,$rightAlias),pair($rightAlias,$leftAlias)],
           operation=[^DynaFunction(name = 'equal',
                                   parameters=[ ^Literal(value=$endDate->toOne()),
@@ -63,7 +63,7 @@ function meta::relational::functions::pureToSqlQuery::calendarAggregations::inse
   // insert the joins in the tree.
   let child    = ^JoinTreeNode(alias=$rightAlias, join=$join   , joinType=JoinType.LEFT_OUTER, database=meta::relational::functions::pureToSqlQuery::calendarAggregations::CalendarDatabase, joinName='calendarJoin'   +$nodeId);
   let childEnd = ^JoinTreeNode(alias=$rightAlias, join=$joinEnd, joinType=JoinType.LEFT_OUTER, database=meta::relational::functions::pureToSqlQuery::calendarAggregations::CalendarDatabase, joinName='calendarEndJoin'+$nodeId);
-  let treeWithCalendarJoin      = applyJoinInTree(           $operation.select.data->toOne(),            $operation.currentTreeNode->toOne(), $child   , $operation           , $nodeId       , JoinType.LEFT_OUTER, true, false, [], $state, $context, $extensions);
+  let treeWithCalendarJoin      = applyJoinInTree(       $dateColCursor.select.data->toOne(),        $dateColCursor.currentTreeNode->toOne(), $child   , $dateColCursor       , $nodeId       , JoinType.LEFT_OUTER, true, false, [], $state, $context, $extensions);
   let treeWithBothCalendarJoins = applyJoinInTree($treeWithCalendarJoin.select.data->toOne(), $treeWithCalendarJoin.currentTreeNode->toOne(), $childEnd, $treeWithCalendarJoin, $nodeId+'_end', JoinType.LEFT_OUTER, true, false, [], $state, $context, $extensions);
 
   $treeWithBothCalendarJoins;
@@ -77,21 +77,27 @@ function meta::relational::functions::pureToSqlQuery::calendarAggregations::proc
   let calendarType = $expression->instanceValuesAtParameter(1, $vars, $state.inScopeVars)->cast(@String    )->toOne();
   let endDate      = $expression->instanceValuesAtParameter(2, $vars, $state.inScopeVars)->cast(@StrictDate)->toOne();
 
-  // Insert the two Calendar joins.
-  let selectWithBothCalendarJoins = meta::relational::functions::pureToSqlQuery::calendarAggregations::insertCalendarJoins($dateCol.select,$endDate, $calendarType, $nodeId, $operation, $state, $context, $extensions);
-  let calendarAlias    = $selectWithBothCalendarJoins->cast(@SelectWithCursor).currentTreeNode.childrenData->cast(@JoinTreeNode)->filter(x | $x.join.name == 'calendarJoin'   +$nodeId).alias->toOne();
-  let calendarEndAlias = $selectWithBothCalendarJoins->cast(@SelectWithCursor).currentTreeNode.childrenData->cast(@JoinTreeNode)->filter(x | $x.join.name == 'calendarEndJoin'+$endDate->toString()+$nodeId).alias->toOne();
-
   // Get the "synthetiseFooBarCaseCondition" corresponding to the fooBar function called by the user.
   let calendarFunction = getSupportedCalendarFunctions()->filter(x|$x.aggFunction == $expression.func);
 
+  // Insert the two Calendar joins.
+  let selectWithBothCalendarJoins = meta::relational::functions::pureToSqlQuery::calendarAggregations::insertCalendarJoins($dateCol,$endDate, $calendarType, $nodeId, $operation, $state, $context, $extensions);
+
+  // Merge the 'calendarJoins' and 'valueCol' SQLs
+  let sqlWithBothCalendarJoins = $selectWithBothCalendarJoins.select->concatenate($valueCol.select)->mergeSQLQueryData($nodeId, $state, $context, $extensions);
+
   // Generates: case when (caseCondition) then valueCol / normalisationFactor else null end.
-  let caseCondition = $calendarFunction.handler->toOne()->meta::pure::functions::lang::eval($calendarAlias, $calendarEndAlias,$valueCol.select.columns->toOne()->cast(@TableAliasColumn));
+  let calendarAlias    = $selectWithBothCalendarJoins->cast(@SelectWithCursor).currentTreeNode.childrenData->cast(@JoinTreeNode)->filter(x | $x.join.name == 'calendarJoin'   +$nodeId).alias->toOne();
+  let calendarEndAlias = $selectWithBothCalendarJoins->cast(@SelectWithCursor).currentTreeNode.childrenData->cast(@JoinTreeNode)->filter(x | $x.join.name == 'calendarEndJoin'+$endDate->toString()+$nodeId).alias->toOne();
+  let caseCondition = $calendarFunction.handler->toOne()->meta::pure::functions::lang::eval($calendarAlias, $calendarEndAlias,$sqlWithBothCalendarJoins.columns->toOne()->cast(@TableAliasColumn));
 
   // insert caseValue result into the tree.
-  let sqlWithBothCalendarJoins = $selectWithBothCalendarJoins.select;
   let sqlWithBothCalendarJoinsAndCaseCol = ^$sqlWithBothCalendarJoins(columns = $caseCondition);
-  let selectWithBothCalendarJoinsAndCaseCol = ^$selectWithBothCalendarJoins(select = $sqlWithBothCalendarJoinsAndCaseCol);
+  let selectWithBothCalendarJoinsAndCaseCol = ^$selectWithBothCalendarJoins(
+    select = $sqlWithBothCalendarJoinsAndCaseCol,
+    positionBeforeLastApplyJoinTreeNode = if($selectWithBothCalendarJoins.positionBeforeLastApplyJoinTreeNode->isEmpty(),|[],|$selectWithBothCalendarJoins.positionBeforeLastApplyJoinTreeNode->toOne()->findOneNode($selectWithBothCalendarJoins.select.data->toOne(), $sqlWithBothCalendarJoinsAndCaseCol.data->toOne())),
+    currentTreeNode = $sqlWithBothCalendarJoinsAndCaseCol.data->toOne()
+    );
 
   // Return the tree
   $selectWithBothCalendarJoinsAndCaseCol;

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/calendarAggregation/tests/testCalendarFunctions.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/calendarAggregation/tests/testCalendarFunctions.pure
@@ -1,14 +1,15 @@
 
-
 ###Relational
 Database meta::relational::tests::functions::pureToSqlQuery::calendarAggregations::EmployeeDatabase
 (
    include meta::relational::functions::pureToSqlQuery::calendarAggregations::CalendarDatabase
 
    Table EmployeeTable(id INT PRIMARY KEY, hireDate DATE, hireType VARCHAR(10), fteFactor DOUBLE)
+   Table EmployeeDetailsTable(id INT PRIMARY KEY, birthDate DATE, yearsOfExperience DOUBLE)
    Table FirmTable(firmName VARCHAR(100) PRIMARY KEY, employeeId INT PRIMARY KEY)
 
    Join JoinEmployeeToFirm(EmployeeTable.id = FirmTable.employeeId)
+   Join JoinEmployeeToemployeeDetails(EmployeeTable.id = EmployeeDetailsTable.id)
 )
 
 ###Mapping
@@ -22,7 +23,12 @@ Mapping meta::relational::tests::functions::pureToSqlQuery::calendarAggregations
       hireDate : [EmployeeDatabase]EmployeeTable.hireDate,
       hireType : [EmployeeDatabase]EmployeeTable.hireType,
       fteFactor: [EmployeeDatabase]EmployeeTable.fteFactor,
-      firmName : [EmployeeDatabase]@JoinEmployeeToFirm | FirmTable.firmName
+      firmName : [EmployeeDatabase]@JoinEmployeeToFirm | FirmTable.firmName,
+      employeeDetails
+      (
+        birthDate : [EmployeeDatabase]@JoinEmployeeToemployeeDetails | EmployeeDetailsTable.birthDate,
+        yearsOfExperience : [EmployeeDatabase]@JoinEmployeeToemployeeDetails | EmployeeDetailsTable.yearsOfExperience
+      )
    }
 )
 
@@ -45,12 +51,19 @@ Class meta::relational::tests::functions::pureToSqlQuery::calendarAggregations::
    hireType : String[1];
    fteFactor: Float[1];
    firmName : String[0..1];
+   employeeDetails : employeeDetails[1];
+}
+
+Class meta::relational::tests::functions::pureToSqlQuery::calendarAggregations::employeeDetails
+{
+   birthDate : Date[1];
+   yearsOfExperience : Integer[1];
 }
 
 function <<test.BeforePackage>> meta::relational::tests::functions::pureToSqlQuery::calendarAggregations::setUp():Boolean[1]
 {
   let connection = testRuntime(EmployeeDatabase).connectionByElement(EmployeeDatabase)->cast(@TestDatabaseConnection);
-   
+
   dropAndCreateTableInDb(EmployeeDatabase, 'EmployeeTable', $connection);
   executeInDb('insert into EmployeeTable (id, hireDate, hireType, fteFactor) values ( 1,\'2018-12-31\',\'Campus\' ,0.13);', $connection);
   executeInDb('insert into EmployeeTable (id, hireDate, hireType, fteFactor) values ( 2,\'2019-01-01\',\'Lateral\',0.14);', $connection);
@@ -115,6 +128,10 @@ function <<test.BeforePackage>> meta::relational::tests::functions::pureToSqlQue
   dropAndCreateTableInDb(EmployeeDatabase, 'FirmTable', $connection);
   executeInDb('insert into FirmTable (firmName,employeeId) values (\'GS\',19);', $connection);
   executeInDb('insert into FirmTable (firmName,employeeId) values (\'JP\',20);', $connection);
+
+  dropAndCreateTableInDb(EmployeeDatabase, 'EmployeeDetailsTable', $connection);
+  executeInDb('insert into EmployeeDetailsTable (id, birthDate, yearsOfExperience) values ( 1,\'2022-01-01\',10);', $connection);
+  executeInDb('insert into EmployeeDetailsTable (id, birthDate, yearsOfExperience) values (27,\'2021-01-01\',10);', $connection);
 
   dropAndCreateSchemaInDb('LegendCalendarSchema', $connection);
   dropAndCreateTableInDb(EmployeeDatabase, 'LegendCalendarSchema' ,    'NY_Calendar', $connection);
@@ -181,6 +198,7 @@ function <<test.BeforePackage>> meta::relational::tests::functions::pureToSqlQue
   executeInDb('insert into LegendCalendarSchema.NY_Calendar ('+$columnNames+') values (\'2021-12-16\',350,\'Thu\',\'2021-12-16\', -54,242,12,54,4,\'2021-11-19\',\'2021-09-24\',\'2020-12-18\',12,\'2021-12-31\',4,50,\'2021-12-13\',2021,\'2021-12-15\',11,3,2020,22,252);', $connection);
   executeInDb('insert into LegendCalendarSchema.NY_Calendar ('+$columnNames+') values (\'2021-10-15\',288,\'Fri\',\'2021-10-15\', -63,199,11,11,5,\'2021-09-18\',\'2021-07-24\',\'2020-10-17\',10,\'2021-10-29\',4,41,\'2021-10-11\',2021,\'2021-10-14\', 9,3,2020,21,252);', $connection);
   executeInDb('insert into LegendCalendarSchema.NY_Calendar ('+$columnNames+') values (\'2021-10-16\',289,\'Sat\',\'2021-10-18\', -62,200,12,12,1,\'2021-09-18\',\'2021-07-24\',\'2020-10-17\',10,\'2021-10-29\',4,42,\'2021-10-18\',2021,\'2021-10-15\', 9,3,2020,21,252);', $connection);
+
 
   true;
 }
@@ -1406,8 +1424,8 @@ function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::calen
    ,EmployeeMapping, testRuntime(), relationalExtensions(), noDebug());
   assertEquals(['hireType,pma,Campus,0.23666666666666666,Lateral,0.255,'], toCSV($result.values)->replace('\n', ','));
 }
- 
- 
+
+
 function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::calendarAggregations::testPwaValueOnStartYear():Boolean[1]
 {
   let result = execute(|
@@ -1501,4 +1519,30 @@ function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::calen
        ['hireType','ytd'])
    ,EmployeeMapping, testRuntime(), relationalExtensions(), noDebug());
   assertSameSQL('select "root".hireType as "hireType", sum(case when "london_calendar_0".currentYear = "london_calendar_1".currentYear and "london_calendar_0".fiscalDay <= "london_calendar_1".fiscalDay then "root".fteFactor else null end) as "ytd" from EmployeeTable as "root" left outer join LegendCalendarSchema.London_Calendar as "london_calendar_0" on ("root".hireDate = "london_calendar_0".date) left outer join LegendCalendarSchema.London_Calendar as "london_calendar_1" on (\'2022-11-16\' = "london_calendar_1".date) group by "hireType"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::calendarAggregations::testSubclassDate():Boolean[1]
+{
+  let result = execute(|
+   Employee.all()
+     ->groupBy(
+       [],
+       [ agg(p | ytd($p.employeeDetails.birthDate, 'NY', %2022-11-16, $p.fteFactor), y | $y->sum()) ],
+       ['ytd'])
+   ,EmployeeMapping, testRuntime(), relationalExtensions(), noDebug());
+  assertSameSQL('select sum(case when "ny_calendar_0".currentYear = "ny_calendar_1".currentYear and "ny_calendar_0".fiscalDay <= "ny_calendar_1".fiscalDay then "root".fteFactor else null end) as "ytd" from EmployeeTable as "root" left outer join EmployeeDetailsTable as "employeedetailstable_0" on ("root".id = "employeedetailstable_0".id) left outer join LegendCalendarSchema.NY_Calendar as "ny_calendar_0" on ("employeedetailstable_0".birthDate = "ny_calendar_0".date) left outer join LegendCalendarSchema.NY_Calendar as "ny_calendar_1" on (\'2022-11-16\' = "ny_calendar_1".date)', $result);
+  assertEquals(['ytd,0.13,'], toCSV($result.values)->replace('\n', ','));
+}
+
+function <<test.Test>> meta::relational::tests::functions::pureToSqlQuery::calendarAggregations::testSubclassValue():Boolean[1]
+{
+  let result = execute(|
+   Employee.all()
+     ->groupBy(
+       [],
+       [ agg(p | ytd($p.hireDate, 'NY', %2022-11-16, $p.employeeDetails.yearsOfExperience), y | $y->sum()) ],
+       ['ytd'])
+   ,EmployeeMapping, testRuntime(), relationalExtensions(), noDebug());
+  assertSameSQL('select sum(case when "ny_calendar_0".currentYear = "ny_calendar_1".currentYear and "ny_calendar_0".fiscalDay <= "ny_calendar_1".fiscalDay then "employeedetailstable_0".yearsOfExperience else null end) as "ytd" from EmployeeTable as "root" left outer join LegendCalendarSchema.NY_Calendar as "ny_calendar_0" on ("root".hireDate = "ny_calendar_0".date) left outer join LegendCalendarSchema.NY_Calendar as "ny_calendar_1" on (\'2022-11-16\' = "ny_calendar_1".date) left outer join EmployeeDetailsTable as "employeedetailstable_0" on ("root".id = "employeedetailstable_0".id)', $result);
+  assertEquals(['ytd,10.0,'], toCSV($result.values)->replace('\n', ','));
 }


### PR DESCRIPTION
Calendar aggregate functions ytd/mtd (year-to-date, month-to-date) etc…

What type of PR is this?
New feature.

What does this PR do / why is it needed ?
Make all 31 Calendar aggregations available in Legend as first-class functions, and allow them to calculate based on nested attributes.