### PR TITLE
SearchDocumentGeneration - Add backwards compatible metamodel

### DIFF
--- a/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/metamodel.pure
+++ b/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/metamodel.pure
@@ -67,6 +67,9 @@ Class meta::analytics::search::metamodel::class::ClassProperty
 }
 
 // DATASPACE DOCUMENT
+Class <<doc.deprecated>> meta::analytics::search::metamodel::dataspace::RootDocument extends meta::analytics::search::metamodel::dataspace::DataSpaceDocument
+{
+}
 Class meta::analytics::search::metamodel::dataspace::DataSpaceDocument extends meta::analytics::search::metamodel::PackageableRootDocument
 {
   defaultExecutionContext: String[1];
@@ -75,6 +78,9 @@ Class meta::analytics::search::metamodel::dataspace::DataSpaceDocument extends m
   taxonomies: String[*];
 }
 
+Class <<doc.deprecated>> meta::analytics::search::metamodel::dataspace::ExecutionContextDocument extends meta::analytics::search::metamodel::dataspace::ExecutionContext
+{
+}
 Class meta::analytics::search::metamodel::dataspace::ExecutionContext
 {
   name: String[1];
@@ -97,6 +103,9 @@ Class meta::analytics::search::metamodel::mapping::MappingDocument extends meta:
   includedMappings: String[*];
 }
 
+Class <<doc.deprecated>> meta::analytics::search::metamodel::mapping::DatabaseColumnDocument extends meta::analytics::search::metamodel::mapping::DatabaseColumn
+{
+}
 Class meta::analytics::search::metamodel::mapping::DatabaseColumn
 {
   database: String[1];


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?

Metamodel was refactored in https://github.com/finos/legend-engine/pull/1658
This change adds back the old classes for backwards compatibility, pointing to the new ones whilst downstream changes are made.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

