### PR TITLE
Allow function name to be different between protocol and model

### DIFF
--- a/legend-engine-language-pure-compiler/src/test/resources/functionExample.json
+++ b/legend-engine-language-pure-compiler/src/test/resources/functionExample.json
@@ -22,7 +22,7 @@
           ]
         }
       ],
-      "name": "func1__Date_1_",
+      "name": "func1",
       "package": "model::domain::test",
       "parameters": [],
       "postConstraints": [],

--- a/legend-engine-language-pure-compiler/src/test/resources/functionWithLambdaVariable.json
+++ b/legend-engine-language-pure-compiler/src/test/resources/functionWithLambdaVariable.json
@@ -82,7 +82,7 @@
           }
         }
       ],
-      "name": "funcx__Any_MANY_",
+      "name": "funcx",
       "package": "test",
       "parameters": [],
       "postConstraints": [],

--- a/legend-engine-language-pure-compiler/src/test/resources/queryWithPathVariable.json
+++ b/legend-engine-language-pure-compiler/src/test/resources/queryWithPathVariable.json
@@ -354,7 +354,7 @@
           }
         }
       ],
-      "name": "blah_Person_1__Boolean_1_",
+      "name": "blah",
       "package": "test",
       "parameters": [
         {


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

To preserve backward compatibility, this eases the [new compiler validations](https://github.com/finos/legend-engine/pull/1644) on element names to allow function names to differ between the protocol and the compiled model.

#### Does this PR introduce a user-facing change?

No