### PR TITLE
Generate freemarker functions for included enumeration mappings

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -131,6 +131,10 @@ function <<access.private>> meta::pure::mapping::updatePropertyMappingIDWithSuff
      );
 }
 
+function meta::pure::mapping::allEnumerationMappings(m: Mapping[1]): EnumerationMapping<Any>[*]
+{
+  $m.enumerationMappings->concatenate($m.includes->map(i | $i.included->allEnumerationMappings()))
+}
 
 
 

--- a/legend-engine-pure-ide-light/pom.xml
+++ b/legend-engine-pure-ide-light/pom.xml
@@ -144,6 +144,11 @@
             <artifactId>legend-engine-xt-xml-runtime</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <!-- Access to Legend Execute in IDE Light -->
 
     </dependencies>

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/projection/testFilter.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/projection/testFilter.pure
@@ -102,3 +102,33 @@ function <<test.Test>> meta::relational::tests::projection::filter::testCompress
    assertEquals('select concat("root".FIRSTNAME, \' \', "root".LASTNAME) as "Name", "locationtable_0".PLACE as "place", "locationtable_1".date as "CD" from personTable as "root" left outer join locationTable as "locationtable_0" on ("root".ID = "locationtable_0".PERSONID and "locationtable_0".PLACE = \'New York\') left outer join locationTable as "locationtable_1" on ("root".ID = "locationtable_1".PERSONID and "locationtable_1".PLACE in (\'New York\', \'Hoboken\'))', $result->sqlRemoveFormatting());
 }
 
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::projection::filter::testParametrizedEnumFilter(): Boolean[1]
+{
+  let runtime = meta::relational::tests::testRuntime();
+  let connection = $runtime.connections->at(0)->cast(@meta::relational::runtime::TestDatabaseConnection);
+  
+  let runtimeWithTestData = ^$runtime(
+    connections = ^$connection(
+      testDataSetupCsv =
+        'default\n'+
+        'addressTable\n'+
+        'ID,TYPE,NAME\n'+
+        '1,1,Address_1\n'+
+        '2,2,Address_2\n'+
+        '-----\n'
+      )
+  );
+ 
+  let func = {g: GeographicEntityType[1]|
+    Address.all()
+      ->filter(a | $a.type == $g)
+      ->meta::pure::graphFetch::execution::graphFetch(#{Address{ name }}#)
+      ->meta::pure::graphFetch::execution::serialize(#{Address{ name }}#)
+      ->meta::pure::mapping::from(simpleRelationalMapping, $runtimeWithTestData);
+  };
+  
+  let res = meta::legend::executeLegendQuery($func, [pair('g', 'CITY')], ^meta::pure::runtime::ExecutionContext(), meta::relational::extension::relationalExtensions());
+
+  assertJsonStringsEqual('{"builder":{"_type":"json"},"values":{"name":"Address_1"}}', $res);
+}
+

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
@@ -176,9 +176,9 @@ function meta::relational::mapping::addEnumMapSupportFunctions(sq:meta::pure::ma
 {
    let enumParam = $sq.inScopeVars->keyValues().second->map(p | $p.values)->filter(e | $e->instanceOf(PlanVarPlaceHolder))->map(p | $p->cast(@PlanVarPlaceHolder).type)->filter(e | $e->instanceOf(Enumeration));
    let enumMapTemplateFunctions = if($enumParam->isNotEmpty(),
-                                      |$m.enumerationMappings->filter(e | $e.enumeration->in($enumParam))->map(enum | let concatStr = if($enum.enumValueMappings->at(0).sourceValues->type() == String, |'\'', |'');
-                                                                                                                      let enumHashMap = $enum.enumValueMappings->map(e | '"'+ $e.enum->cast(@Enum).name +'":"'+ $concatStr + $e.sourceValues->makeString('\', \'') + $concatStr + '"')->makeString(', ');
-                                                                                                                      '<#function enumMap_' + fetchEnumFullPath($enum) + ' inputVal> <#assign enumMap = {'->concatenate($enumHashMap)->concatenate('}> <#if inputVal?has_content> <#return enumMap[inputVal]> <#else> <#return ""> </#if> </#function>')->makeString(' ');),
+                                      |$m->allEnumerationMappings()->filter(e | $e.enumeration->in($enumParam))->map(enum | let concatStr = if($enum.enumValueMappings->at(0).sourceValues->type() == String, |'\'', |'');
+                                                                                                                            let enumHashMap = $enum.enumValueMappings->map(e | '"'+ $e.enum->cast(@Enum).name +'":"'+ $concatStr + $e.sourceValues->makeString('\', \'') + $concatStr + '"')->makeString(', ');
+                                                                                                                            '<#function enumMap_' + fetchEnumFullPath($enum) + ' inputVal> <#assign enumMap = {'->concatenate($enumHashMap)->concatenate('}> <#if inputVal?has_content> <#return enumMap[inputVal]> <#else> <#return ""> </#if> </#function>')->makeString(' ');),
                                       |[]);
 }
 


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Freemarker functions are currently generated for only enumeration mappings at the top level. This PR extends it to those from included mappings

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

