### PR TITLE
Uniform withHeader flag in temp table creation for different result types

### DIFF
--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/StreamResultToTempTableVisitor.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/StreamResultToTempTableVisitor.java
@@ -122,9 +122,10 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
             try (TemporaryFile tempFile = new TemporaryFile(config.tempPath, RequestIdGenerator.generateId()))
             {
                 CsvSerializer csvSerializer;
+                boolean withHeader = false;
                 if (result instanceof RelationalResult)
                 {
-                    csvSerializer = new RelationalResultToCSVSerializer((RelationalResult) result, true);
+                    csvSerializer = new RelationalResultToCSVSerializer((RelationalResult) result, withHeader);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -145,7 +146,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 else if (result instanceof RealizedRelationalResult)
                 {
                     RealizedRelationalResult realizedRelationalResult = (RealizedRelationalResult) this.result;
-                    csvSerializer = new RealizedRelationalResultCSVSerializer(realizedRelationalResult, this.databaseTimeZone, false, false);
+                    csvSerializer = new RealizedRelationalResultCSVSerializer(realizedRelationalResult, this.databaseTimeZone, withHeader, false);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -155,7 +156,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof StreamingObjectResult)
                 {
-                    csvSerializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, true);
+                    csvSerializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, withHeader);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -165,7 +166,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof TempTableStreamingResult)
                 {
-                    csvSerializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, true);
+                    csvSerializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, withHeader);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -210,9 +211,10 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
             try (TemporaryFile tempFile = new TemporaryFile(config.tempPath))
             {
                 CsvSerializer csvSerializer;
+                boolean withHeader = true;
                 if (result instanceof RelationalResult)
                 {
-                    csvSerializer = new RelationalResultToCSVSerializer((RelationalResult) result, true);
+                    csvSerializer = new RelationalResultToCSVSerializer((RelationalResult) result, withHeader);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -232,7 +234,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof RealizedRelationalResult)
                 {
-                    csvSerializer = new RealizedRelationalResultCSVSerializer((RealizedRelationalResult) result, this.databaseTimeZone, true, false);
+                    csvSerializer = new RealizedRelationalResultCSVSerializer((RealizedRelationalResult) result, this.databaseTimeZone, withHeader, false);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -243,7 +245,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof StreamingObjectResult)
                 {
-                    csvSerializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, true);
+                    csvSerializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, withHeader);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -253,7 +255,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof TempTableStreamingResult)
                 {
-                    csvSerializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, true);
+                    csvSerializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, withHeader);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

SF commands for temp table creation do not expect header to be present in CSV file. However, the flag is not uniform across all types of results currently being handled for a database type. As a result, extra row with header (column names) is added to the temp table in case of TDS cross store joins.

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

