### PR TITLE
Sourcetree Calc: Fix unions with differing source property levels

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -492,7 +492,7 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeForPrope
 
          let withNextSetImpl     = $childSetImpls->fold(
                                       {setImpl, tree |
-                                         let appendAtPaths = $propertyPaths.current->filter(path| $path.values->isNotEmpty());
+                                         let appendAtPaths = $propertyPaths.current;
                                          if($appendAtPaths->isEmpty(),
                                             | $tree->enrichSourceTreeNode($setImpl, $tgtPgft, $extensions),
                                             | $appendAtPaths->fold({path,tree | $tree->enrichSourceTreeNodeAtPath($path, $setImpl, $tgtPgft, $extensions)}, $tree)
@@ -573,13 +573,18 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNode(srcNode
 
 function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeAtPath(srcNode:GraphFetchTree[1], path:List<PropertyPathNode>[1], setImplementation: PureInstanceSetImplementation[1], tgtPgft:PropertyGraphFetchTree[1], extensions:meta::pure::extension::Extension[*]): GraphFetchTree[1]
 {
-   let head = $path.values->at(0);
-   let tail = $path.values->tail();
-   
-   if($tail->isEmpty(),
-      | ^$srcNode(subTrees=$srcNode.subTrees->cast(@PropertyGraphFetchTree)->map(st|if($st.property == $head.property, |$st->enrichSourceTreeNode($setImplementation, $tgtPgft, $extensions), |$st))),
-      | ^$srcNode(subTrees=$srcNode.subTrees->cast(@PropertyGraphFetchTree)->map(st|if($st.property == $head.property, |$st->enrichSourceTreeNodeAtPath(list($tail), $setImplementation, $tgtPgft, $extensions), |$st)))
-   );
+  // If path is empty then we are enriching the source node rather than the subTrees
+   if($path.values->isEmpty(),
+      | let enrichedSourceNode = enrichSourceTreeNode($srcNode, $setImplementation, $tgtPgft, $extensions);
+        ^$enrichedSourceNode(subTrees=$enrichedSourceNode.subTrees->concatenate($srcNode.subTrees)->removeDuplicates());,
+      | let head = $path.values->at(0);
+        let tail = $path.values->tail();
+        
+        if($tail->isEmpty(),
+            | ^$srcNode(subTrees=$srcNode.subTrees->cast(@PropertyGraphFetchTree)->map(st|if($st.property == $head.property, |$st->enrichSourceTreeNode($setImplementation, $tgtPgft, $extensions), |$st))),
+            | ^$srcNode(subTrees=$srcNode.subTrees->cast(@PropertyGraphFetchTree)->map(st|if($st.property == $head.property, |$st->enrichSourceTreeNodeAtPath(list($tail), $setImplementation, $tgtPgft, $extensions), |$st)))
+        );
+   ); 
 }
 
 function <<access.private>> meta::pure::graphFetch::addPassThroughSubTrees(srcNode:GraphFetchTree[1], tgtNode:GraphFetchTree[1], extensions:meta::pure::extension::Extension[*]): GraphFetchTree[1]

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
@@ -1749,6 +1749,97 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withFilters::UnionMapping
 
 )
 
+###Pure
+// Union mapping where sources are a mix between root class and property access
+Class meta::pure::graphFetch::tests::sourceTreeCalc::Asset
+{
+  calcTyp: Float[0..1];
+  redempVal: Float[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::AssetPutSchedule
+{
+  putScheduleDt: StrictDate[0..1];
+  putSchedulePct: Float[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::Debt
+{
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::PrincipalRedemptionSchedule
+{
+  startDate: StrictDate[1];
+  endDate: StrictDate[0..1];
+  redempPrice: Float[0..1];
+  redempAmount: Float[0..1];
+}
+
+Association meta::pure::graphFetch::tests::sourceTreeCalc::Asset_AssetPutSchedule
+{
+  BO: meta::pure::graphFetch::tests::sourceTreeCalc::Asset[1];
+  putSch: meta::pure::graphFetch::tests::sourceTreeCalc::AssetPutSchedule[*];
+}
+
+Association meta::pure::graphFetch::tests::sourceTreeCalc::Debt_PrincipalRedemptionSchedule
+{
+  principleRedemptionSchedule: meta::pure::graphFetch::tests::sourceTreeCalc::PrincipalRedemptionSchedule[*];
+  debt: meta::pure::graphFetch::tests::sourceTreeCalc::Debt[1];
+}
+
+function <<meta::pure::profiles::test.Test>> meta::pure::mapping::modelToModel::test::alloy::simple::sourceTreeCalc::unionMappingFromSourceRootandSourceProperty():Boolean[1]
+{
+  let tree = #{meta::pure::graphFetch::tests::sourceTreeCalc::Debt{principleRedemptionSchedule{startDate,redempPrice,redempAmount,endDate}}}#;
+
+  let expectedString = 'Asset\n' +
+                        '(\n' +
+                        '  calcTyp\n' +
+                        '  putSch\n' +
+                        '  (\n' + 
+                        '    putScheduleDt\n' + 
+                        '    putSchedulePct\n' + 
+                        '  )\n' + 
+                        '  redempVal\n' +
+                        ')';
+
+  let sourceTree = meta::pure::graphFetch::calculateSourceTree($tree, 
+                                                                meta::pure::graphFetch::tests::sourceTreeCalc::MappingUnionFromRootClassAndProperty,
+                                                                meta::pure::extension::defaultExtensions());
+  assertEquals($expectedString, $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString());
+}
+
+
+###Mapping
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::MappingUnionFromRootClassAndProperty
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::Debt: Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::Asset
+    principleRedemptionSchedule[m1]: $src,
+    principleRedemptionSchedule[m2]: $src.putSch
+  }
+  *meta::pure::graphFetch::tests::sourceTreeCalc::PrincipalRedemptionSchedule: Operation
+  {
+    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(m1,m2)
+  }
+  meta::pure::graphFetch::tests::sourceTreeCalc::PrincipalRedemptionSchedule[m1]: Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::Asset
+    ~filter $src->isNotEmpty()
+    redempAmount: if($src.calcTyp->toOne()->floor()->in([0,1,2,3,4]), |$src.redempVal, |[]),
+    startDate: 2023->date(6, 6),
+    redempPrice: if(!($src.calcTyp->toOne()->floor()->in([0,1,2,3,4])), |$src.redempVal, |[])
+  }
+  meta::pure::graphFetch::tests::sourceTreeCalc::PrincipalRedemptionSchedule[m2]: Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::AssetPutSchedule
+    ~filter $src->isNotEmpty()
+    redempPrice: $src.putSchedulePct,
+    startDate: $src.putScheduleDt->toOne(),
+    endDate: $src.putScheduleDt
+  }
+)
+
 
 ###Pure
 import meta::pure::graphFetch::tests::sourceTreeCalc::withFlatteningInTransform::*;


### PR DESCRIPTION
#### What type of PR is this?

Bugfix

#### What does this PR do / why is it needed ?
Fix source tree calculation for union mappings where one union element is starting from the source and another from property access
