### PR TITLE
PureIDELight: Fix name in buildRepositories

### DIFF
--- a/legend-engine-pure-ide-light/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
+++ b/legend-engine-pure-ide-light/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
@@ -46,7 +46,7 @@ public class PureIDELight extends PureIDEServer
                 .with(this.buildCore("legend-engine-xt-relationalStore-bigquery-pure", "relational_bigquery"))
                 .with(this.buildCore("legend-engine-xt-relationalStore-spanner-pure", "relational_spanner"))
                 .with(this.buildCore("legend-engine-xt-relationalStore-athena-pure", "relational_athena"))
-                .with(this.buildCore("legend-engine-xt-relationalStore-store-entitlement-pure", "core_relational_store_entitlement"))
+                .with(this.buildCore("legend-engine-xt-relationalStore-store-entitlement-pure", "relational_store_entitlement"))
                 .with(this.buildCore("legend-engine-xt-serviceStore-pure", "servicestore"))
                 .with(this.buildCore("legend-engine-xt-text-pure-metamodel", "text-metamodel"))
                 .with(this.buildCore("legend-engine-xt-data-space-pure-metamodel", "data-space-metamodel"))


### PR DESCRIPTION
#### What type of PR is this?

Bugfix

#### What does this PR do / why is it needed ?
Fix name of module in buildRepositories in PureIDELight. Allows IDELight to launch without throwing missing repository exception

