### PR TITLE
fixed reverse function (alloy) and added test for it

### DIFF
--- a/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
+++ b/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
@@ -785,6 +785,13 @@ public class Library
         return sorted;
     }
 
+    public static <T> List<T> reverse(List<T> col)
+    {
+        ArrayList<T> reversed = new ArrayList<T>(col);
+        Collections.reverse(reversed);
+        return reversed;
+    }
+
     public static <T, U> U fold(List<T> col, BiFunction<? super T, U, U> accumulator, U identity)
     {
         java.util.function.BinaryOperator<U> dummyCombiner = (U combine1, U combine2) -> combine1;

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/collectionsLibrary.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/collectionsLibrary.pure
@@ -58,8 +58,8 @@ function meta::pure::executionPlan::platformBinding::legendJava::library::collec
          fc1(init_T_MANY__T_MANY_,                                               {ctx,collection               | if($collection.type->isJavaList(), |$library->j_invoke('init', $collection, $collection.type), | j_null($ctx.returnType->elementType())) }),
          fc1(tail_T_MANY__T_MANY_,                                               {ctx,collection               | $collection->j_streamOf()->js_skip(j_long(1))}),
          fc1(last_T_MANY__T_$0_1$_,                                              {ctx,collection               | if($collection.type->isJavaList(), | j_conditional($collection->j_invoke('isEmpty', []), j_null($collection.type->elementType()) ,$collection->j_invoke('get', $collection->j_invoke('size', [])->j_minus(j_int(1)))), | $collection )}),
-         fc1(reverse_T_m__T_m_,                                                  {ctx,collection               | if($collection.type->isJavaList(), | javaCollections()->j_invoke('reverse', javaArrayList($collection.type->elementType())->j_new($collection), $collection.type), | $collection ) }),
-         
+         fc1(reverse_T_m__T_m_,                                                  {ctx,collection               | if($collection.type->isJavaList(), | $library->j_invoke('reverse', $collection, $collection.type), | $collection) }),
+
          fc1(sort_T_m__T_m_,                                                     {ctx,collection               | if($collection.type->isJavaList(), | $library->j_invoke('sort', $collection, $collection.type), | $collection) }),
          fc2(sort_T_m__Function_$0_1$__T_m_,                                     {ctx,collection,comp          | if($collection.type->isJavaList(), | sortComp($ctx, $collection, $comp, $library),              | $collection) }),
          fc2(sortBy_T_m__Function_$0_1$__T_m_,                                   {ctx,collection,key           | if($collection.type->isJavaList(), | sortBy($collection, $key, $library),                       | $collection) }),

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/collectionsLibraryTests.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/collectionsLibraryTests.pure
@@ -124,6 +124,19 @@ meta::pure::executionPlan::platformBinding::legendJava::library::collection::tes
 
 function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
 {  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }
+meta::pure::executionPlan::platformBinding::legendJava::library::collection::tests::testReverse() : Boolean[1]
+{
+   javaExpressionTests(engineConventions([]))
+      ->addTest('reverse collection', {|[1, 3, 2]->reverse()}, 'org.finos.legend.engine.plan.dependencies.util.Library.reverse(java.util.Arrays.asList(1L, 3L, 2L))', javaList(javaLong()))
+         ->assert('%s.size() == 3')
+         ->assert('(%s).get(0).equals(2L)')
+         ->assert('(%s).get(1).equals(3L)')
+         ->assert('(%s).get(2).equals(1L)')
+      ->runTests();
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }
 meta::pure::executionPlan::platformBinding::legendJava::library::collection::tests::testCollectionQueries() : Boolean[1]
 {
    javaExpressionTests(engineConventions([]))


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

If you call reverse() function in Alloy Studio it will throw Java error "void cannot be converted to java.util.List<>"

#### Which issue(s) this PR fixes:

The one described above.

#### Other notes for reviewers:

The issue was cause by the fact that someone assumed that Collections.reverse() returns the reversed collection, but it acutally returns void and modifies the collection passed as an argument.

#### Does this PR introduce a user-facing change?

No.
