### PR TITLE
feature: added sqrt function with test (alloy)

### DIFF
--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/mathLibrary.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/mathLibrary.pure
@@ -99,7 +99,8 @@ function meta::pure::executionPlan::platformBinding::legendJava::library::math::
 
          fc1(cos_Number_1__Float_1_,                                   {ctx,num        | javaMath()->j_invoke('cos', $num->j_box()->j_invoke('doubleValue', []), javaDouble())}),
          fc1(sin_Number_1__Float_1_,                                   {ctx,num        | javaMath()->j_invoke('sin', $num->j_box()->j_invoke('doubleValue', []), javaDouble())}),
-         fc2(pow_Number_1__Number_1__Number_1_,                        {ctx,num1,num2  | javaStrictMath()->j_invoke('pow', [$num1->j_box()->j_invoke('doubleValue', []), $num2->j_box()->j_invoke('doubleValue', [])], javaDouble())})         
+         fc2(pow_Number_1__Number_1__Number_1_,                        {ctx,num1,num2  | javaStrictMath()->j_invoke('pow', [$num1->j_box()->j_invoke('doubleValue', []), $num2->j_box()->j_invoke('doubleValue', [])], javaDouble())}),
+         fc1(sqrt_Number_1__Float_1_,                                  {ctx,num        | javaMath()->j_invoke('sqrt', $num->j_box()->j_invoke('doubleValue', []), javaDouble())})
       ]);
 
    $conventions->registerLibrary($lib);

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
@@ -110,6 +110,18 @@ meta::pure::executionPlan::platformBinding::legendJava::library::math::tests::te
       ->runTests();
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }
+meta::pure::executionPlan::platformBinding::legendJava::library::math::tests::testSqrt() : Boolean[1]
+{
+   javaExpressionTests(engineConventions([]))
+      ->addTest('Sqrt (integer root)', {|sqrt(16.0d)}, 'Math.sqrt(new java.math.BigDecimal("16.0").doubleValue())', javaDouble())
+         ->assert('%s == 4.0d')
+      ->addTest('Sqrt (real root)', {|sqrt(3.0d)}, 'Math.sqrt(new java.math.BigDecimal("3.0").doubleValue())', javaDouble())
+         ->assert('%s > 1.732d')
+         ->assert('%s < 1.7321d')
+      ->runTests();
+}
 
 function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
 {  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

It adds sqrt() function to Alloy (along with test for it). Right now when trying to use sqrt() in Alloy Studio the following error pops up: "meta::pure::functions::math::sqrt_Number_1__Float_1_ is not supported yet!"

#### Other notes for reviewers:

It's just one line adding a call to Math.sqrt() similar to how functions like sin() work.

#### Does this PR introduce a user-facing change?

No
