### PR TITLE
add defaultParameterValues to Query

### DIFF
--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
@@ -139,7 +139,7 @@ public class QueryStoreManager
             });
         }
         String DEFAULT_PARAMETER_VALUES_CONST = "defaultParameterValues";
-        if(document.get(DEFAULT_PARAMETER_VALUES_CONST) != null)
+        if (document.get(DEFAULT_PARAMETER_VALUES_CONST) != null)
         {
             query.defaultParameterValues = ListIterate.collect(document.getList(DEFAULT_PARAMETER_VALUES_CONST, Document.class), _doc ->
             {

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
@@ -35,6 +35,7 @@ import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.application.query.model.Query;
 import org.finos.legend.engine.application.query.model.QueryEvent;
+import org.finos.legend.engine.application.query.model.QueryParameterValue;
 import org.finos.legend.engine.application.query.model.QuerySearchSpecification;
 import org.finos.legend.engine.application.query.model.QueryStoreStats;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.StereotypePtr;
@@ -135,6 +136,17 @@ public class QueryStoreManager
                 stereotypePtr.profile = _doc.getString("profile");
                 stereotypePtr.value = _doc.getString("value");
                 return stereotypePtr;
+            });
+        }
+        String DEFAULT_PARAMETER_VALUES_CONST = "defaultParameterValues";
+        if(document.get(DEFAULT_PARAMETER_VALUES_CONST) != null)
+        {
+            query.defaultParameterValues = ListIterate.collect(document.getList(DEFAULT_PARAMETER_VALUES_CONST, Document.class), _doc ->
+            {
+                QueryParameterValue queryParameterValue = new QueryParameterValue();
+                queryParameterValue.name = _doc.getString("name");
+                queryParameterValue.content = _doc.getString("content");
+                return queryParameterValue;
             });
         }
         return query;

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
@@ -36,6 +36,8 @@ public class Query
     public List<TaggedValue> taggedValues;
     public List<StereotypePtr> stereotypes;
 
+    public List<QueryParameterValue> defaultParameterValues;
+
     // We make it clear that we only allow a single owner
     public String owner;
 }

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryParameterValue.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryParameterValue.java
@@ -1,0 +1,23 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.application.query.model;
+
+
+public class QueryParameterValue
+{
+    public String name;
+
+    public String content;
+}

--- a/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
+++ b/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.application.query.model.Query;
 import org.finos.legend.engine.application.query.model.QueryEvent;
+import org.finos.legend.engine.application.query.model.QueryParameterValue;
 import org.finos.legend.engine.application.query.model.QueryProjectCoordinates;
 import org.finos.legend.engine.application.query.model.QuerySearchSpecification;
 import org.finos.legend.engine.application.query.utils.TestMongoClientProvider;

--- a/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
+++ b/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/api/TestQueryStoreManager.java
@@ -130,6 +130,7 @@ public class TestQueryStoreManager
         public String content = "content";
         public List<TaggedValue> taggedValues = Collections.emptyList();
         public List<StereotypePtr> stereotypes = Collections.emptyList();
+        public List<QueryParameterValue> parameterValues = Collections.emptyList();
 
         static TestQueryBuilder create(String id, String name, String owner)
         {
@@ -170,6 +171,12 @@ public class TestQueryStoreManager
             return this;
         }
 
+        TestQueryBuilder withParameterValues(List<QueryParameterValue> parameterValues)
+        {
+            this.parameterValues = parameterValues;
+            return this;
+        }
+
         Query build()
         {
             Query query = new Query();
@@ -185,6 +192,7 @@ public class TestQueryStoreManager
             query.description = this.description;
             query.taggedValues = this.taggedValues;
             query.stereotypes = this.stereotypes;
+            query.defaultParameterValues = this.parameterValues;
             return query;
         }
     }
@@ -214,6 +222,14 @@ public class TestQueryStoreManager
         taggedValue.profile = profile;
         taggedValue.value = stereotype;
         return taggedValue;
+    }
+
+    private static QueryParameterValue createTestParameterValue(String name, String value)
+    {
+        QueryParameterValue queryParameterValue = new QueryParameterValue();
+        queryParameterValue.content = value;
+        queryParameterValue.name = name;
+        return queryParameterValue;
     }
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -449,6 +465,38 @@ public class TestQueryStoreManager
         Assert.assertEquals(2, queryStoreManager.searchQueries(new TestQuerySearchSpecificationBuilder().withStereotypes(Lists.fixedSize.of(stereotype2)).build(), currentUser).size());
         Assert.assertEquals(3, queryStoreManager.searchQueries(new TestQuerySearchSpecificationBuilder().withStereotypes(Lists.fixedSize.of(stereotype1, stereotype2)).build(), currentUser).size());
         Assert.assertEquals(3, queryStoreManager.searchQueries(new TestQuerySearchSpecificationBuilder().withStereotypes(Lists.fixedSize.of(stereotype1, stereotype2, stereotype3)).build(), currentUser).size());
+    }
+
+    @Test
+    public void testGetQueriesWithParameterValues() throws Exception
+    {
+        String currentUser = "testUser";
+        QueryParameterValue param1 = createTestParameterValue("booleanParam1", "true");
+        QueryParameterValue param2 = createTestParameterValue("stringParam2", "'myString'");
+        QueryParameterValue param3 = createTestParameterValue("myListParam3", "['d','a']");
+        Query testQuery1 = TestQueryBuilder.create("1", "query1", currentUser).build();
+        Query testQuery2 = TestQueryBuilder.create("2", "query2", currentUser).withParameterValues(Lists.fixedSize.of(param1)).build();
+        Query testQuery3 = TestQueryBuilder.create("3", "query3", currentUser).withParameterValues(Lists.fixedSize.of(param2)).build();
+        Query testQuery4 = TestQueryBuilder.create("4", "query4", currentUser).withParameterValues(Lists.fixedSize.of(param1, param2, param3)).build();
+        queryStoreManager.createQuery(testQuery1, currentUser);
+        queryStoreManager.createQuery(testQuery2, currentUser);
+        queryStoreManager.createQuery(testQuery3, currentUser);
+        queryStoreManager.createQuery(testQuery4, currentUser);
+
+        Query query1 = queryStoreManager.getQuery("1");
+        Assert.assertEquals(0, query1.defaultParameterValues.size());
+
+        Query query2 = queryStoreManager.getQuery("2");
+        Assert.assertEquals(1, query2.defaultParameterValues.size());
+        Assert.assertEquals("booleanParam1", query2.defaultParameterValues.get(0).name);
+        Assert.assertEquals("true", query2.defaultParameterValues.get(0).content);
+
+        Query query4 = queryStoreManager.getQuery("4");
+        Assert.assertEquals(3, query4.defaultParameterValues.size());
+        Assert.assertEquals("booleanParam1", query4.defaultParameterValues.get(0).name);
+        Assert.assertEquals("stringParam2", query4.defaultParameterValues.get(1).name);
+        Assert.assertEquals("myListParam3", query4.defaultParameterValues.get(2).name);
+        Assert.assertEquals("['d','a']", query4.defaultParameterValues.get(2).content);
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

Add `defaultParameterValues` to Query for QueryStore for Query Application. 
Motivation is to be able to save user's default parameter values, so saved queries are easier and more intuitive to execute. 
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Improvement to Legend Query workflow
<!--
Describe change being introduced by this PR.
-->
Add `defaultParameterValues` to Query 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
