### PR TITLE
SourceTreeCalc: Fix union and non-union traversal via root object

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -478,7 +478,6 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeForPrope
                                                                                                                  $pgft->getSubTreeNodesAtPath($val, $setClasses->cast(@Class<Any>), $extensions);
                                                                                                             );
                                                                                                      ));
-
          let srcNodeProperties   = $withSubTypes->filter(p | $owner->getAllTypeGeneralisations()->contains($p.property->meta::pure::functions::meta::ownerClass()));
          let withFoundProperties = $srcNode->addSubTrees($srcNodeProperties);
 
@@ -490,16 +489,19 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeForPrope
                                    | $withFoundProperties
                                   );
 
-         let withNextSetImpl     = $childSetImpls->fold(
-                                      {setImpl, tree |
-                                         let appendAtPaths = $propertyPaths.current;
-                                         if($appendAtPaths->isEmpty(),
-                                            | $tree->enrichSourceTreeNode($setImpl, $tgtPgft, $extensions),
-                                            | $appendAtPaths->fold({path,tree | $tree->enrichSourceTreeNodeAtPath($path, $setImpl, $tgtPgft, $extensions)}, $tree)
-                                         );
-                                      },
-                                      $withRootSubTypes
-                                   );
+         let withNextSetImpl     = $childSetImpls->fold({setImpl, tree |
+                                                        let appendAtPaths = $propertyPaths.current->removeDuplicates();
+                                                        if($appendAtPaths->isEmpty(),
+                                                            | $tree->enrichSourceTreeNode($setImpl, $tgtPgft, $extensions),
+                                                            | $appendAtPaths->fold({path,tree | 
+                                                                      if($path.values->isEmpty(), 
+                                                                        | $tree->enrichSourceTreeNode($setImpl, $tgtPgft, $extensions),
+                                                                        | $tree->enrichSourceTreeNodeAtPath($path, $setImpl, $tgtPgft, $extensions))                                                     
+                                                              }, $tree)
+                                                        );
+                                                        },
+                                                        $withRootSubTypes
+                                                      );
 
          let withPassThruSubTrees = if($childSetImpls->isEmpty() && $returnType->instanceOf(Class) && $requiredProperty->toOne()->isPropertyAutoMapped($setImplementation),
                                       |let appendAtPaths = $propertyPaths.current->filter(path| $path.values->isNotEmpty());

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
@@ -1842,6 +1842,132 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::MappingUnionFromRootClass
 
 
 ###Pure
+// Union mapping with multiple src property accesses within and outside the union
+
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::Tradable
+{
+  bid: meta::pure::graphFetch::tests::sourceTreeCalc::Identifier1[*];
+}
+
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::Identifier1
+{
+  FROM_Z: StrictDate[1];
+  THRU_Z: StrictDate[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::Identifier2
+{
+
+  FROM_Z: StrictDate[1];
+  THRU_Z: StrictDate[1];
+}
+
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::Equity
+{
+  EquityTradable: meta::pure::graphFetch::tests::sourceTreeCalc::Tradable[*];
+  id2: meta::pure::graphFetch::tests::sourceTreeCalc::Identifier2[*];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::EquityPayload
+{
+  data: meta::pure::graphFetch::tests::sourceTreeCalc::Equity[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::EquityPayloadList
+{
+  payload: meta::pure::graphFetch::tests::sourceTreeCalc::EquityPayload[*];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::EquityTarget
+{
+  Identifiers2: meta::pure::graphFetch::tests::sourceTreeCalc::Identifier2[*];
+  Identifiers1: meta::pure::graphFetch::tests::sourceTreeCalc::Identifier1[*];
+}
+
+
+function <<meta::pure::profiles::test.Test>> meta::pure::mapping::modelToModel::test::alloy::simple::sourceTreeCalc::unionMappingAndSimpleMappingSourceAccesses():Boolean[1]
+{
+
+  let tree = #{meta::pure::graphFetch::tests::sourceTreeCalc::EquityTarget{Identifiers2{FROM_Z,THRU_Z},Identifiers1{FROM_Z,THRU_Z}}}#;
+
+  let expectedString ='EquityPayloadList\n' +
+                      '(\n' +
+                      '  payload\n' +
+                      '  (\n' +
+                      '    data\n' +
+                      '    (\n' +
+                      '      EquityTradable\n' +
+                      '      (\n' +
+                      '        bid\n' +
+                      '        (\n' +
+                      '          FROM_Z\n' +
+                      '          THRU_Z\n' +
+                      '        )\n' +
+                      '      )\n' +
+                      '      id2\n' +
+                      '      (\n' +
+                      '        FROM_Z\n' +
+                      '        THRU_Z\n' +
+                      '      )\n' +
+                      '    )\n' +
+                      '  )\n' +
+                      ')';
+  
+
+  let sourceTree = meta::pure::graphFetch::calculateSourceTree($tree, 
+                                                                meta::pure::graphFetch::tests::sourceTreeCalc::EquityTargetMapping,
+                                                                meta::pure::extension::defaultExtensions());
+  assertEquals($expectedString, $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString());
+}
+
+
+###Mapping
+
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::EquityTargetMapping
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::EquityTarget: Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::EquityPayloadList
+    Identifiers2[prodid]: $src,
+    Identifiers1[union1]: $src,
+    Identifiers1[union2]: $src
+
+
+  }
+  
+  *meta::pure::graphFetch::tests::sourceTreeCalc::Identifier1 : Operation
+  {
+    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(union1, union2)
+  }
+  meta::pure::graphFetch::tests::sourceTreeCalc::Identifier2[prodid]: Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::EquityPayloadList
+   
+    FROM_Z*: $src.payload.data.id2.FROM_Z,
+    THRU_Z*: $src.payload.data.id2.THRU_Z
+  }
+  meta::pure::graphFetch::tests::sourceTreeCalc::Identifier1[union1]: Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::EquityPayloadList
+    
+    FROM_Z*: $src.payload.data.EquityTradable.bid.FROM_Z,
+    THRU_Z*: $src.payload.data.EquityTradable.bid.THRU_Z
+  }
+  meta::pure::graphFetch::tests::sourceTreeCalc::Identifier1[union2]: Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::EquityPayloadList
+    FROM_Z*: $src.payload.data.id2.FROM_Z,
+    THRU_Z*: $src.payload.data.id2.THRU_Z
+  }
+ 
+)
+
+
+
+###Pure
 import meta::pure::graphFetch::tests::sourceTreeCalc::withFlatteningInTransform::*;
 
 Class meta::pure::graphFetch::tests::sourceTreeCalc::withFlatteningInTransform::Source_A


### PR DESCRIPTION
#### What type of PR is this?

Bugfix

#### What does this PR do / why is it needed ?
Handle multiple paths via $src in M2M mappings - in particular this fixes an issue where a top level mapping passes down the $src object to both a union and non-union mapping, where the mappings access a common set of properties. 

This fixes a case missed in a previous commit https://github.com/finos/legend-engine/pull/1605