### PR TITLE
Add TDS concatenate method that takes multiple additional TDSs

### DIFF
--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -730,6 +730,7 @@ function meta::pure::router::routing::shouldStopFunctions(extensions:meta::pure:
     projectWithColumnSubset_T_MANY__Function_MANY__String_MANY__String_MANY__TabularDataSet_1_,
     groupByWithWindowSubset_K_MANY__Function_MANY__AggregateValue_MANY__String_MANY__String_MANY__String_MANY__TabularDataSet_1_,
     concatenate_TabularDataSet_1__TabularDataSet_1__TabularDataSet_1_,
+    concatenate_TabularDataSet_1__TabularDataSet_MANY__TabularDataSet_1_,
     renameColumns_TabularDataSet_1__Pair_MANY__TabularDataSet_1_,
     min_Number_MANY__Number_$0_1$_,
     olapGroupBy_TabularDataSet_1__String_MANY__SortInformation_$0_1$__OlapOperation_1__String_1__TabularDataSet_1_,

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/tds.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/tds.pure
@@ -448,21 +448,30 @@ function
 }
 
 function 
-   {doc.doc = 'Append the rows from the second TDS to the rows in the first TDS.  N.B. The column must be the same for the two input TDSs'}
-   meta::pure::tds::concatenate(tds1:TabularDataSet[1], tds2:TabularDataSet[1]):TabularDataSet[1]
+   {doc.doc = 'Append the rows from the additional TDSs to the rows in the first TDS.  N.B. The column must be the same for the TDSs'}
+   meta::pure::tds::concatenate(tds1:TabularDataSet[1], tdss:TabularDataSet[*]):TabularDataSet[1]
 {
+  $tdss->forAll(tds2|
    assert($tds1.columns->size() == $tds2.columns->size(), | 'Number of columns must match to concatenate, got ' + $tds1.columns.name->joinStrings('[', ',', ']') + ' and ' +  $tds2.columns.name->joinStrings('[', ',', ']') );
    assertEquals($tds1.columns.name, $tds2.columns.name, | 'Columns names must match to concatenate, got ' + $tds1.columns.name->joinStrings('[', ',', ']') + ' and ' +  $tds2.columns.name->joinStrings('[', ',', ']') );
    assert(zip($tds1.columns, $tds2.columns)->forAll(pair | 
                assertEquals($pair.first.name, $pair.second.name); 
                assertEquals($pair.first.type, $pair.second.type, | 'Column types must match to concatenate, mismatched for column ' + $pair.first.name + ' (' + $pair.first.type->makeString() + ' vs ' + $pair.second.type->makeString() + ')');
             ));
+  );
 
    let tds = ^TabularDataSet(columns=$tds1.columns->map(col|^TDSColumn(offset=$col.offset, name=$col.name, type=$col.type)));
 
-   let newRows = $tds1.rows->concatenate($tds2.rows)->map(r|^TDSRow(parent=$tds,values=$r.values));
+   let newRows = $tds1.rows->concatenate($tdss.rows)->map(r|^TDSRow(parent=$tds,values=$r.values));
    $tds->mutateAdd('rows', $newRows);
    $tds;
+}
+
+function 
+   {doc.doc = 'Append the rows from the second TDS to the rows in the first TDS.  N.B. The column must be the same for the two input TDSs'}
+   meta::pure::tds::concatenate(tds1:TabularDataSet[1], tds2:TabularDataSet[1]):TabularDataSet[1]
+{
+   $tds1->concatenate($tds2->toOneMany());
 }
 
 function meta::pure::tds::validatePaths(paths:Path<Nil,Any|*>[*]):Boolean[1]

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -1993,10 +1993,18 @@ function meta::relational::functions::pureToSqlQuery::processFunctionExpressionF
 function meta::relational::functions::pureToSqlQuery::flattenConcatenate(f:ValueSpecification[1]):ValueSpecification[*]
 {
    $f->match([
-      fe:FunctionExpression[1] | if ($fe.func->in([concatenate_T_MANY__T_MANY__T_MANY_, union_T_MANY__T_MANY__T_MANY_, concatenate_TabularDataSet_1__TabularDataSet_1__TabularDataSet_1_]),
+      fe:FunctionExpression[1] | if ($fe.func->in([
+                                            concatenate_T_MANY__T_MANY__T_MANY_, union_T_MANY__T_MANY__T_MANY_, 
+                                            concatenate_TabularDataSet_1__TabularDataSet_1__TabularDataSet_1_,
+                                            concatenate_TabularDataSet_1__TabularDataSet_MANY__TabularDataSet_1_
+                                            ]),
                                        | $fe.parametersValues->at(0)->flattenConcatenate()->concatenate($fe.parametersValues->at(1)->flattenConcatenate()),
                                        | $fe
                                  );,
+      iv:InstanceValue[1]| $iv.values->match([
+                              v:ValueSpecification[*]|$v, 
+                              a:Any[*]| $iv
+                                ]),
       v:ValueSpecification[1] | $v
    ])
 }
@@ -7391,6 +7399,7 @@ function meta::relational::functions::pureToSqlQuery::getSupportedFunctions():Ma
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::project_T_MANY__Path_MANY__TabularDataSet_1_, second=meta::relational::functions::pureToSqlQuery::processProjectPaths_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::project_T_MANY__ColumnSpecification_MANY__TabularDataSet_1_, second=meta::relational::functions::pureToSqlQuery::processProjectColumns_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::concatenate_TabularDataSet_1__TabularDataSet_1__TabularDataSet_1_, second=meta::relational::functions::pureToSqlQuery::processConcatenate_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::concatenate_TabularDataSet_1__TabularDataSet_MANY__TabularDataSet_1_, second=meta::relational::functions::pureToSqlQuery::processConcatenate_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::groupBy_TabularDataSet_1__String_MANY__AggregateValue_MANY__TabularDataSet_1_, second=meta::relational::functions::pureToSqlQuery::processGroupBy_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::filter_TabularDataSet_1__Function_1__TabularDataSet_1_, second=meta::relational::functions::pureToSqlQuery::processTdsFilter_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::tds::distinct_TabularDataSet_1__TabularDataSet_1_, second=meta::relational::functions::pureToSqlQuery::processDistinct_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testTDSConcatenate.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testTDSConcatenate.pure
@@ -41,6 +41,31 @@ function <<test.Test>> meta::relational::tests::tds::tdsConcatenate::testSimpleC
       $result->sqlRemoveFormatting());   
 }
 
+function <<test.Test>> meta::relational::tests::tds::tdsConcatenate::testMultiConcatenate():Boolean[1]
+{
+   let result = execute(
+      |Person.all()
+         ->project([col(p|$p.lastName + '_0', 'lastName')])
+         ->concatenate([
+            Person.all()->project([col(p|$p.lastName + '_1', 'lastName')]),
+            Person.all()->project([col(p|$p.lastName + '_2', 'lastName')]),
+            Person.all()->project([col(p|$p.lastName + '_3', 'lastName')])
+            ])
+      ,
+      simpleRelationalMapping, 
+      testRuntime(), meta::relational::extension::relationalExtensions());
+   
+   let tds = $result.values->toOne()->sort([asc('lastName')]);
+   
+   assertSize($tds.columns, 1);   
+   
+   assertEquals('Allen_0,Allen_1,Allen_2,Allen_3,Harris_0,Harris_1,Harris_2,Harris_3,Hill_0,Hill_0,Hill_1,Hill_1,Hill_2,Hill_2,Hill_3,Hill_3,Johnson_0,Johnson_1,Johnson_2,Johnson_3,Roberts_0,Roberts_1,Roberts_2,Roberts_3,Smith_0,Smith_1,Smith_2,Smith_3',
+      $tds.rows->map(r|$r.values->makeString('|'))->makeString(','));
+   
+   assertEquals('select "unionalias_0"."lastName" as "lastName" from (select concat("root".LASTNAME, \'_0\') as "lastName" from personTable as "root" UNION ALL select concat("root".LASTNAME, \'_1\') as "lastName" from personTable as "root" UNION ALL select concat("root".LASTNAME, \'_2\') as "lastName" from personTable as "root" UNION ALL select concat("root".LASTNAME, \'_3\') as "lastName" from personTable as "root") as "unionalias_0"', 
+      $result->sqlRemoveFormatting());   
+}
+
 function <<test.Test>> meta::relational::tests::tds::tdsConcatenate::testConcatenateWithPreOperation1():Boolean[1]
 {
    let result = execute(


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

Add TDS concatenate method that takes multiple additional TDSs.  This avoids having to perform lots of sequential individual concatenates, which can lead to unnecessary of deep level function call depth.

Instead of ``concatenate($a, conctenate($b, concatenate($c, $d)))``, you can now do ``$a->concatenate([$b,$c,$d])``
