### PR TITLE
fix: divide scale issue

### DIFF
--- a/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
+++ b/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
@@ -50,6 +50,7 @@ public class Library
     private static final List<Class> PRIMITIVE_CLASS_COMPARISON_ORDER = Arrays.asList(Long.class, Double.class, PureDate.class, Boolean.class, String.class);
     private static final Comparator<Object> DEFAULT_COMPARATOR = Library::compareInt;
     private static final TimeZone GMT_TIME_ZONE = TimeZone.getTimeZone("GMT");
+    private static final int SCALE = 34;
 
     public static PureDate adjustDate(PureDate date, long number, DurationUnit unit)
     {
@@ -489,7 +490,7 @@ public class Library
         }
     }
 
-    public static double divide(Number left, Number right)
+    public static double divide(Number left, Number right, long scale)
     {
         if (right.doubleValue() == 0)
         {
@@ -497,28 +498,33 @@ public class Library
         }
         if (left instanceof BigDecimal && right instanceof BigDecimal)
         {
-            return ((BigDecimal) left).divide((BigDecimal) right, RoundingMode.HALF_UP).doubleValue();
+            return ((BigDecimal) left).divide((BigDecimal) right, (int) scale, RoundingMode.HALF_UP).doubleValue();
         }
         else if (left instanceof BigDecimal && right instanceof Long)
         {
-            return ((BigDecimal) left).divide(BigDecimal.valueOf(right.longValue()), RoundingMode.HALF_UP).doubleValue();
+            return ((BigDecimal) left).divide(BigDecimal.valueOf(right.longValue()), (int) scale, RoundingMode.HALF_UP).doubleValue();
         }
         else if (left instanceof BigDecimal && right instanceof Double)
         {
-            return ((BigDecimal) left).divide(BigDecimal.valueOf(right.doubleValue()), RoundingMode.HALF_UP).doubleValue();
+            return ((BigDecimal) left).divide(BigDecimal.valueOf(right.doubleValue()), (int) scale, RoundingMode.HALF_UP).doubleValue();
         }
         else if (left instanceof Long && right instanceof BigDecimal)
         {
-            return BigDecimal.valueOf(left.longValue()).divide((BigDecimal) right, RoundingMode.HALF_UP).doubleValue();
+            return BigDecimal.valueOf(left.longValue()).divide((BigDecimal) right, (int) scale, RoundingMode.HALF_UP).doubleValue();
         }
         else if (left instanceof Double && right instanceof BigDecimal)
         {
-            return BigDecimal.valueOf(left.doubleValue()).divide((BigDecimal) right, RoundingMode.HALF_UP).doubleValue();
+            return BigDecimal.valueOf(left.doubleValue()).divide((BigDecimal) right, (int) scale, RoundingMode.HALF_UP).doubleValue();
         }
         else
         {
             return (left instanceof Long ? left.longValue() : left.doubleValue()) / (right instanceof Long ? right.longValue() : right.doubleValue());
         }
+    }
+
+    public static double divide(Number left, Number right)
+    {
+        return Library.divide(left, right, Library.SCALE);
     }
 
     public static Number rem(Number left, Number right)

--- a/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
+++ b/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
@@ -50,7 +50,6 @@ public class Library
     private static final List<Class> PRIMITIVE_CLASS_COMPARISON_ORDER = Arrays.asList(Long.class, Double.class, PureDate.class, Boolean.class, String.class);
     private static final Comparator<Object> DEFAULT_COMPARATOR = Library::compareInt;
     private static final TimeZone GMT_TIME_ZONE = TimeZone.getTimeZone("GMT");
-    private static final int SCALE = 34;
 
     public static PureDate adjustDate(PureDate date, long number, DurationUnit unit)
     {
@@ -524,7 +523,7 @@ public class Library
 
     public static double divide(Number left, Number right)
     {
-        return Library.divide(left, right, Library.SCALE);
+        return Library.divide(left, right, 20L);
     }
 
     public static Number rem(Number left, Number right)

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
@@ -99,6 +99,25 @@ meta::pure::executionPlan::platformBinding::legendJava::library::math::tests::te
          ->assert('%s == 35.0')
       ->addTest('Float n\'ary times', {|[6.0, 7.0, 5.0]->times()}, 'java.util.Arrays.asList(6.0, 7.0, 5.0).stream().reduce(1.0, org.finos.legend.engine.plan.dependencies.util.Library::floatMultiply).doubleValue()', javaDouble())
          ->assert('%s == 210.0')
+      // extra divide tests
+      ->addTest('Integer Divide', {|1 / 2}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(1L, 2L)', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Decimal Scale 0 Decimal Scale 0 Divide', {|1D / 2D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1"), new java.math.BigDecimal("2"))', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Decimal Scale 1 Decimal Scale 0 Divide', {|1.0D / 2D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1.0"), new java.math.BigDecimal("2"))', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Decimal Scale 0 Decimal Scale 1 Divide', {|1D / 2.0D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1"), new java.math.BigDecimal("2.0"))', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Decimal Scale 0 Integer Divide', {|1D / 2}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1"), 2L)', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Decimal Scale 0 Float Divide', {|1D / 2.0}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1"), 2.0)', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Integer Decimal Scale 0 Divide', {|1 / 2D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(1L, new java.math.BigDecimal("2"))', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Float Decimal Scale 1 Divide', {|1.0 / 2D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(1.0, new java.math.BigDecimal("2"))', javaDouble())
+         ->assert('%s == 0.5')
+      ->addTest('Float Divide', {|1.0 / 2.0}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(1.0, 2.0)', javaDouble())
+         ->assert('%s == 0.5')
       // go
       ->runTests();
 }

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
@@ -62,6 +62,9 @@ meta::pure::executionPlan::platformBinding::legendJava::library::math::tests::te
          ->assert('(%s).equals(new java.math.BigDecimal("13.1"))')
       ->addTest('Decimal n\'ary plus', {|[6.9D, 2.6D, 5.8D]->plus()}, 'java.util.Arrays.asList(new java.math.BigDecimal("6.9"), new java.math.BigDecimal("2.6"), new java.math.BigDecimal("5.8")).stream().reduce(java.math.BigDecimal.ZERO, org.finos.legend.engine.plan.dependencies.util.Library::decimalPlus)', javaBigDecimal())
          ->assert('(%s).equals(new java.math.BigDecimal("15.3"))')
+      ->addTest('Number Divide', {|1.0D / 3.0D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1.0"), new java.math.BigDecimal("3.0"))', javaDouble())
+         ->assert('%s > 0.333333')
+         ->assert('%s < 0.34')
       ->addTest('Decimal Divide', {|10.10D->divide(2.1D, 1)}, 'new java.math.BigDecimal("10.10").divide(new java.math.BigDecimal("2.1"), new Long(1L).intValue(), java.math.RoundingMode.HALF_UP)', javaBigDecimal())
          ->assert('(%s).equals(new java.math.BigDecimal("4.8"))')
       //Integer

--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/mathLibraryTests.pure
@@ -62,7 +62,7 @@ meta::pure::executionPlan::platformBinding::legendJava::library::math::tests::te
          ->assert('(%s).equals(new java.math.BigDecimal("13.1"))')
       ->addTest('Decimal n\'ary plus', {|[6.9D, 2.6D, 5.8D]->plus()}, 'java.util.Arrays.asList(new java.math.BigDecimal("6.9"), new java.math.BigDecimal("2.6"), new java.math.BigDecimal("5.8")).stream().reduce(java.math.BigDecimal.ZERO, org.finos.legend.engine.plan.dependencies.util.Library::decimalPlus)', javaBigDecimal())
          ->assert('(%s).equals(new java.math.BigDecimal("15.3"))')
-      ->addTest('Number Divide', {|1.0D / 3.0D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1.0"), new java.math.BigDecimal("3.0"))', javaDouble())
+      ->addTest('Number Divide with Decimals', {|1.0D / 3.0D}, 'org.finos.legend.engine.plan.dependencies.util.Library.divide(new java.math.BigDecimal("1.0"), new java.math.BigDecimal("3.0"))', javaDouble())
          ->assert('%s > 0.333333')
          ->assert('%s < 0.34')
       ->addTest('Decimal Divide', {|10.10D->divide(2.1D, 1)}, 'new java.math.BigDecimal("10.10").divide(new java.math.BigDecimal("2.1"), new Long(1L).intValue(), java.math.RoundingMode.HALF_UP)', javaBigDecimal())


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Previous divide() function implementation which used Java.math.BigDecimal.divide() failed to specify scale for the operation which is a big issue as the default scale will be scale of the first number in the division which causes unpredictable behaviour. For example dividing 1 by 2 will just result in 1.

#### Which issue(s) this PR fixes:

|left|right|pre fix|post fix|
|----|-----|-------|--------|
|1   |2    |0.5    |0.5     |
|1D  |2D   |1      |0.5     |
|1.0D|2D   |0.5    |0.5     |
|1D  |2.0D |1      |0.5     |
|1D  |2    |1      |0.5     |
|1D  |2.0  |1      |0.5     |
|1   |2D   |1      |0.5     |
|1.0 |2D   |0.5    |0.5     |
|1.0 |2.0  |0.5    |0.5     |

#### Other notes for reviewers:

I came up with the 34 value for scale by running few tests in PURE IDE, but it would be prudent to consult this value with someone more aware of the real needs of PURE language in Alloy context.

#### Does this PR introduce a user-facing change?

No.
