### PR TITLE
Support streaming from Mongo cursor

### DIFF
--- a/legend-engine-extensions-collection-execution/pom.xml
+++ b/legend-engine-extensions-collection-execution/pom.xml
@@ -91,6 +91,10 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-nonrelationalStore-mongodb-executionPlan</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-elasticsearch-V7-executionPlan</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/legend-engine-extensions-collection-execution/src/test/java/org/finos/legend/engine/extensions/collection/execution/TestExtensions.java
+++ b/legend-engine-extensions-collection-execution/src/test/java/org/finos/legend/engine/extensions/collection/execution/TestExtensions.java
@@ -51,6 +51,7 @@ public class TestExtensions
                 .with(RelationalExecutionExtension.class)
                 .with(ExternalFormatExecutionExtension.class)
                 .with(ServiceStoreExecutionExtension.class)
+                .with(org.finos.legend.engine.plan.execution.stores.mongodb.MongoDBStoreExecutionExtension.class)
                 .with(org.finos.legend.engine.plan.execution.stores.elasticsearch.v7.Elasticsearch7ExecutionExtension.class);
     }
 
@@ -100,6 +101,7 @@ public class TestExtensions
                 .with(InMemoryStoreExecutorBuilder.class)
                 .with(RelationalStoreExecutorBuilder.class)
                 .with(ServiceStoreExecutorBuilder.class)
+                .with(org.finos.legend.engine.plan.execution.stores.mongodb.plugin.MongoDBStoreExecutorBuilder.class)
                 .with(org.finos.legend.engine.plan.execution.stores.elasticsearch.v7.plugin.ElasticsearchV7StoreExecutorBuilder.class);
     }
 

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/pom.xml
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/pom.xml
@@ -122,10 +122,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-runtime</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-json-runtime</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.finos.legend.engine</groupId>-->
+<!--            <artifactId>legend-engine-xt-json-runtime</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-dependencies</artifactId>
@@ -133,6 +133,10 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-javaCompiler</artifactId>
         </dependency>
         <!-- ENGINE -->
 

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/pom.xml
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/pom.xml
@@ -122,10 +122,6 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-external-shared-format-runtime</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.finos.legend.engine</groupId>-->
-<!--            <artifactId>legend-engine-xt-json-runtime</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-dependencies</artifactId>

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/MongoDBExecutor.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/MongoDBExecutor.java
@@ -23,7 +23,7 @@ import org.bson.Document;
 import org.finos.legend.authentication.credentialprovider.CredentialProviderProvider;
 import org.finos.legend.engine.plan.execution.stores.mongodb.auth.MongoDBConnectionSpecification;
 import org.finos.legend.engine.plan.execution.stores.mongodb.auth.MongoDBStoreConnectionProvider;
-import org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoCursorResult;
+import org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoDBResult;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.MongoDBConnection;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.identity.credential.AnonymousCredential;
@@ -41,7 +41,7 @@ public class MongoDBExecutor
         this.credentialProviderProvider = credentialProviderProvider;
     }
 
-    public MongoCursorResult executeMongoDBQuery(String dbCommand, MongoDBConnection dbConnection)
+    public MongoDBResult executeMongoDBQuery(String dbCommand, MongoDBConnection dbConnection)
     {
         try
         {
@@ -56,13 +56,13 @@ public class MongoDBExecutor
 
             ObjectMapper mapper = new ObjectMapper();
             ArrayNode arrayNode = mapper.createArrayNode();
-            MongoCursorResult mongoCursorResult;
+            MongoDBResult mongoDBResult;
             try
             {
                 MongoCursor<Document> cursor = mongoDatabase.getCollection(bsonCmd.getString("aggregate"))
                         .aggregate(bsonCmd.getList("pipeline", Document.class))
                         .batchSize(DEFAULT_BATCH_SIZE).iterator();
-                mongoCursorResult = new MongoCursorResult(cursor);
+                mongoDBResult = new MongoDBResult(mongoClient, cursor);
             }
             catch (Exception e)
             {
@@ -71,7 +71,7 @@ public class MongoDBExecutor
                         e,
                         ExceptionCategory.SERVER_EXECUTION_ERROR);
             }
-            return mongoCursorResult;
+            return mongoDBResult;
         }
         catch (Exception e)
         {

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/MongoDBExecutor.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/MongoDBExecutor.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.plan.execution.stores.mongodb;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.mongodb.client.MongoClient;
@@ -22,23 +21,14 @@ import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
 import org.finos.legend.authentication.credentialprovider.CredentialProviderProvider;
-import org.finos.legend.authentication.credentialprovider.impl.UserPasswordCredentialProvider;
-import org.finos.legend.authentication.intermediationrule.IntermediationRuleProvider;
-import org.finos.legend.authentication.intermediationrule.impl.UserPasswordFromVaultRule;
-import org.finos.legend.authentication.vault.CredentialVaultProvider;
-import org.finos.legend.authentication.vault.PlatformCredentialVaultProvider;
-import org.finos.legend.authentication.vault.impl.PropertiesFileCredentialVault;
-import org.finos.legend.authentication.vault.impl.SystemPropertiesCredentialVault;
-import org.finos.legend.engine.plan.execution.result.InputStreamResult;
 import org.finos.legend.engine.plan.execution.stores.mongodb.auth.MongoDBConnectionSpecification;
 import org.finos.legend.engine.plan.execution.stores.mongodb.auth.MongoDBStoreConnectionProvider;
+import org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoCursorResult;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.MongoDBConnection;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.identity.credential.AnonymousCredential;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Properties;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionCategory;
 
 public class MongoDBExecutor
 {
@@ -51,7 +41,7 @@ public class MongoDBExecutor
         this.credentialProviderProvider = credentialProviderProvider;
     }
 
-    public InputStreamResult executeMongoDBQuery(String dbCommand, MongoDBConnection dbConnection)
+    public MongoCursorResult executeMongoDBQuery(String dbCommand, MongoDBConnection dbConnection)
     {
         try
         {
@@ -66,26 +56,29 @@ public class MongoDBExecutor
 
             ObjectMapper mapper = new ObjectMapper();
             ArrayNode arrayNode = mapper.createArrayNode();
-
-            try (MongoCursor<Document> cursor = mongoDatabase.getCollection(bsonCmd.getString("aggregate"))
-                    .aggregate(bsonCmd.getList("pipeline", Document.class))
-                    .batchSize(DEFAULT_BATCH_SIZE).iterator())
+            MongoCursorResult mongoCursorResult;
+            try
             {
-                while (cursor.hasNext())
-                {
-                    JsonNode jsonNode = mapper.readTree(cursor.next().toJson());
-                    arrayNode.add(jsonNode);
-                }
+                MongoCursor<Document> cursor = mongoDatabase.getCollection(bsonCmd.getString("aggregate"))
+                        .aggregate(bsonCmd.getList("pipeline", Document.class))
+                        .batchSize(DEFAULT_BATCH_SIZE).iterator();
+                mongoCursorResult = new MongoCursorResult(cursor);
             }
-
-            InputStream inputStream = new ByteArrayInputStream(arrayNode.toString().getBytes());
-
-            return new InputStreamResult(inputStream);
-
+            catch (Exception e)
+            {
+                throw new EngineException(
+                        String.format("Failed to execute query : %s, database: %s", dbCommand.toString(), dbConnection.dataSourceSpecification.databaseName),
+                        e,
+                        ExceptionCategory.SERVER_EXECUTION_ERROR);
+            }
+            return mongoCursorResult;
         }
         catch (Exception e)
         {
-            throw new RuntimeException("error streaming MongoDB Results", e);
+            throw new EngineException(
+                    String.format("Failed to execute query : %s, database: %s", dbCommand.toString(), dbConnection.dataSourceSpecification.databaseName),
+                    e,
+                    ExceptionCategory.SERVER_EXECUTION_ERROR);
         }
     }
 

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/MongoDBStoreExecutionExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/MongoDBStoreExecutionExtension.java
@@ -40,80 +40,8 @@ public class MongoDBStoreExecutionExtension implements IMongoDBStoreExecutionExt
             else if (executionNode instanceof MongoDBDocumentInternalizeExecutionNode)
             {
                 return executionNode.accept(executionState.getStoreExecutionState(StoreType.NonRelational_MongoDB).getVisitor(profiles, executionState));
-                //return executeDocumentInternalizeExecutionNode((MongoDBDocumentInternalizeExecutionNode) executionNode, profiles, executionState);
             }
             return null;
         }));
     }
-
-    /*
-    private Result executeDocumentInternalizeExecutionNode(MongoDBDocumentInternalizeExecutionNode node, MutableList<CommonProfile> profiles, ExecutionState executionState)
-    {
-        InputStream stream = ExecutionHelper.inputStreamFromResult(node.executionNodes().getFirst().accept(new ExecutionNodeExecutor(profiles, new ExecutionState(executionState))));
-        StreamingObjectResult<?> streamingObjectResult = executeInternalizeExecutionNode(node, stream, profiles, executionState);
-        return applyConstraints(streamingObjectResult, node.checked, node.enableConstraints);
-    }
-
-
-    private StreamingObjectResult<?> executeInternalizeExecutionNode(MongoDBDocumentInternalizeExecutionNode node, InputStream inputStream, MutableList<CommonProfile> profiles, ExecutionState executionState)
-    {
-        try
-        {
-            String specificsClassName = JavaHelper.getExecutionClassFullName((JavaPlatformImplementation) node.implementation);
-            //We don't need specifics class for reader - as we know the object.
-            Class<?> specificsClass = ExecutionNodeJavaPlatformHelper.getClassToExecute(node, specificsClassName, executionState, profiles);
-            IJsonDeserializeExecutionNodeSpecifics specifics = (IJsonDeserializeExecutionNodeSpecifics) specificsClass.getConstructor().newInstance();
-
-            // checked made true and enableConstraints made false as these are incorporated in ExternalFormatRuntime centrally
-            StoreStreamReadingObjectsIterator<?> storeObjectsIterator = StoreStreamReadingObjectsIterator.newObjectsIterator(specifics.streamReader(inputStream), false, true);
-
-            Stream<?> objectStream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(storeObjectsIterator, Spliterator.ORDERED), false);
-            return new StreamingObjectResult<>(objectStream);
-        }
-        catch (Exception e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private Result applyConstraints(StreamingObjectResult<?> streamingObjectResult, boolean checked, boolean enableConstraints)
-    {
-        Stream<IChecked<?>> checkedStream = (Stream<IChecked<?>>) streamingObjectResult.getObjectStream();
-        Stream<IChecked<?>> withConstraints = enableConstraints
-                ? checkedStream.map(this::applyConstraints)
-                : checkedStream;
-        if (checked)
-        {
-            return new StreamingObjectResult<>(withConstraints, streamingObjectResult.getResultBuilder(), streamingObjectResult);
-        }
-        else
-        {
-            Stream<?> objectStream = ExternalFormatRuntime.unwrapCheckedStream(withConstraints);
-            return new StreamingObjectResult<>(objectStream, streamingObjectResult.getResultBuilder(), streamingObjectResult);
-        }
-    }
-
-    private IChecked<?> applyConstraints(IChecked<?> checked)
-    {
-        Object value = checked.getValue();
-        List<IDefect> constraintFailures = Collections.emptyList();
-        if (value instanceof Constrained)
-        {
-            constraintFailures = ((Constrained) value).allConstraints();
-        }
-        if (constraintFailures.isEmpty())
-        {
-            return checked;
-        }
-        else
-        {
-            List<IDefect> allDefects = new ArrayList(checked.getDefects());
-            allDefects.addAll(constraintFailures);
-            return allDefects.stream().anyMatch(d -> d.getEnforcementLevel() == EnforcementLevel.Critical)
-                    ? BasicChecked.newChecked(null, checked.getSource(), allDefects)
-                    : BasicChecked.newChecked(checked.getValue(), checked.getSource(), allDefects);
-        }
-    }
-
-     */
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/compiler/MongoDBDocumentFormatJavaCompilerExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/compiler/MongoDBDocumentFormatJavaCompilerExtension.java
@@ -1,0 +1,47 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.mongodb.compiler;
+
+import com.mongodb.client.MongoCursor;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.finos.legend.engine.plan.execution.nodes.helpers.platform.ExecutionPlanJavaCompilerExtension;
+import org.finos.legend.engine.plan.execution.stores.mongodb.specifics.IMongoDocumentDeserializeExecutionNodeSpecifics;
+import org.finos.legend.engine.shared.javaCompiler.ClassPathFilter;
+import org.finos.legend.engine.shared.javaCompiler.ClassPathFilters;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MongoDBDocumentFormatJavaCompilerExtension implements ExecutionPlanJavaCompilerExtension
+{
+    static final Map<String, Class<?>> DEPENDENCIES = new LinkedHashMap<>();
+    private static final String PURE_PACKAGE = "meta::external::store::mongodb::executionPlan::platformBinding::legendJava::";
+
+
+    static
+    {
+        DEPENDENCIES.put("org.bson.Document", Document.class);
+        DEPENDENCIES.put("com.mongodb.client.MongoCursor", MongoCursor.class);
+        DEPENDENCIES.put("org.bson.conversions.Bson", Bson.class);
+        DEPENDENCIES.put(PURE_PACKAGE + "_IMongoDocumentDeserializeExecutionNodeSpecifics", IMongoDocumentDeserializeExecutionNodeSpecifics.class);
+    }
+
+    @Override
+    public ClassPathFilter getExtraClassPathFilter()
+    {
+        return ClassPathFilters.fromClasses(DEPENDENCIES.values());
+    }
+}

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/compiler/MongoDBDocumentFormatJavaCompilerExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/compiler/MongoDBDocumentFormatJavaCompilerExtension.java
@@ -18,6 +18,8 @@ import com.mongodb.client.MongoCursor;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.legend.engine.plan.execution.nodes.helpers.platform.ExecutionPlanJavaCompilerExtension;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoDBResult;
 import org.finos.legend.engine.plan.execution.stores.mongodb.specifics.IMongoDocumentDeserializeExecutionNodeSpecifics;
 import org.finos.legend.engine.shared.javaCompiler.ClassPathFilter;
 import org.finos.legend.engine.shared.javaCompiler.ClassPathFilters;
@@ -36,6 +38,8 @@ public class MongoDBDocumentFormatJavaCompilerExtension implements ExecutionPlan
         DEPENDENCIES.put("org.bson.Document", Document.class);
         DEPENDENCIES.put("com.mongodb.client.MongoCursor", MongoCursor.class);
         DEPENDENCIES.put("org.bson.conversions.Bson", Bson.class);
+        DEPENDENCIES.put("org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoDBResult", MongoDBResult.class);
+        DEPENDENCIES.put("org.finos.legend.engine.plan.execution.result.Result", Result.class);
         DEPENDENCIES.put(PURE_PACKAGE + "_IMongoDocumentDeserializeExecutionNodeSpecifics", IMongoDocumentDeserializeExecutionNodeSpecifics.class);
     }
 

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/plugin/MongoDBExecutionNodeExecutor.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/plugin/MongoDBExecutionNodeExecutor.java
@@ -15,12 +15,12 @@
 package org.finos.legend.engine.plan.execution.stores.mongodb.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.MongoCursor;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
+import org.bson.Document;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.authentication.credentialprovider.CredentialProviderProvider;
-import org.finos.legend.engine.external.format.json.read.IJsonDeserializeExecutionNodeSpecifics;
-import org.finos.legend.engine.external.shared.runtime.read.ExecutionHelper;
 import org.finos.legend.engine.external.shared.utils.ExternalFormatRuntime;
 import org.finos.legend.engine.language.pure.grammar.to.MongoDBQueryJsonComposer;
 import org.finos.legend.engine.plan.dependencies.domain.dataQuality.BasicChecked;
@@ -36,6 +36,8 @@ import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.plan.execution.result.object.StreamingObjectResult;
 import org.finos.legend.engine.plan.execution.stores.inMemory.plugin.StoreStreamReadingObjectsIterator;
 import org.finos.legend.engine.plan.execution.stores.mongodb.MongoDBExecutor;
+import org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoCursorResult;
+import org.finos.legend.engine.plan.execution.stores.mongodb.specifics.IMongoDocumentDeserializeExecutionNodeSpecifics;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.DatabaseCommand;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.MongoDBConnection;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.MongoDBDocumentInternalizeExecutionNode;
@@ -46,7 +48,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.JavaPl
 import org.pac4j.core.profile.CommonProfile;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -113,23 +114,32 @@ public class MongoDBExecutionNodeExecutor implements ExecutionNodeVisitor<Result
 
     private Result executeDocumentInternalizeExecutionNode(MongoDBDocumentInternalizeExecutionNode node, MutableList<CommonProfile> profiles, ExecutionState executionState)
     {
-        InputStream stream = ExecutionHelper.inputStreamFromResult(node.executionNodes().getFirst().accept(new ExecutionNodeExecutor(profiles, new ExecutionState(executionState))));
-        StreamingObjectResult<?> streamingObjectResult = executeInternalizeExecutionNode(node, stream, profiles, executionState);
+        MongoCursor<Document> resultCursor = getResultCursor(node.executionNodes().getFirst().accept(new ExecutionNodeExecutor(profiles, new ExecutionState(executionState))));
+        StreamingObjectResult<?> streamingObjectResult = executeInternalizeExecutionNode(node, resultCursor, profiles, executionState);
         return applyConstraints(streamingObjectResult, node.checked, node.enableConstraints);
     }
 
+    private MongoCursor<Document> getResultCursor(Result mongoResult)
+    {
+        if (mongoResult instanceof MongoCursorResult)
+        {
+            return ((MongoCursorResult) mongoResult).getMongoCursor();
+        }
+        return null;
+    }
 
-    private StreamingObjectResult<?> executeInternalizeExecutionNode(MongoDBDocumentInternalizeExecutionNode node, InputStream inputStream, MutableList<CommonProfile> profiles, ExecutionState executionState)
+
+    private StreamingObjectResult<?> executeInternalizeExecutionNode(MongoDBDocumentInternalizeExecutionNode node, MongoCursor<Document> resultCursor, MutableList<CommonProfile> profiles, ExecutionState executionState)
     {
         try
         {
             String specificsClassName = JavaHelper.getExecutionClassFullName((JavaPlatformImplementation) node.implementation);
             //We don't need specifics class for reader - as we know the object.
             Class<?> specificsClass = ExecutionNodeJavaPlatformHelper.getClassToExecute(node, specificsClassName, executionState, profiles);
-            IJsonDeserializeExecutionNodeSpecifics specifics = (IJsonDeserializeExecutionNodeSpecifics) specificsClass.getConstructor().newInstance();
+            IMongoDocumentDeserializeExecutionNodeSpecifics specifics = (IMongoDocumentDeserializeExecutionNodeSpecifics) specificsClass.getConstructor().newInstance();
 
             // checked made true and enableConstraints made false as these are incorporated in ExternalFormatRuntime centrally
-            StoreStreamReadingObjectsIterator<?> storeObjectsIterator = StoreStreamReadingObjectsIterator.newObjectsIterator(specifics.streamReader(inputStream), false, true);
+            StoreStreamReadingObjectsIterator<?> storeObjectsIterator = StoreStreamReadingObjectsIterator.newObjectsIterator(specifics.streamReader(resultCursor), false, true);
 
             Stream<?> objectStream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(storeObjectsIterator, Spliterator.ORDERED), false);
             return new StreamingObjectResult<>(objectStream);

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/result/MongoCursorResult.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/result/MongoCursorResult.java
@@ -1,0 +1,58 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.mongodb.result;
+
+import com.mongodb.client.MongoCursor;
+import org.bson.Document;
+import org.finos.legend.engine.plan.execution.result.ExecutionActivity;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.result.ResultVisitor;
+import org.finos.legend.engine.plan.execution.result.builder.Builder;
+import org.finos.legend.engine.plan.execution.result.builder.stream.StreamBuilder;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MongoCursorResult extends Result
+{
+    private final MongoCursor<Document> mongoCursor;
+
+    public MongoCursorResult(MongoCursor<Document> mongoCursor)
+    {
+        this(mongoCursor, Collections.emptyList());
+    }
+
+    public MongoCursorResult(MongoCursor<Document> mongoCursor, List<ExecutionActivity> activities)
+    {
+        super("success", activities);
+        this.mongoCursor = mongoCursor;
+    }
+
+    public MongoCursor<Document> getMongoCursor()
+    {
+        return this.mongoCursor;
+    }
+
+    public Builder getResultBuilder()
+    {
+        return new StreamBuilder();
+    }
+
+    @Override
+    public <V> V accept(ResultVisitor<V> resultVisitor)
+    {
+        throw new UnsupportedOperationException("Streaming MongoCursorResult result is not supported. Please raise a issue with dev team");
+    }
+}

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/result/MongoDBResult.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/result/MongoDBResult.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.plan.execution.stores.mongodb.result;
 
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCursor;
 import org.bson.Document;
 import org.finos.legend.engine.plan.execution.result.ExecutionActivity;
@@ -25,19 +26,22 @@ import org.finos.legend.engine.plan.execution.result.builder.stream.StreamBuilde
 import java.util.Collections;
 import java.util.List;
 
-public class MongoCursorResult extends Result
+public class MongoDBResult extends Result
 {
     private final MongoCursor<Document> mongoCursor;
 
-    public MongoCursorResult(MongoCursor<Document> mongoCursor)
+    private final MongoClient mongoClient;
+
+    public MongoDBResult(MongoClient mongoClient, MongoCursor<Document> mongoCursor)
     {
-        this(mongoCursor, Collections.emptyList());
+        this(mongoClient, mongoCursor, Collections.emptyList());
     }
 
-    public MongoCursorResult(MongoCursor<Document> mongoCursor, List<ExecutionActivity> activities)
+    public MongoDBResult(MongoClient mongoClient, MongoCursor<Document> mongoCursor, List<ExecutionActivity> activities)
     {
         super("success", activities);
         this.mongoCursor = mongoCursor;
+        this.mongoClient = mongoClient;
     }
 
     public MongoCursor<Document> getMongoCursor()
@@ -51,8 +55,15 @@ public class MongoCursorResult extends Result
     }
 
     @Override
+    public void close()
+    {
+        this.mongoCursor.close();
+        this.mongoClient.close();
+    }
+
+    @Override
     public <V> V accept(ResultVisitor<V> resultVisitor)
     {
-        throw new UnsupportedOperationException("Streaming MongoCursorResult result is not supported. Please raise a issue with dev team");
+        throw new UnsupportedOperationException("Streaming MongoDBResult result is not supported. Please raise a issue with dev team");
     }
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/specifics/IMongoDocumentDeserializeExecutionNodeSpecifics.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/specifics/IMongoDocumentDeserializeExecutionNodeSpecifics.java
@@ -14,11 +14,10 @@
 
 package org.finos.legend.engine.plan.execution.stores.mongodb.specifics;
 
-import com.mongodb.client.MongoCursor;
-import org.bson.Document;
 import org.finos.legend.engine.plan.dependencies.store.inMemory.IStoreStreamReader;
+import org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoDBResult;
 
 public interface IMongoDocumentDeserializeExecutionNodeSpecifics
 {
-    IStoreStreamReader streamReader(MongoCursor<Document> mCursor);
+    IStoreStreamReader streamReader(MongoDBResult mongoResult);
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/specifics/IMongoDocumentDeserializeExecutionNodeSpecifics.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/specifics/IMongoDocumentDeserializeExecutionNodeSpecifics.java
@@ -14,7 +14,11 @@
 
 package org.finos.legend.engine.plan.execution.stores.mongodb.specifics;
 
-public class MongoDBRootGraphExecutionNodeSpecifics
-{
+import com.mongodb.client.MongoCursor;
+import org.bson.Document;
+import org.finos.legend.engine.plan.dependencies.store.inMemory.IStoreStreamReader;
 
+public interface IMongoDocumentDeserializeExecutionNodeSpecifics
+{
+    IStoreStreamReader streamReader(MongoCursor<Document> mCursor);
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/resources/META-INF/services/org.finos.legend.engine.plan.execution.nodes.helpers.platform.ExecutionPlanJavaCompilerExtension
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/resources/META-INF/services/org.finos.legend.engine.plan.execution.nodes.helpers.platform.ExecutionPlanJavaCompilerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.plan.execution.stores.mongodb.compiler.MongoDBDocumentFormatJavaCompilerExtension

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/MongoDBCompilerExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/MongoDBCompilerExtension.java
@@ -116,7 +116,7 @@ public class MongoDBCompilerExtension implements IMongoDBStoreCompilerExtension
 
                         if (bindingDetail instanceof Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail)
                         {
-                            List<PropertyMapping> propertyMappings = MongoDBCompilerHelper.generatePropertyMappings((Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail) bindingDetail, mongoDBSetImplementation._class(), mongoDBSetImplementation._id(), embeddedSetImplementations, mongoDBSetImplementation, classMapping.sourceInformation, processedClasses, context, parentMapping, false);
+                            List<PropertyMapping> propertyMappings = MongoDBCompilerHelper.generatePropertyMappings((Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail) bindingDetail, mongoDBSetImplementation._class(), mongoDBSetImplementation._id(), embeddedSetImplementations, mongoDBSetImplementation, classMapping.sourceInformation, processedClasses, context, parentMapping);
                             mongoDBSetImplementation._propertyMappings(Lists.mutable.ofAll(propertyMappings).toImmutable());
                         }
                         else

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/util/MongoDBCompilerHelper.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/util/MongoDBCompilerHelper.java
@@ -167,7 +167,7 @@ public class MongoDBCompilerHelper
         return pureValidator;
     }
 
-    public static List<PropertyMapping> generatePropertyMappings(Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail bindingDetail, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass, String sourceSetId, List<EmbeddedSetImplementation> embeddedSetImplementations, PropertyMappingsImplementation owner, SourceInformation sourceInformation, Set<Class<?>> processedClasses, CompileContext context, org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping parent, boolean fromAssociation)
+    public static List<PropertyMapping> generatePropertyMappings(Root_meta_external_shared_format_binding_validation_SuccessfulBindingDetail bindingDetail, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass, String sourceSetId, List<EmbeddedSetImplementation> embeddedSetImplementations, PropertyMappingsImplementation owner, SourceInformation sourceInformation, Set<Class<?>> processedClasses, CompileContext context, org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping parent)
     {
         String classFullPath = HelperModelBuilder.getElementFullPath(pureClass, context.pureModel.getExecutionSupport());
 
@@ -177,7 +177,7 @@ public class MongoDBCompilerHelper
         }
         processedClasses.add(pureClass);
 
-        RichIterable<Property> properties = fromAssociation ? bindingDetail.mappedPropertiesForClass(pureClass, context.getExecutionSupport()) : pureClass._properties();
+        RichIterable<Property> properties = bindingDetail.mappedPropertiesForClass(pureClass, context.getExecutionSupport());
 
         RichIterable<Property> primitiveProperties = properties.select(prop -> core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_isPrimitiveValueProperty_AbstractProperty_1__Boolean_1_(prop, context.getExecutionSupport()));
         RichIterable<Property> nonPrimitiveProperties = properties.select(prop -> !core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_isPrimitiveValueProperty_AbstractProperty_1__Boolean_1_(prop, context.getExecutionSupport()));
@@ -224,7 +224,7 @@ public class MongoDBCompilerHelper
         propertyMapping._sourceSetImplementationId(newSourceSetId);
         propertyMapping._targetSetImplementationId(id);
 
-        propertyMapping._propertyMappings(FastList.newList(generatePropertyMappings(bindingDetail, pureClass, id, embeddedSetImplementations, propertyMapping, sourceInformation, new HashSet<>(processedClasses), context, parent, fromAssociation)).toImmutable());
+        propertyMapping._propertyMappings(FastList.newList(generatePropertyMappings(bindingDetail, pureClass, id, embeddedSetImplementations, propertyMapping, sourceInformation, new HashSet<>(processedClasses), context, parent)).toImmutable());
 
         embeddedSetImplementations.add(propertyMapping);
         return propertyMapping;

--- a/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
@@ -181,20 +181,21 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
    let modifiedJsonReaderClass = $existingJsonReaderClass->modifyJsonReaderForMongoCursor($pureClass, $conventions->className($pureClass), $path, $context);
    let modifiedStoreReaderProj = $storeReaderProject->replaceClass($modifiedJsonReaderClass);
 
-   let sourceCursorParam       = j_parameter(javaMongoDocumentCursor(), 'mCursor');
+   let sourceDBResultParam       = j_parameter(javaMongoDBResult(), 'mResult');
    let streamReaderMethodCodes = $conventions->jsonReaderClass($path, $pureClass)
-                                             ->j_new($sourceCursorParam)
+                                             ->j_new($sourceDBResultParam)
                                              ->j_return();
 
    let executeClassWithImports = $conventions->planNodeClass('public', $path, 'Execute')
                                              ->usingKnownPackages($conventions->knownPackages())
                                              ->imports($conventions->standardImports())
                                              ->imports(javaMongoCursor())
+                                             ->imports(javaMongoDBResult())
                                              ->imports([_IMongoDocumentDeserializeExecutionNodeSpecifics, StoreStreamReader]->map(x | $conventions->className($x)))
                                              ->implements($conventions->className(_IMongoDocumentDeserializeExecutionNodeSpecifics));
 
    let executeClass = $executeClassWithImports->addMethod(
-      javaMethod(['public'], $conventions->className(StoreStreamReader), 'streamReader', [$sourceCursorParam], $streamReaderMethodCodes)
+      javaMethod(['public'], $conventions->className(StoreStreamReader), 'streamReader', [$sourceDBResultParam], $streamReaderMethodCodes)
    );
 
    let executeProject = newProject()->addClasses($executeClass);
@@ -252,8 +253,10 @@ function <<access.private>> meta::external::store::mongodb::executionPlan::platf
   //proto:meta::external::language::java::metamodel::Class[1], pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], context:GenerationContext[1])
   $origClass->imports(javaBsonDocument())
       ->imports(javaMongoCursor())
+      ->imports(javaMongoDBResult())
+      ->removeUnusedImports()
       ->addField(javaField('private', javaMongoDocumentCursor(), 'mCursor'))
-      ->addMongoCursorConstructor()
+      ->addMongoResultConstructor()
       ->replaceInitReading($context.typeInfos->hasDecimal())
       ->replaceIsFinished()
       ->replaceDestroyReading()
@@ -276,14 +279,28 @@ function <<access.private>> meta::external::store::mongodb::executionPlan::platf
   javaClass('com.mongodb.client.MongoCursor');
 }
 
-function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::addMongoCursorConstructor(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::javaMongoDBResult(): meta::external::language::java::metamodel::Class[1]
 {
-   let mCursor = j_parameter(javaMongoDocumentCursor(),'mCursor');
+  javaClass('org.finos.legend.engine.plan.execution.stores.mongodb.result.MongoDBResult');
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::removeUnusedImports(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]
+{
+   ^$class(additionalImports = $class.additionalImports
+    ->filter({m| $m->in(['com.fasterxml.jackson.core.JsonToken', 
+      'com.fasterxml.jackson.core.filter.FilteringParserDelegate',
+      'com.fasterxml.jackson.core.filter.JsonPointerBasedFilter',
+      'com.fasterxml.jackson.core.JsonFactory'])->not()}));
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::addMongoResultConstructor(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]
+{
+   let mResult = j_parameter(javaMongoDBResult(),'mongoResult');
 
    $class->addConstructor(
-      javaConstructor([], [$mCursor]->cast(@meta::external::language::java::metamodel::Parameter),
+      javaConstructor([], [$mResult]->cast(@meta::external::language::java::metamodel::Parameter),
          [
-            j_this($class)->j_field('mCursor')->j_assign($mCursor)
+            j_this($class)->j_field('mCursor')->j_assign($mResult->j_invoke('getMongoCursor', [], javaMongoDocumentCursor()))
          ]
       )
    );
@@ -319,8 +336,10 @@ function <<access.private>> meta::external::store::mongodb::executionPlan::platf
 function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::replaceDestroyReading(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]
 {
    let jThis  = j_this($class);
-   let closeCursor = $jThis->j_field('mCursor')->j_invoke('close',[], javaVoid());
-   let newDestroyReadingMethod = javaMethod('public', javaVoid(), 'destroyReading', [],[$closeCursor]);
+   //let closeCursor = $jThis->j_field('mCursor')->j_invoke('close',[], javaVoid());
+   //let newDestroyReadingMethod = javaMethod('public', javaVoid(), 'destroyReading', [],[$closeCursor]);
+   // Blank out destroyReading, as we are not maintaining anything internally.
+   let newDestroyReadingMethod = javaMethod('public', javaVoid(), 'destroyReading', [],[]);
 
    ^$class(methods = $class.methods->filter({m| $m.name != 'destroyReading'})->concatenate($newDestroyReadingMethod));
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
@@ -129,8 +129,9 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
                spm : MongoDBPropertyMapping[1]           | [],
                epm : EmbeddedMongoDBSetImplementation[1] | []
             ]
-
-         )
+         ),
+         ^LegendJavaPlatformDependencyUpdateExtension(
+                   platformDependencyUpdate = {conventions: Conventions[1], extensions: Extension[*] | extendMongoDocumentJavaEngineDependencies($conventions)})
 
       ],
       // Prep Context
@@ -150,14 +151,7 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
             s: MongoDBDocumentInternalizeExecutionNode[1] | $s->meta::external::store::mongodb::executionPlan::platformBinding::legendJava::generateForMongoDocumentInternalizeExecutionNode($path, $context, $debug),
             n: ExecutionNode[1]                            | ^GeneratedCode()
          ])
-      },
-
-      // adhoc Extensions
-      adhocExtensions = [
-        ^LegendJavaPlatformDependencyUpdateExtension(
-          platformDependencyUpdate = {conventions: Conventions[1], extensions: Extension[*] | extendMongoDocumentJavaEngineDependencies($conventions)})
-      ]
-
+      }
    )
 }
 

--- a/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::pure::executionPlan::platformBinding::legendJava::shared::dataQuality::*;
 import meta::pure::model::unit::*;
 import meta::external::shared::format::executionPlan::platformBinding::legendJava::*;
 import meta::external::shared::format::utils::*;
@@ -46,6 +47,8 @@ import meta::external::store::mongodb::metamodel::pure::*;
 import meta::external::store::mongodb::metamodel::mapping::*;
 import meta::pure::executionPlan::platformBinding::localBinding::*;
 
+import meta::pure::executionPlan::platformBinding::legendJava::library::jackson::*;
+
 function meta::external::store::mongodb::executionPlan::platformBinding::legendJava::mongoDBStoreLegendJavaPlatformBindingExtension(): LegendJavaPlatformBindingExtension[1]
 {
    ^LegendJavaPlatformBindingExtension
@@ -64,14 +67,14 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
 
          ^meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::LegendJavaInMemoryGraphFetchExtension
          (
-          
+
             filterCodeGenerator = {set: InstanceSetImplementation[1], src: Code[1], withoutFilter: Code[1..*], context: GenerationContext[1], debug:DebugContext[1] |
                [
                   mdsi: MongoDBSetImplementation[1]  | $withoutFilter,
                   emsi: EmbeddedMongoDBSetImplementation[1]  | $withoutFilter
                ]
             }
-            
+
             ,
             mappingTransformExtractors = [
                {spm : MongoDBPropertyMapping[1] | let dummyLambda = {|'ok'};
@@ -126,7 +129,7 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
                spm : MongoDBPropertyMapping[1]           | [],
                epm : EmbeddedMongoDBSetImplementation[1] | []
             ]
-            
+
          )
 
       ],
@@ -147,7 +150,14 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
             s: MongoDBDocumentInternalizeExecutionNode[1] | $s->meta::external::store::mongodb::executionPlan::platformBinding::legendJava::generateForMongoDocumentInternalizeExecutionNode($path, $context, $debug),
             n: ExecutionNode[1]                            | ^GeneratedCode()
          ])
-      }
+      },
+
+      // adhoc Extensions
+      adhocExtensions = [
+        ^LegendJavaPlatformDependencyUpdateExtension(
+          platformDependencyUpdate = {conventions: Conventions[1], extensions: Extension[*] | extendMongoDocumentJavaEngineDependencies($conventions)})
+      ]
+
    )
 }
 
@@ -161,7 +171,7 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
    let dependentClass     = $context.typeInfos->classDependenciesViaPropertiesWithSubTypes($pureClass);
    let readableClasses    = $pureClass->concatenate($dependentClass);
    let readableEnums      = $context.typeInfos->enumDependenciesViaProperties($pureClass);
-   
+
    let bindingDetail      = $context->nodeInfosForPath($path).data->toOne()->cast(@SuccessfulBindingDetail);
    let mainClassProject   = $pureClass->createStreamReadingDataClass($path, $context, ^ConstraintCheckingGenerationContext(enableConstraints=$node.enableConstraints, topLevelOnly=$node.tree->isEmpty(), graphFetchTree=$node.tree), $debug->indent());
    let dataClassesProject = if($dependentClass->isEmpty(),
@@ -170,27 +180,33 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
                               );
 
    let storeReaderProject = createJsonReading($pureClass, $conventions->className($pureClass), $path, $node.config->cast(@MongoDBDocumentInternalizeConfig).path, $readableClasses, $readableEnums, $context, $debug->indent());
+   // Swap out the readChecked with Documents from cursor.next().toJson()
+   let expectedClass = $context.conventions->jsonReaderClass($path, $pureClass);
+   let existingJsonReaderClass = $storeReaderProject->allClasses()
+    ->filter(c | $c.simpleName == $context.conventions->jsonReaderClass($path, $pureClass).simpleName)->toOne();
+   let modifiedJsonReaderClass = $existingJsonReaderClass->modifyJsonReaderForMongoCursor($pureClass, $conventions->className($pureClass), $path, $context);
+   let modifiedStoreReaderProj = $storeReaderProject->replaceClass($modifiedJsonReaderClass);
 
-   let sourceStreamParam       = j_parameter(javaInputStream(), 'sourceStream');
+   let sourceCursorParam       = j_parameter(javaMongoDocumentCursor(), 'mCursor');
    let streamReaderMethodCodes = $conventions->jsonReaderClass($path, $pureClass)
-                                             ->j_new($sourceStreamParam)
+                                             ->j_new($sourceCursorParam)
                                              ->j_return();
 
    let executeClassWithImports = $conventions->planNodeClass('public', $path, 'Execute')
                                              ->usingKnownPackages($conventions->knownPackages())
                                              ->imports($conventions->standardImports())
-                                             ->imports(javaInputStream())
-                                             ->imports([_IJsonDeserializeExecutionNodeSpecifics, StoreStreamReader]->map(x | $conventions->className($x)))
-                                             ->implements($conventions->className(_IJsonDeserializeExecutionNodeSpecifics));
+                                             ->imports(javaMongoCursor())
+                                             ->imports([_IMongoDocumentDeserializeExecutionNodeSpecifics, StoreStreamReader]->map(x | $conventions->className($x)))
+                                             ->implements($conventions->className(_IMongoDocumentDeserializeExecutionNodeSpecifics));
 
    let executeClass = $executeClassWithImports->addMethod(
-      javaMethod(['public'], $conventions->className(StoreStreamReader), 'streamReader', [$sourceStreamParam], $streamReaderMethodCodes)
+      javaMethod(['public'], $conventions->className(StoreStreamReader), 'streamReader', [$sourceCursorParam], $streamReaderMethodCodes)
    );
 
    let executeProject = newProject()->addClasses($executeClass);
    let allProjects    = $executeProject
       ->concatenate($dataClassesProject)
-      ->concatenate($storeReaderProject)
+      ->concatenate($modifiedStoreReaderProj)
       ->concatenate($streamReaderMethodCodes->dependencies()->resolveAndGetProjects())
       ->toOneMany();
 
@@ -214,12 +230,12 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
    let simpleType                          = ^SimpleJavaType(pureType=$class, javaType=$conventions->className($class));
    let sourceRecordTree                    = $externalFormatContract.sourceRecordSerializeTree->toOne();
    let returnType                          = if($node.checked, | ^CheckedJavaType(checkedOf=$simpleType, source=^SimpleJavaType(pureType=$sourceRecordTree.class, javaType=$conventions->className($sourceRecordTree.class))), | $simpleType);
-   let bindingDetail                       = if($externalFormatContract.externalFormatBindingValidator->isNotEmpty(), 
+   let bindingDetail                       = if($externalFormatContract.externalFormatBindingValidator->isNotEmpty(),
                                                 | $externalFormatContract.externalFormatBindingValidator->toOne()->eval($node.binding),
                                                 | []);
    let nodeInfo                            = ^NodeInfo(
-                                                  path            = $path, 
-                                                  returnType      = $returnType, 
+                                                  path            = $path,
+                                                  returnType      = $returnType,
                                                   graphFetchTrees = $sourceRecordTree,
                                                   data            = $bindingDetail
                                               );
@@ -237,6 +253,125 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
 }
 
 
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::modifyJsonReaderForMongoCursor(origClass:meta::external::language::java::metamodel::Class[1], pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], context:GenerationContext[1]): meta::external::language::java::metamodel::Class[1]
+{
+  //proto:meta::external::language::java::metamodel::Class[1], pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], context:GenerationContext[1])
+  $origClass->imports(javaBsonDocument())
+      ->imports(javaMongoCursor())
+      ->addField(javaField('private', javaMongoDocumentCursor(), 'mCursor'))
+      ->addMongoCursorConstructor()
+      ->replaceInitReading($context.typeInfos->hasDecimal())
+      ->replaceIsFinished()
+      ->replaceDestroyReading()
+      ->replaceCheckedObjects($pureClass, $javaInterface, $path, $context)
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::javaMongoDocumentCursor(): meta::external::language::java::metamodel::ParameterizedType[1]
+{
+  let documentClass =    ^meta::external::language::java::metamodel::Class(simpleName = 'Document', package = ^meta::external::language::java::metamodel::Package(name = 'bson', parent = ^meta::external::language::java::metamodel::Package(name = 'org')));
+  ^meta::external::language::java::metamodel::ParameterizedType(rawType=javaClass('com.mongodb.client.MongoCursor'), typeArguments=$documentClass->toBoxed());
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::javaBsonDocument(): meta::external::language::java::metamodel::Class[1]
+{
+  javaClass('org.bson.Document');
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::javaMongoCursor(): meta::external::language::java::metamodel::Class[1]
+{
+  javaClass('com.mongodb.client.MongoCursor');
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::addMongoCursorConstructor(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]
+{
+   let mCursor = j_parameter(javaMongoDocumentCursor(),'mCursor');
+
+   $class->addConstructor(
+      javaConstructor([], [$mCursor]->cast(@meta::external::language::java::metamodel::Parameter),
+         [
+            j_this($class)->j_field('mCursor')->j_assign($mCursor)
+         ]
+      )
+   );
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::replaceInitReading(class:meta::external::language::java::metamodel::Class[1], useBigDecimalForFloats:Boolean[0..1]): meta::external::language::java::metamodel::Class[1]
+{
+   let jThis  = j_this($class);
+   let objectMapper = $jThis->j_field('objectMapper');
+   let objectMapperInstantiation = if($useBigDecimalForFloats->isTrue(),
+                                      | $objectMapper->j_assign(objectMapper()->j_new([])->j_invoke('configure', [deserializationFeatureBigDecimalForFloats()->j_field('USE_BIG_DECIMAL_FOR_FLOATS', deserializationFeatureBigDecimalForFloats()), j_true()] , objectMapper())),
+                                      | $objectMapper->j_assign(objectMapper()->j_new([]))
+                                    );
+   let newInitMethod = javaMethod('public', javaVoid(), 'initReading', [],[$objectMapperInstantiation]);
+
+   ^$class(methods = $class.methods->filter({m| $m.name != 'initReading'})->concatenate($newInitMethod));
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::replaceIsFinished(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]
+{
+   let jThis  = j_this($class);
+   let exception        = j_parameter(javaIllegalStateException(), 'ex');
+   let exCheckExpression = $exception->j_invoke('getMessage', [], javaString())->j_invoke('equals', j_string('Cursor has been closed'))->j_if(j_boolean('true')->j_return(), $exception->j_throw());
+   //let exCheckExpression = $exception->j_throw();
+
+   let cursorFinished = j_not($jThis->j_field('mCursor')->j_invoke('hasNext',[], javaBoolean()))->j_return()->j_try(j_catch($exception, $exCheckExpression));
+   
+   let newIsFinishedMethod = javaMethod('public', javaBoolean(), 'isFinished', [],[$cursorFinished]);
+   // Remove nextToken, getCurrentToken method as we don't need it.
+   ^$class(methods = $class.methods->filter({m| $m.name->in(['isFinished', 'nextToken','getCurrentToken'])->not()})->concatenate($newIsFinishedMethod));
+}
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::replaceDestroyReading(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]
+{
+   let jThis  = j_this($class);
+   let closeCursor = $jThis->j_field('mCursor')->j_invoke('close',[], javaVoid());
+   let newDestroyReadingMethod = javaMethod('public', javaVoid(), 'destroyReading', [],[$closeCursor]);
+
+   ^$class(methods = $class.methods->filter({m| $m.name != 'destroyReading'})->concatenate($newDestroyReadingMethod));
+}
+
+
+
+function <<access.private>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::replaceCheckedObjects(proto:meta::external::language::java::metamodel::Class[1], pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], context:GenerationContext[1]): meta::external::language::java::metamodel::Class[1]
+{
+   let conv            = $context.conventions;
+   let checkedClass    = $context.baseProject->toOne()->resolve($conv->className(meta::pure::dataQuality::Checked));
+   let checkedSource   = javaParameterizedType($checkedClass, $javaInterface);
+   let checked         = j_variable($checkedSource, 'object');
+   let sourceRead      = $pureClass->readMethodName($conv);
+   let ioEx            = j_parameter(javaIOException(), 'e');
+   let jThis           = j_this($proto);
+   let recordType      = $conv->className(meta::pure::mapping::modelToModel::JsonDataRecord);
+   let json            = j_variable(javaString(), 'json');
+   let recordNumber    = j_variable(javaLong(), 'recordNumber');
+   let source          = j_variable($recordType, 'source');
+   let node            = j_variable(jsonNode(), 'node');
+
+   let newReadChecked =
+      javaMethod('public', javaCollection($checkedSource), 'readCheckedObjects', [],
+         [
+            $jThis->j_field('recordCount')->j_inc(),
+
+            $node->j_declare($jThis->j_field('objectMapper', objectMapper())->j_invoke('readTree', [$jThis->j_field('mCursor', javaMongoDocumentCursor())->j_invoke('next', [], javaBsonDocument())->j_invoke('toJson', [], javaString())], jsonNode())),
+            $checked->j_declare($jThis->j_invoke($sourceRead, [$node], $checkedSource)),
+
+            $recordNumber->j_declare($jThis->j_field('recordCount')),
+            $json->j_declare($node->j_invoke('toString', [])),
+
+            $source->j_declare($recordType->j_newAnon([], [
+               j_method('public', javaLong(), $conv->getterName('number'), [], $recordNumber->j_return()),
+               j_method('public', javaString(), $conv->getterName('record'), [], $json->j_return())
+            ])),
+
+            javaCollections()->j_invoke('singleton', $conv->dynamicChecked($conv->checkedGetDefects($checked), $source, $conv->checkedGetValue($checked)), javaCollection($checkedSource))->j_return()
+         ]->j_ioExTryCatch()
+      );
+
+
+   ^$proto(methods = $proto.methods->filter({m| $m.name != 'readCheckedObjects'})->concatenate($newReadChecked));
+}
+
 function meta::external::store::mongodb::executionPlan::platformBinding::legendJava::mongoDBLegendJavaPlatformBindingExtensions(): Extension[*]
 {
 //Pulls together store extension + PlatformBinding extension to a single method.
@@ -252,6 +387,28 @@ function meta::external::store::mongodb::executionPlan::platformBinding::legendJ
   ])
   ]
 }
+
+
+
+Class meta::external::store::mongodb::executionPlan::platformBinding::legendJava::_IMongoDocumentDeserializeExecutionNodeSpecifics {}
+
+/*
+ * This function should be assigned to the router extension:
+ *
+ *     plan_javaRuntime_enginePlatformDependencies_conventions = meta::external::format::json::executionPlan::platformBinding::legendJava::extendJavaEngineDependencies_Conventions_1__Conventions_1_
+ */
+
+function meta::external::store::mongodb::executionPlan::platformBinding::legendJava::extendMongoDocumentJavaEngineDependencies(conventions:Conventions[1]):Conventions[1]
+{
+   let jIStoreStreamReader = $conventions->className(meta::pure::executionPlan::platformBinding::legendJava::StoreStreamReader);
+
+   let jIMongoDocumentDeserializeExecutionNodeSpecifics = javaClass('public', 'org.finos.legend.engine.plan.execution.stores.mongodb.specifics.IMongoDocumentDeserializeExecutionNodeSpecifics')
+      ->addMethod(javaMethod('public', $jIStoreStreamReader, 'mCursor', [javaParam(javaMongoDocumentCursor(), 'p0')]));
+
+   $conventions
+      ->addProvidedType(meta::external::store::mongodb::executionPlan::platformBinding::legendJava::_IMongoDocumentDeserializeExecutionNodeSpecifics, $jIMongoDocumentDeserializeExecutionNodeSpecifics);
+}
+
 
 function <<LocalPlatformBinding.TestPlanBinder>> meta::external::store::mongodb::executionPlan::platformBinding::legendJava::bindMongoDBTestPlanToPlatform(): LocalPlatformBinder[1]
 {

--- a/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/test/pureSetup.txt
+++ b/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/test/pureSetup.txt
@@ -123,7 +123,7 @@ MongoDBConnection test::mongodb::testConnection
 {
     database: userDatabase;
     store: test::mongodb::mydatabase;
-    serverURLs: [localhost:49634];
+    serverURLs: [localhost:27017];
     authentication: # UserPassword {
         username: 'sa';
         password: SystemPropertiesSecret


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?
Replace ExternalFormatInternalize execution node(that was using InputStream as input) with MongoDocumentFormatInternalize execution node that takes MongoCursor as input & iterate through that to build the result json.
Minor clean up - No special processing for associated processing while constructing property mapping

