### PR TITLE
Enable graphFetch for InlineMappings

### DIFF
--- a/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchCommon.pure
+++ b/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchCommon.pure
@@ -134,7 +134,7 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::legendJa
       let fieldType   = $conventions->pureTypeToJavaType($p);
       let noMappingDefaultToEmpty = ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->isNoMappingDefaultToEmpty($p);
       let noMappingPassThru = $p.owner->instanceOf(meta::pure::metamodel::type::Class) && ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->passThruProperty($p, $extensions);
-      if (  !$isMerged && $p.owner->instanceOf(meta::pure::metamodel::type::Class) && ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->cast(@InstanceSetImplementation)->_propertyMappingsByPropertyName($p.name->toOne())->isEmpty() && !($p->hasGeneratedMilestoningDatePropertyStereotype()) && !($noMappingDefaultToEmpty || $noMappingPassThru ) ,
+      if (  !$isMerged && $p.owner->instanceOf(meta::pure::metamodel::type::Class) && ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->cast(@InstanceSetImplementation)->propertyMappingsByPropertyName($p.name->toOne())->isEmpty() && !($p->hasGeneratedMilestoningDatePropertyStereotype()) && !($noMappingDefaultToEmpty || $noMappingPassThru ) ,
          {|  
             $javaClass->addMethod(javaMethod(['public'], $fieldType, $getterName, [], j_throw(javaUnsupportedOperationException()->j_new(j_string('No mapping for property \'' + $p.name->toOne() +'\'')))))
          ;},

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -338,7 +338,7 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::assertC
    assert($r->meta::relational::functions::pureToSqlQuery::getDistinct() != true,  | 'Store distinct not allowed in graph fetch flow');
    
    $simplePrimitiveProperties->forAll({prop |
-      assert($prop->meta::pure::milestoning::hasGeneratedMilestoningPropertyStereotype() || $setImpl->_propertyMappingsByPropertyName($prop.name->toOne())->isNotEmpty(),
+      assert($prop->meta::pure::milestoning::hasGeneratedMilestoningPropertyStereotype() || $setImpl->propertyMappingsByPropertyName($prop.name->toOne())->isNotEmpty(),
              | 'Property "' + $prop.name->toOne() + '" is not mapped in the set: "' + $setImpl.id + '"')
    });
 }

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
@@ -267,12 +267,26 @@ function meta::relational::mapping::findPropertyMapping(property:AbstractPropert
 
 function meta::relational::mapping::dataTypePropertyMappings(impl:RelationalInstanceSetImplementation[1]):PropertyMapping[*]
 {
-   $impl->allPropertyMappings()->map(pm | $pm.property->genericType().typeArguments->at(1).rawType->toOne()->match([
-                                              d : meta::pure::metamodel::type::DataType[1] | $pm,
-                                              a : Any[1] | []
-                                             ]))
+  let propertyMappings = $impl->allPropertyMappings();
+  let allPropertyMappings = if($impl->instanceOf(InlineEmbeddedSetImplementation), | $propertyMappings->concatenate($impl->cast(@InlineEmbeddedSetImplementation)->inlineEmbeddedProperties()), | $propertyMappings);
+  $allPropertyMappings->map(pm | $pm.property->genericType().typeArguments->at(1).rawType->toOne()->match([
+                                                                                                            d : meta::pure::metamodel::type::DataType[1] | $pm,
+                                                                                                            a : Any[1] | []
+                                                                                                          ]));
 }
 
+function <<access.private>> meta::relational::mapping::inlineEmbeddedProperties(_this:InlineEmbeddedSetImplementation[1]):PropertyMapping[*]
+{
+  if($_this.owner->isEmpty(),
+      | [],
+      | let propertyMappings = $_this.owner->toOne()->propertyMappingsByPropertyName($_this.property.name->toOne())->filter(pm | !$pm->instanceOf(EmbeddedSetImplementation));
+        if($propertyMappings->isEmpty(),
+            | let cm = $_this.parent->_classMappingByIdRecursive($_this.inlineSetImplementationId);
+              let result = $cm->cast(@InstanceSetImplementation)->toOne()->allPropertyMappings();
+              $result->map(r | ^$r(owner = $_this.owner, sourceSetImplementationId = $_this.sourceSetImplementationId));,
+            | $propertyMappings);
+    )
+}
 
 function meta::relational::mapping::resolvePrimaryKey(rsi: RelationalInstanceSetImplementation[1]):RelationalOperationElement[*]
 {

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/embedded/testInlineEmbeddedNested.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/embedded/testInlineEmbeddedNested.pure
@@ -18,6 +18,7 @@ import meta::relational::tests::csv::*;
 import meta::relational::tests::mapping::embedded::advanced::mapping::*;
 import meta::relational::tests::mapping::embedded::advanced::model::*;
 import meta::relational::tests::mapping::embedded::advanced::*;
+import meta::pure::graphFetch::execution::*;
 
 function <<test.Test>> meta::relational::tests::mapping::embedded::advanced::inline::nested::testProjection():Boolean[1]
 {
@@ -114,3 +115,17 @@ function <<test.Test>> meta::relational::tests::mapping::embedded::advanced::inl
 
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> meta::relational::tests::mapping::embedded::advanced::inline::nested::testInlineInEmbeddedGraphFetch():Boolean[1]
+{
+   let tree = #{
+                  BondDetail {
+                                type,
+                                issuer { address { name } },
+                                holder { address { name } }
+                             }
+              }#;
+   let result = execute(|BondDetail.all()->filter(b | $b.holder.address.name == 'addressh1' )
+                                    ->graphFetch($tree)->serialize($tree)
+                                    , testInlineInEmbeddedPropertyMapping, testRuntime(), meta::relational::extension::relationalExtensions());
+  assertJsonStringsEqual('[{"holder":{"address":{"name":"addressh1"}},"type":"5 years","issuer":{"address":{"name":"addressi1"}}},{"holder":{"address":{"name":"addressh1"}},"type":"5 years","issuer":{"address":{"name":"addressi2"}}}]' , $result.values);
+}


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?
Users can now do graphFetch queries with InlineMappings, only TDS is supported earlier.

#### Does this PR introduce a user-facing change?
No
