### PR TITLE
Enforce free section grammar composing

### DIFF
--- a/docs/store/extensions/Relational/Databases/spanner/spanner-example-model.pure
+++ b/docs/store/extensions/Relational/Databases/spanner/spanner-example-model.pure
@@ -26,7 +26,7 @@ Service foo::service::firmService
             assertion_1:
               EqualToJson
               #{
-                expected : 
+                expected:
                   ExternalFormat
                   #{
                     contentType: 'application/json';
@@ -74,7 +74,7 @@ Service foo::service::personService
             assertion_1:
               EqualToJson
               #{
-                expected : 
+                expected:
                   ExternalFormat
                   #{
                     contentType: 'application/json';
@@ -122,7 +122,7 @@ Service foo::service::customerService
             assertion_1:
               EqualToJson
               #{
-                expected : 
+                expected:
                   ExternalFormat
                   #{
                     contentType: 'application/json';

--- a/legend-engine-language-pure-dsl-generation/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestFileGenerationGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-generation/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestFileGenerationGrammarRoundtrip.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.language.pure.grammar.test;
 
-import org.finos.legend.engine.language.pure.grammar.test.TestGrammarRoundtrip;
 import org.junit.Test;
 
 public class TestFileGenerationGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
@@ -77,7 +76,7 @@ public class TestFileGenerationGrammarRoundtrip extends TestGrammarRoundtrip.Tes
     @Test
     public void testFileGenerationWithImport()
     {
-        test("###FileGeneration\n" +
+        testWithSectionInfoPreserved("###FileGeneration\n" +
                 "import anything::*;\n" +
                 "Avro model::AvroConfig\n" +
                 "{\n" +

--- a/legend-engine-language-pure-dsl-generation/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestGenerationSpecificationGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-generation/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestGenerationSpecificationGrammarRoundtrip.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.language.pure.grammar.test;
 
-import org.finos.legend.engine.language.pure.grammar.test.TestGrammarRoundtrip;
 import org.junit.Test;
 
 public class TestGenerationSpecificationGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
@@ -47,7 +46,7 @@ public class TestGenerationSpecificationGrammarRoundtrip extends TestGrammarRoun
     @Test
     public void testGenerationSpecificationWithImport()
     {
-        test("###GenerationSpecification\n" +
+        testWithSectionInfoPreserved("###GenerationSpecification\n" +
                 "import anything::*;\n" +
                 "GenerationSpecification test::x\n" +
                 "{\n" +

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestServiceCompilationFromGrammar.java
@@ -1283,7 +1283,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1341,7 +1341,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1405,7 +1405,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1463,7 +1463,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1479,7 +1479,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1541,7 +1541,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1619,7 +1619,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1677,7 +1677,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1687,7 +1687,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1751,7 +1751,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1771,7 +1771,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1781,7 +1781,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1845,7 +1845,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1865,7 +1865,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1875,7 +1875,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1915,7 +1915,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1936,7 +1936,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1946,7 +1946,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -2171,7 +2171,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2193,7 +2193,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2240,7 +2240,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2256,7 +2256,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2303,7 +2303,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2313,7 +2313,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2378,7 +2378,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2441,7 +2441,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2502,7 +2502,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2564,7 +2564,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2626,7 +2626,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2688,7 +2688,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2750,7 +2750,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -2809,7 +2809,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
         //                "            assert1:\n" +
         //                "              EqualToJson\n" +
         //                "              #{\n" +
-        //                "                expected : \n" +
+        //                "                expected:\n" +
         //                "                  ExternalFormat\n" +
         //                "                  #{\n" +
         //                "                    contentType: 'application/json';\n" +
@@ -2979,7 +2979,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -3021,7 +3021,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -3063,7 +3063,7 @@ public class TestServiceCompilationFromGrammar extends TestCompilationFromGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarParser.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarParser.java
@@ -976,7 +976,7 @@ public class TestServiceGrammarParser extends TestGrammarParser.TestGrammarParse
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -1058,7 +1058,7 @@ public class TestServiceGrammarParser extends TestGrammarParser.TestGrammarParse
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1168,7 +1168,7 @@ public class TestServiceGrammarParser extends TestGrammarParser.TestGrammarParse
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
@@ -273,7 +273,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     @Test
     public void testServiceWithImport()
     {
-        test("###Service\n" +
+        testWithSectionInfoPreserved("###Service\n" +
                 "import meta::*;\n" +
                 "Service meta::pure::myServiceSingle\n" +
                 "{\n" +

--- a/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
+++ b/legend-engine-language-pure-dsl-service/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceGrammarRoundtrip.java
@@ -479,7 +479,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -537,7 +537,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -606,7 +606,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -688,7 +688,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -746,7 +746,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -762,7 +762,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -824,7 +824,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -903,7 +903,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1010,7 +1010,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1020,7 +1020,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1090,7 +1090,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1100,7 +1100,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1116,7 +1116,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1185,7 +1185,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1195,7 +1195,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1211,7 +1211,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1256,7 +1256,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1266,7 +1266,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert2:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1282,7 +1282,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualTo\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  'expected result content';\n" +
                 "              }#\n" +
                 "          ]\n" +
@@ -1598,7 +1598,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1639,7 +1639,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1680,7 +1680,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1721,7 +1721,7 @@ public class TestServiceGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposer.java
@@ -87,7 +87,6 @@ public class PureGrammarComposer
             }
         }
 
-        // FIXME: the following logic should be removed completely when we move to use extensions
         Predicate<PackageableElement> isDomainElement = e ->
                 (e instanceof Class) ||
                         (e instanceof Association) ||

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/test/assertion/HelperTestAssertionGrammarComposer.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/test/assertion/HelperTestAssertionGrammarComposer.java
@@ -60,7 +60,7 @@ public class HelperTestAssertionGrammarComposer
         if (testAssertion instanceof EqualTo)
         {
             EqualTo equalTo = (EqualTo) testAssertion;
-            String content = context.getIndentationString() + "expected : \n"
+            String content = context.getIndentationString() + "expected:\n"
                     + indentedString + equalTo.expected.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(updatedContext).build()) + ";";
 
             return new ContentWithType(EqualToGrammarParser.TYPE, content);
@@ -68,7 +68,7 @@ public class HelperTestAssertionGrammarComposer
         else if (testAssertion instanceof EqualToJson)
         {
             EqualToJson equalToJson = (EqualToJson) testAssertion;
-            String content = context.getIndentationString() + "expected : \n"
+            String content = context.getIndentationString() + "expected:\n"
                     + HelperEmbeddedDataGrammarComposer.composeEmbeddedData(equalToJson.expected, updatedContext) + ";";
 
             return new ContentWithType(EqualToJsonGrammarParser.TYPE, content);

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/parser/TestMappingGrammarParser.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/parser/TestMappingGrammarParser.java
@@ -346,7 +346,7 @@ public class TestMappingGrammarParser extends TestGrammarParser.TestGrammarParse
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -409,7 +409,7 @@ public class TestMappingGrammarParser extends TestGrammarParser.TestGrammarParse
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -456,7 +456,7 @@ public class TestMappingGrammarParser extends TestGrammarParser.TestGrammarParse
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -529,7 +529,7 @@ public class TestMappingGrammarParser extends TestGrammarParser.TestGrammarParse
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestConnectionGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestConnectionGrammarRoundtrip.java
@@ -51,7 +51,7 @@ public class TestConnectionGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
     @Test
     public void testConnectionWithImport()
     {
-        test("Class meta::myClass\n" +
+        testWithSectionInfoPreserved("Class meta::myClass\n" +
                 "{\n" +
                 "  name: String[1];\n" +
                 "}\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -477,15 +477,11 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
                 "  println('ok');\n" +
                 "  'a';\n" +
                 "}\n");
-
-        test("###Pure\n" +
-                "function test::getDateTime(): DateTime[1]\n" +
+        test("function test::getDateTime(): DateTime[1]\n" +
                 "{\n" +
                 "  %1970-01-01T00:00:00.000\n" +
                 "}\n");
-
-        test("###Pure\n" +
-                "function test::getStrictDate(): StrictDate[1]\n" +
+        test("function test::getStrictDate(): StrictDate[1]\n" +
                 "{\n" +
                 "  %1970-01-01\n" +
                 "}\n");
@@ -711,7 +707,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     @Test
     public void testClassWithImport()
     {
-        test("import anything::*;\n" +
+        testWithSectionInfoPreserved("import anything::*;\n" +
                 "Class <<goes.businesstemporal>> {goes.doc = 'bla'} anything::A extends B, B\n" +
                 "[\n" +
                 "  $this.ok->toOne() == 1,\n" +
@@ -746,7 +742,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     @Test
     public void testEnumerationWithImport()
     {
-        test("import anything::*;\n" +
+        testWithSectionInfoPreserved("import anything::*;\n" +
                 "Profile anything::goes\n" +
                 "{\n" +
                 "  stereotypes: [test];\n" +
@@ -764,7 +760,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     @Test
     public void testAssociationWithImport()
     {
-        test("import anything::*;\n" +
+        testWithSectionInfoPreserved("import anything::*;\n" +
                 "Class anything::goes2\n" +
                 "{\n" +
                 "}\n" +
@@ -785,7 +781,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     @Test
     public void testFunctionWithImport()
     {
-        test("import anything::*;\n" +
+        testWithSectionInfoPreserved("import anything::*;\n" +
                 "Class anything::goes2\n" +
                 "{\n" +
                 "}\n" +
@@ -805,21 +801,17 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     @Test
     public void testDefaultValue()
     {
-        test("import test::*;\n" +
-                "Class my::exampleRootType\n" +
+        test("Class my::exampleRootType\n" +
                 "{\n" +
                 "}\n\n" +
-
                 "Class my::exampleSubType extends my::exampleRootType\n" +
                 "{\n" +
                 "}\n\n" +
-
                 "Enum test::EnumWithDefault\n" +
                 "{\n" +
                 "  DefaultValue,\n" +
                 "  AnotherValue\n" +
                 "}\n\n" +
-
                 "Class test::A\n" +
                 "{\n" +
                 "  stringProperty: String[1] = 'default';\n" +
@@ -881,8 +873,7 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     @Test
     public void testLambdaWithBiTemporalClass()
     {
-        test("###Pure\n" +
-                "Class <<temporal.bitemporal>> main::Person\n" +
+        test("Class <<temporal.bitemporal>> main::Person\n" +
                 "{\n" +
                 "  name: String[1];\n" +
                 "  firm: main::Firm[1];\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
@@ -164,7 +164,7 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -224,7 +224,7 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -241,7 +241,7 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -296,7 +296,7 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -306,7 +306,7 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "            assert2:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
@@ -499,7 +499,7 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     @Test
     public void testMappingWithImport()
     {
-        test("Class anything::goes\n" +
+        testWithSectionInfoPreserved("Class anything::goes\n" +
                 "{\n" +
                 "  name: String[*];\n" +
                 "}\n" +
@@ -660,8 +660,7 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     @Test
     public void testAggregationAware()
     {
-        test("###Pure\n" +
-                "Class test::Product\n" +
+        test("Class test::Product\n" +
                 "{\n" +
                 "  id: Integer[1];\n" +
                 "  producer: test::Person[1];\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestRuntimeGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestRuntimeGrammarRoundtrip.java
@@ -79,7 +79,7 @@ public class TestRuntimeGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     @Test
     public void testRuntimeWithImport()
     {
-        test("Class meta::mySimpleClass\n" +
+        testWithSectionInfoPreserved("Class meta::mySimpleClass\n" +
                 "{\n" +
                 "  name: String[1];\n" +
                 "}\n" +
@@ -175,7 +175,6 @@ public class TestRuntimeGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "\n" +
                 "\n" +
                 "###Runtime\n" +
-                "import meta::*;\n" +
                 "Runtime meta::mySimpleRuntime\n" +
                 "{\n" +
                 "  mappings:\n" +

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestSectionRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestSectionRoundtrip.java
@@ -71,7 +71,7 @@ public class TestSectionRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundt
     public void testSectionIndexKeepingSectionAndElementsInOrder()
     {
         // the ordering of sections is preserved
-        test("###Runtime\n" +
+        testWithSectionInfoPreserved("###Runtime\n" +
                 "import a::b::*;\n" +
                 "import runtime::a::d::*;\n" +
                 "import runtime::a::e::*;\n" +
@@ -133,7 +133,16 @@ public class TestSectionRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundt
     @Test
     public void testSectionWithDuplicatedImports()
     {
-        String unformatted = "###Runtime\n" +
+        testFormatWithSectionInfoPreserved("###Runtime\n" +
+                "import a::b::*;\n" +
+                "import runtime::a1::*;\n" +
+                "import runtime::a::e::*;\n" +
+                "Runtime meta::mySimpleRuntime\n" +
+                "{\n" +
+                "  mappings:\n" +
+                "  [\n" +
+                "  ];\n" +
+                "}\n", "###Runtime\n" +
                 "import a::b::*;\n" +
                 "import runtime::a1::*;\n" +
                 "import runtime::a::e::*;\n" +
@@ -146,17 +155,7 @@ public class TestSectionRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundt
                 "  [\n" +
                 "  ];\n" +
                 "}\n" +
-                "\n\n";
-        testFormat("###Runtime\n" +
-                "import a::b::*;\n" +
-                "import runtime::a1::*;\n" +
-                "import runtime::a::e::*;\n" +
-                "Runtime meta::mySimpleRuntime\n" +
-                "{\n" +
-                "  mappings:\n" +
-                "  [\n" +
-                "  ];\n" +
-                "}\n", unformatted);
+                "\n\n");
     }
 
     @Test
@@ -300,7 +299,7 @@ public class TestSectionRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundt
                 "Class A\n" +
                 "{\n" +
                 "}\n";
-        testFormatWithoutSectionIndex("Class A\n" +
+        testFormat("Class A\n" +
                 "{\n" +
                 "}\n" +
                 "\n" +

--- a/legend-engine-protocol-api/pom.xml
+++ b/legend-engine-protocol-api/pom.xml
@@ -31,6 +31,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-functionActivator-protocol</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- ANNOTATIONS -->

--- a/legend-engine-protocol-api/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/PureProtocol.java
+++ b/legend-engine-protocol-api/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/PureProtocol.java
@@ -95,7 +95,7 @@ public class PureProtocol
                 }));
         result.storeSubtypes = storeSubtypes.toList();
 
-        MutableSet<String> functionActivatorsSubtypes = Sets.mutable.empty();
+        MutableSet<String> functionActivatorSubtypes = Sets.mutable.empty();
         PureProtocolExtensionLoader.extensions().forEach(extension ->
                 LazyIterate.flatCollect(extension.getExtraProtocolSubTypeInfoCollectors(), Function0::value).forEach(info ->
                 {
@@ -103,23 +103,23 @@ public class PureProtocol
                     {
                         if (FunctionActivator.class.isAssignableFrom(subType.getOne()))
                         {
-                            if (functionActivatorsSubtypes.contains(subType.getTwo()))
+                            if (functionActivatorSubtypes.contains(subType.getTwo()))
                             {
                                 // ignore duplications
                                 return;
                             }
-                            functionActivatorsSubtypes.add(subType.getTwo());
+                            functionActivatorSubtypes.add(subType.getTwo());
                         }
                     });
                 }));
-        result.functionActivatorsSubtypes = functionActivatorsSubtypes.toList();
+        result.functionActivatorSubtypes = functionActivatorSubtypes.toList();
         return Response.status(200).type(MediaType.APPLICATION_JSON).entity(result).build();
     }
 
     public static class SubtypeInfoResult
     {
         public List<String> storeSubtypes;
-        public List<String> functionActivatorsSubtypes;
+        public List<String> functionActivatorSubtypes;
     }
 }
 

--- a/legend-engine-protocol-api/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/PureProtocol.java
+++ b/legend-engine-protocol-api/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/PureProtocol.java
@@ -18,10 +18,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.utility.LazyIterate;
+import org.finos.legend.engine.protocol.functionActivator.metamodel.FunctionActivator;
 import org.finos.legend.engine.protocol.pure.v1.ProtocolToClassifierPathLoader;
 import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtensionLoader;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -29,6 +33,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -62,6 +67,59 @@ public class PureProtocol
                     });
                 }));
         return Response.status(200).type(MediaType.APPLICATION_JSON).entity("[" + result.entrySet().stream().map(entry -> "{\"type\":\"" + entry.getKey() + "\",\"classifierPath\":\"" + entry.getValue() + "\"}").collect(Collectors.joining(",")) + "]").build();
+    }
+
+    @GET
+    @Path("getSubtypeInfo")
+    @ApiOperation(value = "Get the protocol serialization subtype information")
+    @Consumes({MediaType.APPLICATION_JSON})
+    public Response getSubtypeInfo()
+    {
+        SubtypeInfoResult result = new SubtypeInfoResult();
+        MutableSet<String> storeSubtypes = Sets.mutable.empty();
+        PureProtocolExtensionLoader.extensions().forEach(extension ->
+                LazyIterate.flatCollect(extension.getExtraProtocolSubTypeInfoCollectors(), Function0::value).forEach(info ->
+                {
+                    info.getSubTypes().forEach(subType ->
+                    {
+                        if (Store.class.isAssignableFrom(subType.getOne()))
+                        {
+                            if (storeSubtypes.contains(subType.getTwo()))
+                            {
+                                // ignore duplications
+                                return;
+                            }
+                            storeSubtypes.add(subType.getTwo());
+                        }
+                    });
+                }));
+        result.storeSubtypes = storeSubtypes.toList();
+
+        MutableSet<String> functionActivatorsSubtypes = Sets.mutable.empty();
+        PureProtocolExtensionLoader.extensions().forEach(extension ->
+                LazyIterate.flatCollect(extension.getExtraProtocolSubTypeInfoCollectors(), Function0::value).forEach(info ->
+                {
+                    info.getSubTypes().forEach(subType ->
+                    {
+                        if (FunctionActivator.class.isAssignableFrom(subType.getOne()))
+                        {
+                            if (functionActivatorsSubtypes.contains(subType.getTwo()))
+                            {
+                                // ignore duplications
+                                return;
+                            }
+                            functionActivatorsSubtypes.add(subType.getTwo());
+                        }
+                    });
+                }));
+        result.functionActivatorsSubtypes = functionActivatorsSubtypes.toList();
+        return Response.status(200).type(MediaType.APPLICATION_JSON).entity(result).build();
+    }
+
+    public static class SubtypeInfoResult
+    {
+        public List<String> storeSubtypes;
+        public List<String> functionActivatorsSubtypes;
     }
 }
 

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_18_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_18_0/models/metamodel.pure
@@ -793,7 +793,7 @@ Class meta::protocols::pure::v1_18_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_18_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_18_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_18_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_18_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_18_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_19_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_19_0/models/metamodel.pure
@@ -793,7 +793,7 @@ Class meta::protocols::pure::v1_19_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_19_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_19_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_19_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_19_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_19_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_20_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_20_0/models/metamodel.pure
@@ -788,7 +788,7 @@ Class meta::protocols::pure::v1_20_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_20_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_20_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_20_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_20_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_20_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_21_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_21_0/models/metamodel.pure
@@ -783,7 +783,7 @@ Class meta::protocols::pure::v1_21_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_21_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_21_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_21_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_21_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_21_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_22_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_22_0/models/metamodel.pure
@@ -783,7 +783,7 @@ Class meta::protocols::pure::v1_22_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_22_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_22_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_22_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_22_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_22_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_23_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_23_0/models/metamodel.pure
@@ -789,7 +789,7 @@ Class meta::protocols::pure::v1_23_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_23_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_23_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_23_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_23_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_23_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_24_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_24_0/models/metamodel.pure
@@ -789,7 +789,7 @@ Class meta::protocols::pure::v1_24_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_24_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_24_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_24_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_24_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_24_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_25_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_25_0/models/metamodel.pure
@@ -789,7 +789,7 @@ Class meta::protocols::pure::v1_25_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_25_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_25_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_25_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_25_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_25_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/models/metamodel.pure
@@ -789,7 +789,7 @@ Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_26_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_26_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_27_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_27_0/models/metamodel.pure
@@ -789,7 +789,7 @@ Class meta::protocols::pure::v1_27_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_27_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_27_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_27_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_27_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_27_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_28_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_28_0/models/metamodel.pure
@@ -780,7 +780,7 @@ Class meta::protocols::pure::v1_28_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_28_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_28_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_28_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_28_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_28_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_29_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_29_0/models/metamodel.pure
@@ -780,7 +780,7 @@ Class meta::protocols::pure::v1_29_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_29_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_29_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_29_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_29_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_29_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_30_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_30_0/models/metamodel.pure
@@ -780,7 +780,7 @@ Class meta::protocols::pure::v1_30_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_30_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_30_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_30_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_30_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_30_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_31_0/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_31_0/models/metamodel.pure
@@ -780,7 +780,7 @@ Class meta::protocols::pure::v1_31_0::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::v1_31_0::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::v1_31_0::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::v1_31_0::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::v1_31_0::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::v1_31_0::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/metamodel.pure
@@ -787,7 +787,7 @@ Class meta::protocols::pure::vX_X_X::metamodel::executableMapping::Test
 
 Class meta::protocols::pure::vX_X_X::metamodel::executableMapping::TestAssert
 {
-   expected : meta::protocols::pure::vX_X_X::metamodel::valueSpecification::ValueSpecification[*];
+   expected:meta::protocols::pure::vX_X_X::metamodel::valueSpecification::ValueSpecification[*];
    inputs : meta::protocols::pure::vX_X_X::metamodel::valueSpecification::ValueSpecification[*];
    comparisonKey : meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::Lambda[0..1];
    comparisonType : ComparisonType[0..1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/testTdsSchema.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/testTdsSchema.pure
@@ -278,19 +278,19 @@ function meta::pure::tds::schema::tests::assertSchemaRoundTripEquality(query : F
    assertSchemaRoundTripEquality($expected, $query, $extensions);
 }
    
-function meta::pure::tds::schema::tests::assertSchemaRoundTripEquality(expected : TDSColumn[*], query : FunctionDefinition<{->TabularDataSet[1]}>[1]) : Boolean[1]
+function meta::pure::tds::schema::tests::assertSchemaRoundTripEquality(expected:TDSColumn[*], query : FunctionDefinition<{->TabularDataSet[1]}>[1]) : Boolean[1]
 {   
    assertSchemaRoundTripEquality($expected, $query, defaultExtensions());
 }  
 
-function meta::pure::tds::schema::tests::assertSchemaRoundTripEquality(expected : TDSColumn[*], query : FunctionDefinition<{->TabularDataSet[1]}>[1], extensions:Extension[*]) : Boolean[1]
+function meta::pure::tds::schema::tests::assertSchemaRoundTripEquality(expected:TDSColumn[*], query : FunctionDefinition<{->TabularDataSet[1]}>[1], extensions:Extension[*]) : Boolean[1]
 {
    let actual = $query->meta::pure::tds::schema::resolveSchema($extensions);
    
    assertSchemaEquality($expected, $actual);     
 }  
 
-function meta::pure::tds::schema::tests::assertSchemaEquality(expected : TDSColumn[*], actual : TDSColumn[*]) : Boolean[1]
+function meta::pure::tds::schema::tests::assertSchemaEquality(expected:TDSColumn[*], actual : TDSColumn[*]) : Boolean[1]
 {   
    let areEqual = ($expected->size() == $actual->size())
       && ($expected->zip($actual)->forAll(p|

--- a/legend-engine-test-runner-mapping/src/test/java/org/finos/legend/engine/testable/mapping/extension/TestMappingTestRunner.java
+++ b/legend-engine-test-runner-mapping/src/test/java/org/finos/legend/engine/testable/mapping/extension/TestMappingTestRunner.java
@@ -87,7 +87,7 @@ public class TestMappingTestRunner
             "            assert1:\n" +
             "              EqualToJson\n" +
             "              #{\n" +
-            "                expected : \n" +
+            "                expected:\n" +
             "                  ExternalFormat\n" +
             "                  #{\n" +
             "                    contentType: 'application/json';\n" +
@@ -194,7 +194,7 @@ public class TestMappingTestRunner
             "            assert1:\n" +
             "              EqualToJson\n" +
             "              #{\n" +
-            "                expected : \n" +
+            "                expected:\n" +
             "                  ExternalFormat\n" +
             "                  #{\n" +
             "                    contentType: 'application/json';\n" +

--- a/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
+++ b/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
@@ -233,7 +233,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -304,7 +304,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -393,7 +393,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -464,7 +464,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -555,12 +555,12 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
+                        "                expected:'{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
                         "              }#,\n" +
                         "            assert2:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -631,12 +631,12 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
+                        "                expected:'{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
                         "              }#,\n" +
                         "            assert2:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -728,7 +728,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
+                        "                expected:'{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
                         "              }#\n" +
                         "          ]\n" +
                         "        },\n" +
@@ -740,7 +740,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -816,7 +816,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id2\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
+                        "                expected:'{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id2\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
                         "              }#\n" +
                         "          ]\n" +
                         "        },\n" +
@@ -828,7 +828,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -857,7 +857,7 @@ public class TestServiceTestSuite
         Assert.assertEquals(1, ((TestExecuted) serviceStoreTestResultsWithMultipleTests2.get(0)).assertStatuses.size());
         Assert.assertTrue(((TestExecuted) serviceStoreTestResultsWithMultipleTests2.get(0)).assertStatuses.get(0) instanceof AssertFail);
         Assert.assertEquals("assert1", ((AssertFail) ((TestExecuted) serviceStoreTestResultsWithMultipleTests2.get(0)).assertStatuses.get(0)).id);
-        Assert.assertEquals("Expected : {\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id2\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}, Found : {\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}", ((AssertFail) ((TestExecuted) serviceStoreTestResultsWithMultipleTests2.get(0)).assertStatuses.get(0)).message);
+        Assert.assertEquals("expected:{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id2\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}, Found : {\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}", ((AssertFail) ((TestExecuted) serviceStoreTestResultsWithMultipleTests2.get(0)).assertStatuses.get(0)).message);
 
         Assert.assertTrue(serviceStoreTestResultsWithMultipleTests2.get(1) instanceof TestExecuted);
         Assert.assertEquals(TestExecutionStatus.PASS, ((TestExecuted) serviceStoreTestResultsWithMultipleTests2.get(1)).testExecutionStatus);
@@ -909,7 +909,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
+                        "                expected:'{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
                         "              }#\n" +
                         "          ]\n" +
                         "        }\n" +
@@ -938,7 +938,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -1062,7 +1062,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"stringParam\":\"dummy\",\"integerParam\":1,\"floatParam\":1.123,\"booleanParam\":false}';\n" +
+                        "                expected:'{\"stringParam\":\"dummy\",\"integerParam\":1,\"floatParam\":1.123,\"booleanParam\":false}';\n" +
                         "              }#\n" +
                         "          ]\n" +
                         "        }\n" +
@@ -1170,7 +1170,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"stringParam\":\"dummy\",\"integerParam\":1,\"floatParam\":1.123,\"booleanParam\":false}';\n" +
+                        "                expected:'{\"stringParam\":\"dummy\",\"integerParam\":1,\"floatParam\":1.123,\"booleanParam\":false}';\n" +
                         "              }#\n" +
                         "          ]\n" +
                         "        }\n" +
@@ -1250,7 +1250,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -1325,7 +1325,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1509,7 +1509,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1585,7 +1585,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1793,7 +1793,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1847,7 +1847,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1901,7 +1901,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -1987,7 +1987,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -2436,7 +2436,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -2535,7 +2535,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -2633,7 +2633,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -3302,7 +3302,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualTo\n" +
                         "              #{\n" +
-                        "                expected : '{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
+                        "                expected:'{\"kerberos\":\"dummy kerberos\",\"employeeID\":\"dummy id\",\"title\":\"dummy title\",\"firstName\":\"dummy firstName\",\"lastName\":\"dummy lastname\",\"countryCode\":\"dummy countryCode\"}';\n" +
                         "              }#\n" +
                         "          ]\n" +
                         "        },\n" +
@@ -3314,7 +3314,7 @@ public class TestServiceTestSuite
                         "            assert1:\n" +
                         "              EqualToJson\n" +
                         "              #{\n" +
-                        "                expected : \n" +
+                        "                expected:\n" +
                         "                  ExternalFormat\n" +
                         "                  #{\n" +
                         "                    contentType: 'application/json';\n" +
@@ -3569,7 +3569,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +
@@ -3586,7 +3586,7 @@ public class TestServiceTestSuite
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithFailedServiceTestKeys.pure
+++ b/legend-engine-test-runner-service/src/test/resources/testable/service/serviceGrammarWithFailedServiceTestKeys.pure
@@ -44,7 +44,7 @@ Service testServiceStoreTestSuites::TestService
             assert1:
               EqualToJson
               #{
-                expected : 
+                expected:
                   ExternalFormat
                   #{
                     contentType: 'application/json';

--- a/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/assertion/TestAssertionEvaluator.java
+++ b/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/assertion/TestAssertionEvaluator.java
@@ -64,7 +64,7 @@ public class TestAssertionEvaluator implements org.finos.legend.engine.protocol.
             else
             {
                 AssertFail assertFail = new AssertFail();
-                assertFail.message = "Expected : " + expected + ", Found : " + actual.toString();
+                assertFail.message = "expected:" + expected + ", Found : " + actual.toString();
 
                 assertionStatus = assertFail;
             }

--- a/legend-engine-testable/src/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
+++ b/legend-engine-testable/src/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
@@ -76,7 +76,7 @@ public class TestTestAssertionEvaluator
         AssertionStatus assertionStatus = equalTo.accept(new TestAssertionEvaluator(constantResult));
 
         Assert.assertTrue(assertionStatus instanceof AssertFail);
-        Assert.assertEquals("Expected : [1, 2], Found : [1, 5]", ((AssertFail) assertionStatus).message);
+        Assert.assertEquals("expected:[1, 2], Found : [1, 5]", ((AssertFail) assertionStatus).message);
     }
 
     @Test

--- a/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/language/pure/dsl/authentication/grammar/test/TestAuthenticationGrammarRoundtrip_AuthenticationTypes.java
+++ b/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/language/pure/dsl/authentication/grammar/test/TestAuthenticationGrammarRoundtrip_AuthenticationTypes.java
@@ -20,10 +20,26 @@ import org.junit.Test;
 public class TestAuthenticationGrammarRoundtrip_AuthenticationTypes extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
 {
     @Test
+    public void userPasswordAuthenticationWithImport()
+    {
+        testWithSectionInfoPreserved("###AuthenticationDemo\n" +
+                "import test::*;\n" +
+                "AuthenticationDemo demo::demo1\n" +
+                "{\n" +
+                "  authentication: # UserPassword {\n" +
+                "    username: 'alice';\n" +
+                "    password: PropertiesFileSecret\n" +
+                "    {\n" +
+                "      propertyName: 'property1';\n" +
+                "    };\n" +
+                "  }#;\n" +
+                "}\n");
+    }
+
+    @Test
     public void userPasswordAuthentication()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # UserPassword {\n" +
@@ -40,7 +56,6 @@ public class TestAuthenticationGrammarRoundtrip_AuthenticationTypes extends Test
     public void apiTokenAuthentication()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # ApiKey {\n" +
@@ -58,7 +73,6 @@ public class TestAuthenticationGrammarRoundtrip_AuthenticationTypes extends Test
     public void encryptedKeyPairAuthentication()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # EncryptedPrivateKey {\n" +
@@ -79,7 +93,6 @@ public class TestAuthenticationGrammarRoundtrip_AuthenticationTypes extends Test
     public void gcpWIFWithAWSIdP()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # GCPWIFWithAWSIdP {\n" +

--- a/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/language/pure/dsl/authentication/grammar/test/TestAuthenticationGrammarRoundtrip_SecretTypes.java
+++ b/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/language/pure/dsl/authentication/grammar/test/TestAuthenticationGrammarRoundtrip_SecretTypes.java
@@ -23,7 +23,6 @@ public class TestAuthenticationGrammarRoundtrip_SecretTypes extends TestGrammarR
     public void propertiesSecret()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # UserPassword {\n" +
@@ -40,7 +39,6 @@ public class TestAuthenticationGrammarRoundtrip_SecretTypes extends TestGrammarR
     public void environmentSecret()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # UserPassword {\n" +
@@ -57,7 +55,6 @@ public class TestAuthenticationGrammarRoundtrip_SecretTypes extends TestGrammarR
     public void systemPropertiesSecret()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # UserPassword {\n" +
@@ -74,7 +71,6 @@ public class TestAuthenticationGrammarRoundtrip_SecretTypes extends TestGrammarR
     public void awsSecretsManagerSecret_WithDefaultCredentials()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # UserPassword {\n" +
@@ -96,7 +92,6 @@ public class TestAuthenticationGrammarRoundtrip_SecretTypes extends TestGrammarR
     public void awsSecretsManagerSecret_WithStaticCredentials()
     {
         test("###AuthenticationDemo\n" +
-                "import test::*;\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # UserPassword {\n" +
@@ -125,9 +120,7 @@ public class TestAuthenticationGrammarRoundtrip_SecretTypes extends TestGrammarR
     @Test
     public void awsSecretsManagerSecret_WithSTSAssumeRoleCredentials()
     {
-        test("" +
-                "###AuthenticationDemo\n" +
-                "import test::*;\n" +
+        test("###AuthenticationDemo\n" +
                 "AuthenticationDemo demo::demo1\n" +
                 "{\n" +
                 "  authentication: # UserPassword {\n" +

--- a/legend-engine-xt-diagram-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestDiagramGrammarRoundtrip.java
+++ b/legend-engine-xt-diagram-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestDiagramGrammarRoundtrip.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.engine.language.pure.grammar.test;
 
-import org.finos.legend.engine.language.pure.grammar.test.TestGrammarRoundtrip;
 import org.junit.Test;
 
 public class TestDiagramGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
@@ -166,7 +165,7 @@ public class TestDiagramGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     @Test
     public void testDiagramWithImport()
     {
-        test("###Diagram\n" +
+        testWithSectionInfoPreserved("###Diagram\n" +
                 "import anything::*;\n" +
                 "Diagram meta::pure::MyDiagram\n" +
                 "{\n" +

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-grammar/src/test/java/org/finos/legend/engine/language/stores/elasticsearch/v7/to/TestElasticsearchGrammarRoundtrip.java
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-grammar/src/test/java/org/finos/legend/engine/language/stores/elasticsearch/v7/to/TestElasticsearchGrammarRoundtrip.java
@@ -21,10 +21,26 @@ import org.junit.Test;
 public class TestElasticsearchGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
 {
     @Test
+    public void testWithImport()
+    {
+        testWithSectionInfoPreserved("###Elasticsearch\n" +
+                "import abc::*;\n" +
+                "Elasticsearch7Cluster abc::abc::Store\n" +
+                "{\n" +
+                "  indices: [\n" +
+                "    index1: {\n" +
+                "      properties: [\n" +
+                "        prop1: Keyword\n" +
+                "      ];\n" +
+                "    }\n" +
+                "  ];\n" +
+                "}\n\n");
+    }
+
+    @Test
     public void testStoreRoundtripSingleIndexSingleProperty()
     {
         test("###Elasticsearch\n" +
-                "import abc::abc::*;\n" +
                 "Elasticsearch7Cluster abc::abc::Store\n" +
                 "{\n" +
                 "  indices: [\n" +
@@ -41,7 +57,6 @@ public class TestElasticsearchGrammarRoundtrip extends TestGrammarRoundtrip.Test
     public void testStoreRoundtripSingleIndexMultipleProperties()
     {
         test("###Elasticsearch\n" +
-                "import abc::abc::*;\n" +
                 "Elasticsearch7Cluster abc::abc::Store\n" +
                 "{\n" +
                 "  indices: [\n" +
@@ -68,7 +83,6 @@ public class TestElasticsearchGrammarRoundtrip extends TestGrammarRoundtrip.Test
     public void testStoreRoundtripSingleIndexPropertyWithFieldsNested()
     {
         test("###Elasticsearch\n" +
-                "import abc::abc::*;\n" +
                 "Elasticsearch7Cluster abc::abc::Store\n" +
                 "{\n" +
                 "  indices: [\n" +
@@ -93,7 +107,6 @@ public class TestElasticsearchGrammarRoundtrip extends TestGrammarRoundtrip.Test
     public void testStoreRoundtripSingleIndexWithWrappedNames()
     {
         test("###Elasticsearch\n" +
-                "import abc::abc::*;\n" +
                 "Elasticsearch7Cluster abc::abc::Store\n" +
                 "{\n" +
                 "  indices: [\n" +
@@ -118,7 +131,6 @@ public class TestElasticsearchGrammarRoundtrip extends TestGrammarRoundtrip.Test
     public void testStoreRoundtripMultipleIndexProperty()
     {
         test("###Elasticsearch\n" +
-                "import abc::abc::*;\n" +
                 "Elasticsearch7Cluster abc::abc::Store\n" +
                 "{\n" +
                 "  indices: [\n" +

--- a/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/binding/validation/validation.pure
+++ b/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/binding/validation/validation.pure
@@ -86,10 +86,10 @@ function <<access.private>> meta::external::format::json::binding::validation::m
        let actualMultiplicity = $propertyMatchedByName->toOne()->functionReturnMultiplicity();
       
        if( !subsumesType($actualReturnType, $requiredReturnType) && !subsumesType($requiredReturnType, $actualReturnType), 
-          |^FailedBindingDetail(errorMessages = 'Incompatible return type for json schema property(' + $propertyToBeMatched.name->orElse('Unknown property name') + '). Expected : ' + $requiredReturnType->elementToPath() + ', Found : ' + $actualReturnType->elementToPath() + '.'),
+          |^FailedBindingDetail(errorMessages = 'Incompatible return type for json schema property(' + $propertyToBeMatched.name->orElse('Unknown property name') + '). expected:' + $requiredReturnType->elementToPath() + ', Found : ' + $actualReturnType->elementToPath() + '.'),
           |
        if( !multiplicitySubsumes($actualMultiplicity, $requiredMultiplicity), 
-          |^FailedBindingDetail(errorMessages = 'Incompatible multiplicity for json schema property(' + $propertyToBeMatched.name->orElse('Unknown property name') + '). Expected : ' + $requiredMultiplicity->printMultiplicity() + ', Found : ' + $actualMultiplicity->printMultiplicity() + '.'),
+          |^FailedBindingDetail(errorMessages = 'Incompatible multiplicity for json schema property(' + $propertyToBeMatched.name->orElse('Unknown property name') + '). expected:' + $requiredMultiplicity->printMultiplicity() + ', Found : ' + $actualMultiplicity->printMultiplicity() + '.'),
           |[];));
    );
 }

--- a/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/test/TestMasteryGrammarRoundtrip.java
+++ b/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/test/TestMasteryGrammarRoundtrip.java
@@ -24,12 +24,12 @@ public class TestMasteryGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     @Test
     public void masteryRoundTripFull()
     {
-        test(TestMasteryCompilationFromGrammar.COMPLETE_CORRECT_MASTERY_MODEL);
+        testWithSectionInfoPreserved(TestMasteryCompilationFromGrammar.COMPLETE_CORRECT_MASTERY_MODEL);
     }
 
     @Test
     public void masteryRoundTripMinimum()
     {
-        test(TestMasteryCompilationFromGrammar.MINIMUM_CORRECT_MASTERY_MODEL);
+        testWithSectionInfoPreserved(TestMasteryCompilationFromGrammar.MINIMUM_CORRECT_MASTERY_MODEL);
     }
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/MongoDBGrammarComposerExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/MongoDBGrammarComposerExtension.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.language.pure.grammar.integration;
 
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.tuple.Tuples;
@@ -60,6 +61,16 @@ public class MongoDBGrammarComposerExtension implements IMongoDBGrammarComposerE
         });
     }
 
+    @Override
+    public List<Function3<List<PackageableElement>, PureGrammarComposerContext, List<String>, PureFreeSectionGrammarComposerResult>> getExtraFreeSectionComposers()
+    {
+        return Lists.fixedSize.with((elements, context, composedSections) ->
+        {
+            MutableList<MongoDatabase> composableElements = ListIterate.selectInstancesOf(elements, MongoDatabase.class);
+            return composableElements.isEmpty() ? null : new PureFreeSectionGrammarComposerResult(composableElements.collect(MongoDBSchemaComposer::renderMongoDBStore).makeString("###" + MongoDBGrammarParserExtension.NAME + "\n", "\n\n", ""), composableElements);
+        });
+    }
+
 
     public List<Function2<Connection, PureGrammarComposerContext, Pair<String, String>>> getExtraConnectionValueComposers()
     {
@@ -73,7 +84,7 @@ public class MongoDBGrammarComposerExtension implements IMongoDBGrammarComposerE
                         context.getIndentationString() + "{\n" +
                                 context.getIndentationString() + getTabString() + "database: " + mongoDBConnection.dataSourceSpecification.databaseName + ";\n" +
                                 context.getIndentationString() + getTabString() + "store: " + mongoDBConnection.element + ";\n" +
-                                context.getIndentationString() + getTabString() + "serverURLs: [" + this.getMongoDBURLs(mongoDBConnection.dataSourceSpecification.serverURLs)  + "];\n" +
+                                context.getIndentationString() + getTabString() + "serverURLs: [" + this.getMongoDBURLs(mongoDBConnection.dataSourceSpecification.serverURLs) + "];\n" +
                                 context.getIndentationString() + getTabString() + "authentication: " + IAuthenticationGrammarComposerExtension.renderAuthentication(mongoDBConnection.authenticationSpecification, 1, context) + ";\n" +
                                 context.getIndentationString() + "}");
             }

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/util/MongoDBSchemaComposer.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/util/MongoDBSchemaComposer.java
@@ -26,7 +26,7 @@ import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarCompos
 public class MongoDBSchemaComposer
 {
 
-    public static Object renderMongoDBStore(MongoDatabase monogDBStore)
+    public static String renderMongoDBStore(MongoDatabase monogDBStore)
     {
         StringBuilder builder = new StringBuilder();
         int baseIndent = 1;

--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/test/java/org/finos/legend/engine/language/pure/grammar/integration/TestMongoDBGrammarRoundTrip.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/test/java/org/finos/legend/engine/language/pure/grammar/integration/TestMongoDBGrammarRoundTrip.java
@@ -17,7 +17,6 @@ package org.finos.legend.engine.language.pure.grammar.integration;
 import org.finos.legend.engine.language.pure.grammar.test.TestGrammarRoundtrip;
 import org.junit.Test;
 
-//TODO : Convert to round trip after getting composer setup.
 public class TestMongoDBGrammarRoundTrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
 {
 

--- a/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceContextGrammarRoundtrip.java
+++ b/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceContextGrammarRoundtrip.java
@@ -20,10 +20,20 @@ import org.junit.Test;
 public class TestPersistenceContextGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
 {
     @Test
+    public void testPersistenceContextWithImport()
+    {
+        testWithSectionInfoPreserved("###Persistence\n" +
+                "import test::*;\n" +
+                "PersistenceContext test::TestPersistenceContext\n" +
+                "{\n" +
+                "  persistence: test::TestPersistence;\n" +
+                "}\n");
+    }
+
+    @Test
     public void persistenceContextPermitOptionalFieldsToBeEmpty()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "PersistenceContext test::TestPersistenceContext\n" +
                 "{\n" +
                 "  persistence: test::TestPersistence;\n" +
@@ -33,15 +43,12 @@ public class TestPersistenceContextGrammarRoundtrip extends TestGrammarRoundtrip
     @Test
     public void persistenceContextPlatformDefault()
     {
-        testFormat(
-                "###Persistence\n" +
-                        "import test::*;\n" +
+        testFormat("###Persistence\n" +
                         "PersistenceContext test::TestPersistenceContext\n" +
                         "{\n" +
                         "  persistence: test::TestPersistence;\n" +
                         "}\n",
                 "###Persistence\n" +
-                        "import test::*;\n" +
                         "PersistenceContext test::TestPersistenceContext\n" +
                         "{\n" +
                         "  persistence: test::TestPersistence;\n" +
@@ -53,7 +60,6 @@ public class TestPersistenceContextGrammarRoundtrip extends TestGrammarRoundtrip
     public void persistenceContextSingleServiceParameter()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "PersistenceContext test::TestPersistenceContext\n" +
                 "{\n" +
                 "  persistence: test::TestPersistence;\n" +
@@ -69,7 +75,6 @@ public class TestPersistenceContextGrammarRoundtrip extends TestGrammarRoundtrip
     public void persistenceContextSinkConnectionPointer()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "PersistenceContext test::TestPersistenceContext\n" +
                 "{\n" +
                 "  persistence: test::TestPersistence;\n" +
@@ -99,7 +104,6 @@ public class TestPersistenceContextGrammarRoundtrip extends TestGrammarRoundtrip
     public void persistenceContextSinkConnectionEmbedded()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "PersistenceContext test::TestPersistenceContext\n" +
                 "{\n" +
                 "  persistence: test::TestPersistence;\n" +
@@ -135,7 +139,6 @@ public class TestPersistenceContextGrammarRoundtrip extends TestGrammarRoundtrip
                 "  }#;\n" +
                 "}\n");
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "PersistenceContext test::TestPersistenceContext\n" +
                 "{\n" +
                 "  persistence: test::TestPersistence;\n" +

--- a/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarRoundtrip.java
+++ b/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarRoundtrip.java
@@ -23,7 +23,6 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
     public void persistencePermitOptionalFieldsToBeEmptyFlat()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "Persistence test::TestPersistence\n" +
                 "{\n" +
                 "  doc: 'test doc';\n" +
@@ -67,7 +66,6 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
     public void persistencePermitOptionalFieldsToBeEmptyMultiFlat()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "Persistence test::TestPersistence\n" +
                 "{\n" +
                 "  doc: 'test doc';\n" +
@@ -137,7 +135,6 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
     public void persistenceFlat()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "Persistence test::TestPersistence\n" +
                 "{\n" +
                 "  doc: 'test doc';\n" +
@@ -211,7 +208,6 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
                 "}\n");
 
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "Persistence test::TestPersistence\n" +
                 "{\n" +
                 "  doc: 'test doc';\n" +
@@ -260,7 +256,6 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
     public void persistenceFlatWithTest()
     {
         String persistenceCodeBlock = "###Persistence\n" +
-                "import test::*;\n" +
                 "PersistenceContext test::TestPersistenceContext\n" +
                 "{\n" +
                 "  persistence: test::TestPersistence;\n" +
@@ -514,7 +509,7 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
                 "  ]\n";
 
         String persistenceCodeWithTest = String.format(persistenceCodeBlock, persistenceTestCodeBlock, testMockUp);
-        test(persistenceCodeWithTest);
+        testWithSectionInfoPreserved(persistenceCodeWithTest);
     }
 
 
@@ -522,7 +517,6 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
     public void persistenceMultiFlat()
     {
         test("###Persistence\n" +
-                "import test::*;\n" +
                 "Persistence test::TestPersistence\n" +
                 "{\n" +
                 "  doc: 'test doc';\n" +

--- a/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarRoundtrip.java
+++ b/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarRoundtrip.java
@@ -494,7 +494,7 @@ public class TestPersistenceGrammarRoundtrip extends TestGrammarRoundtrip.TestGr
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-xt-relationalStore-executionPlan-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/schema/SchemaExplorationApi.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/schema/SchemaExplorationApi.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.plan.execution.stores.relational.connection.api.schema;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.language.pure.modelManager.ModelManager;
@@ -54,8 +55,9 @@ public class SchemaExplorationApi
         this.connectionManager = relationalStoreExecutor.getStoreState().getRelationalExecutor().getConnectionManager();
     }
 
-    @Path("schemaExploration")
     @POST
+    @Path("schemaExploration")
+    @ApiOperation(value = "Use JDBC connection to survey database metadata (schemas, tables, columns, etc.) and build database Pure model")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
     public Response buildDatabase(DatabaseBuilderInput databaseBuilderInput, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)
@@ -74,8 +76,9 @@ public class SchemaExplorationApi
         }
     }
 
-    @Path("executeRawSQL")
     @POST
+    @Path("executeRawSQL")
+    @ApiOperation(value = "Use JDBC connection to execute SQL (this API is meant for non-production use case such exploring/previewing data, its result set is capped)")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.TEXT_PLAIN)
     public Response executeRawSQL(RawSQLExecuteInput input, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm)

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalEmbeddedDataGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalEmbeddedDataGrammarRoundtrip.java
@@ -87,7 +87,7 @@ public class TestRelationalEmbeddedDataGrammarRoundtrip extends TestGrammarRound
                 "            shouldPass:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
@@ -21,28 +21,7 @@ public class TestRelationalGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
     @Test
     public void testRelationalSimpleFull()
     {
-        test("Class simple::Person\n" +
-                "{\n" +
-                "  firstName: String[1];\n" +
-                "  lastName: String[1];\n" +
-                "  otherNames: String[*];\n" +
-                "}\n" +
-                "\n" +
-                "Class simple::Firm\n" +
-                "{\n" +
-                "  employees: simple::Person[*];\n" +
-                "  legalName: String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Enum simple::GeographicEntityType\n" +
-                "{\n" +
-                "  CITY,\n" +
-                "  COUNTRY,\n" +
-                "  REGION\n" +
-                "}\n" +
-                "\n" +
-                "\n" +
-                "###Relational\n" +
+        test("###Relational\n" +
                 "Database simple::dbInc\n" +
                 "(\n" +
                 "  Schema productSchema\n" +
@@ -119,6 +98,28 @@ public class TestRelationalGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
                 ")\n" +
                 "\n" +
                 "\n" +
+                "###Pure\n" +
+                "Class simple::Person\n" +
+                "{\n" +
+                "  firstName: String[1];\n" +
+                "  lastName: String[1];\n" +
+                "  otherNames: String[*];\n" +
+                "}\n" +
+                "\n" +
+                "Class simple::Firm\n" +
+                "{\n" +
+                "  employees: simple::Person[*];\n" +
+                "  legalName: String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Enum simple::GeographicEntityType\n" +
+                "{\n" +
+                "  CITY,\n" +
+                "  COUNTRY,\n" +
+                "  REGION\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
                 "###Mapping\n" +
                 "Mapping simple::simpleRelationalMappingInc\n" +
                 "(\n" +
@@ -146,7 +147,8 @@ public class TestRelationalGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
                 "      location: [dbInc]@location_PlaceOfInterest,\n" +
                 "      placeOfInterest: [dbInc]@location_PlaceOfInterest\n" +
                 "    )\n" +
-                "  }\n\n" +
+                "  }\n" +
+                "\n" +
                 "  simple::GeographicEntityType: EnumerationMapping GE\n" +
                 "  {\n" +
                 "    CITY: [1]\n" +

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
@@ -133,7 +133,7 @@ public class TestRelationalMappingGrammarRoundtrip extends TestGrammarRoundtrip.
                 "            shouldPass:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testTdsSchema.pure
+++ b/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testTdsSchema.pure
@@ -113,7 +113,7 @@ function meta::relational::tds::schema::tests::assertSchemaRoundTripEquality(que
    meta::pure::tds::schema::tests::assertSchemaRoundTripEquality($query, extensions());
 }
    
-function meta::relational::tds::schema::tests::assertSchemaRoundTripEquality(expected : TDSColumn[*], query : FunctionDefinition<{->TabularDataSet[1]}>[1]) : Boolean[1]
+function meta::relational::tds::schema::tests::assertSchemaRoundTripEquality(expected:TDSColumn[*], query : FunctionDefinition<{->TabularDataSet[1]}>[1]) : Boolean[1]
 {   
    meta::pure::tds::schema::tests::assertSchemaRoundTripEquality($expected, $query, extensions());
 }  

--- a/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/testable/mapping/TestMappingTestRunner.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/testable/mapping/TestMappingTestRunner.java
@@ -169,7 +169,7 @@ public class TestMappingTestRunner
                 "            assert1:\n" +
                 "              EqualToJson\n" +
                 "              #{\n" +
-                "                expected : \n" +
+                "                expected:\n" +
                 "                  ExternalFormat\n" +
                 "                  #{\n" +
                 "                    contentType: 'application/json';\n" +

--- a/legend-engine-xt-serviceStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreMappingGrammarRoundtrip.java
+++ b/legend-engine-xt-serviceStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestServiceStoreMappingGrammarRoundtrip.java
@@ -206,7 +206,7 @@ public class TestServiceStoreMappingGrammarRoundtrip extends TestGrammarRoundtri
             "            assert1:\n" +
             "              EqualToJson\n" +
             "              #{\n" +
-            "                expected : \n" +
+            "                expected:\n" +
             "                  ExternalFormat\n" +
             "                  #{\n" +
             "                    contentType: 'application/json';\n" +


### PR DESCRIPTION
Every extension grammar composer needs to implement `getExtraFreeSectionComposers()` since this is required for tools like `Studio` and `SDLC` to properly roundtrip elements individually (and  also `SectionIndex` is not available in those areas). This PR enforces that by correcting currently violating extensions and changing tests to enforce the free section roundtrip check

Also, this sneaks in a small change required by https://github.com/finos/legend-studio/pull/2226 - adding an API to fetch subtype information