### PR TITLE
Enable executions from Legend Studio & prod version support

### DIFF
--- a/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/MongoDBCompilerExtension.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/src/main/java/org/finos/legend/engine/language/pure/grammar/integration/MongoDBCompilerExtension.java
@@ -17,16 +17,16 @@ package org.finos.legend.engine.language.pure.grammar.integration;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.external.shared.format.model.ExternalFormatExtension;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperExternalFormat;
-import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperMappingBuilder;
-import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.language.pure.grammar.integration.extensions.IMongoDBStoreCompilerExtension;
@@ -34,6 +34,7 @@ import org.finos.legend.engine.language.pure.grammar.integration.util.MongoDBCom
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.MongoDBConnection;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.MongoDatabase;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.RootMongoDBClassMapping;
+import org.finos.legend.engine.protocol.pure.PureClientVersions;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.externalFormat.Binding;
@@ -42,7 +43,6 @@ import org.finos.legend.engine.shared.core.operational.errorManagement.EngineExc
 import org.finos.legend.pure.generated.*;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.*;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -129,5 +129,19 @@ public class MongoDBCompilerExtension implements IMongoDBStoreCompilerExtension
                     return null;
                 }
         );
+    }
+
+    @Override
+    public List<Procedure<Procedure2<String, List<String>>>> getExtraElementForPathToElementRegisters()
+    {
+        return Collections.singletonList(registerElementForPathToElement ->
+        {
+            ImmutableList<String> versions = PureClientVersions.versionsSince("v1_31_0");
+            versions.forEach(v -> registerElementForPathToElement.value(
+                            "meta::protocols::pure::" + v + "::extension::store::mongodb",
+                            Collections.singletonList("getMongoDBStoreExtension_String_1__SerializerExtension_1_")
+                    )
+            );
+        });
     }
 }

--- a/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/executionPlan/executionPlan_mongodb.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/executionPlan/executionPlan_mongodb.pure
@@ -1,0 +1,36 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import meta::protocols::pure::v1_31_0::metamodel::executionPlan::graphFetch::*;
+import meta::pure::executionPlan::*;
+import meta::json::*;
+import meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::*;
+import meta::protocols::pure::v1_31_0::metamodel::executionPlan::store::mongodb::*;
+
+Class meta::protocols::pure::v1_31_0::metamodel::executionPlan::store::mongodb::MongoDBExecutionNode extends meta::protocols::pure::v1_31_0::metamodel::executionPlan::ExecutionNode
+{
+    databaseCommand : String[1];
+    connection      : MongoDBConnection[1];
+}
+
+Class meta::protocols::pure::v1_31_0::metamodel::executionPlan::store::mongodb::MongoDBDocumentInternalizeExecutionNode extends meta::protocols::pure::v1_31_0::metamodel::executionPlan::ExecutionNode
+{
+   contentType       : String[1];
+   binding           : String[1];
+   enableConstraints : Boolean[1];
+   checked           : Boolean[1];
+   tree              : meta::protocols::pure::v1_31_0::metamodel::valueSpecification::raw::RootGraphFetchTree[0..1];
+   //config            : meta::external::shared::format::MongoDBDocumentInternalizeInternalizeConfig[0..1];
+}

--- a/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/extensions/extension.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/extensions/extension.pure
@@ -1,0 +1,23 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Class meta::protocols::pure::v1_31_0::extension::store::mongodb::MongoDBModuleSerializerExtension extends meta::protocols::pure::v1_31_0::extension::ModuleSerializerExtension
+{
+   transfers_connection_transformDatabaseConnection : meta::pure::metamodel::function::Function<{String[1], String[1], String[1] -> meta::pure::metamodel::function::Function<{Nil[1]->meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBConnection[1]}>[*]}>[0..1];
+}
+
+Profile meta::protocols::pure::v1_31_0::extension::store::mongodb::MongoDBModule
+{
+   stereotypes: [SerializerExtension];
+}

--- a/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/extensions/extension_mongodb.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/extensions/extension_mongodb.pure
@@ -1,0 +1,114 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_31_0::transformation::fromPureGraph::executionPlan::*;
+import meta::external::store::mongodb::metamodel::aggregation::*;
+import meta::json::*;
+import meta::external::store::mongodb::metamodel::*;
+import  meta::external::store::mongodb::mapping::*;
+import meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::*;
+import meta::external::store::mongodb::runtime::*;
+import meta::pure::mapping::*;
+
+import meta::external::store::mongodb::metamodel::*;
+import meta::external::store::mongodb::metamodel::runtime::*;
+import meta::external::store::mongodb::graphFetch::executionPlan::*;
+import meta::protocols::pure::v1_31_0::extension::store::mongodb::*;
+import meta::protocols::pure::v1_31_0::metamodel::executionPlan::*;
+import meta::external::store::mongodb::runtime::connections::*;
+
+function meta::protocols::pure::v1_31_0::extension::store::mongodb::getMongoDBStoreExtension(type:String[1]):meta::pure::extension::SerializerExtension[1]
+{
+   let res = [
+      pair('mongoDB', | meta::protocols::pure::v1_31_0::extension::store::mongodb::getMongoDBStoreExtension())
+   ]->filter(f|$f.first == $type);
+   assert($res->isNotEmpty(), |'Can\'t find the type '+$type);
+   $res->at(0).second->eval();
+}
+
+function meta::protocols::pure::v1_31_0::extension::store::mongodb::getMongoDBStoreExtension():meta::protocols::pure::v1_31_0::extension::SerializerExtension_v1_31_0[1]
+{
+   ^meta::protocols::pure::v1_31_0::extension::SerializerExtension_v1_31_0
+   (
+
+   moduleSerializerExtensions = meta::protocols::pure::v1_31_0::extension::store::mongodb::mongoDBModuleSerializerExtension(),
+   transfers_executionPlan_transformNode = {mapping:Mapping[1], extensions:meta::pure::extension::Extension[*] |
+          [
+              men:meta::external::store::mongodb::metamodel::pure::MongoDBExecutionNode[1] |
+
+                  ^meta::protocols::pure::v1_31_0::metamodel::executionPlan::store::mongodb::MongoDBExecutionNode(
+                    _type           = 'MongoDBExecutionNode',
+                    resultType      = $men.resultType->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                    databaseCommand = $men.databaseCommand->getDatabaseCommandJSON(),
+                    connection      = $men.connection->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::transformDatabaseConnection($extensions)
+                ),
+              mdIntern: meta::external::store::mongodb::metamodel::pure::MongoDBDocumentInternalizeExecutionNode[1] |
+                ^meta::protocols::pure::v1_31_0::metamodel::executionPlan::store::mongodb::MongoDBDocumentInternalizeExecutionNode(
+                    _type             = 'MongoDBDocumentInternalizeExecutionNode',
+                    checked           = $mdIntern.checked,
+                    enableConstraints = $mdIntern.enableConstraints,
+                    binding           = $mdIntern.binding->elementToPath(),
+                    contentType       = $mdIntern.binding.contentType,
+                    tree              = $mdIntern.tree->map(t| $t->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], ^Map<String,List<Any>>(), $extensions))->cast(@meta::protocols::pure::v1_31_0::metamodel::valueSpecification::raw::RootGraphFetchTree),
+                    resultType        = $mdIntern.resultType->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                    resultSizeRange   = $mdIntern.resultSizeRange->map(s| $s->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::domain::transformMultiplicity())
+                ),
+              exfin: meta::external::shared::format::executionPlan::ExternalFormatInternalizeExecutionNode[1] |
+                ^meta::protocols::pure::v1_31_0::metamodel::external::shared::format::executionPlan::ExternalFormatInternalizeExecutionNode(
+                  _type             = 'externalFormatInternalize',
+                  resultType        = $exfin.resultType->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::executionPlan::transformResultType($mapping, $extensions),
+                  resultSizeRange   = $exfin.resultSizeRange->map(s| $s->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::domain::transformMultiplicity()),
+                  tree              = $exfin.tree->map(t| $t->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], ^Map<String,List<Any>>(), $extensions))->cast(@meta::protocols::pure::v1_31_0::metamodel::valueSpecification::raw::RootGraphFetchTree),
+                  binding           = $exfin.binding->elementToPath(),
+                  enableConstraints = $exfin.enableConstraints,
+                  checked           = $exfin.checked,
+                  contentType       = $exfin.binding.contentType
+                )
+          ];
+       }
+   )
+}
+
+function meta::protocols::pure::v1_31_0::extension::store::mongodb::getDatabaseCommandJSON(databaseCommand: meta::external::store::mongodb::metamodel::aggregation::DatabaseCommand[1]): String[1]
+{
+    // MongoDBOperationElement
+    let config = meta::json::config(true, true, true, true, '_type', false);
+    let customSerializers = [
+    {
+        m: MongoDBOperationElement[1], s: meta::json::JSONState[1] |
+          let elem = meta::json::anyToJSON($m, $s, 1000, $config)->cast(@meta::json::JSONObject);
+          ^$elem(keyValuePairs = $elem.keyValuePairs->filter(x | $x.key.value != '_type')->concatenate(meta::json::newJSONKeyValue('_type', ^meta::json::JSONString(value = $m->class().name->toLowerFirstCharacter()->toOne()))));
+    },
+    {
+        m: BaseTypeValue[1], s: meta::json::JSONState[1] |
+          let elem = meta::json::anyToJSON($m, $s, 1000, $config)->cast(@meta::json::JSONObject);
+          ^$elem(keyValuePairs = $elem.keyValuePairs->filter(x | $x.key.value != '_type')->concatenate(meta::json::newJSONKeyValue('_type', ^meta::json::JSONString(value = $m->class().name->toLowerFirstCharacter()->toOne()))));
+    }
+    ];
+    meta::json::toJSON($databaseCommand, $customSerializers, 1000, $config);
+}
+
+function meta::protocols::pure::v1_31_0::extension::store::mongodb::mongoDBModuleSerializerExtension(): meta::protocols::pure::v1_31_0::extension::store::mongodb::MongoDBModuleSerializerExtension[1]
+{
+  let dbSpecificExtensions = meta::protocols::pure::v1_31_0::extension::store::mongodb::MongoDBModule->stereotype('SerializerExtension').modelElements->cast(@meta::pure::metamodel::function::Function<{->meta::protocols::pure::v1_31_0::extension::store::mongodb::MongoDBModuleSerializerExtension[1]}>)
+    ->map(f| $f->eval())->sortBy(e| $e.module);
+
+  let transformDatabaseConnection = $dbSpecificExtensions.transfers_connection_transformDatabaseConnection;
+
+  ^meta::protocols::pure::v1_31_0::extension::store::mongodb::MongoDBModuleSerializerExtension(
+    module = 'mongoDB',
+    transfers_connection_transformDatabaseConnection = if($transformDatabaseConnection->isNotEmpty(), |$transformDatabaseConnection->toOne(), |[])
+  );
+
+}

--- a/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/metamodel/runtime_mongodb.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/metamodel/runtime_mongodb.pure
@@ -1,0 +1,43 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+Class meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBConnection extends meta::protocols::pure::v1_31_0::metamodel::runtime::Connection
+{
+   type : String[1];
+   timeZone : String[0..1];
+   quoteIdentifiers : Boolean[0..1];
+   dataSourceSpecification: meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBDatasourceSpecification[1];
+   authenticationSpecification: meta::protocols::pure::v1_31_0::metamodel::runtime::connection::authentication::AuthenticationSpecification[1];
+}
+
+Class meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBDatasourceSpecification // extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
+{
+   serverURLs: meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBURL[1..*];
+   databaseName: String[0..1];
+   useSSL: Boolean[0..1];
+   connectionTimeoutMS: Integer[0..1];
+   socketTimeoutMS: Integer[0..1];
+   maxIdleTimeMS: Integer[0..1];
+   maxLifeTimeMS: Integer[0..1];
+   maxPoolSize: Integer[0..1];
+   waitQueueMultiple: Integer[0..1];
+   waitQueueTimeoutMS: Integer[0..1];
+}
+
+Class meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBURL
+{
+    baseUrl: String[1];
+    port: Integer[1];
+}

--- a/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/transfers/connection_mongodb.pure
+++ b/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/protocols/pure/v1_31_0/transfers/connection_mongodb.pure
@@ -1,0 +1,58 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::*;
+import meta::protocols::pure::v1_31_0::transformation::fromPureGraph::authentication::*;
+import meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::*;
+import meta::external::store::mongodb::metamodel::pure::runtime::*;
+
+function meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::transformDatabaseConnection(otherConnection: MongoDBConnection[1], extensions:meta::pure::extension::Extension[*]):meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBConnection[1]
+{
+   let _type = $otherConnection->class()->toString();
+   let element = $otherConnection.element->match([d:meta::pure::store::Store[1]|$d->elementToPath(),s:String[1]|$s]);
+   let type = $otherConnection.type->toString();
+   $otherConnection->match($extensions.serializerExtension('v1_31_0')->cast(@meta::protocols::pure::v1_31_0::extension::SerializerExtension_v1_31_0).moduleSerializerExtension('mongoDB')->cast(@meta::protocols::pure::v1_31_0::extension::store::mongodb::MongoDBModuleSerializerExtension).transfers_connection_transformDatabaseConnection->map(f | $f->eval($_type, $element, $type))->concatenate([
+
+      dbCon: MongoDBConnection[1]|
+         ^meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBConnection(
+                  _type = $_type,
+                  element = $element,
+                  dataSourceSpecification = $dbCon.dataSourceSpecification->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::transformSourceSpec(),
+                  authenticationSpecification = $dbCon.authenticationSpecification->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::authentication::transformAuthenticationSpecification($extensions),
+                  type = $type
+                   )
+      ]
+    )->toOneMany());
+}
+
+function meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::transformSourceSpec(sourceSpec: meta::external::store::mongodb::metamodel::runtime::MongoDBDatasourceSpecification[1]):meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBDatasourceSpecification[1]
+{
+  ^meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBDatasourceSpecification(
+    serverURLs = meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::transformServerURLs($sourceSpec.serverURLs),
+    databaseName = $sourceSpec.databaseName,
+    useSSL = $sourceSpec.useSSL,
+    connectionTimeoutMS = $sourceSpec.connectionTimeoutMS,
+    socketTimeoutMS = $sourceSpec.socketTimeoutMS,
+    maxIdleTimeMS = $sourceSpec.maxIdleTimeMS,
+    maxLifeTimeMS = $sourceSpec.maxLifeTimeMS,
+    maxPoolSize = $sourceSpec.maxPoolSize,
+    waitQueueMultiple = $sourceSpec.waitQueueMultiple,
+    waitQueueTimeoutMS = $sourceSpec.waitQueueTimeoutMS
+  )
+}
+
+function meta::protocols::pure::v1_31_0::transformation::fromPureGraph::connection::store::mongodb::transformServerURLs(urls: meta::external::store::mongodb::metamodel::runtime::MongoDBURL[1..*]):meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBURL[1..*]
+{
+  $urls->map(url | ^meta::protocols::pure::v1_31_0::metamodel::store::mongodb::connection::MongoDBURL(baseUrl = $url.baseUrl, port = $url.port));
+}


### PR DESCRIPTION
…… (#30)

* added getExtraElementForPathToElementRegisters in MongoDBCompilerExtension

* added v1_31_0 protocol

#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?
Add PathToElementRegisters for Legend studio to load the Mongo execution plan serializers. (via compiler extension)
Add a fixed version (1_31_0) - to enable production version support in engine for Mongo


