### PR TITLE
Fix DataSpace Search Document Generation

### DIFF
--- a/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/trans.pure
+++ b/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/trans.pure
@@ -115,7 +115,7 @@ function meta::analytics::search::transformation::dataspace::buildExecutionConte
 function meta::analytics::search::transformation::dataspace::buildClassDocuments(mapping: meta::pure::mapping::Mapping[1]): meta::analytics::search::metamodel::class::SimpleClassElement[*]
 {
   let analysedMapping = meta::analytics::mapping::modelCoverage::analyze($mapping, true, true);
-  $analysedMapping.mappedEntities->map(e|
+  $analysedMapping.mappedEntities->filter(e|$e.info.isRootEntity == true)->map(e|
     ^meta::analytics::search::metamodel::class::SimpleClassElement(
       name = $e.path->split('::')->last()->toOne(),
       package = $e.path,

--- a/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/transTest.pure
+++ b/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/transTest.pure
@@ -117,7 +117,7 @@ function <<meta::pure::profiles::test.Test>> meta::analytics::search::transforma
   let result = meta::analytics::search::transformation::buildDocument(meta::analytics::search::transformation::test::getTestDataSpaceWithoutDescription(), meta::analytics::search::transformation::test::buildTestProjectCoordinates())->cast(@meta::analytics::search::metamodel::BaseRootDocument);
   assert($result.type == meta::analytics::search::metamodel::DocumentType.DataSpace);
   let json = $result->alloyToJSON();
-  assert($json == '{"taggedValues":{},"package":"meta::analytics::search::transformation::test","defaultExecutionContext":"testContext","name":"TestDataSpace","projectCoordinates":{"versionId":"0.0.1-SNAPSHOT","groupId":"org.finos.test","artifactId":"test-project"},"id":"meta::analytics::search::transformation::test::TestDataSpace","type":"DataSpace","executionContexts":[{"runtimePath":"meta::analytics::search::transformation::test::TestRuntime","name":"testContext","mappingPath":"meta::analytics::search::transformation::test::sampleMappingTest"}]}');
+  assert($json == '{"taggedValues":{},"package":"meta::analytics::search::transformation::test","defaultExecutionContext":"testContext","name":"TestDataSpace","projectCoordinates":{"versionId":"0.0.1-SNAPSHOT","groupId":"org.finos.test","artifactId":"test-project"},"id":"meta::analytics::search::transformation::test::TestDataSpace","type":"DataSpace","executionContexts":[{"runtimePath":"meta::analytics::search::transformation::test::TestRuntime","classes":[{"taggedValues":{},"package":"meta::analytics::search::transformation::test::Address","name":"Address","properties":[{"taggedValues":{},"name":"zipcode"}]},{"taggedValues":{},"stereotypes":["temporal.processingtemporal"],"package":"meta::analytics::search::transformation::test::Firm","name":"Firm","properties":[{"taggedValues":{},"name":"id"},{"taggedValues":{},"name":"employees"},{"taggedValues":{},"name":"incType"}]},{"taggedValues":{"doc.doc":"Entity Details"},"stereotypes":["temporal.processingtemporal","test.Test"],"package":"meta::analytics::search::transformation::test::LegalEntity","name":"LegalEntity","properties":[{"taggedValues":{},"stereotypes":["temporal.processingtemporal"],"name":"legalName"},{"taggedValues":{},"name":"address"},{"taggedValues":{},"stereotypes":["milestoning.generatedmilestoningdateproperty"],"name":"processingDate"},{"taggedValues":{},"stereotypes":["milestoning.generatedmilestoningdateproperty"],"name":"milestoning"}]},{"taggedValues":{"doc.doc":"Person Details"},"package":"meta::analytics::search::transformation::test::Person","name":"Person","properties":[{"taggedValues":{"doc.doc":"firstName of the person"},"name":"firstName"},{"taggedValues":{"doc.doc":"lastName of the person"},"name":"lastName"}]},{"taggedValues":{},"package":"meta::analytics::search::transformation::test::Street","name":"Street","properties":[{"taggedValues":{},"name":"streetName"}]}],"name":"testContext","mappingPath":"meta::analytics::search::transformation::test::sampleRelationalMapping"}]}');
 }
 
 function <<meta::pure::profiles::test.Test>> meta::analytics::search::transformation::test::testDataSpaceWithDescriptionDocumentGeneration(): Boolean[1]
@@ -129,18 +129,18 @@ function <<meta::pure::profiles::test.Test>> meta::analytics::search::transforma
   let result = meta::analytics::search::transformation::buildDocument($testDataspace, meta::analytics::search::transformation::test::buildTestProjectCoordinates())->cast(@meta::analytics::search::metamodel::BaseRootDocument);
   assert($result.type == meta::analytics::search::metamodel::DocumentType.DataSpace);
   let json = $result->alloyToJSON();
-  assert($json == '{"taggedValues":{},"package":"meta::analytics::search::transformation::test","defaultExecutionContext":"testContext","name":"TestDataSpace","description":"This is a test description","projectCoordinates":{"versionId":"0.0.1-SNAPSHOT","groupId":"org.finos.test","artifactId":"test-project"},"id":"meta::analytics::search::transformation::test::TestDataSpace","type":"DataSpace","executionContexts":[{"runtimePath":"meta::analytics::search::transformation::test::TestRuntime","name":"testContext","mappingPath":"meta::analytics::search::transformation::test::sampleMappingTest"}]}');
+  assert($json == '{"taggedValues":{},"package":"meta::analytics::search::transformation::test","defaultExecutionContext":"testContext","name":"TestDataSpace","description":"This is a test description","projectCoordinates":{"versionId":"0.0.1-SNAPSHOT","groupId":"org.finos.test","artifactId":"test-project"},"id":"meta::analytics::search::transformation::test::TestDataSpace","type":"DataSpace","executionContexts":[{"runtimePath":"meta::analytics::search::transformation::test::TestRuntime","classes":[{"taggedValues":{},"package":"meta::analytics::search::transformation::test::Address","name":"Address","properties":[{"taggedValues":{},"name":"zipcode"}]},{"taggedValues":{},"stereotypes":["temporal.processingtemporal"],"package":"meta::analytics::search::transformation::test::Firm","name":"Firm","properties":[{"taggedValues":{},"name":"id"},{"taggedValues":{},"name":"employees"},{"taggedValues":{},"name":"incType"}]},{"taggedValues":{"doc.doc":"Entity Details"},"stereotypes":["temporal.processingtemporal","test.Test"],"package":"meta::analytics::search::transformation::test::LegalEntity","name":"LegalEntity","properties":[{"taggedValues":{},"stereotypes":["temporal.processingtemporal"],"name":"legalName"},{"taggedValues":{},"name":"address"},{"taggedValues":{},"stereotypes":["milestoning.generatedmilestoningdateproperty"],"name":"processingDate"},{"taggedValues":{},"stereotypes":["milestoning.generatedmilestoningdateproperty"],"name":"milestoning"}]},{"taggedValues":{"doc.doc":"Person Details"},"package":"meta::analytics::search::transformation::test::Person","name":"Person","properties":[{"taggedValues":{"doc.doc":"firstName of the person"},"name":"firstName"},{"taggedValues":{"doc.doc":"lastName of the person"},"name":"lastName"}]},{"taggedValues":{},"package":"meta::analytics::search::transformation::test::Street","name":"Street","properties":[{"taggedValues":{},"name":"streetName"}]}],"name":"testContext","mappingPath":"meta::analytics::search::transformation::test::sampleRelationalMapping"}]}');
 }
 
 function meta::analytics::search::transformation::test::getTestDataSpaceWithoutDescription(): meta::pure::metamodel::dataSpace::DataSpace[1]
 {
   let executionContext = ^meta::pure::metamodel::dataSpace::DataSpaceExecutionContext(
     name = 'testContext',
-    mapping = meta::analytics::search::transformation::test::sampleMappingTest,
+    mapping = meta::analytics::search::transformation::test::sampleRelationalMapping,
     defaultRuntime = ^meta::pure::runtime::PackageableRuntime(
       name = 'meta::analytics::search::transformation::test::TestRuntime',
       runtimeValue = ^meta::pure::runtime::EngineRuntime(
-        mappings = [meta::analytics::search::transformation::test::sampleMappingTest],
+        mappings = [meta::analytics::search::transformation::test::sampleRelationalMapping],
         connections = []
       )
     )
@@ -409,7 +409,7 @@ Mapping meta::analytics::search::transformation::test::sampleRelationalMapping
     ~mainTable [meta::analytics::search::transformation::test::sampleDB]PersonTable
     firstName: [meta::analytics::search::transformation::test::sampleDB]PersonTable.firstName,
     lastName: [meta::analytics::search::transformation::test::sampleDB]PersonTable.lastName
-  }
+  }  
   *meta::analytics::search::transformation::test::LegalEntity: Operation
   {
     meta::pure::router::operations::inheritance_OperationSetImplementation_1__SetImplementation_MANY_()


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Some Data Spaces that use mapping features such as unions fail to generate a document due to a call to pathToElement() not being able to resolve a PackageableElement.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

