### PR TITLE
Upgrade jacoco-maven-plugin version to 0.8.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,7 @@
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
         <versions.maven.plugin.version>2.7</versions.maven.plugin.version>
         <nexus.staging.maven.plugin.version>1.6.8</nexus.staging.maven.plugin.version>
-        <jacoco.maven.plugin.version>0.8.5</jacoco.maven.plugin.version>
+        <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
         <exec.maven.plugin.version>3.0.0</exec.maven.plugin.version>
         <build-helper.maven.plugin.version>3.2.0</build-helper.maven.plugin.version>
         <dockerfile.maven.plugin.version>1.4.13</dockerfile.maven.plugin.version>


### PR DESCRIPTION
#### What type of PR is this?

Dependency upgrade

#### What does this PR do / why is it needed ?

The current version of jacoco-maven-plugin (0.8.5) is not compatible with JDK 17. This upgrades to 0.8.10, which is.

#### Does this PR introduce a user-facing change?

No, this change will affect only the build.