### PR TITLE
minor cleanups for mapping testable #1600

### DIFF
--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/extension/ConnectionFactoryExtension.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/extension/ConnectionFactoryExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store;
 
@@ -56,14 +57,14 @@ public interface ConnectionFactoryExtension
         return Optional.empty();
     }
 
-    default Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(PureModelContextData pureModelContextData, Store store, EmbeddedData data)
+    default Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(List<DataElement> dataElements, Store store, EmbeddedData data)
     {
         return Optional.empty();
     }
 
-    default Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStoreWithMultiInputs(PureModelContextData pureModelContextData, Store store, EmbeddedData data)
+    default Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStoreWithMultiInputs(List<DataElement> dataElements, Store store, EmbeddedData data)
     {
-        return this.tryBuildTestConnectionsForStore(pureModelContextData, store, data);
+        return this.tryBuildTestConnectionsForStore(dataElements, store, data);
     }
 
     default Optional<InputStream> tryBuildInputStreamForStore(PureModelContextData pureModelContextData, Store store, EmbeddedData data)

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/data/EmbeddedDataHelper.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/data/EmbeddedDataHelper.java
@@ -18,6 +18,8 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
 
+import java.util.List;
+
 public class EmbeddedDataHelper
 {
 
@@ -31,11 +33,31 @@ public class EmbeddedDataHelper
         return dataElement;
     }
 
+    public static DataElement findDataElement(List<DataElement> dataElementList, String fullPath)
+    {
+        DataElement dataElement = Iterate.detect(dataElementList, e -> (fullPath.equals(e.getPath())));
+        if (dataElement == null)
+        {
+            throw new RuntimeException("Data Element '" + fullPath + "' not found.");
+        }
+        return dataElement;
+    }
+
     public static EmbeddedData resolveEmbeddedData(PureModelContextData pureModelContextData, EmbeddedData embeddedData)
     {
         if (embeddedData instanceof DataElementReference)
         {
             DataElement dataElement = resolveDataElement(pureModelContextData, ((DataElementReference)embeddedData).dataElement);
+            return dataElement.data;
+        }
+        return embeddedData;
+    }
+
+    public static EmbeddedData resolveDataElementWithList(List<DataElement> dataElementList, EmbeddedData embeddedData)
+    {
+        if (embeddedData instanceof DataElementReference)
+        {
+            DataElement dataElement = findDataElement(dataElementList, ((DataElementReference)embeddedData).dataElement);
             return dataElement.data;
         }
         return embeddedData;

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/modelToModel/connection/ModelStoreTestConnectionFactory.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/modelToModel/connection/ModelStoreTestConnectionFactory.java
@@ -43,7 +43,7 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
     private static String APPLICATION_JSON = "application/json";
     private static String APPLICATION_XML = "application/xml";
 
-    public Connection resolveExternalFormatData(ExternalFormatData externalFormatData, String _class, boolean useDefaultExecutor)
+    private Connection resolveExternalFormatData(ExternalFormatData externalFormatData, String _class, boolean useDefaultExecutor)
     {
         if (APPLICATION_JSON.equals(externalFormatData.contentType))
         {
@@ -81,7 +81,7 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
         }
     }
 
-    private Optional<Pair<Connection, List<Closeable>>> buildModelStoreConnectionsForStore(PureModelContextData pureModelContextData, ModelStoreData modelStoreData, boolean useDefaultExecutor)
+    private Optional<Pair<Connection, List<Closeable>>> buildModelStoreConnectionsForStore(List<DataElement> dataElements, ModelStoreData modelStoreData, boolean useDefaultExecutor)
     {
         List<ModelTestData> modelTestData = modelStoreData.modelData;
         for (ModelTestData data : modelTestData)
@@ -90,7 +90,7 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
             if (data instanceof ModelEmbeddedTestData)
             {
                 ModelEmbeddedTestData modelEmbeddedData = (ModelEmbeddedTestData) data;
-                EmbeddedData resolvedEmbeddedData = EmbeddedDataHelper.resolveEmbeddedData(pureModelContextData, modelEmbeddedData.data);
+                EmbeddedData resolvedEmbeddedData = EmbeddedDataHelper.resolveDataElementWithList(dataElements, modelEmbeddedData.data);
                 if (resolvedEmbeddedData instanceof ExternalFormatData)
                 {
                     Connection connection = resolveExternalFormatData((ExternalFormatData) resolvedEmbeddedData, _class, useDefaultExecutor);
@@ -107,7 +107,7 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
                 ValueSpecification vs = modelInstanceData.instances;
                 if (vs instanceof PackageableElementPtr)
                 {
-                    EmbeddedData testDataElement = EmbeddedDataHelper.resolveDataElement(pureModelContextData, ((PackageableElementPtr) vs).fullPath).data;
+                    EmbeddedData testDataElement = EmbeddedDataHelper.findDataElement(dataElements, ((PackageableElementPtr) vs).fullPath).data;
                     if (testDataElement instanceof ExternalFormatData)
                     {
                         Connection connection = resolveExternalFormatData((ExternalFormatData) testDataElement, _class, useDefaultExecutor);
@@ -130,22 +130,22 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
 
 
     @Override
-    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(PureModelContextData pureModelContextData, Store store, EmbeddedData testData)
+    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(List<DataElement> dataElements, Store store, EmbeddedData testData)
     {
         if (store instanceof ModelStore && testData instanceof ModelStoreData)
         {
-            return buildModelStoreConnectionsForStore(pureModelContextData, (ModelStoreData) testData, false);
+            return buildModelStoreConnectionsForStore(dataElements, (ModelStoreData) testData, false);
         }
         return Optional.empty();
     }
 
 
     @Override
-    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStoreWithMultiInputs(PureModelContextData pureModelContextData, Store store, EmbeddedData testData)
+    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStoreWithMultiInputs(List<DataElement> dataElements, Store store, EmbeddedData testData)
     {
         if (store instanceof ModelStore && testData instanceof ModelStoreData)
         {
-            return buildModelStoreConnectionsForStore(pureModelContextData, (ModelStoreData) testData, true);
+            return buildModelStoreConnectionsForStore(dataElements, (ModelStoreData) testData, true);
         }
         return Optional.empty();
     }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/legend/service/metamodel.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/legend/service/metamodel.pure
@@ -188,48 +188,11 @@ Class meta::legend::service::metamodel::PostValidationAssertion<T|m>
 
 Diagram meta::legend::service::metamodel::ServiceDiagram(width=0.0, height=0.0)
 {
-    TypeView cview_7(
-        type=meta::pure::test::TestSuite,
-        position=(1220.40967, 409.00000),
-        width=97.38477,
-        height=44.00000,
-        stereotypesVisible=true,
-        attributesVisible=true,
-        attributeStereotypesVisible=true,
-        attributeTypesVisible=true,
-        color=#FFFFCC,
-        lineWidth=1.0)
-
     TypeView cview_4(
         type=meta::pure::test::AtomicTest,
         position=(856.43457, 404.00000),
         width=179.96191,
         height=72.00000,
-        stereotypesVisible=true,
-        attributesVisible=true,
-        attributeStereotypesVisible=true,
-        attributeTypesVisible=true,
-        color=#FFFFCC,
-        lineWidth=1.0)
-
-    TypeView cview_3(
-        type=meta::legend::service::metamodel::ServiceTest,
-        position=(853.00000, 548.00000),
-        width=186.86914,
-        height=72.00000,
-        stereotypesVisible=true,
-        attributesVisible=true,
-        attributeStereotypesVisible=true,
-        attributeTypesVisible=true,
-        color=#FFFFCC,
-        lineWidth=1.0)
-
-
-    TypeView cview_13(
-        type=meta::pure::data::EmbeddedData,
-        position=(1801.94825, 690.00000),
-        width=107.35156,
-        height=44.00000,
         stereotypesVisible=true,
         attributesVisible=true,
         attributeStereotypesVisible=true,
@@ -273,12 +236,59 @@ Diagram meta::legend::service::metamodel::ServiceDiagram(width=0.0, height=0.0)
         color=#FFFFCC,
         lineWidth=1.0)
 
+    TypeView cview_3(
+        type=meta::legend::service::metamodel::ServiceTest,
+        position=(853.00000, 548.00000),
+        width=186.86914,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_17(
+        type=meta::legend::service::metamodel::ServiceTestSuite,
+        position=(1142.46241, 495.00000),
+        width=115.82422,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_7(
+        type=meta::pure::test::TestSuite,
+        position=(1144.40967, 390.00000),
+        width=105.56689,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
 
     TypeView cview_16(
         type=meta::legend::service::metamodel::ServiceTestData,
-        position=(1534.62403, 576.50000),
-        width=112.49609,
-        height=30.00000,
+        position=(1236.46241, 575.00000),
+        width=256.73633,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_18(
+        type=meta::legend::service::metamodel::ConnectionTestData,
+        position=(1371.46241, 690.00000),
+        width=165.48145,
+        height=72.00000,
         stereotypesVisible=true,
         attributesVisible=true,
         attributeStereotypesVisible=true,
@@ -307,14 +317,13 @@ Diagram meta::legend::service::metamodel::ServiceDiagram(width=0.0, height=0.0)
     GeneralizationView gview_2(
         source=cview_7,
         target=cview_5,
-        points=[(1269.10205,431.00000),(1116.12939,294.00000)],
+        points=[(1197.19311,419.00000),(1116.12939,294.00000)],
         label='',
         color=#000000,
         lineWidth=-1.0,
         lineStyle=SIMPLE)
 
-
-    GeneralizationView gview_4(
+    GeneralizationView gview_3(
         source=cview_14,
         target=cview_15,
         points=[(445.57398,621.00000),(444.84571,294.00000)],
@@ -323,8 +332,16 @@ Diagram meta::legend::service::metamodel::ServiceDiagram(width=0.0, height=0.0)
         lineWidth=-1.0,
         lineStyle=SIMPLE)
 
+    GeneralizationView gview_4(
+        source=cview_17,
+        target=cview_7,
+        points=[(1200.37452,510.00000),(1197.19312,419.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
 
-    PropertyView pview_1(
+    PropertyView pview_0(
         property=meta::pure::test::Testable.tests,
         source=cview_15,
         target=cview_5,
@@ -338,5 +355,31 @@ Diagram meta::legend::service::metamodel::ServiceDiagram(width=0.0, height=0.0)
         nameVisible=true,
         lineStyle=SIMPLE)
 
+    PropertyView pview_1(
+        property=meta::legend::service::metamodel::ServiceTestSuite.serviceTestData,
+        source=cview_17,
+        target=cview_16,
+        points=[(1200.37452,510.00000),(1364.83057,597.00000)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
 
+    PropertyView pview_2(
+        property=meta::legend::service::metamodel::ServiceTestData.connectionsTestData,
+        source=cview_16,
+        target=cview_18,
+        points=[(1364.83057,597.00000),(1454.20313,726.00000)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
 }

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/data/data.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/data/data.pure
@@ -55,6 +55,13 @@ Class meta::pure::data::ModelInstanceData extends meta::pure::data::ModelData
   instances: InstanceValue[1];
 }
 
+Class meta::pure::test::StoreTestData
+{
+    doc: String[0..1];
+    data: meta::pure::data::EmbeddedData[1];
+    store: meta::pure::store::Store[1];
+}
+
 Class meta::external::shared::format::metamodel::data::ExternalFormatData extends EmbeddedData
 {
   contentType : String[1];

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/test/testable.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/test/testable.pure
@@ -29,13 +29,6 @@ Class <<typemodifiers.abstract>> meta::pure::test::AtomicTest extends Test
     assertions  : TestAssertion[1..*];
 }
 
-Class meta::pure::test::StoreTestData
-{
-    doc: String[0..1];
-    data: meta::pure::data::EmbeddedData[1];
-    store: meta::pure::store::Store[1];
-}
-
 Association meta::pure::test::TestSuiteAtomicTest
 {
     suite       : TestSuite[0..1];   

--- a/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunnerContext.java
+++ b/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunnerContext.java
@@ -21,10 +21,13 @@ import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.ConnectionVisitor;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.generated.Root_meta_pure_runtime_Connection;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
+
+import java.util.List;
 
 public class MappingTestRunnerContext
 {
@@ -36,12 +39,14 @@ public class MappingTestRunnerContext
     final RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions;
     final org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping mapping;
     final PlanExecutor.ExecuteArgsBuilder executeBuilder;
+    final List<DataElement> dataElements;
 
     public MappingTestRunnerContext(Root_meta_pure_test_TestSuite metamodelTestSuite, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping mapping, PureModel pureModel, PureModelContextData pureModelContextData, MutableList<PlanTransformer> executionPlanTransformers,
                                     ConnectionVisitor<Root_meta_pure_runtime_Connection> connectionVisitor, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions)
     {
         this.pureModel = pureModel;
         this.pureModelContextData = pureModelContextData;
+        this.dataElements = pureModelContextData.getElementsOfType(DataElement.class);
         this.mapping = mapping;
         this.executionPlanTransformers = executionPlanTransformers;
         this.connectionVisitor = connectionVisitor;

--- a/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/testsupport/MongoDBStoreTestConnectionFactory.java
+++ b/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/testsupport/MongoDBStoreTestConnectionFactory.java
@@ -23,7 +23,6 @@ import org.finos.legend.engine.protocol.mongodb.schema.metamodel.pure.MongoDatab
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.runtime.MongoDBDatasourceSpecification;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.runtime.MongoDBURL;
 import org.finos.legend.engine.protocol.pure.v1.extension.ConnectionFactoryExtension;
-import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
@@ -36,6 +35,7 @@ import java.util.Optional;
 
 public class MongoDBStoreTestConnectionFactory implements ConnectionFactoryExtension
 {
+    @Override
     public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnection(Connection sourceConnection, EmbeddedData data)
     {
         if (sourceConnection instanceof MongoDBConnection && data instanceof MongoDBStoreEmbeddedData)
@@ -70,7 +70,8 @@ public class MongoDBStoreTestConnectionFactory implements ConnectionFactoryExten
         return Optional.empty();
     }
 
-    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(PureModelContextData pureModelContextData, Store testStore, EmbeddedData data)
+    @Override
+    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(List<DataElement> dataElements, Store testStore, EmbeddedData data)
     {
         if (testStore instanceof MongoDatabase)
         {

--- a/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/test/RelationalConnectionFactory.java
+++ b/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/test/RelationalConnectionFactory.java
@@ -18,9 +18,9 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ConnectionFactoryExtension;
-import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
@@ -96,7 +96,7 @@ public class RelationalConnectionFactory implements ConnectionFactoryExtension
     }
 
     @Override
-    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(PureModelContextData pureModelContextData, Store testStore, EmbeddedData data)
+    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(List<DataElement> dataElements, Store testStore, EmbeddedData data)
     {
         if (testStore instanceof Database)
         {

--- a/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/test/ServiceStoreTestConnectionFactory.java
+++ b/legend-engine-xt-serviceStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/service/test/ServiceStoreTestConnectionFactory.java
@@ -18,7 +18,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.protocol.pure.v1.extension.ConnectionFactoryExtension;
-import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedData;
 import org.finos.legend.engine.protocol.pure.v1.model.data.ServiceStoreEmbeddedData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
@@ -65,7 +64,7 @@ public class ServiceStoreTestConnectionFactory implements ConnectionFactoryExten
     }
 
     @Override
-    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(PureModelContextData pureModelContextData, Store testStore, EmbeddedData data)
+    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(List<DataElement> dataElements, Store testStore, EmbeddedData data)
     {
         if (testStore instanceof ServiceStore)
         {


### PR DESCRIPTION
#### What type of PR is this?

Addressing some points of discussion on https://github.com/finos/legend-engine/pull/1600

- move StoreTestData to `data.pure`
- remove pmcd from connectinTestFactory to prevent inproper usage of interface. 



