### PR TITLE
Update TestLocalH2ConnectionCreation.java to resolve test failure

### DIFF
--- a/legend-engine-xt-relationalStore-executionPlan-connection-tests/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/TestLocalH2ConnectionCreation.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection-tests/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/test/TestLocalH2ConnectionCreation.java
@@ -106,7 +106,7 @@ public class TestLocalH2ConnectionCreation extends DbSpecificTests
     @Test
     public void testNorthwindLoader_WithRepeatedLoading() throws Exception
     {
-        Identity identity1 = IdentityFactoryProvider.getInstance().makeIdentityForTesting("identity1");
+        Identity identity1 = IdentityFactoryProvider.getInstance().makeIdentityForTesting("identity2");
         RelationalDatabaseConnection db1Conn1 = this.buildLocalH2DatasourceSpec(Lists.mutable.with(
                 "call loadNorthwindData();", "call loadNorthwindData();"));
 


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

Resolve test failures (from checking specific connection counts for a given user in other tests)

userAcquiresSingleConnection (org.finos.legend.engine.plan.execution.stores.relational.connection.test.TestLocalH2ConnectionCreation) failed

userAcquiresConcurrentConnectionsToDifferentDbs (org.finos.legend.engine.plan.execution.stores.relational.connection.test.TestLocalH2ConnectionCreation) failed

