### PR TITLE
Handle empty queries

### DIFF
--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
@@ -91,4 +91,10 @@ public class ExecutionDispatcher extends SqlBaseParserBaseVisitor<SessionHandler
             return nextResult;
         }
     }
+
+    public static SessionHandler getEmptySessionHandler()
+    {
+        return EMPTY_SESSION_HANDLER;
+    }
+
 }

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
@@ -330,6 +330,7 @@ public class PostgresWireProtocol
                         : getAccessControl.apply(session.sessionSettings());
                     Messages.sendErrorResponse(channel, accessControl, t);
                     */
+                    LOGGER.error("Unable to handle query", t);
                     Messages.sendErrorResponse(channel, t);
                 }
                 catch (Throwable ti)

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendResultSet.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendResultSet.java
@@ -66,7 +66,6 @@ public class LegendResultSet implements PostgresResultSet
             case "StrictDate":
                 LocalDate localDate = ISO_LOCAL_DATE.parse(value, LocalDate::from);
                 long toEpochMilli = localDate.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
-                System.out.println("actual : " + toEpochMilli);
                 return toEpochMilli;
             case "Date":
             case "DateTime":

--- a/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -183,6 +183,33 @@ public class PostgresServerTest
         }
     }
 
+    @Test
+    public void testConnectionIsValid() throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                "dummy", "dummy")
+        )
+        {
+            // This triggers an empty query and expects an empty response
+            boolean isValid = connection.isValid(1);
+            Assert.assertTrue(isValid);
+        }
+    }
+
+    @Test
+    public void testEmptyQuery() throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                "dummy", "dummy");
+             PreparedStatement statement = connection.prepareStatement("")
+        )
+        {
+            int rowCount = statement.executeUpdate();
+            Assert.assertEquals(0, rowCount);
+        }
+    }
+
+
     @AfterClass
     public static void tearDown()
     {


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Add support for empty queries
<!--
Describe change being introduced by this PR.
-->

#### Other notes for reviewers:
`Connection.isValid` in Postgres JDBC driver invokes an empty query and expects an empty response.
This PR forwards the empty query to the empty session handler
