### PR TITLE
Add support for SHOW TRANSACTION queries

### DIFF
--- a/legend-engine-xt-sql-postgres-server/pom.xml
+++ b/legend-engine-xt-sql-postgres-server/pom.xml
@@ -285,6 +285,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
@@ -43,6 +43,13 @@ public class ExecutionDispatcher extends SqlBaseParserBaseVisitor<SessionHandler
         return EMPTY_SESSION_HANDLER;
     }
 
+    @Override
+    public SessionHandler visitShowTransaction(SqlBaseParser.ShowTransactionContext ctx)
+    {
+        // TODO: Handle show transaction instead of routing to metadata session handler
+        return metaDataSessionHandler;
+    }
+
     /**
      * Visit the <code>SELECT</code> query context.
      * Select query gets the name default from the antlr definition

--- a/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/ExecutionDispatcherTest.java
+++ b/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/ExecutionDispatcherTest.java
@@ -76,6 +76,12 @@ public class ExecutionDispatcherTest
         assertDataSessionHandler("SELECT * FROM service.\"/testService\"");
     }
 
+    @Test
+    public void testShowTxnLevel()
+    {
+        assertMetadataSessionHandler("SHOW TRANSACTION ISOLATION LEVEL");
+    }
+
     private static void assertEmptySessionHandler(String query)
     {
         SessionHandler sessionHandler = getSessionHandler(query);

--- a/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -22,6 +22,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.eclipse.collections.api.tuple.Pair;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -136,6 +138,45 @@ public class PostgresServerTest
                 "dummy", "dummy");
              PreparedStatement statement = connection.prepareStatement("SELECT 1");
              ResultSet resultSet = statement.executeQuery()
+        )
+        {
+            int rows = 0;
+            while (resultSet.next())
+            {
+                rows++;
+            }
+            Assert.assertEquals(1, rows);
+        }
+    }
+
+    @Test
+    public void testShowTxn() throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                "dummy", "dummy");
+             PreparedStatement statement = connection.prepareStatement("SHOW TRANSACTION ISOLATION LEVEL");
+             ResultSet resultSet = statement.executeQuery()
+        )
+        {
+            int rows = 0;
+            while (resultSet.next())
+            {
+                rows++;
+            }
+            Assert.assertEquals(1, rows);
+        }
+    }
+
+    @Test
+    public void testHikariConnection() throws SQLException
+    {
+        HikariConfig jdbcConfig = new HikariConfig();
+        jdbcConfig.setJdbcUrl("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres");
+        jdbcConfig.setUsername("dummy");
+        try (HikariDataSource dataSource = new HikariDataSource(jdbcConfig);
+             Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement("SELECT 1");
+             ResultSet resultSet = preparedStatement.executeQuery()
         )
         {
             int rows = 0;


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Add support for `SHOW TRANSACTION` queries.
These queries are executed during the pool creation of HikariCP to validate the connection.
<!--
Describe change being introduced by this PR.
-->

#### Other notes for reviewers:
`SHOW TRANSACTION` queries are temporary routed to metadata handler until it can be supported in Alloy SQL
#### Does this PR introduce a user-facing change?
No
<!--
-->
