### PR TITLE
Propagate execution errors to Legend SQL client

### DIFF
--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/ExceptionError.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/ExceptionError.java
@@ -35,6 +35,11 @@ public class ExceptionError
     private SourceInformation sourceInformation;
     private EngineErrorType errorType;
 
+    public ExceptionError()
+    {
+        // DO NOT DELETE: this resets the default constructor for Jackson
+    }
+
     ExceptionError(int code, String message)
     {
         this.status = "error";

--- a/legend-engine-xt-sql-postgres-server/pom.xml
+++ b/legend-engine-xt-sql-postgres-server/pom.xml
@@ -149,6 +149,10 @@
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
@@ -29,6 +29,28 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import org.finos.legend.engine.postgres.auth.AuthenticationMethod;
+import org.finos.legend.engine.postgres.auth.AuthenticationMethodType;
+import org.finos.legend.engine.postgres.auth.AuthenticationProvider;
+import org.finos.legend.engine.postgres.auth.KerberosIdentityProvider;
+import org.finos.legend.engine.postgres.config.GSSConfig;
+import org.finos.legend.engine.postgres.handler.PostgresResultSet;
+import org.finos.legend.engine.postgres.handler.PostgresResultSetMetaData;
+import org.finos.legend.engine.postgres.types.PGType;
+import org.finos.legend.engine.postgres.types.PGTypes;
+import org.finos.legend.engine.postgres.utils.ExceptionUtil;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.shared.core.kerberos.SubjectTools;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+import org.slf4j.Logger;
+
+import javax.net.ssl.SSLSession;
+import javax.security.auth.Subject;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
@@ -46,27 +68,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import javax.net.ssl.SSLSession;
-import javax.security.auth.Subject;
-
-import org.finos.legend.engine.postgres.auth.AuthenticationMethod;
-import org.finos.legend.engine.postgres.auth.AuthenticationMethodType;
-import org.finos.legend.engine.postgres.auth.AuthenticationProvider;
-import org.finos.legend.engine.postgres.auth.KerberosIdentityProvider;
-import org.finos.legend.engine.postgres.config.GSSConfig;
-import org.finos.legend.engine.postgres.handler.PostgresResultSet;
-import org.finos.legend.engine.postgres.handler.PostgresResultSetMetaData;
-import org.finos.legend.engine.postgres.types.PGType;
-import org.finos.legend.engine.postgres.types.PGTypes;
-import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.kerberos.SubjectTools;
-import org.ietf.jgss.GSSContext;
-import org.ietf.jgss.GSSCredential;
-import org.ietf.jgss.GSSException;
-import org.ietf.jgss.GSSManager;
-import org.ietf.jgss.GSSName;
-import org.ietf.jgss.Oid;
-import org.slf4j.Logger;
 import static org.finos.legend.engine.postgres.FormatCodes.getFormatCode;
 
 
@@ -891,7 +892,7 @@ public class PostgresWireProtocol
         }
         catch (Exception e)
         {
-            throw new RuntimeException(e);
+            throw ExceptionUtil.wrapException(e);
         }
     }
 

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
@@ -27,6 +27,7 @@ import org.finos.legend.engine.postgres.handler.PostgresPreparedStatement;
 import org.finos.legend.engine.postgres.handler.PostgresResultSet;
 import org.finos.legend.engine.postgres.handler.PostgresStatement;
 import org.finos.legend.engine.postgres.handler.SessionHandler;
+import org.finos.legend.engine.postgres.utils.ExceptionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -329,7 +330,7 @@ public class Session implements AutoCloseable
         }
         catch (Exception e)
         {
-            throw new RuntimeException(e);
+            throw ExceptionUtil.wrapException(e);
         }
     }
 

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
@@ -209,7 +209,7 @@ public class Session implements AutoCloseable
                 }
                 catch (Exception e)
                 {
-                    throw new RuntimeException(e);
+                    throw ExceptionUtil.wrapException(e);
                 }
             default:
                 throw new AssertionError("Unsupported type: " + type);

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsClient.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsClient.java
@@ -99,29 +99,21 @@ public class LegendTdsClient implements LegendExecutionClient
     protected JsonNode executeQueryApi(String query)
     {
         LOGGER.info("executing query " + query);
-        String uri = protocol + "://" + this.host + ":" + this.port + "/api/sql/v1/execution/executeQueryString";
-        HttpPost req = new HttpPost(uri);
-
-        StringEntity stringEntity = new StringEntity(query, UTF_8);
-        stringEntity.setContentType(TEXT_PLAIN);
-        req.setEntity(stringEntity);
-
-        try (CloseableHttpClient client = (CloseableHttpClient) HttpClientBuilder.getHttpClient(new BasicCookieStore());
-             CloseableHttpResponse res = client.execute(req))
-        {
-            return handleResponse(query, () -> res.getEntity().getContent(), () -> res.getStatusLine().getStatusCode());
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
+        String apiPath = "/api/sql/v1/execution/executeQueryString";
+        return executeApi(query, apiPath);
     }
 
 
     protected JsonNode executeSchemaApi(String query)
     {
         LOGGER.info("executing schema query " + query);
-        String uri = protocol + "://" + this.host + ":" + this.port + "/api/sql/v1/execution/getSchemaFromQueryString";
+        String apiPath = "/api/sql/v1/execution/getSchemaFromQueryString";
+        return executeApi(query, apiPath);
+    }
+
+    private JsonNode executeApi(String query, String apiPath)
+    {
+        String uri = protocol + "://" + this.host + ":" + this.port + apiPath;
         HttpPost req = new HttpPost(uri);
 
         StringEntity stringEntity = new StringEntity(query, UTF_8);

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsClientException.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsClientException.java
@@ -1,0 +1,24 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.postgres.handler.legend;
+
+public class LegendTdsClientException extends RuntimeException
+{
+    public LegendTdsClientException(String message)
+    {
+        super(message);
+    }
+}

--- a/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/utils/ExceptionUtil.java
+++ b/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/utils/ExceptionUtil.java
@@ -1,0 +1,32 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.postgres.utils;
+
+public class ExceptionUtil
+{
+    public static RuntimeException wrapException(Exception e)
+    {
+        if (!(e instanceof RuntimeException))
+        {
+            return new RuntimeException(e);
+
+        }
+        else
+        {
+            return (RuntimeException) e;
+        }
+    }
+}

--- a/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -303,7 +303,8 @@ public class PostgresServerTest
             PSQLException exception = Assert.assertThrows(PSQLException.class, statement::executeQuery);
             ServerErrorMessage serverErrorMessage = exception.getServerErrorMessage();
             Assert.assertNotNull(serverErrorMessage);
-            Assert.assertEquals("PureAssertFailException: Assert failure at (resource:/core_external_query_sql/binding/fromPure/fromPure.pure line:1744 column:5), \"no column found named some_random_column_name\"", serverErrorMessage.getMessage());
+            Assert.assertNotNull(serverErrorMessage.getMessage());
+            Assert.assertTrue(serverErrorMessage.getMessage().endsWith("\"no column found named some_random_column_name\""));
         }
     }
 
@@ -333,7 +334,8 @@ public class PostgresServerTest
             PSQLException exception = Assert.assertThrows(PSQLException.class, statement::getMetaData);
             ServerErrorMessage serverErrorMessage = exception.getServerErrorMessage();
             Assert.assertNotNull(serverErrorMessage);
-            Assert.assertEquals("PureAssertFailException: Assert failure at (resource:/core_external_query_sql/binding/fromPure/fromPure.pure line:1744 column:5), \"no column found named some_random_column_name\"", serverErrorMessage.getMessage());
+            Assert.assertNotNull(serverErrorMessage.getMessage());
+            Assert.assertTrue(serverErrorMessage.getMessage().endsWith("\"no column found named some_random_column_name\""));
         }
     }
 

--- a/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsTestClient.java
+++ b/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsTestClient.java
@@ -37,15 +37,20 @@ public class LegendTdsTestClient extends LegendTdsClient
     @Override
     protected JsonNode executeQueryApi(String query)
     {
-        Invocation.Builder builder = resourceTestRule.target("sql/v1/execution/executeQueryString").request();
-        Response response = builder.post(Entity.text(query));
-        return handleResponse(query, () -> (InputStream) response.getEntity(), response::getStatus);
+        String path = "sql/v1/execution/executeQueryString";
+        return executeApi(query, path);
     }
 
     @Override
     protected JsonNode executeSchemaApi(String query)
     {
-        Invocation.Builder builder = resourceTestRule.target("sql/v1/execution/getSchemaFromQueryString").request();
+        String path = "sql/v1/execution/getSchemaFromQueryString";
+        return executeApi(query, path);
+    }
+
+    private JsonNode executeApi(String query, String path)
+    {
+        Invocation.Builder builder = resourceTestRule.target(path).request();
         Response response = builder.post(Entity.text(query));
         return handleResponse(query, () -> (InputStream) response.getEntity(), response::getStatus);
     }

--- a/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsTestClient.java
+++ b/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsTestClient.java
@@ -18,20 +18,14 @@ package org.finos.legend.engine.postgres.handler.legend;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.tuple.Tuples;
-import org.eclipse.collections.impl.utility.LazyIterate;
-import org.eclipse.collections.impl.utility.internal.IterableIterate;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.slf4j.Logger;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
-import java.util.Collections;
-import java.util.List;
+import java.io.InputStream;
 
 public class LegendTdsTestClient extends LegendTdsClient
 {
@@ -52,20 +46,7 @@ public class LegendTdsTestClient extends LegendTdsClient
     {
         Invocation.Builder builder = resourceTestRule.target("sql/v1/execution/executeQueryString").request();
         Response response = builder.post(Entity.text(query));
-        String responseString = response.readEntity(String.class);
-
-        if (response.getStatus() != 200)
-        {
-            LOGGER.error(String.format("Status: [%s], Response: [%s]", response.getStatusInfo(), responseString));
-        }
-        try
-        {
-            return mapper.readValue(responseString, JsonNode.class);
-        }
-        catch (JsonProcessingException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return handleResponse(query, () -> (InputStream) response.getEntity(), response::getStatus);
     }
 
     @Override

--- a/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsTestClient.java
+++ b/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTdsTestClient.java
@@ -15,12 +15,8 @@
 
 package org.finos.legend.engine.postgres.handler.legend;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.finos.legend.engine.shared.core.ObjectMapperFactory;
-import org.slf4j.Logger;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
@@ -30,9 +26,6 @@ import java.io.InputStream;
 public class LegendTdsTestClient extends LegendTdsClient
 {
     private final ResourceTestRule resourceTestRule;
-    private static final ObjectMapper mapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
-    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(LegendTdsTestClient.class);
-
 
     public LegendTdsTestClient(ResourceTestRule resourceTestRule)
     {
@@ -54,19 +47,6 @@ public class LegendTdsTestClient extends LegendTdsClient
     {
         Invocation.Builder builder = resourceTestRule.target("sql/v1/execution/getSchemaFromQueryString").request();
         Response response = builder.post(Entity.text(query));
-        String responseString = response.readEntity(String.class);
-
-        if (response.getStatus() != 200)
-        {
-            LOGGER.error(String.format("Status: [%s], Response: [%s]", response.getStatusInfo(), responseString));
-        }
-        try
-        {
-            return mapper.readValue(responseString, JsonNode.class);
-        }
-        catch (JsonProcessingException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return handleResponse(query, () -> (InputStream) response.getEntity(), response::getStatus);
     }
 }

--- a/legend-engine-xt-sql-query/src/test/java/org/finos/legend/engine/query/sql/api/CatchAllExceptionMapper.java
+++ b/legend-engine-xt-sql-query/src/test/java/org/finos/legend/engine/query/sql/api/CatchAllExceptionMapper.java
@@ -1,0 +1,31 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.query.sql.api;
+
+import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionTool;
+import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class CatchAllExceptionMapper implements ExceptionMapper<Exception>
+{
+    @Override
+    public Response toResponse(Exception exception)
+    {
+        return ExceptionTool.exceptionManager(exception, LoggingEventType.CATCH_ALL, null);
+    }
+}

--- a/legend-engine-xt-sql-query/src/test/java/org/finos/legend/engine/query/sql/api/execute/SqlExecuteTest.java
+++ b/legend-engine-xt-sql-query/src/test/java/org/finos/legend/engine/query/sql/api/execute/SqlExecuteTest.java
@@ -26,6 +26,7 @@ import org.finos.legend.engine.language.pure.modelManager.ModelManager;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.protocol.pure.PureClientVersions;
+import org.finos.legend.engine.query.sql.api.CatchAllExceptionMapper;
 import org.finos.legend.engine.query.sql.api.MockPac4jFeature;
 import org.finos.legend.engine.query.sql.api.sources.TestSQLSourceProvider;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
@@ -75,6 +76,7 @@ public class SqlExecuteTest
                 .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
                 .addResource(sqlExecute)
                 .addResource(new MockPac4jFeature())
+                .addResource(new CatchAllExceptionMapper())
                 .build();
         return Tuples.pair(pureModel,resources);
     }


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
This PR adds functionality to propagate execution errors to the Legend SQL client.
Previously, all queries appear to have succeeded with empty result set.

<!--
Describe change being introduced by this PR.
-->

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
No