### PR TITLE
Allow engine to still work with legacy H2 version 1.4.200

### DIFF
--- a/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
+++ b/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
@@ -139,6 +139,19 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-h2-1.4.200-execution</artifactId>
+            <scope>runtime</scope>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- XML -->

--- a/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/AlloyH2Server.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/AlloyH2Server.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational;
 
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.h2.H2Manager;
 import org.h2.tools.Server;
 import org.slf4j.Logger;
 
@@ -24,12 +25,22 @@ public class AlloyH2Server extends Server
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(AlloyH2Server.class);
 
     private static final String H2_ALLOWED_CLASSES_PROPERTY = "h2.allowedClasses";
-    private static final String H2_ALLOWED_CLASSES_DEFAULT = "org.h2.*,org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions";
 
     public static Server startServer(int port) throws SQLException
     {
+        String h2AllowedClassesDefault;
+
+        if (H2Manager.getMajorVersion() == 2)
+        {
+            h2AllowedClassesDefault = "org.h2.*,org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions";
+        }
+        else
+        {
+            h2AllowedClassesDefault = "org.h2.*,org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions_1_4_200";
+        }
+
         LOGGER.debug("startServer port {}", port);
-        System.setProperty(H2_ALLOWED_CLASSES_PROPERTY, System.getProperty(H2_ALLOWED_CLASSES_PROPERTY, H2_ALLOWED_CLASSES_DEFAULT));
+        System.setProperty(H2_ALLOWED_CLASSES_PROPERTY, System.getProperty(H2_ALLOWED_CLASSES_PROPERTY, h2AllowedClassesDefault));
         return Server.createTcpServer("-ifNotExists", "-tcpPort", String.valueOf(port)).start();
     }
 

--- a/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/DefaultH2AuthenticationStrategy.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/DefaultH2AuthenticationStrategy.java
@@ -21,6 +21,7 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.authe
 import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.keys.AuthenticationStrategyKey;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.keys.DefaultH2AuthenticationStrategyKey;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.DatabaseManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.h2.H2Manager;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.DataSourceWithStatistics;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.state.ConnectionStateManager;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.state.IdentityState;
@@ -39,14 +40,16 @@ public class DefaultH2AuthenticationStrategy extends AuthenticationStrategy
     private static final String SA_USER = "sa";
     private static final String SA_PASSWORD = "";
     private static final List<String> LEGEND_H2_EXTENSION_SQLs = getLegendH2ExtensionSQLs();
+    private static final List<String> LEGEND_H2_1_4_200_EXTENSION_SQLs = getLegendH2_1_4_200_ExtensionSQLs();
 
     @Override
     public Connection getConnectionImpl(DataSourceWithStatistics ds, Identity identity) throws ConnectionException
     {
         try
         {
+            List<String> legendH2ExtensionSQLs = H2Manager.getMajorVersion() == 2 ? LEGEND_H2_EXTENSION_SQLs : LEGEND_H2_1_4_200_EXTENSION_SQLs;
             Connection connection = ds.getDataSource().getConnection();
-            for (String sql : LEGEND_H2_EXTENSION_SQLs)
+            for (String sql : legendH2ExtensionSQLs)
             {
                 try (Statement statement = connection.createStatement())
                 {
@@ -103,6 +106,16 @@ public class DefaultH2AuthenticationStrategy extends AuthenticationStrategy
                 "CREATE ALIAS IF NOT EXISTS legend_h2_extension_json_parse FOR \"org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions.legend_h2_extension_json_parse\";",
                 "CREATE ALIAS IF NOT EXISTS legend_h2_extension_base64_decode FOR \"org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions.legend_h2_extension_base64_decode\";",
                 "CREATE ALIAS IF NOT EXISTS legend_h2_extension_base64_encode FOR \"org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions.legend_h2_extension_base64_encode\";"
+        );
+    }
+
+    private static List<String> getLegendH2_1_4_200_ExtensionSQLs()
+    {
+        return Arrays.asList(
+                "CREATE ALIAS IF NOT EXISTS legend_h2_extension_json_navigate FOR \"org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions_1_4_200.legend_h2_extension_json_navigate\";",
+                "CREATE ALIAS IF NOT EXISTS legend_h2_extension_json_parse FOR \"org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions_1_4_200.legend_h2_extension_json_parse\";",
+                "CREATE ALIAS IF NOT EXISTS legend_h2_extension_base64_decode FOR \"org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions_1_4_200.legend_h2_extension_base64_decode\";",
+                "CREATE ALIAS IF NOT EXISTS legend_h2_extension_base64_encode FOR \"org.finos.legend.engine.plan.execution.stores.relational.LegendH2Extensions_1_4_200.legend_h2_extension_base64_encode\";"
         );
     }
 }

--- a/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/h2/H2Manager.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/h2/H2Manager.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.h2;
 
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.AuthenticationStrategy;
@@ -25,8 +27,18 @@ import java.util.Properties;
 public class H2Manager extends DatabaseManager
 {
     public static final String DATABASE_TO_UPPER = "DATABASE_TO_UPPER";
-    private static final String DEFAULT_H2_PROPERTIES = System.getProperty("legend.test.h2.properties",
-            ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR;MODE=LEGACY");
+
+    public static int getMajorVersion()
+    {
+        try
+        {
+            return DriverManager.getDriver("jdbc:h2:").getMajorVersion();
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeException("cannot identify H2 driver major version", e);
+        }
+    }
 
     @Override
     public MutableList<String> getIds()
@@ -47,7 +59,20 @@ public class H2Manager extends DatabaseManager
         {
             databaseName += String.format(";%s=%s", DATABASE_TO_UPPER, extraUserDataSourceProperties.getProperty(DATABASE_TO_UPPER));
         }
-        return "jdbc:h2:tcp://" + host + ":" + port + "/mem:" + databaseName + DEFAULT_H2_PROPERTIES;
+
+        String defaultH2Properties;
+
+        if (getMajorVersion() == 2)
+        {
+            defaultH2Properties = System.getProperty("legend.test.h2.properties",
+                    ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR;MODE=LEGACY");
+        }
+        else
+        {
+            defaultH2Properties = "";
+        }
+
+        return "jdbc:h2:tcp://" + host + ":" + port + "/mem:" + databaseName + defaultH2Properties;
     }
 
     @Override

--- a/legend-engine-xt-relationalStore-executionPlan/pom.xml
+++ b/legend-engine-xt-relationalStore-executionPlan/pom.xml
@@ -27,6 +27,16 @@
     <packaging>jar</packaging>
     <name>Legend Engine - XT - Relational Store - Execution Plan</name>
 
+    <profiles>
+       <!-- To test some of the legacy H2 classes-->
+        <profile>
+            <id>h2-1.4.200</id>
+            <properties>
+                <h2.version>1.4.200</h2.version>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/legend-engine-xt-relationalStore-h2-1.4.200-execution/pom.xml
+++ b/legend-engine-xt-relationalStore-h2-1.4.200-execution/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023 Goldman Sachs
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine</artifactId>
+        <version>4.15.8-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>legend-engine-xt-relationalStore-h2-1.4.200-execution</artifactId>
+    <packaging>jar</packaging>
+    <name>Legend Engine - XT - Relational Store - H2 - 1.4.200 - Execution</name>
+    <description>
+        This is a module to help still support the H2 extensions that compile and work with legacy version 1.4.200.
+
+        Legend Engine moved to use version 2.1.x, but there are downstream projects that need more time to move to this version.
+
+        Hence, classes here are required to allow Engine to run on backward compatible mode on H2
+    </description>
+
+    <dependencies>
+        <!-- DRIVERS -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.200</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+        </dependency>
+        <!-- DRIVERS -->
+    </dependencies>
+</project>

--- a/legend-engine-xt-relationalStore-h2-1.4.200-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/LegendH2Extensions_1_4_200.java
+++ b/legend-engine-xt-relationalStore-h2-1.4.200-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/LegendH2Extensions_1_4_200.java
@@ -1,0 +1,126 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
+import org.h2.value.Value;
+import org.h2.value.ValueBoolean;
+import org.h2.value.ValueDouble;
+import org.h2.value.ValueFloat;
+import org.h2.value.ValueInt;
+import org.h2.value.ValueLong;
+import org.h2.value.ValueNull;
+import org.h2.value.ValueString;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unused")
+public class LegendH2Extensions_1_4_200
+{
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getNewStandardObjectMapper();
+
+    public static Value legend_h2_extension_json_navigate(Value json, Value property, Value arrayIndex) throws Exception
+    {
+        if (json == ValueNull.INSTANCE)
+        {
+            return ValueNull.INSTANCE;
+        }
+
+        Object res;
+        if (arrayIndex == ValueNull.INSTANCE)
+        {
+            res = OBJECT_MAPPER.readValue(json.getString(), HashMap.class).get(property.getString());
+        }
+        else
+        {
+            ArrayList<?> list = OBJECT_MAPPER.readValue(json.getString(), ArrayList.class);
+            res = arrayIndex.getInt() < list.size() ? list.get(arrayIndex.getInt()) : null;
+        }
+
+        if (res == null)
+        {
+            return ValueNull.INSTANCE;
+        }
+        else if (res instanceof Map || res instanceof List)
+        {
+            return ValueString.get(OBJECT_MAPPER.writeValueAsString(res));
+        }
+        else if (res instanceof String)
+        {
+            return ValueString.get((String) res);
+        }
+        else if (res instanceof Boolean)
+        {
+            return ValueBoolean.get((boolean) res);
+        }
+        else if (res instanceof Double)
+        {
+            return ValueDouble.get((double) res);
+        }
+        else if (res instanceof Float)
+        {
+            return ValueFloat.get((float) res);
+        }
+        else if (res instanceof Integer)
+        {
+            return ValueInt.get((int) res);
+        }
+        else if (res instanceof Long)
+        {
+            return ValueLong.get((long) res);
+        }
+
+        throw new RuntimeException("Unsupported value in H2 extension function");
+
+    }
+
+    public static Value legend_h2_extension_json_parse(Value json) throws Exception
+    {
+        if (json == ValueNull.INSTANCE)
+        {
+            return ValueNull.INSTANCE;
+        }
+
+        // Ensure validity of JSON
+        Object res;
+        try
+        {
+            res = OBJECT_MAPPER.readValue(json.getString(), HashMap.class);
+        }
+        catch (JsonProcessingException e)
+        {
+            throw new RuntimeException("Unable to parse json as a Map. Content: '" + json.getString() + "'. Error: '" + e.getMessage() + "'");
+        }
+
+        return ValueString.get(OBJECT_MAPPER.writeValueAsString(res));
+    }
+
+    public static String legend_h2_extension_base64_decode(String string)
+    {
+        return string == null ? null : new String(Base64.decodeBase64(string));
+    }
+
+    public static String legend_h2_extension_base64_encode(String string)
+    {
+        return string == null ? null : Base64.encodeBase64URLSafeString(string.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
         <module>legend-engine-xt-relationalStore-executionPlan-connection</module>
         <module>legend-engine-xt-relationalStore-executionPlan-connection-tests</module>
         <module>legend-engine-xt-relationalStore-executionPlan-connection-api</module>
+        <module>legend-engine-xt-relationalStore-h2-1.4.200-execution</module>
         <module>legend-engine-xt-relationalStore-pure</module>
         <module>legend-engine-xt-relationalStore-postgres-execution-tests</module>
         <module>legend-engine-xt-relationalStore-api</module>
@@ -305,7 +306,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>4.5.7</legend.pure.version>
+        <legend.pure.version>4.5.8</legend.pure.version>
         <legend.shared.version>0.23.7</legend.shared.version>
 
         <!-- SONAR -->


### PR DESCRIPTION
#### What type of PR is this?

 Bug Fix

#### What does this PR do / why is it needed ?

This PR introduce further backward compatibility on H2, allowing projects importing engine to still run 1.4.200, given them more time to migrate to 2.1.x

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
