### PR TITLE
fix schema exploration endpoint when pattern is empty

### DIFF
--- a/legend-engine-xt-relationalStore-executionPlan-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/schema/SchemaExportation.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection-api/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/schema/SchemaExportation.java
@@ -125,7 +125,7 @@ public class SchemaExportation
             database.name = this.databaseBuilderInput.targetDatabase.name;
             if (config.patterns == null || config.patterns.isEmpty())
             {
-                config.setPatterns(FastList.newListWith(new DatabasePattern(null, null)));
+                return database;
             }
             this.preProcessInput(this.databaseBuilderInput);
             database.schemas = FastList.newList();

--- a/legend-engine-xt-relationalStore-executionPlan-connection-api/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/schema/TestSchemaExploration.java
+++ b/legend-engine-xt-relationalStore-executionPlan-connection-api/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/api/schema/TestSchemaExploration.java
@@ -67,15 +67,17 @@ public class TestSchemaExploration
     }
 
     @Test
-    public void testDefaults() throws Exception
+    public void testEmptyPatterns() throws Exception
     {
         DatabaseBuilderInput databaseBuilderInput = new DatabaseBuilderInput();
         databaseBuilderInput.connection = createCommonConnection();
         databaseBuilderInput.targetDatabase._package = "my::package";
         databaseBuilderInput.targetDatabase.name = "db";
 
-        Database expected = filterCommonDatabase(FastList.newListWith("SCHEMA_1", "SCHEMA11"), FastList.newList(), false, false);
-        test(databaseBuilderInput, expected);
+        test(databaseBuilderInput, filterCommonDatabase(FastList.newList(), FastList.newList(), false, false));
+
+        databaseBuilderInput.config.patterns = FastList.newList();
+        test(databaseBuilderInput, filterCommonDatabase(FastList.newList(), FastList.newList(), false, false));
     }
 
     @Test
@@ -86,6 +88,7 @@ public class TestSchemaExploration
         databaseBuilderInput.targetDatabase._package = "my::package";
         databaseBuilderInput.targetDatabase.name = "db";
         databaseBuilderInput.config.enrichTables = true;
+        databaseBuilderInput.config.patterns = FastList.newListWith(new DatabasePattern(null, null));
 
         Database expected = filterCommonDatabase(FastList.newListWith("SCHEMA_1", "SCHEMA11"), FastList.newListWith("TABLE_1", "TABLE11"), false, false);
         test(databaseBuilderInput, expected);
@@ -100,6 +103,7 @@ public class TestSchemaExploration
         databaseBuilderInput.targetDatabase.name = "db";
         databaseBuilderInput.config.enrichTables = true;
         databaseBuilderInput.config.enrichColumns = true;
+        databaseBuilderInput.config.patterns = FastList.newListWith(new DatabasePattern(null, null));
 
         Database expected = filterCommonDatabase(FastList.newListWith("SCHEMA_1", "SCHEMA11"), FastList.newListWith("TABLE_1", "TABLE11"), true, false);
         test(databaseBuilderInput, expected);


### PR DESCRIPTION
fix an issue with schema exploration endpoint when the pattern is empty, the generated database would be empty