### PR TITLE
Extend change tokens functionality

### DIFF
--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastBooleanStringTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsBooleanString");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": true\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": true\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": false\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastBooleanTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsBoolean");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": true\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": true\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": false\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastCustomMapTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsCustomMap");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastCustomNestedTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsCustomNested");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsCustomPrimitiveString");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsCustomPrimitive");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastCustomTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsCustom");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, value=1d}", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastDoubleStringTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsDoubleString");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 123.45\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 123.45\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 67.89\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastDoubleTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsDouble");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 123.45\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 123.45\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 67.89\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastIntegerStringTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsIntegerString");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 100\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 100\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": 300\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastStringQuotesTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsStringQuotes");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"one \\\" two\"\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"one \\\" two\"\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"two \\\" one\"\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
@@ -1,0 +1,116 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+public class GenerateCastStringTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuite("meta::pure::changetoken::tests::getVersionsString");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
+
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"one \\\" two\"\n" +
+                        "}", Map.class); // updated version and new default value field added
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"one \\\" two\"\n" +
+                        "}", Map.class);
+        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
+                .invoke(null, jsonNode, "ftdm:abcdefg123");
+        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}", Map.class); // remove default values
+        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,Object> jsonNode = mapper.readValue(
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"two \\\" one\"\n" +
+                        "}", Map.class);
+        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
+        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
+        Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
+    }
+}

--- a/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTestBase.java
+++ b/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTestBase.java
@@ -55,7 +55,8 @@ public abstract class GenerateCastTestBase
         Path fileName = generatedSourcesDirectory.resolve(
                 "org/finos/legend/engine/generated/meta/pure/changetoken/cast_generation/" + baseClassName + ".java");
         Assert.assertTrue(Files.exists(fileName));
-        LOGGER.debug("==== Generated Class ====\n" + new String(Files.readAllBytes(fileName)));
+        String fileContent = new String(Files.readAllBytes(fileName));
+        LOGGER.debug("==== Generated Class ====\n" + fileContent);
         String fullClassName = "org.finos.legend.engine.generated.meta.pure.changetoken.cast_generation." + baseClassName;
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();

--- a/legend-engine-xt-changetoken-pure/pom.xml
+++ b/legend-engine-xt-changetoken-pure/pom.xml
@@ -146,6 +146,14 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-platform-functions-json-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-extension-functions-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-javaGeneration-pure</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken.definition.json
+++ b/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken.definition.json
@@ -1,5 +1,5 @@
 {
   "name" : "core_pure_changetoken",
   "pattern" : "(meta::pure::changetoken)(::.*)?",
-  "dependencies" : ["platform", "platform_functions", "core", "core_external_language_java"]
+  "dependencies" : ["platform", "platform_functions", "platform_functions_json", "core", "core_external_language_java"]
 }

--- a/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation.pure
+++ b/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation.pure
@@ -21,6 +21,7 @@ import meta::pure::functions::meta::*;
 import meta::external::language::java::metamodel::*;
 import meta::pure::changetoken::cast_generation::*;
 import meta::pure::functions::collection::*;
+import meta::json::*;
 
 // entry point into cast generation
 function meta::pure::changetoken::cast_generation::generateCast(versionsFuncName:String[1], outputClassName:String[1]):Project[1]
@@ -432,14 +433,26 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
 ):Code[1]  
 {
   let valVar = j_variable(javaObject(), 'value');
+  let mapVar = j_variable(objectNode(), 'value');
 
   // if (type.equals(token.class))
   j_if(
     $typeVar->j_invoke('equals', [j_string($token.class)]),
     $token.defaultValue->match([
       // objectNode.put(fieldName, defaultValue)
-      df:ConstValue[1] | $objVar->j_invoke('put', [j_string($token.fieldName), j_int($df.value->cast(@Integer))], javaVoid()),
-      df:CopyValue[1] | 
+      df:ConstValue[1] | if(_isPrimitive($token.fieldType) || !_isComplex($df.value),|
+      [
+        $valVar->j_declare([_getValueAsFieldType($token.fieldType, $df.value)]),
+        $objVar->j_invoke('put', [j_string($token.fieldName), $valVar], javaVoid())
+      ],| j_block([
+        $mapVar->j_declare(javaStream()->j_invoke('of',
+        $df.value->cast(@String)->parseJSON()->cast(@meta::json::JSONObject).keyValuePairs->map(kv | _inlineJsonValue($kv.key.value, $kv.value)),
+        javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()))
+      ]->concatenate([
+        $objVar->j_invoke('put', [j_string($token.fieldName), $mapVar], javaVoid())
+      ]))
+      ),
+      df:CopyValue[1] |
       [
         // Object value = resolveRelativeReference(rootObjectNode, path, "../existingValue");
         $valVar->j_declare($class->j_invoke('resolveRelativeReference', [
@@ -454,6 +467,110 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
   );
 }
 
+function <<access.private>> meta::pure::changetoken::cast_generation::_inlineJsonValue(
+key: String[1],
+json:JSONElement[1]
+) : Code[1]
+{
+  simpleEntry()->j_new([j_string($key),
+    $json->match([
+      b:JSONBoolean[1] | j_boolean($b.value),
+      s:JSONString[1] | j_string($s.value),
+      n:JSONNumber[1] | $n.value->match([i:Integer[1] | j_int($i), f:Float[1] | j_double($f)]),
+      o:JSONObject[1] | javaStream()->j_invoke('of',
+      $o.keyValuePairs->map(kv | _inlineJsonValue($kv.key.value, $kv.value)),
+      javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()),
+      n:JSONNull[1] | j_null()
+    ])
+  ])
+}
+
+function <<access.private>> meta::pure::changetoken::cast_generation::_isComplex(
+value: Any[1]
+) : Boolean[1]
+{
+  if($value->instanceOf(String) && $value->cast(@String)->startsWith('{') && $value->cast(@String)->endsWith('}'),
+     | true,
+     | false
+  );
+}
+
+function <<access.private>> meta::pure::changetoken::cast_generation::_isPrimitive(
+type: String[1]
+) : Boolean[1]
+{
+   if($type->equalIgnoreCase('Boolean[1]'),
+      | true,
+      |
+   if($type->equalIgnoreCase('Float[1]') || $type->equalIgnoreCase('Double[1]'),
+      | true,
+      |
+   if($type->equalIgnoreCase('Integer[1]'),
+      | true,
+      |
+   if($type->equalIgnoreCase('String[1]'),
+      | true,
+      | false
+   ))));
+}
+
+function <<access.private>> meta::pure::changetoken::cast_generation::_getValueAsFieldType(
+type: String[1],
+value: Any[1]
+) : Code[1]
+{
+   if($type->equalIgnoreCase('Boolean[1]'),
+      | $value->match([b:Boolean[1] | j_boolean($b), s:String[1] | j_boolean($s)]),
+      |
+   if($type->equalIgnoreCase('Float[1]') || $type->equalIgnoreCase('Double[1]'),
+      | $value->match([f:Float[1] | j_double($f), s:String[1] | j_double($s)]),
+      |
+   if($type->equalIgnoreCase('Integer[1]'),
+      | $value->match([i:Integer[1] | j_int($i), s:String[1] | j_int($s)]),
+      |
+   if($type->equalIgnoreCase('String[1]'),
+      | j_string(stripMatchingQuotes($value->cast(@String))),
+      | _buildJavaObject($value);
+   ))));
+}
+
+function <<access.private>> meta::pure::changetoken::cast_generation::_buildJavaObject(
+value: Any[1]
+) : Code[1]
+{
+  if($value->instanceOf(Map),
+     | javaStream()->j_invoke('of',
+     $value->cast(@Map<String, Any>)->map(m | $m->keys()->map(k | _inlineMap($k, $m->get($k)))),
+     javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()),
+     |
+  if($value->instanceOf(String),
+     | j_string(stripMatchingQuotes($value->cast(@String))),
+    {| fail('Do not know how to build Java object'); j_null();}
+   ));
+}
+
+function <<access.private>> meta::pure::changetoken::cast_generation::_inlineMap(
+key: String[1],
+value: Any[0..1]
+) : Code[1]
+{
+  simpleEntry()->j_new([j_string($key),
+    $value->match([
+      b:Boolean[1] | j_boolean($b),
+      s:String[1] | j_string($s),
+      n:Number[1] | $n->match([i:Integer[1] | j_int($i), f:Float[1] | j_double($f)]),
+      o:Map<String, Any>[1] | javaStream()->j_invoke('of',
+      $o->cast(@Map<String, Any>)->map(m | $m->keys()->map(k | _inlineMap($k, $m->get($k)))),
+      javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()),
+      n:Any[0] | j_null()
+    ])
+  ])
+}
+
+function <<access.private>> meta::pure::changetoken::cast_generation::stripMatchingQuotes(s:String[1]):String[1]
+{
+  if($s->startsWith('"') && $s->endsWith('"'), | $s->parseJSON()->cast(@meta::json::JSONString).value, | $s);
+}
 
 function <<access.private>> meta::pure::changetoken::cast_generation::_getChangeFieldTypeConverter(
   fromType : String[1],
@@ -496,19 +613,38 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
   class:meta::external::language::java::metamodel::Class[1],
   token:AddField[1], objVar:Code[1], typeVar:Code[1], version:String[1], pathVar:Code[1], rootObjVar:Code[1], resVar:Code[1]):Code[1]
 {
+  let valVar = j_variable(javaObject(), 'value');
+  let mapVar = j_variable(objectNode(), 'value');
+
   // if (type.equals(token.class))
   j_if(
     $typeVar->j_invoke('equals', [j_string($token.class)]),
     $token.defaultValue->match([
-      df:ConstValue[1] |
-      [
+      df:ConstValue[1] | if(_isPrimitive($token.fieldType) || !_isComplex($df.value),|
+      j_block([
+        $valVar->j_declare([_getValueAsFieldType($token.fieldType, $df.value)])
+      ]->concatenate([
         // if ((Integer)objectNode.get(fieldName) != defaultValue) throw new RuntimeException("Cannot remove non-default value" + objectNode.get("fieldName")) // TODO: handle non-int
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_cast(toBoxed(javaInt()))->j_ne(j_int($df->cast(@ConstValue).value->cast(@Integer))),
+        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not(),
             javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
 
         // objectNode.remove(fieldName)
         $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid()) 
-      ],
+      ])),
+      |
+      j_block([
+        $mapVar->j_declare(javaStream()->j_invoke('of',
+        $df.value->cast(@String)->parseJSON()->cast(@meta::json::JSONObject).keyValuePairs->map(kv | _inlineJsonValue($kv.key.value, $kv.value)),
+        javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()))
+      ]->concatenate([
+        // if ((Integer)objectNode.get(fieldName) != defaultValue) throw new RuntimeException("Cannot remove non-default value" + objectNode.get("fieldName")) // TODO: handle non-int
+        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not(),
+        javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+
+        // objectNode.remove(fieldName)
+        $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
+      ]))
+      ),
       df:CopyValue[1] | 
       [
         // setRelativeReference(rootObjectNode, path, "../existingValue", objectNode.get("abc"));
@@ -737,3 +873,5 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateU
 function <<access.private>> meta::pure::changetoken::cast_generation::objectNode():meta::external::language::java::metamodel::Type[1] { javaMap(javaString(), javaObject()); }
 function <<access.private>> meta::pure::changetoken::cast_generation::arrayNode():meta::external::language::java::metamodel::Type[1] { javaList(javaObject()); }
 function <<access.private>> meta::pure::changetoken::cast_generation::javaRawMap():meta::external::language::java::metamodel::Type[1] { javaClass('java.util.Map'); }
+function <<access.private>> meta::pure::changetoken::cast_generation::AbstractMap_SimpleEntry():meta::external::language::java::metamodel::Type[1] { javaClass('java.util.AbstractMap.SimpleEntry'); }
+function <<access.private>> meta::pure::changetoken::cast_generation::simpleEntry():meta::external::language::java::metamodel::Type[1] { ^ParameterizedType(rawType=AbstractMap_SimpleEntry(), typeArguments=[javaString()->toBoxed(), javaObject()->toBoxed()]); }

--- a/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/changetoken_test.pure
+++ b/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/changetoken_test.pure
@@ -40,6 +40,56 @@ Class meta::pure::changetoken::tests::SampleClass
   abc : Integer[1];  
 }
 
+// This is test Versions: AddField with ConstValue(true)
+function meta::pure::changetoken::tests::getVersionsBoolean():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='Boolean[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value=true)
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+// This is test Versions: AddField with ConstValue('true')
+function meta::pure::changetoken::tests::getVersionsBooleanString():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='Boolean[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value='true')
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
 // This is test Versions: AddField with ConstValue(100)
 function meta::pure::changetoken::tests::getVersions():Versions[1]
 {
@@ -63,6 +113,257 @@ function meta::pure::changetoken::tests::getVersions():Versions[1]
       )
     ]
   ); 
+}
+
+// This is test Versions: AddField with ConstValue('100')
+function meta::pure::changetoken::tests::getVersionsIntegerString():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='Integer[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value='100')
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+// This is test Versions: AddField with ConstValue(123.45)
+function meta::pure::changetoken::tests::getVersionsDouble():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='double[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value=123.45)
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+// This is test Versions: AddField with ConstValue('123.45')
+function meta::pure::changetoken::tests::getVersionsDoubleString():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='double[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value='123.45')
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+
+// This is test Versions: AddField with ConstValue('one " two')
+function meta::pure::changetoken::tests::getVersionsString():Versions[1]
+{
+  ^Versions(
+    versions=[
+      ^Version( // base version
+        version='ftdm:abcdefg123'
+      ),
+      ^Version(
+        version='ftdm:abcdefg456',
+        prevVersion='ftdm:abcdefg123',
+        changeTokens=[
+          ^AddField(
+            class='meta::pure::changetoken::tests::SampleClass',
+            fieldName='abc',
+            fieldType='String[1]',
+            safeCast=true,
+            defaultValue=^ConstValue(value='one " two')
+          )
+        ]
+      )
+    ]
+  );
+}
+
+// This is test Versions: AddField with ConstValue('"one \\" two"')
+function meta::pure::changetoken::tests::getVersionsStringQuotes():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='String[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value='"one \\" two"')
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+// This is test Versions: AddField with ConstValue('{"@type":"Custom","value":"0d"}')
+function meta::pure::changetoken::tests::getVersionsCustom():Versions[1]
+{
+  ^Versions(
+    versions=[
+      ^Version( // base version
+        version='ftdm:abcdefg123'
+      ),
+      ^Version(
+        version='ftdm:abcdefg456',
+        prevVersion='ftdm:abcdefg123',
+        changeTokens=[
+          ^AddField(
+            class='meta::pure::changetoken::tests::SampleClass',
+            fieldName='abc',
+            fieldType='Custom[1]',
+            safeCast=true,
+            defaultValue=^ConstValue(value='{"@type":"Custom","value":"0d"}')
+          )
+        ]
+      )
+    ]
+  );
+}
+
+// This is test Versions: AddField with ConstValue('{"@type":"Custom","restricted":true,"value":0,"range":{"@type":"intMinMax","min":-1,"max":1,"round":0.5}}')
+function meta::pure::changetoken::tests::getVersionsCustomNested():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='Custom[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value='{"@type":"Custom","restricted":true,"value":0,"range":{"@type":"intMinMax","min":-1,"max":1,"round":0.5}}')
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+// This is test Versions: AddField with ConstValue(^Map<String, Any>()->put('@type', 'Custom')->put('restricted', true)->put('value', 0)->put('range', ^Map<String, Any>()->put('@type', 'intMinMax')->put('min', -1)->put('max', 1)->put('round', 0.5)))
+function meta::pure::changetoken::tests::getVersionsCustomMap():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='Custom[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value=^Map<String, Any>()->put('@type', 'Custom')->put('restricted', true)->put('value', 0)->put('range', ^Map<String, Any>()->put('@type', 'intMinMax')->put('min', -1)->put('max', 1)->put('round', 0.5)))
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+// This is test Versions: AddField with ConstValue('1970-01-01T00:00:01Z')
+function meta::pure::changetoken::tests::getVersionsCustomPrimitive():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='Custom[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value='1970-01-01T00:00:01Z')
+                            )
+                        ]
+                )
+            ]
+    );
+}
+
+// This is test Versions: AddField with ConstValue('"1970-01-01T00:00:01Z"')
+function meta::pure::changetoken::tests::getVersionsCustomPrimitiveString():Versions[1]
+{
+    ^Versions(
+            versions=[
+                ^Version( // base version
+                        version='ftdm:abcdefg123'
+                ),
+                ^Version(
+                        version='ftdm:abcdefg456',
+                        prevVersion='ftdm:abcdefg123',
+                        changeTokens=[
+                            ^AddField(
+                                    class='meta::pure::changetoken::tests::SampleClass',
+                                    fieldName='abc',
+                                    fieldType='Custom[1]',
+                                    safeCast=true,
+                                    defaultValue=^ConstValue(value='"1970-01-01T00:00:01Z"')
+                            )
+                        ]
+                )
+            ]
+    );
 }
 
 // This is test Versions: AddField with CopyValue(../existingValue)


### PR DESCRIPTION
#### What type of PR is this?
Support Map or embedded JSON string for value of ConstValue as defaultValue property of AddField change token

#### What does this PR do / why is it needed ?
To allow generation of Java code that can upcast/downcast changetokens with adding field of other types then simple integer.

#### Which issue(s) this PR fixes:
N/A

#### Other notes for reviewers:
N/A

#### Does this PR introduce a user-facing change?
N/A