### PR TITLE
Avoid caching setting xml given it could have secrets stored on it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           cache-name: cache-mvn-deps
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

This reduce the scope of the m2 cache to just the repository directory.  The current scope include settings.xml, which could contain secrets on some instances.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
