### PR TITLE
Improvements to Elasticsearch aggregations

### DIFF
--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/TDSResultToCSVSerializer.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/TDSResultToCSVSerializer.java
@@ -119,6 +119,7 @@ public class TDSResultToCSVSerializer extends CsvSerializer
                 case "Integer":
                     return ((Function<Object, Number>) Number.class::cast).andThen(Number::longValue);
                 case "Float":
+                case "Number":
                     return ((Function<Object, Number>) Number.class::cast).andThen(Number::doubleValue);
                 case "Decimal":
                     return BigDecimal.class::cast;

--- a/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/TDSResultToPureFormatSerializer.java
+++ b/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/serialization/TDSResultToPureFormatSerializer.java
@@ -131,6 +131,7 @@ public abstract class TDSResultToPureFormatSerializer extends Serializer
                 case "Integer":
                     return (ThrowingProcedure2<JsonGenerator, Long>) JsonGenerator::writeNumber;
                 case "Float":
+                case "Number":
                     return (ThrowingProcedure2<JsonGenerator, Double>) JsonGenerator::writeNumber;
                 case "Decimal":
                     return (ThrowingProcedure2<JsonGenerator, BigDecimal>) JsonGenerator::writeNumber;

--- a/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/tds.pure
+++ b/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/tds.pure
@@ -629,7 +629,7 @@ function <<access.private>> meta::pure::tds::aggRows<X,Y>(rows : TDSRow[*], colu
          let values = $aggValues->map(aggValue|
                let rowMapValues = $rows->map(row|$aggValue.mapFn->eval($row));
                let value = $aggValue.aggregateFn->eval($rowMapValues);
-               $value;
+               if($value->isEmpty(), |^TDSNull(), |$value);
                );
          ^TDSRow(values = $values, parent=$parent);
       }, {|

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/result/ElasticsearchTDSResultHelper.java
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/result/ElasticsearchTDSResultHelper.java
@@ -131,6 +131,7 @@ public final class ElasticsearchTDSResultHelper
             case "Integer":
                 return JsonNode::asLong;
             case "Float":
+            case "Number":
                 return JsonNode::asDouble;
             case "Decimal":
                 return Functions.chain(JsonNode::asText, BigDecimal::new);
@@ -154,6 +155,7 @@ public final class ElasticsearchTDSResultHelper
             case "Integer":
                 return Functions.chain(Number.class::cast, Number::longValue);
             case "Float":
+            case "Number":
                 return Functions.chain(Number.class::cast, Number::doubleValue);
             case "Decimal":
                 return x ->

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
@@ -747,7 +747,21 @@ function meta::external::store::elasticsearch::v7::pureToEs::supportedAggregatio
 {
   let supported = [
      pair(x: Function<Any>[1] | $x == meta::pure::functions::math::sum_Integer_MANY__Integer_1_, {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(sum = ^SumAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::sum_Float_MANY__Float_1_,     {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(sum = ^SumAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::sum_Number_MANY__Number_1_,   {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(sum = ^SumAggregation(field = $y))})
+    
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::max_Integer_MANY__Integer_$0_1$_, {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(max = ^MaxAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::max_Float_MANY__Float_$0_1$_,     {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(max = ^MaxAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::max_Number_MANY__Number_$0_1$_,   {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(max = ^MaxAggregation(field = $y))})
+    
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::min_Integer_MANY__Integer_$0_1$_, {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(min = ^MinAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::min_Float_MANY__Float_$0_1$_,     {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(min = ^MinAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::min_Number_MANY__Number_$0_1$_,   {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(min = ^MinAggregation(field = $y))})
+
     ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::average_Integer_MANY__Float_1_, {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(avg = ^AverageAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::average_Float_MANY__Float_1_,   {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(avg = ^AverageAggregation(field = $y))})
+    ,pair(x: Function<Any>[1] | $x == meta::pure::functions::math::average_Number_MANY__Float_1_,  {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(avg = ^AverageAggregation(field = $y))})
+
     ,pair(x: Function<Any>[1] | $x == meta::pure::functions::collection::count_Any_MANY__Integer_1_, {x: FunctionExpression[1], y: String[1] | ^AggregationContainer(value_count = ^ValueCountAggregation(field = $y))})
   ];
 }

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_average.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_average.pure
@@ -1,0 +1,44 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::*;
+import meta::pure::tds::*;
+import meta::external::store::elasticsearch::executionTest::testCase::*;
+import meta::external::store::elasticsearch::executionTest::testCase::tds::*;
+import meta::external::store::elasticsearch::executionTest::test::*;
+import meta::external::store::elasticsearch::executionTest::utils::*;
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test avg aggregation on Integer field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::avg::testAverageAggregationIntegerField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('avg', r | $r.getInteger('Budget'), agg | $agg->average())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test avg aggregation on Float field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::avg::testAverageAggregationFloatField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('avg', r | $r.getFloat('Revenue'), agg | $agg->average())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test avg aggregation on Number field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::avg::testAverageAggregationNumberField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('avg', r | $r.getNumber('Revenue'), agg | $agg->average())));
+}

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_count.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_count.pure
@@ -1,0 +1,36 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::*;
+import meta::pure::tds::*;
+import meta::external::store::elasticsearch::executionTest::testCase::*;
+import meta::external::store::elasticsearch::executionTest::testCase::tds::*;
+import meta::external::store::elasticsearch::executionTest::test::*;
+import meta::external::store::elasticsearch::executionTest::utils::*;
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test count aggregation on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::count::testCountAggregation(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('count', r | $r.getString('MainActor.Name'), agg | $agg->count())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test count no result aggregation on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::count::testEmptyCountAggregation(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->filter(r | $r.getString('_id') == 'N/A')->groupBy([], agg('count', r | $r.getString('MainActor.Name'), agg | $agg->count())));
+}

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_max.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_max.pure
@@ -1,0 +1,52 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::*;
+import meta::pure::tds::*;
+import meta::external::store::elasticsearch::executionTest::testCase::*;
+import meta::external::store::elasticsearch::executionTest::testCase::tds::*;
+import meta::external::store::elasticsearch::executionTest::test::*;
+import meta::external::store::elasticsearch::executionTest::utils::*;
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test max aggregation on Integer field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::max::testMaxAggregationIntegerField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('max', r | $r.getInteger('Budget'), agg | $agg->max())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test max aggregation on Float field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::max::testMaxAggregationFloatField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('max', r | $r.getFloat('Revenue'), agg | $agg->max())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test max aggregation on Number field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::max::testMaxAggregationNumberField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('max', r | $r.getNumber('Revenue'), agg | $agg->max())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test max aggregation no result on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::max::testEmptyMaxAggregation(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->filter(r | $r.getString('_id') == 'N/A')->groupBy([], agg('max', r | $r.getNumber('Revenue'), agg | $agg->max())));
+}

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_min.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_min.pure
@@ -1,0 +1,53 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::*;
+import meta::pure::tds::*;
+import meta::external::store::elasticsearch::executionTest::testCase::*;
+import meta::external::store::elasticsearch::executionTest::testCase::tds::*;
+import meta::external::store::elasticsearch::executionTest::test::*;
+import meta::external::store::elasticsearch::executionTest::utils::*;
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test min aggregation on Integer field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::min::testMinAggregationIntegerField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('min', r | $r.getInteger('Budget'), agg | $agg->min())));
+}
+
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test min aggregation on Float field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::min::testMinAggregationFloatField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('min', r | $r.getFloat('Revenue'), agg | $agg->min())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test min aggregation on Number field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::min::testMinAggregationNumberField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('min', r | $r.getNumber('Revenue'), agg | $agg->min())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test min aggregation no result on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::min::testEmptyMinAggregation(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->filter(r | $r.getString('_id') == 'N/A')->groupBy([], agg('min', r | $r.getNumber('Revenue'), agg | $agg->min())));
+}

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_sum.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_sum.pure
@@ -1,0 +1,52 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::*;
+import meta::pure::tds::*;
+import meta::external::store::elasticsearch::executionTest::testCase::*;
+import meta::external::store::elasticsearch::executionTest::testCase::tds::*;
+import meta::external::store::elasticsearch::executionTest::test::*;
+import meta::external::store::elasticsearch::executionTest::utils::*;
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test sum aggregation on Integer field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sum::testSumAggregationIntegerField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('sum', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test sum aggregation on Float field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sum::testSumAggregationFloatField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('sum', r | $r.getFloat('Revenue'), agg | $agg->sum())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test sum aggregation on Number field on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sum::testSumAggregationNumberField(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->groupBy([], agg('sum', r | $r.getNumber('Revenue'), agg | $agg->sum())));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test sum aggregation no result on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sum::testEmptySumAggregation(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->filter(r | $r.getString('_id') == 'N/A')->groupBy([], agg('sum', r | $r.getNumber('Revenue'), agg | $agg->sum())));
+}


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

This further improves elasticsearch aggregation support. 

- Support for `sum` on Float and Number TDS columns
- Support for `max` aggregation
- Support for `min` aggregation
- Support for `average` aggregation

Further improve test coverage of these aggregations, including edge case where the are no results to max/min.

BugFix TDS aggregations to return `TDSNull` when aggregation function does not returns any value.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

~~TDS BugFix could affect some users~~ Integration testing does not show any immediate impact.