### PR TITLE
Persistence: Fix null check for Spec V2

### DIFF
--- a/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
+++ b/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
@@ -171,7 +171,7 @@ public class HelperPersistenceComposer
 
     private static String renderServiceOutputTargets(List<ServiceOutputTarget> serviceOutputTargets, int indentLevel, PureGrammarComposerContext context)
     {
-        if (serviceOutputTargets.isEmpty())
+        if (serviceOutputTargets == null || serviceOutputTargets.isEmpty())
         {
             return "";
         }


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

A null check is needed for ServiceOutputTargets, a V2-only construct, in case user is using V1 spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
