### PR TITLE
Pure Grammar: Handle divide with scale in grammar composer

### DIFF
--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
@@ -762,6 +762,11 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         {
             return "!(" + parameters.get(0).accept(this) + ")";
         }
+        // Special case divide_Decimal_1__Decimal_1__Integer_1__Decimal_1_ so that we don't use infix version
+        else if ("divide".equals(function) && parameters.size() == 3)
+        {
+            return HelperValueSpecificationGrammarComposer.renderFunction(appliedFunction, this);
+        }
         else if (HelperValueSpecificationGrammarComposer.SPECIAL_INFIX.get(function) != null)
         {
             // handle arithmetic operators that we might need to add parenthesis to force precedence

--- a/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -488,6 +488,15 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     }
 
     @Test
+    public void testDecimalWithScale()
+    {
+        test("function withPath::f(d1: Decimal[1], d2: Decimal[1]): Decimal[1]\n" +
+                "{\n" +
+                "  $d1->divide($d2, 2)\n" +
+                "}\n");
+    }
+
+    @Test
     public void testBooleanPrecedence1()
     {
         testFormat("function withPath::f(s: Integer[1]): String[1]\n" +


### PR DESCRIPTION
#### What type of PR is this?

Bugfix

#### What does this PR do / why is it needed ?

Fix grammar composer for divide function that takes in a scale with decimal types - we should not use the infix operator for this function (as we do for normal divide function)

#### Does this PR introduce a user-facing change?

Yes - grammar composer will correctly produce Pure syntax for divide with scale function
