### PR TITLE
Support adaptive batching in Graph Fetch 

### DIFF
--- a/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/graphFetch/AdaptiveBatching.java
+++ b/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/graphFetch/AdaptiveBatching.java
@@ -1,0 +1,88 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package org.finos.legend.engine.plan.execution.graphFetch;
+
+import org.finos.legend.engine.plan.execution.nodes.state.ExecutionState;
+
+public class AdaptiveBatching
+{
+    public static long getAdaptiveBatchSize(ExecutionState executionState)
+    {
+        if (executionState.adaptiveGraphBatchStats == null)
+        {
+            executionState.adaptiveGraphBatchStats = new AdaptiveGraphBatchStats(0, 64);
+            return executionState.adaptiveGraphBatchStats.previousBatchSize;
+        }
+        long softLimit = executionState.getGraphFetchExecutionConfiguration().getGraphFetchSoftMemoryLimitPercentage() * executionState.getGraphFetchExecutionConfiguration().getGraphFetchBatchMemoryHardLimit() / 100;
+        long previousBatchMemoryUtilization = executionState.adaptiveGraphBatchStats.previousBatchMemoryUtilization;
+
+        executionState.adaptiveGraphBatchStats.addPreviousAverageToStats(executionState.adaptiveGraphBatchStats.previousBatchMemoryUtilization, executionState.adaptiveGraphBatchStats.previousBatchSize);
+        long avgMemoryUtilizationInBytesPerObject = (long) executionState.adaptiveGraphBatchStats.getWeightedAverage();
+        long changeInBatchSize = softLimit / (avgMemoryUtilizationInBytesPerObject + 1) - executionState.adaptiveGraphBatchStats.previousBatchSize;
+
+        return getNewBatchSize(executionState, changeInBatchSize, softLimit, previousBatchMemoryUtilization);
+    }
+
+    public static long getNewBatchSize(ExecutionState executionState, long changeInBatchSize, long softLimit, long previousBatchMemoryUtilization)
+    {
+        long newBatchSize;
+
+        if (changeInBatchSize > 0)
+        {
+            double reductionFactor = (softLimit - previousBatchMemoryUtilization) / (1.0 * softLimit);
+            long increment = (long) Math.pow(10, executionState.adaptiveGraphBatchStats.incrementRate);
+            newBatchSize = getNewBatchSizeWithIncrement(executionState, changeInBatchSize, reductionFactor, increment);
+        }
+        else
+        {
+            long reductionFactor = (long) Math.pow(2, executionState.adaptiveGraphBatchStats.decrementRate);
+            long previousBatchSize = executionState.adaptiveGraphBatchStats.previousBatchSize;
+
+            if (previousBatchSize + changeInBatchSize > previousBatchSize / reductionFactor)
+            {
+                newBatchSize = previousBatchSize + changeInBatchSize;
+                executionState.adaptiveGraphBatchStats.decrementRate = 1;
+            }
+            else
+            {
+                newBatchSize = previousBatchSize / reductionFactor;
+                executionState.adaptiveGraphBatchStats.decrementRate += 1;
+            }
+            executionState.adaptiveGraphBatchStats.incrementRate = 1;
+        }
+        newBatchSize = newBatchSize <= 0 ? 1 : newBatchSize;
+        executionState.adaptiveGraphBatchStats.previousBatchSize = newBatchSize;
+        return newBatchSize;
+    }
+
+    private static long getNewBatchSizeWithIncrement(ExecutionState executionState, long changeInBatchSize, double reductionFactor, long increment)
+    {
+        long newBatchSize;
+        if ((long) (changeInBatchSize * reductionFactor) < increment)
+        {
+            changeInBatchSize = (long) (changeInBatchSize * reductionFactor);
+            executionState.adaptiveGraphBatchStats.incrementRate = 1;
+        }
+        else
+        {
+            changeInBatchSize = increment;
+            executionState.adaptiveGraphBatchStats.incrementRate += 1;
+        }
+        executionState.adaptiveGraphBatchStats.decrementRate = 1;
+        newBatchSize = executionState.adaptiveGraphBatchStats.previousBatchSize + changeInBatchSize;
+        return newBatchSize;
+    }
+}

--- a/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/graphFetch/AdaptiveGraphBatchStats.java
+++ b/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/graphFetch/AdaptiveGraphBatchStats.java
@@ -1,0 +1,80 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.graphFetch;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class AdaptiveGraphBatchStats
+{
+    public long previousBatchMemoryUtilization;
+    protected long previousBatchSize;
+    protected long incrementRate;   // counter for incrementing batch size
+    protected long decrementRate;   // counter for decrementing batch size
+    private final List<BatchStats> lastTenBatchesStats;
+
+    public AdaptiveGraphBatchStats(long previousBatchMemoryUtilization, long previousBatchSize)
+    {
+        this.previousBatchMemoryUtilization = previousBatchMemoryUtilization;
+        this.previousBatchSize = previousBatchSize;
+        this.incrementRate = 1;
+        this.decrementRate = 1;
+        if (previousBatchMemoryUtilization != 0 && previousBatchSize != 0)
+        {
+            this.lastTenBatchesStats = new ArrayList<>(Arrays.asList(new BatchStats(previousBatchMemoryUtilization, previousBatchSize)));
+        }
+        else
+        {
+            this.lastTenBatchesStats = new ArrayList<>();
+        }
+    }
+
+    public void addPreviousAverageToStats(long previousBatchMemoryUtilization, long previousBatchSize)
+    {
+        this.lastTenBatchesStats.add(new BatchStats(previousBatchMemoryUtilization, previousBatchSize));
+        if (this.lastTenBatchesStats.size() > 10)
+        {
+            this.lastTenBatchesStats.remove(0);
+        }
+    }
+
+    public double getWeightedAverage()
+    {
+        double weight = 1.0;
+        double weightedBatchSize = 0.0;
+        double weightedMemoryUtilization = 0.0;
+        for (int i = this.lastTenBatchesStats.size() - 1; i >= 0; i--)
+        {
+            BatchStats batchStats = this.lastTenBatchesStats.get(i);
+            weightedBatchSize += weight * batchStats.batchSize;
+            weightedMemoryUtilization += weight * batchStats.batchMemoryUtilization;
+            weight -= 0.1;
+        }
+        return weightedMemoryUtilization / weightedBatchSize;
+    }
+
+    static class BatchStats
+    {
+        public final long batchSize;
+        public final long batchMemoryUtilization;
+
+        BatchStats(long batchMemoryUtilization, long batchSize)
+        {
+            this.batchSize = batchSize;
+            this.batchMemoryUtilization = batchMemoryUtilization;
+        }
+    }
+}

--- a/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/graphFetch/GraphFetchExecutionConfiguration.java
+++ b/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/graphFetch/GraphFetchExecutionConfiguration.java
@@ -1,0 +1,85 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.graphFetch;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GraphFetchExecutionConfiguration
+{
+    public static final long DEFAULT_BATCH_MEMORY_LIMIT = 104_849_600L; /* 100MB - 100 * 1024 * 1024 */
+    public static final long DEFAULT_SOFT_MEMORY_LIMIT_PERCENTAGE = 50;
+    public static final boolean DEFAULT_USE_ADAPTIVE_BATCHING = false;
+    public static final long DEFAULT_BATCH_SIZE = 1000;
+
+    public static final long SOFT_MEMORY_TO_USE_FULL_MEMORY_PERCENTAGE = 100;
+
+    @JsonProperty
+    private final long batchMemoryLimit;
+    @JsonProperty
+    private final long softMemoryLimitPercentage;
+    @JsonProperty
+    private final boolean useAdaptiveBatching;
+    @JsonProperty
+    private final long defaultBatchSize;
+
+    public GraphFetchExecutionConfiguration()
+    {
+        this.batchMemoryLimit = DEFAULT_BATCH_MEMORY_LIMIT;
+        this.softMemoryLimitPercentage = DEFAULT_SOFT_MEMORY_LIMIT_PERCENTAGE;
+        this.useAdaptiveBatching = DEFAULT_USE_ADAPTIVE_BATCHING;
+        this.defaultBatchSize = DEFAULT_BATCH_SIZE;
+    }
+
+    public GraphFetchExecutionConfiguration(long graphFetchBatchMemoryLimit, long graphFetchSoftMemoryLimitPercentage, boolean useAdaptiveBatching, long graphFetchDefaultBatchSize)
+    {
+        this.batchMemoryLimit = graphFetchBatchMemoryLimit;
+        this.softMemoryLimitPercentage = graphFetchSoftMemoryLimitPercentage;
+        this.useAdaptiveBatching = useAdaptiveBatching;
+        this.defaultBatchSize = graphFetchDefaultBatchSize;
+    }
+
+    public GraphFetchExecutionConfiguration(long graphFetchBatchMemoryLimit)
+    {
+        this.batchMemoryLimit = graphFetchBatchMemoryLimit;
+        this.softMemoryLimitPercentage = SOFT_MEMORY_TO_USE_FULL_MEMORY_PERCENTAGE;
+        this.useAdaptiveBatching = DEFAULT_USE_ADAPTIVE_BATCHING;
+        this.defaultBatchSize = DEFAULT_BATCH_SIZE;
+    }
+
+    public long getGraphFetchBatchMemoryHardLimit()
+    {
+        return batchMemoryLimit;
+    }
+
+    public long getGraphFetchBatchMemorySoftLimit()
+    {
+        return (batchMemoryLimit * softMemoryLimitPercentage) / 100;
+    }
+
+    public long getGraphFetchSoftMemoryLimitPercentage()
+    {
+        return softMemoryLimitPercentage;
+    }
+
+    public boolean shouldUseAdaptiveBatching()
+    {
+        return useAdaptiveBatching;
+    }
+
+    public long getGraphFetchDefaultBatchSize()
+    {
+        return defaultBatchSize;
+    }
+}

--- a/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/ExecutionNodeExecutor.java
+++ b/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/ExecutionNodeExecutor.java
@@ -504,6 +504,11 @@ public class ExecutionNodeExecutor implements ExecutionNodeVisitor<Result>
 
                 rowCount.addAndGet(batch.getRowCount());
 
+                if (this.executionState.adaptiveGraphBatchStats != null)
+                {
+                    this.executionState.adaptiveGraphBatchStats.previousBatchMemoryUtilization = batch.getTotalObjectMemoryUtilization();
+                }
+
                 if (nonEmptyObjectList)
                 {
                     long currentObjectCount = objectCount.addAndGet(parentObjects.size());

--- a/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/graphFetch/TestAdaptiveBatching.java
+++ b/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/graphFetch/TestAdaptiveBatching.java
@@ -1,0 +1,81 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package org.finos.legend.engine.plan.execution.graphFetch;
+
+import org.eclipse.collections.impl.factory.Maps;
+import org.finos.legend.engine.plan.execution.nodes.state.ExecutionState;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class TestAdaptiveBatching
+{
+    // Tests the return value when previous batch stats are null
+    @Test
+    public void testAdaptiveBatchingWithNoStats()
+    {
+        ExecutionState fakeExecutionState = new ExecutionState(Maps.mutable.empty(), Collections.emptyList(), Collections.emptyList());
+        Assert.assertEquals(64, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+    }
+
+    // Tests the increase in batch size when far off from the soft limit
+    @Test
+    public void testIncreaseInBatchSizeFarFromSoftLimit()
+    {
+        GraphFetchExecutionConfiguration graphFetchExecutionConfiguration = new GraphFetchExecutionConfiguration(GraphFetchExecutionConfiguration.DEFAULT_BATCH_MEMORY_LIMIT, GraphFetchExecutionConfiguration.DEFAULT_SOFT_MEMORY_LIMIT_PERCENTAGE, true, GraphFetchExecutionConfiguration.DEFAULT_BATCH_SIZE);
+        ExecutionState fakeExecutionState = new ExecutionState(Maps.mutable.empty(), Collections.emptyList(), Collections.emptyList(), true, graphFetchExecutionConfiguration);
+        fakeExecutionState.adaptiveGraphBatchStats = new AdaptiveGraphBatchStats(0, 64);
+        Assert.assertEquals(74, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+        Assert.assertEquals(174, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+        Assert.assertEquals(1174, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+        Assert.assertEquals(11174, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+    }
+
+    // Tests the increase in batch size when near the soft limit
+    @Test
+    public void testIncreaseInBatchSizeNearSoftLimit()
+    {
+        GraphFetchExecutionConfiguration graphFetchExecutionConfiguration = new GraphFetchExecutionConfiguration(200, GraphFetchExecutionConfiguration.DEFAULT_SOFT_MEMORY_LIMIT_PERCENTAGE, true, GraphFetchExecutionConfiguration.DEFAULT_BATCH_SIZE);
+        ExecutionState fakeExecutionState = new ExecutionState(Maps.mutable.empty(), Collections.emptyList(), Collections.emptyList(), true, graphFetchExecutionConfiguration);
+        fakeExecutionState.adaptiveGraphBatchStats = new AdaptiveGraphBatchStats(49, 1);
+
+        Assert.assertEquals(1, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+        Assert.assertEquals(1, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+    }
+
+    // Tests exponential decrease in batch size
+    @Test
+    public void testExponentialDecreaseInBatchSize()
+    {
+        GraphFetchExecutionConfiguration graphFetchExecutionConfiguration = new GraphFetchExecutionConfiguration(200, GraphFetchExecutionConfiguration.DEFAULT_SOFT_MEMORY_LIMIT_PERCENTAGE, true, GraphFetchExecutionConfiguration.DEFAULT_BATCH_SIZE);
+        ExecutionState fakeExecutionState = new ExecutionState(Maps.mutable.empty(), Collections.emptyList(), Collections.emptyList(), true, graphFetchExecutionConfiguration);
+        fakeExecutionState.adaptiveGraphBatchStats = new AdaptiveGraphBatchStats(400, 4);
+
+        Assert.assertEquals(2, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+    }
+
+    // Tests ideal decrease in batch size
+    @Test
+    public void testIdealDecreaseInBatchSize()
+    {
+        GraphFetchExecutionConfiguration graphFetchExecutionConfiguration = new GraphFetchExecutionConfiguration(200, GraphFetchExecutionConfiguration.DEFAULT_SOFT_MEMORY_LIMIT_PERCENTAGE, true, GraphFetchExecutionConfiguration.DEFAULT_BATCH_SIZE);
+        ExecutionState fakeExecutionState = new ExecutionState(Maps.mutable.empty(), Collections.emptyList(), Collections.emptyList(), true, graphFetchExecutionConfiguration);
+        fakeExecutionState.adaptiveGraphBatchStats = new AdaptiveGraphBatchStats(120, 4);
+
+        Assert.assertEquals(3, AdaptiveBatching.getAdaptiveBatchSize(fakeExecutionState));
+    }
+}

--- a/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/main/java/org/finos/legend/engine/language/pure/dsl/service/execution/AbstractServicePlanExecutor.java
@@ -22,6 +22,7 @@ import org.finos.legend.engine.plan.execution.PlanExecutorInfo;
 import org.finos.legend.engine.plan.execution.cache.ExecutionCacheBuilder;
 import org.finos.legend.engine.plan.execution.cache.graphFetch.GraphFetchCache;
 import org.finos.legend.engine.plan.execution.cache.graphFetch.GraphFetchCrossAssociationKeys;
+import org.finos.legend.engine.plan.execution.graphFetch.GraphFetchExecutionConfiguration;
 import org.finos.legend.engine.plan.execution.result.ConstantResult;
 import org.finos.legend.engine.plan.execution.result.ErrorResult;
 import org.finos.legend.engine.plan.execution.result.Result;
@@ -95,14 +96,26 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
         this(servicePath, executionPlanResource, PlanExecutor.newPlanExecutorWithAvailableStoreExecutors(allowJavaCompilation));
     }
 
+    @Deprecated
     protected AbstractServicePlanExecutor(String servicePath, ExecutionPlan plan, boolean allowJavaCompilation, long graphFetchBatchMemoryLimit)
     {
         this(servicePath, plan, PlanExecutor.newPlanExecutorWithAvailableStoreExecutors(allowJavaCompilation, graphFetchBatchMemoryLimit));
     }
 
+    @Deprecated
     protected AbstractServicePlanExecutor(String servicePath, String executionPlanResource, boolean allowJavaCompilation, long graphFetchBatchMemoryLimit)
     {
         this(servicePath, executionPlanResource, PlanExecutor.newPlanExecutorWithAvailableStoreExecutors(allowJavaCompilation, graphFetchBatchMemoryLimit));
+    }
+
+    protected AbstractServicePlanExecutor(String servicePath, ExecutionPlan plan, boolean allowJavaCompilation, GraphFetchExecutionConfiguration graphFetchExecutionConfiguration)
+    {
+        this(servicePath, plan, PlanExecutor.newPlanExecutorWithAvailableStoreExecutors(allowJavaCompilation, graphFetchExecutionConfiguration));
+    }
+
+    protected AbstractServicePlanExecutor(String servicePath, String executionPlanResource, boolean allowJavaCompilation, GraphFetchExecutionConfiguration graphFetchExecutionConfiguration)
+    {
+        this(servicePath, executionPlanResource, PlanExecutor.newPlanExecutorWithAvailableStoreExecutors(allowJavaCompilation, graphFetchExecutionConfiguration));
     }
 
     protected AbstractServicePlanExecutor(String servicePath, ExecutionPlan plan, boolean allowJavaCompilation, StoreExecutor... storeExecutors)
@@ -198,7 +211,7 @@ public abstract class AbstractServicePlanExecutor implements ServiceRunner
     @Override
     public void setGraphFetchBatchMemoryLimit(long graphFetchBatchMemoryLimit)
     {
-        this.executor.setGraphFetchBatchMemoryLimit(graphFetchBatchMemoryLimit);
+        this.executor.setGraphFetchExecutionConfiguration(new GraphFetchExecutionConfiguration(graphFetchBatchMemoryLimit));
     }
 
     @Override

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -251,7 +251,15 @@ public class Server<T extends ServerConfiguration> extends Application<T>
         MongoDBStoreExecutorConfiguration mongoDBExecutorConfiguration = MongoDBStoreExecutorConfiguration.newInstance().withCredentialProviderProvider(credentialProviderProvider).build();
         MongoDBStoreExecutor mongoDBStoreExecutor = (MongoDBStoreExecutor) new MongoDBStoreExecutorBuilder().build(mongoDBExecutorConfiguration);
 
-        PlanExecutor planExecutor = PlanExecutor.newPlanExecutor(relationalStoreExecutor, serviceStoreExecutor, mongoDBStoreExecutor, InMemory.build());
+        PlanExecutor planExecutor;
+        if (serverConfiguration.graphFetchExecutionConfiguration != null)
+        {
+            planExecutor = PlanExecutor.newPlanExecutor(serverConfiguration.graphFetchExecutionConfiguration, relationalStoreExecutor, serviceStoreExecutor, mongoDBStoreExecutor, InMemory.build());
+        }
+        else
+        {
+            planExecutor = PlanExecutor.newPlanExecutor(relationalStoreExecutor, serviceStoreExecutor, mongoDBStoreExecutor, InMemory.build());
+        }
 
         // Session Management
         SessionTracker sessionTracker = new SessionTracker();

--- a/legend-engine-server/src/main/java/org/finos/legend/engine/server/ServerConfiguration.java
+++ b/legend-engine-server/src/main/java/org/finos/legend/engine/server/ServerConfiguration.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.server;
 import io.dropwizard.Configuration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import org.finos.legend.engine.language.pure.modelManager.sdlc.configuration.MetaDataServerConfiguration;
+import org.finos.legend.engine.plan.execution.graphFetch.GraphFetchExecutionConfiguration;
 import org.finos.legend.engine.plan.execution.stores.relational.config.RelationalExecutionConfiguration;
 import org.finos.legend.engine.plan.execution.stores.relational.config.TemporaryTestDbConfiguration;
 import org.finos.legend.engine.server.core.configuration.DeploymentConfiguration;
@@ -41,6 +42,7 @@ public class ServerConfiguration extends Configuration
     public MetaDataServerConfiguration metadataserver;
     public List<VaultConfiguration> vaults;
     public RelationalExecutionConfiguration relationalexecution;
+    public GraphFetchExecutionConfiguration graphFetchExecutionConfiguration;
     public ErrorHandlingConfiguration errorhandlingconfiguration = new ErrorHandlingConfiguration();
 
     /*

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-runtime/src/main/java/org/finos/legend/engine/external/format/flatdata/FlatDataRuntimeExtension.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-runtime/src/main/java/org/finos/legend/engine/external/format/flatdata/FlatDataRuntimeExtension.java
@@ -56,7 +56,7 @@ public class FlatDataRuntimeExtension implements ExternalFormatRuntimeExtension
             Class<?> specificsClass = ExecutionNodeJavaPlatformHelper.getClassToExecute(node, specificsClassName, executionState, profiles);
             IFlatDataDeserializeExecutionNodeSpecifics<?> specifics = (IFlatDataDeserializeExecutionNodeSpecifics<?>) specificsClass.getConstructor().newInstance();
 
-            specifics.setMaximumSchemaObjectSize(executionState.getGraphFetchBatchMemoryLimit());
+            specifics.setMaximumSchemaObjectSize(executionState.getGraphFetchExecutionConfiguration().getGraphFetchBatchMemorySoftLimit());
 
             FlatDataContext<?> context = specifics.createContext();
             FlatDataReader<?> deserializer = new FlatDataReader<>(context, inputStream);

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-runtime/src/test/java/org/finos/legend/engine/external/format/flatdata/read/test/TestFlatDataQueries.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-runtime/src/test/java/org/finos/legend/engine/external/format/flatdata/read/test/TestFlatDataQueries.java
@@ -28,6 +28,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperValueSpe
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
+import org.finos.legend.engine.plan.execution.graphFetch.GraphFetchExecutionConfiguration;
 import org.finos.legend.engine.plan.execution.result.StreamingResult;
 import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
 import org.finos.legend.engine.plan.generation.PlanGenerator;
@@ -164,7 +165,7 @@ public class TestFlatDataQueries extends TestExternalFormatQueries
 
         try
         {
-            PlanExecutor executor = PlanExecutor.newPlanExecutorBuilder().withGraphFetchBatchMemoryLimit(1).withAvailableStoreExecutors().build();
+            PlanExecutor executor = PlanExecutor.newPlanExecutorBuilder().withGraphFetchExecutionConfiguration(new GraphFetchExecutionConfiguration(1)).withAvailableStoreExecutors().build();
             StreamingResult streamingResult = (StreamingResult) executor.executeWithArgs(executeArgs);
             String res = streamingResult.flush(streamingResult.getSerializer(SerializationFormat.DEFAULT));
             Assert.fail("Exception expected");

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -360,8 +360,8 @@ function meta::relational::graphFetch::executionPlan::planRootGraphFetchExecutio
    let dbConnection = $runtime->connectionByElement($store)->toOne()->cast(@DatabaseConnection)->map(x | ^$x(element = $store));
    let oneRuntime   = ^Runtime(connections = [$dbConnection]);
    let batchSize    = if($fe.func == graphFetch_T_MANY__RootGraphFetchTree_1__Integer_1__T_MANY_ || $fe.func == meta::pure::graphFetch::execution::graphFetchChecked_T_MANY__RootGraphFetchTree_1__Integer_1__Checked_MANY_,
-                       | $fe->instanceValueAtParameter(2)->cast(@Integer), 
-                       | 1000);
+                       | $fe->instanceValueAtParameter(2)->cast(@Integer),
+                       | []);
 
    let simplePrimitiveProperties = $rootTree.subTrees->cast(@PropertyGraphFetchTree).property
                                       ->filter(x | $x->instanceOf(Property))->cast(@Property<Nil,Any|*>)


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

We introduce an adaptive batching algorithm to choose the root batch size in Graph Fetch to utilize maximum memory per batch

- The batch size chosen by the algorithm is almost certain to perform better than the default batch size for varying query complexities. 

- The graph fetch specification is made configurable.

- This relieves users of the responsibility to benchmark and choose the optimal batch size for their queries.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
