### PR TITLE
Add brackets to `in` dynaFunc

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -184,7 +184,7 @@ function meta::relational::functions::sqlQueryToString::default::getDynaFunction
     dynaFnToSql('greaterThanEqual',       $allStates,            ^ToSql(format='%s >= %s')),
     dynaFnToSql('group',                  $allStates,            ^ToSql(format='(%s)')),
     dynaFnToSql('if',                     $allStates,            ^ToSql(format='case when %s then %s else %s end', parametersWithinWhenClause = [true, false, false])),
-    dynaFnToSql('in',                     $allStates,            ^ToSql(format='%s in %s', transform={p:String[2] | if($p->at(1)->startsWith('(') && $p->at(1)->endsWith(')'), | $p, | [$p->at(0), ('(' + $p->at(1) + ')')])})),
+    dynaFnToSql('in',                     $allStates,            ^ToSql(format='(%s in %s)', transform={p:String[2] | if($p->at(1)->startsWith('(') && $p->at(1)->endsWith(')'), | $p, | [$p->at(0), ('(' + $p->at(1) + ')')])})),
     dynaFnToSql('objectReferenceIn',      $allStates,            ^ToSql(format='%s objectReferenceIn %s', transform={p:String[*] | if($p->at(1)->startsWith('(') && $p->at(1)->endsWith(')'), | [$p->at(0), $p->at(1)], | [$p->at(0), ('(' + $p->at(1) + ')')])})),
     dynaFnToSql('isDistinct',             $allStates,            ^ToSql(format='count(distinct(%s)) = count(%s)', transform={p:String[*]|assert($p->isNotEmpty(), |'"isDistinct" aggregation can be applied on primitive values only'); $p->concatenate($p);})),
     dynaFnToSql('isEmpty',                $allStates,            ^ToSql(format='%s is null')),


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
`In` clause without brackets along with an `is not null` currently fails in Snowflake due to SQL Compilation error. Adding brackets around `in` clause fixes the queries.
<!--
Describe change being introduced by this PR.
-->
#### Other notes for reviewers:
Previous SQL that fails: 
```sql
select
  case
    when "root"."COL" in ('val1', 'val2') is not null then 'true'
    else 'false'
  end as "(derivation)"
from
  table as "root"
```

New SQL introduced by this change
```sql
select
  case
    when ("root"."COL" in ('val1', 'val2')) is not null then 'true'
    else 'false'
  end as "(derivation)"
from
  table as "root"
```
#### Does this PR introduce a user-facing change?
No
<!--
-->
