### PR TITLE
Introduce `in` dynaFunc snowflake specific behavior

### DIFF
--- a/.github/workflows/database-trino-integration-test.yml
+++ b/.github/workflows/database-trino-integration-test.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Run Connection Protocol Integration Tests
         env:
           MAVEN_OPTS: -Xmx4g
-        run: mvn -pl legend-engine-xt-relationalStore-trino-execution-tests  -Dtest="ExternalIntegration*Trino*" test
+        run: mvn -pl :legend-engine-xt-relationalStore-trino-execution-tests  -Dtest="ExternalIntegration*Trino*" test

--- a/.github/workflows/database-trino-sql-generation-integration-test.yml
+++ b/.github/workflows/database-trino-sql-generation-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           set -o pipefail
           echo "| Test Representing Db Feature | Support Status |" >> $GITHUB_STEP_SUMMARY
           echo "| ---------------------------- | -------------- |" >> $GITHUB_STEP_SUMMARY
-          mvn -pl legend-engine-xt-relationalStore-trino-execution-tests -Dtest="Test_Relational_DbSpecific_Trino_UsingPureClientTestSuite" test | tee >(grep -o "Tests run:[^T]*" | head -1 | tr -d '\n' >> sql_test_summary.txt) | tee >(echo "Ignored tests deviating from standard: $(grep -c deviating-from-standard)" >> sql_test_summary.txt) | tee >(grep -o "[|] [*][*].*" >> $GITHUB_STEP_SUMMARY)
+          mvn -pl :legend-engine-xt-relationalStore-trino-execution-tests -Dtest="Test_Relational_DbSpecific_Trino_UsingPureClientTestSuite" test | tee >(grep -o "Tests run:[^T]*" | head -1 | tr -d '\n' >> sql_test_summary.txt) | tee >(echo "Ignored tests deviating from standard: $(grep -c deviating-from-standard)" >> sql_test_summary.txt) | tee >(grep -o "[|] [*][*].*" >> $GITHUB_STEP_SUMMARY)
       - name: Write Summary
         if: always()
         run: |

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/snowflake/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/snowflake/snowflakeExtension.pure
@@ -104,6 +104,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
     dynaFnToSql('firstDayOfWeek',         $allStates,            ^ToSql(format='DATE_TRUNC(\'WEEK\', %s)')),
     dynaFnToSql('firstDayOfYear',         $allStates,            ^ToSql(format='DATE_TRUNC(\'YEAR\', %s)')),
     dynaFnToSql('hour',                   $allStates,            ^ToSql(format='date_part(\'hour\', %s)')),
+    dynaFnToSql('in',                     $allStates,            ^ToSql(format='(%s in %s)', transform={p:String[2] | if($p->at(1)->startsWith('(') && $p->at(1)->endsWith(')'), | $p, | [$p->at(0), ('(' + $p->at(1) + ')')])})),
     dynaFnToSql('indexOf',                $allStates,            ^ToSql(format='CHARINDEX(%s)', transform={p:String[2] | $p->at(1) + ', ' + $p->at(0)})),
     dynaFnToSql('isAlphaNumeric',         $allStates,            ^ToSql(format=regexpPattern('%s'), transform={p:String[1]|$p->transformAlphaNumericParamsDefault()})),
     dynaFnToSql('joinStrings',            $allStates,            ^ToSql(format='listagg(%s, %s)')),


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
`In` clause without brackets along with an `is not null` currently fails in Snowflake due to SQL Compilation error. Adding brackets around `in` clause fixes the queries.
<!--
Describe change being introduced by this PR.
-->
#### Other notes for reviewers:
Previous SQL that fails: 
```sql
select
  case
    when "root"."COL" in ('val1', 'val2') is not null then 'true'
    else 'false'
  end as "(derivation)"
from
  table as "root"
```

New SQL introduced by this change
```sql
select
  case
    when ("root"."COL" in ('val1', 'val2')) is not null then 'true'
    else 'false'
  end as "(derivation)"
from
  table as "root"
```
#### Does this PR introduce a user-facing change?
No
<!--
-->
