### PR TITLE
Persistence V2: Add warning for V1 spec

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-grammar/src/test/java/org/finos/legend/engine/pure/dsl/persistence/cloud/compiler/test/TestPersistenceCloudCompilationFromGrammar.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-grammar/src/test/java/org/finos/legend/engine/pure/dsl/persistence/cloud/compiler/test/TestPersistenceCloudCompilationFromGrammar.java
@@ -24,6 +24,8 @@ import org.finos.legend.pure.generated.Root_meta_pure_persistence_metamodel_cont
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -179,7 +181,7 @@ public class TestPersistenceCloudCompilationFromGrammar extends TestCompilationF
                 "      modelClass: test::ServiceResult;\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n");
+                "}\n", null, Collections.singletonList("COMPILATION error at [88:1-117:1]: Persistence Spec V1 will be deprecated. Please shift to using Persistence Spec V2 grammar."));
 
         PureModel model = result.getTwo();
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.ProcessingContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.Warning;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.test.assertion.TestAssertionFirstPassBuilder;
@@ -94,6 +95,7 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                             if (persistence.persister != null)
                             {
                                 purePersistence._persister(HelperPersistenceBuilder.buildPersister(persistence.persister, context));
+                                context.pureModel.addWarnings(Collections.singletonList(new Warning(persistence.sourceInformation, "Persistence Spec V1 will be deprecated. Please shift to using Persistence Spec V2 grammar.")));
                             }
                             purePersistence._notifier(HelperPersistenceBuilder.buildNotifier(persistence.notifier, context));
                             purePersistence._tests(HelperPersistenceBuilder.buildTests(persistence, purePersistence, context));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceCompilationFromGrammar.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceCompilationFromGrammar.java
@@ -65,6 +65,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database;
 import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -1445,7 +1446,7 @@ public class TestPersistenceCompilationFromGrammar extends TestCompilationFromGr
                 "      isTestDataFromServiceOutput: false;\n" +
                 "    }\n" +
                 "  ]\n" +
-                "}\n");
+                "}\n", null, Collections.singletonList("COMPILATION error at [48:1-114:1]: Persistence Spec V1 will be deprecated. Please shift to using Persistence Spec V2 grammar."));
 
         PureModel model = result.getTwo();
 
@@ -1691,7 +1692,7 @@ public class TestPersistenceCompilationFromGrammar extends TestCompilationFromGr
                         "      }\n" +
                         "    ];\n" +
                         "  }\n" +
-                        "}");
+                        "}", null, Collections.singletonList("COMPILATION error at [68:1-149:1]: Persistence Spec V1 will be deprecated. Please shift to using Persistence Spec V2 grammar."));
 
         PureModel model = result.getTwo();
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceContextCompilationFromGrammar.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceContextCompilationFromGrammar.java
@@ -22,6 +22,7 @@ import org.finos.legend.pure.generated.*;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -386,7 +387,7 @@ public class TestPersistenceContextCompilationFromGrammar extends TestCompilatio
                 "      modelClass: test::ServiceResult;\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n");
+                "}\n", null, Collections.singletonList("COMPILATION error at [103:1-132:1]: Persistence Spec V1 will be deprecated. Please shift to using Persistence Spec V2 grammar."));
 
         PureModel model = result.getTwo();
 
@@ -588,7 +589,7 @@ public class TestPersistenceContextCompilationFromGrammar extends TestCompilatio
                 "      modelClass: test::ServiceResult;\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n");
+                "}\n", null, Collections.singletonList("COMPILATION error at [104:1-133:1]: Persistence Spec V1 will be deprecated. Please shift to using Persistence Spec V2 grammar."));
 
         PureModel model = result.getTwo();
 


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

Adding warning to discourage users from creating new Persistence V1 specs while migration takes place

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
