### PR TITLE
Persistence Component: API for extracting staging filters, Support Iceberg and Staging table creation

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/common/FilterType.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/common/FilterType.java
@@ -14,6 +14,10 @@
 
 package org.finos.legend.engine.persistence.components.common;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 public enum FilterType
 {
     GREATER_THAN("GT"),
@@ -32,5 +36,14 @@ public enum FilterType
     public String getType()
     {
         return type;
+    }
+
+    private static final Map<String, FilterType> BY_NAME = Arrays
+            .stream(FilterType.values())
+            .collect(Collectors.toMap(FilterType::getType, java.util.function.Function.identity()));
+
+    public static FilterType fromName(String name)
+    {
+        return BY_NAME.get(name);
     }
 }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/DatasetAdditionalPropertiesAbstract.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/DatasetAdditionalPropertiesAbstract.java
@@ -1,4 +1,4 @@
-// Copyright 2022 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,33 +15,31 @@
 package org.finos.legend.engine.persistence.components.logicalplan.datasets;
 
 import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlanNode;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
 
+import java.util.Map;
 import java.util.Optional;
 
-public interface Dataset extends LogicalPlanNode
+@Immutable
+@Style(
+    typeAbstract = "*Abstract",
+    typeImmutable = "*",
+    jdkOnly = true,
+    optionalAcceptNullable = true,
+    strictBuilder = true
+)
+public interface DatasetAdditionalPropertiesAbstract extends LogicalPlanNode
 {
-    default Optional<DatasetAdditionalProperties> datasetAdditionalProperties()
-    {
-        throw new UnsupportedOperationException();
-    }
+    Optional<TableType> tableType();
 
-    default SchemaDefinition schema()
-    {
-        throw new UnsupportedOperationException();
-    }
+    Optional<TableOrigin> tableOrigin();
 
-    default SchemaReference schemaReference()
-    {
-        throw new UnsupportedOperationException();
-    }
+    Optional<String> externalVolume();
 
-    default DatasetReference datasetReference()
-    {
-        throw new UnsupportedOperationException();
-    }
+    Optional<String> dataPath();
 
-    default Dataset withSchema(SchemaDefinition schema)
-    {
-        throw new UnsupportedOperationException();
-    }
+    Optional<String> filePattern();
+
+    Map<String, String> tags();
 }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/DatasetDefinitionAbstract.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/DatasetDefinitionAbstract.java
@@ -47,6 +47,8 @@ public interface DatasetDefinitionAbstract extends Dataset
 
     SchemaDefinition schema();
 
+    Optional<DatasetAdditionalProperties> datasetAdditionalProperties();
+
     @Derived
     default DatasetReference datasetReference()
     {

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/TableOrigin.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/TableOrigin.java
@@ -1,0 +1,20 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.logicalplan.datasets;
+
+public enum TableOrigin
+{
+    NATIVE, ICEBERG, EXTERNAL, EXTERNAL_STAGE
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/TableType.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/TableType.java
@@ -1,0 +1,20 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.logicalplan.datasets;
+
+public enum TableType
+{
+    TEMPORARY, TRANSIENT, REFERENCE, MEMORY, CACHED
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/AppendOnlyPlanner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/AppendOnlyPlanner.java
@@ -36,6 +36,7 @@ import org.finos.legend.engine.persistence.components.logicalplan.datasets.Field
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Selection;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Create;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Insert;
+import org.finos.legend.engine.persistence.components.logicalplan.operations.Operation;
 import org.finos.legend.engine.persistence.components.logicalplan.values.BatchStartTimestamp;
 import org.finos.legend.engine.persistence.components.logicalplan.values.FieldValue;
 import org.finos.legend.engine.persistence.components.logicalplan.values.Value;
@@ -115,7 +116,13 @@ class AppendOnlyPlanner extends Planner
     @Override
     public LogicalPlan buildLogicalPlanForPreActions(Resources resources)
     {
-        return LogicalPlan.builder().addOps(Create.of(true, mainDataset())).build();
+        List<Operation> operations = new ArrayList<>();
+        operations.add(Create.of(true, mainDataset()));
+        if (options().createStagingDataset())
+        {
+            operations.add(Create.of(true, stagingDataset()));
+        }
+        return LogicalPlan.of(operations);
     }
 
     protected void addPostRunStatsForRowsInserted(Map<StatisticName, LogicalPlan> postRunStatisticsResult)

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/BitemporalDeltaPlanner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/BitemporalDeltaPlanner.java
@@ -290,6 +290,10 @@ class BitemporalDeltaPlanner extends BitemporalPlanner
         List<Operation> operations = new ArrayList<>();
 
         operations.add(Create.of(true, mainDataset()));
+        if (options().createStagingDataset())
+        {
+            operations.add(Create.of(true, stagingDataset()));
+        }
         operations.add(Create.of(true, metadataDataset().orElseThrow(IllegalStateException::new).get()));
 
         if (ingestMode().validityMilestoning().validityDerivation() instanceof SourceSpecifiesFromDateTime)

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/BitemporalSnapshotPlanner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/BitemporalSnapshotPlanner.java
@@ -90,11 +90,14 @@ class BitemporalSnapshotPlanner extends BitemporalPlanner
     @Override
     public LogicalPlan buildLogicalPlanForPreActions(Resources resources)
     {
-        return LogicalPlan.builder()
-            .addOps(
-                Create.of(true, mainDataset()),
-                Create.of(true, metadataDataset().orElseThrow(IllegalStateException::new).get()))
-            .build();
+        List<Operation> operations = new ArrayList<>();
+        operations.add(Create.of(true, mainDataset()));
+        if (options().createStagingDataset())
+        {
+            operations.add(Create.of(true, stagingDataset()));
+        }
+        operations.add(Create.of(true, metadataDataset().orElseThrow(IllegalStateException::new).get()));
+        return LogicalPlan.of(operations);
     }
 
     /*

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalDeltaPlanner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalDeltaPlanner.java
@@ -301,7 +301,13 @@ class NontemporalDeltaPlanner extends Planner
     @Override
     public LogicalPlan buildLogicalPlanForPreActions(Resources resources)
     {
-        return LogicalPlan.builder().addOps(Create.of(true, mainDataset())).build();
+        List<Operation> operations = new ArrayList<>();
+        operations.add(Create.of(true, mainDataset()));
+        if (options().createStagingDataset())
+        {
+            operations.add(Create.of(true, stagingDataset()));
+        }
+        return LogicalPlan.of(operations);
     }
 
     public Optional<Condition> getDataSplitInRangeConditionForStatistics()

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalSnapshotPlanner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/NontemporalSnapshotPlanner.java
@@ -126,7 +126,13 @@ class NontemporalSnapshotPlanner extends Planner
     @Override
     public LogicalPlan buildLogicalPlanForPreActions(Resources resources)
     {
-        return LogicalPlan.builder().addOps(Create.of(true, mainDataset())).build();
+        List<Operation> operations = new ArrayList<>();
+        operations.add(Create.of(true, mainDataset()));
+        if (options().createStagingDataset())
+        {
+            operations.add(Create.of(true, stagingDataset()));
+        }
+        return LogicalPlan.of(operations);
     }
 
     @Override

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/Planner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/Planner.java
@@ -81,6 +81,12 @@ public abstract class Planner
         {
             return false;
         }
+
+        @Default
+        default boolean createStagingDataset()
+        {
+            return false;
+        }
     }
 
     private final Datasets datasets;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/UnitemporalDeltaPlanner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/UnitemporalDeltaPlanner.java
@@ -116,11 +116,16 @@ class UnitemporalDeltaPlanner extends UnitemporalPlanner
     @Override
     public LogicalPlan buildLogicalPlanForPreActions(Resources resources)
     {
-        return LogicalPlan.builder().addOps(
-            Create.of(true, mainDataset()),
-            Create.of(true, metadataDataset().orElseThrow(IllegalStateException::new).get()))
-            .build();
+        List<Operation> operations = new ArrayList<>();
+        operations.add(Create.of(true, mainDataset()));
+        if (options().createStagingDataset())
+        {
+            operations.add(Create.of(true, stagingDataset()));
+        }
+        operations.add(Create.of(true, metadataDataset().orElseThrow(IllegalStateException::new).get()));
+        return LogicalPlan.of(operations);
     }
+
 
     /*
     ------------------

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/UnitemporalSnapshotPlanner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/planner/UnitemporalSnapshotPlanner.java
@@ -91,11 +91,14 @@ class UnitemporalSnapshotPlanner extends UnitemporalPlanner
     @Override
     public LogicalPlan buildLogicalPlanForPreActions(Resources resources)
     {
-        return LogicalPlan.builder()
-            .addOps(
-                Create.of(true, mainDataset()),
-                Create.of(true, metadataDataset().orElseThrow(IllegalStateException::new).get()))
-            .build();
+        List<Operation> operations = new ArrayList<>();
+        operations.add(Create.of(true, mainDataset()));
+        if (options().createStagingDataset())
+        {
+            operations.add(Create.of(true, stagingDataset()));
+        }
+        operations.add(Create.of(true, metadataDataset().orElseThrow(IllegalStateException::new).get()));
+        return LogicalPlan.of(operations);
     }
 
     /*

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/AnsiSqlSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/AnsiSqlSink.java
@@ -39,6 +39,7 @@ import org.finos.legend.engine.persistence.components.logicalplan.datasets.Join;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.JsonExternalDatasetReference;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.SchemaDefinition;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.SchemaReference;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetAdditionalProperties;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Selection;
 import org.finos.legend.engine.persistence.components.logicalplan.modifiers.IfExistsTableModifier;
 import org.finos.legend.engine.persistence.components.logicalplan.modifiers.IfNotExistsTableModifier;
@@ -133,6 +134,7 @@ import org.finos.legend.engine.persistence.components.relational.ansi.sql.visito
 import org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.SumBinaryValueOperatorVisitor;
 import org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.TableModifierVisitor;
 import org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.TabularValuesVisitor;
+import org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.DatasetAdditionalPropertiesVisitor;
 import org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.TruncateVisitor;
 import org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.TableConstraintVisitor;
 import org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.WindowFunctionVisitor;
@@ -177,6 +179,7 @@ public class AnsiSqlSink extends RelationalSink
         logicalPlanVisitorByClass.put(DatasetDefinition.class, new DatasetDefinitionVisitor());
         logicalPlanVisitorByClass.put(DerivedDataset.class, new DerivedDatasetVisitor());
         logicalPlanVisitorByClass.put(JsonExternalDatasetReference.class, new DatasetReferenceVisitor());
+        logicalPlanVisitorByClass.put(DatasetAdditionalProperties.class, new DatasetAdditionalPropertiesVisitor());
 
         logicalPlanVisitorByClass.put(Not.class, new NotVisitor());
         logicalPlanVisitorByClass.put(And.class, new AndVisitor());

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/DatasetAdditionalPropertiesVisitor.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/DatasetAdditionalPropertiesVisitor.java
@@ -1,0 +1,99 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors;
+
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetAdditionalProperties;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.TableOrigin;
+import org.finos.legend.engine.persistence.components.physicalplan.PhysicalPlanNode;
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.CachedTableType;
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.MemoryTableType;
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.TableType;
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.TemporaryTableType;
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.TransientTableType;
+
+import org.finos.legend.engine.persistence.components.transformer.LogicalPlanVisitor;
+import org.finos.legend.engine.persistence.components.transformer.VisitorContext;
+
+import java.util.Map;
+
+public class DatasetAdditionalPropertiesVisitor implements LogicalPlanVisitor<org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetAdditionalProperties>
+{
+    @Override
+    public VisitorResult visit(PhysicalPlanNode prev, DatasetAdditionalProperties current, VisitorContext context)
+    {
+        // Handle Table Type
+        if (current.tableType().isPresent())
+        {
+            handleTableType(prev, current.tableType().get());
+        }
+        // Handle Table Origin
+        if (current.tableOrigin().isPresent())
+        {
+            handleTableOrigin(prev, current.tableOrigin().get());
+        }
+
+        // Handle external Volume
+        if (current.externalVolume().isPresent())
+        {
+            handleExternalVolume(prev, current.externalVolume().get());
+        }
+        // Handle tags
+        if (!current.tags().isEmpty())
+        {
+            handleTags(prev, current.tags());
+        }
+
+        return new VisitorResult(null);
+    }
+
+    protected void handleTableType(PhysicalPlanNode prev, org.finos.legend.engine.persistence.components.logicalplan.datasets.TableType tableType)
+    {
+        TableType mappedTableType = mapTableType(tableType);
+        prev.push(mappedTableType);
+    }
+
+    protected void handleTableOrigin(PhysicalPlanNode prev, TableOrigin tableOrigin)
+    {
+        switch (tableOrigin)
+        {
+            // native tables don't need any special marker
+            // Other table origins not supported in ANSI, will be implemented in respective Sinks
+            case NATIVE: break;
+            default: throw new UnsupportedOperationException("Unsupported Table origin : " + tableOrigin);
+        }
+    }
+
+    protected void handleTags(PhysicalPlanNode prev, Map<String, String> tags)
+    {
+        throw new UnsupportedOperationException("Tags not supported");
+    }
+
+    protected void handleExternalVolume(PhysicalPlanNode prev, String s)
+    {
+        throw new UnsupportedOperationException("External Volume not supported");
+    }
+
+    private TableType mapTableType(org.finos.legend.engine.persistence.components.logicalplan.datasets.TableType tableType)
+    {
+        switch (tableType)
+        {
+            case CACHED: return new CachedTableType();
+            case MEMORY: return new MemoryTableType();
+            case TEMPORARY: return new TemporaryTableType();
+            case TRANSIENT: return new TransientTableType();
+            default: throw new UnsupportedOperationException("Unknown Table type");
+        }
+    }
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/SQLCreateVisitor.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/main/java/org/finos/legend/engine/persistence/components/relational/ansi/sql/visitors/SQLCreateVisitor.java
@@ -37,6 +37,7 @@ public class SQLCreateVisitor implements LogicalPlanVisitor<Create>
         List<LogicalPlanNode> logicalPlanNodes = new ArrayList<>();
         logicalPlanNodes.add(current.dataset().datasetReference());
         logicalPlanNodes.add(current.dataset().schema());
+        current.dataset().datasetAdditionalProperties().ifPresent(logicalPlanNodes::add);
 
         if (current.ifNotExists())
         {

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/AnsiTestArtifacts.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/AnsiTestArtifacts.java
@@ -88,6 +88,13 @@ public class AnsiTestArtifacts
             "\"biz_date\" DATE," +
             "PRIMARY KEY (\"id\", \"name\"))";
 
+    public static String expectedBaseStagingTableCreateQuery = "CREATE TABLE IF NOT EXISTS \"mydb\".\"staging\"(" +
+            "\"id\" INTEGER NOT NULL," +
+            "\"name\" VARCHAR NOT NULL," +
+            "\"amount\" DOUBLE," +
+            "\"biz_date\" DATE," +
+            "PRIMARY KEY (\"id\", \"name\"))";
+
     public static String expectedBaseTableCreateQueryWithUpperCase = "CREATE TABLE IF NOT EXISTS \"MYDB\".\"MAIN\"" +
             "(\"ID\" INTEGER NOT NULL," +
             "\"NAME\" VARCHAR NOT NULL," +
@@ -96,6 +103,14 @@ public class AnsiTestArtifacts
             "PRIMARY KEY (\"ID\", \"NAME\"))";
 
     public static String expectedBaseTablePlusDigestCreateQuery = "CREATE TABLE IF NOT EXISTS \"mydb\".\"main\"(" +
+            "\"id\" INTEGER NOT NULL," +
+            "\"name\" VARCHAR NOT NULL," +
+            "\"amount\" DOUBLE," +
+            "\"biz_date\" DATE," +
+            "\"digest\" VARCHAR," +
+            "PRIMARY KEY (\"id\", \"name\"))";
+
+    public static String expectedStagingTableWithDigestCreateQuery = "CREATE TABLE IF NOT EXISTS \"mydb\".\"staging\"(" +
             "\"id\" INTEGER NOT NULL," +
             "\"name\" VARCHAR NOT NULL," +
             "\"amount\" DOUBLE," +
@@ -121,6 +136,9 @@ public class AnsiTestArtifacts
         "\"VERSION\" INTEGER," +
         "PRIMARY KEY (\"ID\", \"NAME\"))";
     public static String expectedBaseTableCreateQueryWithNoPKs = "CREATE TABLE IF NOT EXISTS \"mydb\".\"main\"(" +
+            "\"id\" INTEGER,\"name\" VARCHAR,\"amount\" DOUBLE,\"biz_date\" DATE,\"digest\" VARCHAR)";
+
+    public static String expectedBaseStagingTableCreateQueryWithNoPKs = "CREATE TABLE IF NOT EXISTS \"mydb\".\"staging\"(" +
             "\"id\" INTEGER,\"name\" VARCHAR,\"amount\" DOUBLE,\"biz_date\" DATE,\"digest\" VARCHAR)";
 
     public static String expectedBaseTableCreateQueryWithAuditAndNoPKs = "CREATE TABLE IF NOT EXISTS \"mydb\".\"main\"" +
@@ -171,6 +189,15 @@ public class AnsiTestArtifacts
             "\"validity_through_target\" DATETIME," +
             "PRIMARY KEY (\"id\", \"name\", \"batch_id_in\", \"validity_from_target\"))";
 
+    public static String expectedBitemporalStagingTableCreateQuery = "CREATE TABLE IF NOT EXISTS \"mydb\".\"staging\"" +
+            "(\"id\" INTEGER NOT NULL," +
+            "\"name\" VARCHAR NOT NULL," +
+            "\"amount\" DOUBLE," +
+            "\"validity_from_reference\" DATETIME NOT NULL," +
+            "\"validity_through_reference\" DATETIME," +
+            "\"digest\" VARCHAR," +
+            "PRIMARY KEY (\"id\", \"name\", \"validity_from_reference\"))";
+
     public static String expectedBitemporalMainTableWithBatchIdDatetimeCreateQuery = "CREATE TABLE IF NOT EXISTS \"mydb\".\"main\"" +
             "(\"id\" INTEGER NOT NULL," +
             "\"name\" VARCHAR NOT NULL," +
@@ -205,6 +232,14 @@ public class AnsiTestArtifacts
             "\"validity_from_target\" DATETIME NOT NULL," +
             "\"validity_through_target\" DATETIME," +
             "PRIMARY KEY (\"id\", \"name\", \"batch_id_in\", \"validity_from_target\"))";
+
+    public static String expectedBitemporalFromOnlyStagingTableCreateQuery = "CREATE TABLE IF NOT EXISTS \"mydb\".\"staging\"" +
+            "(\"id\" INTEGER NOT NULL," +
+            "\"name\" VARCHAR NOT NULL," +
+            "\"amount\" DOUBLE," +
+            "\"validity_from_reference\" DATETIME NOT NULL," +
+            "\"digest\" VARCHAR," +
+            "PRIMARY KEY (\"id\", \"name\", \"validity_from_reference\"))";
 
     public static String expectedBitemporalFromOnlyMainTableBatchIdAndTimeBasedCreateQuery = "CREATE TABLE IF NOT EXISTS \"mydb\".\"main\"" +
             "(\"id\" INTEGER NOT NULL," +

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromAndThroughTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromAndThroughTest.java
@@ -51,7 +51,8 @@ public class BitemporalDeltaSourceSpecifiesFromAndThroughTest extends Bitemporal
                 "AND (sink.\"digest\" = stage.\"digest\") AND ((sink.\"id\" = stage.\"id\") AND (sink.\"name\" = stage.\"name\")) AND (sink.\"validity_from_target\" = stage.\"validity_from_reference\"))))";
 
         Assertions.assertEquals(AnsiTestArtifacts.expectedBitemporalMainTableCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(1));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedBitemporalStagingTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromTest.java
@@ -96,8 +96,9 @@ public class BitemporalDeltaSourceSpecifiesFromTest extends BitemporalDeltaSourc
                 "(SELECT temp.\"id\",temp.\"name\",temp.\"amount\",temp.\"digest\",temp.\"batch_id_in\",temp.\"batch_id_out\",temp.\"validity_from_target\",temp.\"validity_through_target\" FROM \"mydb\".\"temp\" as temp)";
 
         Assertions.assertEquals(AnsiTestArtifacts.expectedBitemporalFromOnlyMainTableCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(1));
-        Assertions.assertEquals(AnsiTestArtifacts.expectedBitemporalFromOnlyTempTableCreateQuery, preActionsSql.get(2));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedBitemporalFromOnlyStagingTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(2));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedBitemporalFromOnlyTempTableCreateQuery, preActionsSql.get(3));
 
         Assertions.assertEquals(expectedStageToTemp, milestoningSql.get(0));
         Assertions.assertEquals(expectedMainToTemp, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/AppendOnlyTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/AppendOnlyTest.java
@@ -43,6 +43,7 @@ public class AppendOnlyTest extends AppendOnlyTestCases
         String insertSql = "INSERT INTO \"mydb\".\"main\" (\"id\", \"name\", \"amount\", \"biz_date\", \"digest\") " +
                 "(SELECT * FROM \"mydb\".\"staging\" as stage)";
         Assertions.assertEquals(AnsiTestArtifacts.expectedBaseTableCreateQueryWithNoPKs, preActionsSqlList.get(0));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedBaseStagingTableCreateQueryWithNoPKs, preActionsSqlList.get(1));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(0));
 
         // Stats

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalDeltaTest.java
@@ -57,6 +57,7 @@ public class NontemporalDeltaTest extends NontemporalDeltaTestCases
             "WHERE (sink.\"id\" = stage.\"id\") AND (sink.\"name\" = stage.\"name\"))))";
 
         Assertions.assertEquals(AnsiTestArtifacts.expectedBaseTablePlusDigestCreateQuery, preActionsSqlList.get(0));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSqlList.get(1));
         Assertions.assertEquals(updateSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalSnapshotTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/NontemporalSnapshotTest.java
@@ -46,6 +46,7 @@ public class NontemporalSnapshotTest extends NontemporalSnapshotTestCases
                 "(SELECT * FROM \"mydb\".\"staging\" as stage)";
 
         Assertions.assertEquals(AnsiTestArtifacts.expectedBaseTableCreateQuery, preActionsSqlList.get(0));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedBaseStagingTableCreateQuery, preActionsSqlList.get(1));
         Assertions.assertEquals(cleanUpMainTableSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaBatchIdBasedTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaBatchIdBasedTest.java
@@ -51,7 +51,8 @@ public class UnitemporalDeltaBatchIdBasedTest extends UnitmemporalDeltaBatchIdBa
                 "AND (sink.\"digest\" = stage.\"digest\") AND ((sink.\"id\" = stage.\"id\") AND (sink.\"name\" = stage.\"name\")))))";
 
         Assertions.assertEquals(AnsiTestArtifacts.expectedMainTableBatchIdBasedCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(1));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotBatchIdBasedTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalSnapshotBatchIdBasedTest.java
@@ -52,7 +52,8 @@ public class UnitemporalSnapshotBatchIdBasedTest extends UnitmemporalSnapshotBat
                 "WHERE NOT (stage.\"digest\" IN (SELECT sink.\"digest\" FROM \"mydb\".\"main\" as sink WHERE sink.\"batch_id_out\" = 999999999)))";
 
         Assertions.assertEquals(AnsiTestArtifacts.expectedMainTableBatchIdBasedCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(1));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(getExpectedMetadataTableCreateQuery(), preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/logicalplan/operations/CreateTableTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/src/test/java/org/finos/legend/engine/persistence/components/logicalplan/operations/CreateTableTest.java
@@ -15,7 +15,9 @@
 package org.finos.legend.engine.persistence.components.logicalplan.operations;
 
 import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlan;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetAdditionalProperties;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetDefinition;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.TableType;
 import org.finos.legend.engine.persistence.components.relational.SqlPlan;
 import org.finos.legend.engine.persistence.components.relational.ansi.AnsiSqlSink;
 import org.finos.legend.engine.persistence.components.relational.ansi.optimizer.UpperCaseOptimizer;
@@ -69,6 +71,7 @@ public class CreateTableTest
             .name("my_table")
             .alias("my_alias")
             .schema(schemaWithAllColumns)
+            .datasetAdditionalProperties(DatasetAdditionalProperties.builder().tableType(TableType.TEMPORARY).build())
             .build();
         Operation create = Create.of(true, dataset);
         LogicalPlan logicalPlan = LogicalPlan.builder().addOps(create).build();
@@ -80,7 +83,7 @@ public class CreateTableTest
 
         List<String> list = physicalPlan.getSqlList();
 
-        String expected = "CREATE TABLE IF NOT EXISTS \"MY_DB\".\"MY_SCHEMA\".\"MY_TABLE\"" +
+        String expected = "CREATE TEMPORARY TABLE IF NOT EXISTS \"MY_DB\".\"MY_SCHEMA\".\"MY_TABLE\"" +
             "(\"COL_INT\" INTEGER NOT NULL PRIMARY KEY,\"COL_INTEGER\" INTEGER NOT NULL UNIQUE,\"COL_BIGINT\" BIGINT," +
             "\"COL_TINYINT\" TINYINT,\"COL_SMALLINT\" SMALLINT,\"COL_CHAR\" CHAR,\"COL_VARCHAR\" VARCHAR," +
             "\"COL_STRING\" VARCHAR,\"COL_TIMESTAMP\" TIMESTAMP,\"COL_DATETIME\" DATETIME,\"COL_DATE\" DATE," +

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/pom.xml
@@ -98,6 +98,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>
+        <!-- JACKSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyTest.java
@@ -48,6 +48,7 @@ public class AppendOnlyTest extends org.finos.legend.engine.persistence.componen
         String insertSql = "INSERT INTO `mydb`.`main` (`id`, `name`, `amount`, `biz_date`, `digest`) " +
                 "(SELECT * FROM `mydb`.`staging` as stage)";
         Assertions.assertEquals(BigQueryTestArtifacts.expectedBaseTableCreateQueryWithNoPKs, preActionsSqlList.get(0));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedStagingTableCreateQueryWithNoPKs, preActionsSqlList.get(1));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(0));
 
         // Stats

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BigQueryTestArtifacts.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BigQueryTestArtifacts.java
@@ -23,6 +23,13 @@ public class BigQueryTestArtifacts
             "`biz_date` DATE," +
             "PRIMARY KEY (`id`, `name`) NOT ENFORCED)";
 
+    public static String expectedStagingTableCreateQuery = "CREATE TABLE IF NOT EXISTS `mydb`.`staging`(" +
+            "`id` INT64 NOT NULL," +
+            "`name` STRING NOT NULL," +
+            "`amount` FLOAT64," +
+            "`biz_date` DATE," +
+            "PRIMARY KEY (`id`, `name`) NOT ENFORCED)";
+
     public static String expectedBaseTableCreateQueryWithUpperCase = "CREATE TABLE IF NOT EXISTS `MYDB`.`MAIN`" +
             "(`ID` INT64 NOT NULL," +
             "`NAME` STRING NOT NULL," +
@@ -31,6 +38,14 @@ public class BigQueryTestArtifacts
             "PRIMARY KEY (`ID`, `NAME`) NOT ENFORCED)";
 
     public static String expectedBaseTablePlusDigestCreateQuery = "CREATE TABLE IF NOT EXISTS `mydb`.`main`(" +
+            "`id` INT64 NOT NULL," +
+            "`name` STRING NOT NULL," +
+            "`amount` FLOAT64," +
+            "`biz_date` DATE," +
+            "`digest` STRING," +
+            "PRIMARY KEY (`id`, `name`) NOT ENFORCED)";
+
+    public static String expectedStagingTableWithDigestCreateQuery = "CREATE TABLE IF NOT EXISTS `mydb`.`staging`(" +
             "`id` INT64 NOT NULL," +
             "`name` STRING NOT NULL," +
             "`amount` FLOAT64," +
@@ -65,6 +80,13 @@ public class BigQueryTestArtifacts
             "PRIMARY KEY (`ID`, `NAME`) NOT ENFORCED)";
 
     public static String expectedBaseTableCreateQueryWithNoPKs = "CREATE TABLE IF NOT EXISTS `mydb`.`main`(" +
+            "`id` INT64," +
+            "`name` STRING," +
+            "`amount` FLOAT64," +
+            "`biz_date` DATE," +
+            "`digest` STRING)";
+
+    public static String expectedStagingTableCreateQueryWithNoPKs = "CREATE TABLE IF NOT EXISTS `mydb`.`staging`(" +
             "`id` INT64," +
             "`name` STRING," +
             "`amount` FLOAT64," +
@@ -197,6 +219,15 @@ public class BigQueryTestArtifacts
             "`validity_through_target` DATETIME," +
             "PRIMARY KEY (`id`, `name`, `batch_id_in`, `validity_from_target`) NOT ENFORCED)";
 
+    public static String expectedBitemporalStagingTableCreateQuery = "CREATE TABLE IF NOT EXISTS `mydb`.`staging`(" +
+            "`id` INT64 NOT NULL," +
+            "`name` STRING NOT NULL," +
+            "`amount` FLOAT64," +
+            "`validity_from_reference` DATETIME NOT NULL," +
+            "`validity_through_reference` DATETIME," +
+            "`digest` STRING," +
+            "PRIMARY KEY (`id`, `name`, `validity_from_reference`) NOT ENFORCED)";
+
     public static String expectedBitemporalMainTableWithBatchIdDatetimeCreateQuery = "CREATE TABLE IF NOT EXISTS `mydb`.`main`" +
             "(`id` INT64 NOT NULL," +
             "`name` STRING NOT NULL," +
@@ -231,6 +262,14 @@ public class BigQueryTestArtifacts
             "`validity_from_target` DATETIME NOT NULL," +
             "`validity_through_target` DATETIME," +
             "PRIMARY KEY (`id`, `name`, `batch_id_in`, `validity_from_target`) NOT ENFORCED)";
+
+    public static String expectedBitemporalFromOnlyStagingTableCreateQuery = "CREATE TABLE IF NOT EXISTS `mydb`.`staging`(" +
+            "`id` INT64 NOT NULL," +
+            "`name` STRING NOT NULL," +
+            "`amount` FLOAT64," +
+            "`validity_from_reference` DATETIME NOT NULL," +
+            "`digest` STRING," +
+            "PRIMARY KEY (`id`, `name`, `validity_from_reference`) NOT ENFORCED)";
 
     public static String expectedBitemporalFromOnlyMainTableBatchIdAndTimeBasedCreateQuery = "CREATE TABLE IF NOT EXISTS `mydb`.`main`" +
             "(`id` INT64 NOT NULL," +

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromAndThroughTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromAndThroughTest.java
@@ -50,7 +50,8 @@ public class BitemporalDeltaSourceSpecifiesFromAndThroughTest extends Bitemporal
                 "AND (sink.`digest` = stage.`digest`) AND ((sink.`id` = stage.`id`) AND (sink.`name` = stage.`name`)) AND (sink.`validity_from_target` = stage.`validity_from_reference`))))";
 
         Assertions.assertEquals(BigQueryTestArtifacts.expectedBitemporalMainTableCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedBitemporalStagingTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromTest.java
@@ -93,8 +93,9 @@ public class BitemporalDeltaSourceSpecifiesFromTest extends BitemporalDeltaSourc
                 "(SELECT temp.`id`,temp.`name`,temp.`amount`,temp.`digest`,temp.`batch_id_in`,temp.`batch_id_out`,temp.`validity_from_target`,temp.`validity_through_target` FROM `mydb`.`temp` as temp)";
 
         Assertions.assertEquals(BigQueryTestArtifacts.expectedBitemporalFromOnlyMainTableCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
-        Assertions.assertEquals(BigQueryTestArtifacts.expectedBitemporalFromOnlyTempTableCreateQuery, preActionsSql.get(2));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedBitemporalFromOnlyStagingTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedBitemporalFromOnlyTempTableCreateQuery, preActionsSql.get(3));
 
         Assertions.assertEquals(expectedStageToTemp, milestoningSql.get(0));
         Assertions.assertEquals(expectedMainToTemp, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaTest.java
@@ -63,6 +63,7 @@ public class NontemporalDeltaTest extends org.finos.legend.engine.persistence.co
             "VALUES (stage.`id`,stage.`name`,stage.`amount`,stage.`biz_date`,stage.`digest`)";
 
         Assertions.assertEquals(BigQueryTestArtifacts.expectedBaseTablePlusDigestCreateQuery, preActionsSqlList.get(0));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSqlList.get(1));
         Assertions.assertEquals(mergeSql, milestoningSqlList.get(0));
 
         // Stats

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalSnapshotTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalSnapshotTest.java
@@ -43,6 +43,7 @@ public class NontemporalSnapshotTest extends NontemporalSnapshotTestCases
                 "(SELECT * FROM `mydb`.`staging` as stage)";
 
         Assertions.assertEquals(BigQueryTestArtifacts.expectedBaseTableCreateQuery, preActionsSqlList.get(0));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedStagingTableCreateQuery, preActionsSqlList.get(1));
         Assertions.assertEquals(BigQueryTestArtifacts.cleanUpMainTableSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaBatchIdBasedTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaBatchIdBasedTest.java
@@ -50,7 +50,8 @@ public class UnitemporalDeltaBatchIdBasedTest extends UnitmemporalDeltaBatchIdBa
                 "AND (sink.`digest` = stage.`digest`) AND ((sink.`id` = stage.`id`) AND (sink.`name` = stage.`name`)))))";
 
         Assertions.assertEquals(BigQueryTestArtifacts.expectedMainTableBatchIdBasedCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotBatchIdBasedTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotBatchIdBasedTest.java
@@ -51,7 +51,8 @@ public class UnitemporalSnapshotBatchIdBasedTest extends UnitmemporalSnapshotBat
                 "WHERE NOT (stage.`digest` IN (SELECT sink.`digest` FROM `mydb`.`main` as sink WHERE sink.`batch_id_out` = 999999999)))";
 
         Assertions.assertEquals(BigQueryTestArtifacts.expectedMainTableBatchIdBasedCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(BigQueryTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/pom.xml
@@ -52,6 +52,15 @@
             <artifactId>eclipse-collections</artifactId>
         </dependency>
         <!-- ECLIPSE COLLECTIONS -->
+        <!-- JACKSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
         <!-- LOGGING -->
         <dependency>

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalGeneratorAbstract.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalGeneratorAbstract.java
@@ -88,6 +88,12 @@ public abstract class RelationalGeneratorAbstract
         return Clock.systemUTC();
     }
 
+    @Default
+    public boolean createStagingDataset()
+    {
+        return false;
+    }
+
     public abstract Set<SchemaEvolutionCapability> schemaEvolutionCapabilitySet();
 
     public abstract Optional<String> batchStartTimestampPattern();
@@ -111,6 +117,7 @@ public abstract class RelationalGeneratorAbstract
             .cleanupStagingData(cleanupStagingData())
             .collectStatistics(collectStatistics())
             .enableSchemaEvolution(enableSchemaEvolution())
+            .createStagingDataset(createStagingDataset())
             .build();
     }
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalIngestorAbstract.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalIngestorAbstract.java
@@ -105,9 +105,15 @@ public abstract class RelationalIngestorAbstract
     }
 
     @Default
-    public boolean createTables()
+    public boolean createDatasets()
     {
         return true;
+    }
+
+    @Default
+    public boolean createStagingDataset()
+    {
+        return false;
     }
 
     @Default
@@ -153,6 +159,7 @@ public abstract class RelationalIngestorAbstract
             .cleanupStagingData(cleanupStagingData())
             .collectStatistics(collectStatistics())
             .enableSchemaEvolution(enableSchemaEvolution())
+            .createStagingDataset(createStagingDataset())
             .build();
     }
 
@@ -247,6 +254,7 @@ public abstract class RelationalIngestorAbstract
             .relationalSink(relationalSink())
             .cleanupStagingData(cleanupStagingData())
             .collectStatistics(collectStatistics())
+            .createStagingDataset(createStagingDataset())
             .enableSchemaEvolution(enableSchemaEvolution())
             .addAllSchemaEvolutionCapabilitySet(schemaEvolutionCapabilitySet())
             .caseConversion(caseConversion())
@@ -258,8 +266,8 @@ public abstract class RelationalIngestorAbstract
         Planner planner = Planners.get(updatedDatasets, enrichedIngestMode, plannerOptions());
         GeneratorResult generatorResult = generator.generateOperations(updatedDatasets, resourcesBuilder.build(), planner, enrichedIngestMode);
 
-        // Create tables
-        if (createTables())
+        // Create Datasets
+        if (createDatasets())
         {
             executor.executePhysicalPlan(generatorResult.preActionsSqlPlan());
         }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalIngestorAbstract.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/RelationalIngestorAbstract.java
@@ -14,11 +14,16 @@
 
 package org.finos.legend.engine.persistence.components.relational.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.persistence.components.common.Datasets;
 import org.finos.legend.engine.persistence.components.common.OptimizationFilter;
 import org.finos.legend.engine.persistence.components.common.Resources;
+import org.finos.legend.engine.persistence.components.common.DatasetFilter;
+import org.finos.legend.engine.persistence.components.common.FilterType;
 import org.finos.legend.engine.persistence.components.common.StatisticName;
 import org.finos.legend.engine.persistence.components.executor.DigestInfo;
 import org.finos.legend.engine.persistence.components.executor.Executor;
@@ -31,30 +36,31 @@ import org.finos.legend.engine.persistence.components.ingestmode.IngestModeVisit
 import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlan;
 import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlanFactory;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Dataset;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.Selection;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetReference;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.ExternalDatasetReference;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Field;
+import org.finos.legend.engine.persistence.components.logicalplan.values.StringValue;
 import org.finos.legend.engine.persistence.components.planner.Planner;
 import org.finos.legend.engine.persistence.components.planner.PlannerOptions;
 import org.finos.legend.engine.persistence.components.planner.Planners;
 import org.finos.legend.engine.persistence.components.relational.CaseConversion;
 import org.finos.legend.engine.persistence.components.relational.RelationalSink;
 import org.finos.legend.engine.persistence.components.relational.SqlPlan;
-import org.finos.legend.engine.persistence.components.relational.executor.RelationalExecutor;
-import org.finos.legend.engine.persistence.components.relational.jdbc.JdbcHelper;
 import org.finos.legend.engine.persistence.components.relational.sql.TabularData;
 import org.finos.legend.engine.persistence.components.relational.sqldom.SqlGen;
 import org.finos.legend.engine.persistence.components.relational.transformer.RelationalTransformer;
 import org.finos.legend.engine.persistence.components.transformer.TransformOptions;
 import org.finos.legend.engine.persistence.components.transformer.Transformer;
 import org.finos.legend.engine.persistence.components.util.LogicalPlanUtils;
+import org.finos.legend.engine.persistence.components.util.MetadataDataset;
+import org.finos.legend.engine.persistence.components.util.MetadataUtils;
 import org.finos.legend.engine.persistence.components.util.SchemaEvolutionCapability;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 
-import java.sql.Connection;
 import java.sql.Date;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -94,6 +100,12 @@ public abstract class RelationalIngestorAbstract
 
     @Default
     public boolean cleanupStagingData()
+    {
+        return true;
+    }
+
+    @Default
+    public boolean createTables()
     {
         return true;
     }
@@ -173,6 +185,22 @@ public abstract class RelationalIngestorAbstract
         return ingest(connection, datasets, dataSplitRanges);
     }
 
+    public List<DatasetFilter> getLatestStagingFilters(RelationalConnection connection, Datasets datasets) throws JsonProcessingException
+    {
+        MetadataDataset metadataDataset = datasets.metadataDataset().isPresent()
+                ? datasets.metadataDataset().get()
+                : MetadataDataset.builder().build();
+        MetadataUtils store = new MetadataUtils(metadataDataset);
+        String tableName = datasets.mainDataset().datasetReference().name().orElseThrow(IllegalStateException::new);
+        Selection selection = store.getLatestStagingFilters(StringValue.of(tableName));
+
+        LogicalPlan logicalPlan = LogicalPlan.builder().addOps(selection).build();
+        Transformer<SqlGen, SqlPlan> transformer = new RelationalTransformer(relationalSink(), transformOptions());
+        Executor<SqlGen, TabularData, SqlPlan> executor = relationalSink().getRelationalExecutor(connection);
+        SqlPlan physicalPlan = transformer.generatePhysicalPlan(logicalPlan);
+        return extractDatasetFilters(metadataDataset, executor, physicalPlan);
+    }
+
     // ---------- UTILITY METHODS ----------
 
     private List<IngestorResult> ingest(RelationalConnection connection, Datasets datasets, List<DataSplitRange> dataSplitRanges)
@@ -231,7 +259,11 @@ public abstract class RelationalIngestorAbstract
         GeneratorResult generatorResult = generator.generateOperations(updatedDatasets, resourcesBuilder.build(), planner, enrichedIngestMode);
 
         // Create tables
-        executor.executePhysicalPlan(generatorResult.preActionsSqlPlan());
+        if (createTables())
+        {
+            executor.executePhysicalPlan(generatorResult.preActionsSqlPlan());
+        }
+
         // The below boolean is created before the execution of pre-actions, hence it represents whether the main table has already existed before that
         if (mainDatasetExists)
         {
@@ -491,4 +523,31 @@ public abstract class RelationalIngestorAbstract
         }
         return Optional.empty();
     }
+
+    private List<DatasetFilter> extractDatasetFilters(MetadataDataset metadataDataset, Executor<SqlGen, TabularData, SqlPlan> executor, SqlPlan physicalPlan) throws JsonProcessingException
+    {
+        List<DatasetFilter> datasetFilters = new ArrayList<>();
+        List<TabularData> results = executor.executePhysicalPlanAndGetResults(physicalPlan);
+        Optional<String> stagingFilters = results.stream()
+                .findFirst()
+                .map(TabularData::getData)
+                .flatMap(t -> t.stream().findFirst())
+                .map(stringObjectMap -> (String) stringObjectMap.get(metadataDataset.stagingFiltersField()));
+
+        // Convert map of Filters to List of Filters
+        if (stagingFilters.isPresent())
+        {
+            Map<String, Map<String, Object>> datasetFiltersMap = new ObjectMapper().readValue(stagingFilters.get(), new TypeReference<Map<String, Map<String, Object>>>() {});
+            for (Map.Entry<String, Map<String, Object>> filtersMapEntry : datasetFiltersMap.entrySet())
+            {
+                for (Map.Entry<String, Object> filterEntry : filtersMapEntry.getValue().entrySet())
+                {
+                    DatasetFilter datasetFilter = DatasetFilter.of(filtersMapEntry.getKey(), FilterType.fromName(filterEntry.getKey()), filterEntry.getValue());
+                    datasetFilters.add(datasetFilter);
+                }
+            }
+        }
+        return datasetFilters;
+    }
+
 }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/jdbc/JdbcTransactionManager.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/jdbc/JdbcTransactionManager.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.persistence.components.relational.jdbc;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -87,7 +88,12 @@ public class JdbcTransactionManager
                     Map<String, Object> row = new HashMap<>();
                     for (int i = 1; i <= columnCount; i++)
                     {
-                        row.put(metaData.getColumnName(i), resultSet.getObject(i));
+                        Object value = resultSet.getObject(i);
+                        if (metaData.getColumnTypeName(i).equalsIgnoreCase("JSON"))
+                        {
+                            value = new String((byte[]) value, StandardCharsets.UTF_8);
+                        }
+                        row.put(metaData.getColumnName(i), value);
                     }
                     resultList.add(row);
                 }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/jdbc/JdbcTransactionManager.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/jdbc/JdbcTransactionManager.java
@@ -89,7 +89,7 @@ public class JdbcTransactionManager
                     for (int i = 1; i <= columnCount; i++)
                     {
                         Object value = resultSet.getObject(i);
-                        if (metaData.getColumnTypeName(i).equalsIgnoreCase("JSON"))
+                        if (metaData.getColumnTypeName(i).equalsIgnoreCase("JSON") && value instanceof byte[])
                         {
                             value = new String((byte[]) value, StandardCharsets.UTF_8);
                         }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/tabletypes/TransientTableType.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/sqldom/tabletypes/TransientTableType.java
@@ -1,0 +1,25 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes;
+
+public class TransientTableType extends TableType
+{
+
+    @Override
+    public void genSql(StringBuilder builder)
+    {
+        builder.append("TRANSIENT");
+    }
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/BaseTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/BaseTest.java
@@ -149,9 +149,9 @@ public class BaseTest
         Collections.sort(expectedFilters, comparator);
         for (int i = 0; i < filters.size(); i++)
         {
-            Assertions.assertEquals(expectedFilters.get(i).fieldName(), expectedFilters.get(i).fieldName());
-            Assertions.assertEquals(expectedFilters.get(i).filterType(), expectedFilters.get(i).filterType());
-            Assertions.assertEquals(expectedFilters.get(i).value(), expectedFilters.get(i).value());
+            Assertions.assertEquals(expectedFilters.get(i).fieldName(), filters.get(i).fieldName());
+            Assertions.assertEquals(expectedFilters.get(i).filterType(), filters.get(i).filterType());
+            Assertions.assertEquals(expectedFilters.get(i).value(), filters.get(i).value());
         }
     }
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/TestUtils.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/TestUtils.java
@@ -385,6 +385,7 @@ public class TestUtils
             .schema(getStagingSchema())
             .alias(stagingTableName)
             .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 3L))
+            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.LESS_THAN_EQUAL, 5L))
             .build();
     }
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/TestUtils.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/TestUtils.java
@@ -373,7 +373,7 @@ public class TestUtils
             .name(stagingTableName)
             .schema(getStagingSchema())
             .alias(stagingTableName)
-            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 2L))
+            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 2))
             .build();
     }
 
@@ -384,8 +384,8 @@ public class TestUtils
             .name(stagingTableName)
             .schema(getStagingSchema())
             .alias(stagingTableName)
-            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 3L))
-            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.LESS_THAN_EQUAL, 5L))
+            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 3))
+            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.LESS_THAN_EQUAL, 5))
             .build();
     }
 
@@ -396,7 +396,7 @@ public class TestUtils
             .name(stagingTableName)
             .schema(getStagingSchemaWithVersion())
             .alias(stagingTableName)
-            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 2L))
+            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 2))
             .build();
     }
 
@@ -407,7 +407,7 @@ public class TestUtils
             .name(stagingTableName)
             .schema(getStagingSchemaWithVersion())
             .alias(stagingTableName)
-            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 3L))
+            .addDatasetFilters(DatasetFilter.of(batchName, FilterType.GREATER_THAN_EQUAL, 3))
             .build();
     }
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/AppendOnlyTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/nontemporal/AppendOnlyTest.java
@@ -384,7 +384,7 @@ class AppendOnlyTest extends BaseTest
         RelationalIngestor ingestor = RelationalIngestor.builder()
                 .ingestMode(ingestMode)
                 .relationalSink(H2Sink.get())
-                .createTables(false)
+                .createDatasets(false)
                 .build();
         try
         {

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/unitemporal/UnitemporalDeltaTest.java
@@ -501,7 +501,8 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilter(dataPass1);
         // 2. Execute plans and verify results
         Map<String, Object> expectedStats = createExpectedStatsMap(3, 0, 3, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
+
         // 3. Assert that the staging table is NOT truncated
         List<Map<String, Object>> stagingTableList = h2Sink.executeQuery("select * from \"TEST\".\"staging\"");
         Assertions.assertEquals(stagingTableList.size(), 6);
@@ -515,7 +516,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilter(dataPass2);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(3, 0, 1, 1, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
 
         // ------------ Perform Pass3 empty batch (No Impact) -------------------------
         String dataPass3 = basePathForInput + "with_staging_filter/with_no_versioning/staging_data_pass3.csv";
@@ -524,7 +525,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilter(dataPass3);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(0, 0, 0, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, fixedClock_2000_01_01);
     }
 
     @Test
@@ -564,7 +565,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass1);
         // 2. Execute plans and verify results
         Map<String, Object> expectedStats = createExpectedStatsMap(3, 0, 3, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
         // 3. Assert that the staging table is NOT truncated
         List<Map<String, Object>> stagingTableList = h2Sink.executeQuery("select * from \"TEST\".\"staging\"");
         Assertions.assertEquals(stagingTableList.size(), 6);
@@ -578,7 +579,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass2);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(4, 0, 1, 1, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
 
         // ------------ Perform Pass3 empty batch (No Impact) -------------------------
         String dataPass3 = basePathForInput + "with_staging_filter/with_max_versioning/greater_than/without_dedup/staging_data_pass3.csv";
@@ -587,7 +588,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass3);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(0, 0, 0, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, fixedClock_2000_01_01);
     }
 
     @Test
@@ -627,7 +628,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass1);
         // 2. Execute plans and verify results
         Map<String, Object> expectedStats = createExpectedStatsMap(3, 0, 3, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
         // 3. Assert that the staging table is NOT truncated
         List<Map<String, Object>> stagingTableList = h2Sink.executeQuery("select * from \"TEST\".\"staging\"");
         Assertions.assertEquals(stagingTableList.size(), 6);
@@ -641,7 +642,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass2);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(4, 0, 1, 2, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
 
         // ------------ Perform Pass3 empty batch (No Impact) -------------------------
         String dataPass3 = basePathForInput + "with_staging_filter/with_max_versioning/greater_than_equal_to/without_dedup/staging_data_pass3.csv";
@@ -650,7 +651,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass3);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(0, 0, 0, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, fixedClock_2000_01_01);
     }
 
     @Test
@@ -690,7 +691,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass1);
         // 2. Execute plans and verify results
         Map<String, Object> expectedStats = createExpectedStatsMap(3, 0, 3, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
         // 3. Assert that the staging table is NOT truncated
         List<Map<String, Object>> stagingTableList = h2Sink.executeQuery("select * from \"TEST\".\"staging\"");
         Assertions.assertEquals(stagingTableList.size(), 6);
@@ -704,7 +705,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass2);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(9, 0, 1, 1, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
 
         // ------------ Perform Pass3 empty batch (No Impact) -------------------------
         String dataPass3 = basePathForInput + "with_staging_filter/with_max_versioning/greater_than/with_dedup/staging_data_pass3.csv";
@@ -713,7 +714,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass3);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(0, 0, 0, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, fixedClock_2000_01_01);
     }
 
     @Test
@@ -753,7 +754,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass1);
         // 2. Execute plans and verify results
         Map<String, Object> expectedStats = createExpectedStatsMap(3, 0, 3, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass1, expectedStats, fixedClock_2000_01_01);
         // 3. Assert that the staging table is NOT truncated
         List<Map<String, Object>> stagingTableList = h2Sink.executeQuery("select * from \"TEST\".\"staging\"");
         Assertions.assertEquals(stagingTableList.size(), 6);
@@ -767,7 +768,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass2);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(9, 0, 1, 3, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass2, expectedStats, fixedClock_2000_01_01);
 
         // ------------ Perform Pass3 empty batch (No Impact) -------------------------
         String dataPass3 = basePathForInput + "with_staging_filter/with_max_versioning/greater_than_equal_to/with_dedup/staging_data_pass3.csv";
@@ -776,7 +777,7 @@ class UnitemporalDeltaTest extends BaseTest
         loadStagingDataWithFilterWithVersion(dataPass3);
         // 2. Execute plans and verify results
         expectedStats = createExpectedStatsMap(0, 0, 0, 0, 0);
-        executePlansAndVerifyResults(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats);
+        executePlansAndVerifyResultsWithStagingFilters(ingestMode, options, datasets, schema, expectedDataPass3, expectedStats, fixedClock_2000_01_01);
     }
 
     @Test

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/AppendOnlyTest.java
@@ -49,6 +49,7 @@ public class AppendOnlyTest extends org.finos.legend.engine.persistence.componen
         String insertSql = "INSERT INTO `mydb`.`main` (`id`, `name`, `amount`, `biz_date`, `digest`) " +
                 "(SELECT * FROM `mydb`.`staging` as stage)";
         Assertions.assertEquals(MemsqlTestArtifacts.expectedBaseTableCreateQueryWithNoPKs, preActionsSqlList.get(0));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedStagingTableCreateQueryWithNoPKs, preActionsSqlList.get(1));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(0));
 
         // Stats

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromAndThroughTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromAndThroughTest.java
@@ -50,7 +50,8 @@ public class BitemporalDeltaSourceSpecifiesFromAndThroughTest extends Bitemporal
                 "AND (sink.`digest` = stage.`digest`) AND ((sink.`id` = stage.`id`) AND (sink.`name` = stage.`name`)) AND (sink.`validity_from_target` = stage.`validity_from_reference`))))";
 
         Assertions.assertEquals(MemsqlTestArtifacts.expectedBitemporalMainTableCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedBitemporalStagingTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/BitemporalDeltaSourceSpecifiesFromTest.java
@@ -93,8 +93,9 @@ public class BitemporalDeltaSourceSpecifiesFromTest extends BitemporalDeltaSourc
                 "(SELECT temp.`id`,temp.`name`,temp.`amount`,temp.`digest`,temp.`batch_id_in`,temp.`batch_id_out`,temp.`validity_from_target`,temp.`validity_through_target` FROM `mydb`.`temp` as temp)";
 
         Assertions.assertEquals(MemsqlTestArtifacts.expectedBitemporalFromOnlyMainTableCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
-        Assertions.assertEquals(MemsqlTestArtifacts.expectedBitemporalFromOnlyTempTableCreateQuery, preActionsSql.get(2));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedBitemporalFromOnlyStagingTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedBitemporalFromOnlyTempTableCreateQuery, preActionsSql.get(3));
 
         Assertions.assertEquals(expectedStageToTemp, milestoningSql.get(0));
         Assertions.assertEquals(expectedMainToTemp, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/MemsqlTestArtifacts.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/MemsqlTestArtifacts.java
@@ -23,6 +23,13 @@ public class MemsqlTestArtifacts
             "`biz_date` DATE," +
             "PRIMARY KEY (`id`, `name`))";
 
+    public static String expectedStagingTableCreateQuery = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`staging`(" +
+            "`id` INTEGER NOT NULL," +
+            "`name` VARCHAR(256) NOT NULL," +
+            "`amount` DOUBLE," +
+            "`biz_date` DATE," +
+            "PRIMARY KEY (`id`, `name`))";
+
     public static String expectedBaseTableCreateQueryWithUpperCase = "CREATE REFERENCE TABLE IF NOT EXISTS `MYDB`.`MAIN`" +
             "(`ID` INTEGER NOT NULL," +
             "`NAME` VARCHAR(256) NOT NULL," +
@@ -31,6 +38,14 @@ public class MemsqlTestArtifacts
             "PRIMARY KEY (`ID`, `NAME`))";
 
     public static String expectedBaseTablePlusDigestCreateQuery = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`main`(" +
+            "`id` INTEGER NOT NULL," +
+            "`name` VARCHAR(256) NOT NULL," +
+            "`amount` DOUBLE," +
+            "`biz_date` DATE," +
+            "`digest` VARCHAR(256)," +
+            "PRIMARY KEY (`id`, `name`))";
+
+    public static String expectedStagingTableWithDigestCreateQuery = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`staging`(" +
             "`id` INTEGER NOT NULL," +
             "`name` VARCHAR(256) NOT NULL," +
             "`amount` DOUBLE," +
@@ -65,6 +80,13 @@ public class MemsqlTestArtifacts
             "PRIMARY KEY (`ID`, `NAME`))";
 
     public static String expectedBaseTableCreateQueryWithNoPKs = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`main`(" +
+            "`id` INTEGER," +
+            "`name` VARCHAR(256)," +
+            "`amount` DOUBLE," +
+            "`biz_date` DATE," +
+            "`digest` VARCHAR(256))";
+
+    public static String expectedStagingTableCreateQueryWithNoPKs = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`staging`(" +
             "`id` INTEGER," +
             "`name` VARCHAR(256)," +
             "`amount` DOUBLE," +
@@ -191,6 +213,15 @@ public class MemsqlTestArtifacts
             "`validity_through_target` DATETIME," +
             "PRIMARY KEY (`id`, `name`, `batch_id_in`, `validity_from_target`))";
 
+    public static String expectedBitemporalStagingTableCreateQuery = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`staging`(" +
+            "`id` INTEGER NOT NULL," +
+            "`name` VARCHAR(256) NOT NULL," +
+            "`amount` DOUBLE," +
+            "`validity_from_reference` DATETIME NOT NULL," +
+            "`validity_through_reference` DATETIME," +
+            "`digest` VARCHAR(256)," +
+            "PRIMARY KEY (`id`, `name`, `validity_from_reference`))";
+
     public static String expectedBitemporalMainTableWithBatchIdDatetimeCreateQuery = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`main`" +
             "(`id` INTEGER NOT NULL," +
             "`name` VARCHAR(256) NOT NULL," +
@@ -225,6 +256,13 @@ public class MemsqlTestArtifacts
             "`validity_from_target` DATETIME NOT NULL," +
             "`validity_through_target` DATETIME," +
             "PRIMARY KEY (`id`, `name`, `batch_id_in`, `validity_from_target`))";
+
+    public static String expectedBitemporalFromOnlyStagingTableCreateQuery = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`staging`" +
+            "(`id` INTEGER NOT NULL," +
+            "`name` VARCHAR(256) NOT NULL," +
+            "`amount` DOUBLE,`validity_from_reference` DATETIME NOT NULL," +
+            "`digest` VARCHAR(256)," +
+            "PRIMARY KEY (`id`, `name`, `validity_from_reference`))";
 
     public static String expectedBitemporalFromOnlyMainTableBatchIdAndTimeBasedCreateQuery = "CREATE REFERENCE TABLE IF NOT EXISTS `mydb`.`main`" +
             "(`id` INTEGER NOT NULL," +

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaTest.java
@@ -55,6 +55,7 @@ public class NontemporalDeltaTest extends NontemporalDeltaTestCases
                 "WHERE (sink.`id` = stage.`id`) AND (sink.`name` = stage.`name`))))";
 
         Assertions.assertEquals(MemsqlTestArtifacts.expectedBaseTablePlusDigestCreateQuery, preActionsSqlList.get(0));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSqlList.get(1));
         Assertions.assertEquals(updateSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalSnapshotTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalSnapshotTest.java
@@ -43,6 +43,7 @@ public class NontemporalSnapshotTest extends NontemporalSnapshotTestCases
                 "(SELECT * FROM `mydb`.`staging` as stage)";
 
         Assertions.assertEquals(MemsqlTestArtifacts.expectedBaseTableCreateQuery, preActionsSqlList.get(0));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedStagingTableCreateQuery, preActionsSqlList.get(1));
         Assertions.assertEquals(MemsqlTestArtifacts.cleanUpMainTableSql, milestoningSqlList.get(0));
         Assertions.assertEquals(insertSql, milestoningSqlList.get(1));
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaBatchIdBasedTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalDeltaBatchIdBasedTest.java
@@ -51,7 +51,8 @@ public class UnitemporalDeltaBatchIdBasedTest extends UnitmemporalDeltaBatchIdBa
                 "AND (sink.`digest` = stage.`digest`) AND ((sink.`id` = stage.`id`) AND (sink.`name` = stage.`name`)))))";
 
         Assertions.assertEquals(MemsqlTestArtifacts.expectedMainTableBatchIdBasedCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotBatchIdBasedTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/UnitemporalSnapshotBatchIdBasedTest.java
@@ -53,7 +53,8 @@ public class UnitemporalSnapshotBatchIdBasedTest extends UnitmemporalSnapshotBat
                 "WHERE NOT (stage.`digest` IN (SELECT sink.`digest` FROM `mydb`.`main` as sink WHERE sink.`batch_id_out` = 999999999)))";
 
         Assertions.assertEquals(MemsqlTestArtifacts.expectedMainTableBatchIdBasedCreateQuery, preActionsSql.get(0));
-        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSql.get(1));
+        Assertions.assertEquals(MemsqlTestArtifacts.expectedMetadataTableCreateQuery, preActionsSql.get(2));
 
         Assertions.assertEquals(expectedMilestoneQuery, milestoningSql.get(0));
         Assertions.assertEquals(expectedUpsertQuery, milestoningSql.get(1));

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
@@ -39,7 +39,14 @@ import org.finos.legend.engine.persistence.components.relational.snowflake.optmi
 import org.finos.legend.engine.persistence.components.relational.snowflake.optmizer.UpperCaseOptimizer;
 import org.finos.legend.engine.persistence.components.relational.snowflake.sql.SnowflakeDataTypeMapping;
 import org.finos.legend.engine.persistence.components.relational.snowflake.sql.SnowflakeJdbcPropertiesToLogicalDataTypeMapping;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.*;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.AlterVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.BatchEndTimestampVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.ClusterKeyVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.SQLCreateVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.SchemaDefinitionVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.FieldVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.ShowVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.DatasetAdditionalPropertiesVisitor;
 import org.finos.legend.engine.persistence.components.relational.sql.TabularData;
 import org.finos.legend.engine.persistence.components.relational.sqldom.SqlGen;
 import org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
@@ -21,6 +21,7 @@ import org.finos.legend.engine.persistence.components.logicalplan.datasets.Clust
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.DataType;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.Field;
 import org.finos.legend.engine.persistence.components.logicalplan.datasets.SchemaDefinition;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetAdditionalProperties;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Alter;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Create;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Show;
@@ -38,13 +39,7 @@ import org.finos.legend.engine.persistence.components.relational.snowflake.optmi
 import org.finos.legend.engine.persistence.components.relational.snowflake.optmizer.UpperCaseOptimizer;
 import org.finos.legend.engine.persistence.components.relational.snowflake.sql.SnowflakeDataTypeMapping;
 import org.finos.legend.engine.persistence.components.relational.snowflake.sql.SnowflakeJdbcPropertiesToLogicalDataTypeMapping;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.AlterVisitor;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.BatchEndTimestampVisitor;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.ClusterKeyVisitor;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.SQLCreateVisitor;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.SchemaDefinitionVisitor;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.FieldVisitor;
-import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.ShowVisitor;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor.*;
 import org.finos.legend.engine.persistence.components.relational.sql.TabularData;
 import org.finos.legend.engine.persistence.components.relational.sqldom.SqlGen;
 import org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils;
@@ -91,6 +86,7 @@ public class SnowflakeSink extends AnsiSqlSink
         logicalPlanVisitorByClass.put(Show.class, new ShowVisitor());
         logicalPlanVisitorByClass.put(BatchEndTimestamp.class, new BatchEndTimestampVisitor());
         logicalPlanVisitorByClass.put(Field.class, new FieldVisitor());
+        logicalPlanVisitorByClass.put(DatasetAdditionalProperties.class, new DatasetAdditionalPropertiesVisitor());
 
         LOGICAL_PLAN_VISITOR_BY_CLASS = Collections.unmodifiableMap(logicalPlanVisitorByClass);
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/DatasetAdditionalPropertiesVisitor.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/DatasetAdditionalPropertiesVisitor.java
@@ -1,0 +1,56 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.relational.snowflake.sql.visitor;
+
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.TableOrigin;
+import org.finos.legend.engine.persistence.components.physicalplan.PhysicalPlanNode;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.common.ExternalVolume;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.tabletypes.IcebergTableType;
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.TableType;
+
+import java.util.Map;
+
+public class DatasetAdditionalPropertiesVisitor extends org.finos.legend.engine.persistence.components.relational.ansi.sql.visitors.DatasetAdditionalPropertiesVisitor
+{
+
+    protected void handleTableOrigin(PhysicalPlanNode prev, TableOrigin tableOrigin)
+    {
+        TableType tableType = mapTableType(tableOrigin);
+        if (tableType != null)
+        {
+            prev.push(tableType);
+        }
+    }
+
+    protected void handleTags(PhysicalPlanNode prev, Map<String, String> tags)
+    {
+        prev.push(tags);
+    }
+
+    protected void handleExternalVolume(PhysicalPlanNode prev, String externalVolume)
+    {
+        prev.push(new ExternalVolume(externalVolume));
+    }
+
+    private TableType mapTableType(TableOrigin tableOrigin)
+    {
+        switch (tableOrigin)
+        {
+            case NATIVE: return null;
+            case ICEBERG: return new IcebergTableType();
+            default: throw new UnsupportedOperationException("Unsupported Table origin : " + tableOrigin);
+        }
+    }
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/SQLCreateVisitor.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/visitor/SQLCreateVisitor.java
@@ -18,7 +18,7 @@ import org.finos.legend.engine.persistence.components.logicalplan.LogicalPlanNod
 import org.finos.legend.engine.persistence.components.logicalplan.modifiers.IfNotExistsTableModifier;
 import org.finos.legend.engine.persistence.components.logicalplan.operations.Create;
 import org.finos.legend.engine.persistence.components.physicalplan.PhysicalPlanNode;
-import org.finos.legend.engine.persistence.components.relational.sqldom.schemaops.statements.CreateTable;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.schemaops.statements.CreateTable;
 import org.finos.legend.engine.persistence.components.transformer.LogicalPlanVisitor;
 import org.finos.legend.engine.persistence.components.transformer.VisitorContext;
 
@@ -37,6 +37,7 @@ public class SQLCreateVisitor implements LogicalPlanVisitor<Create>
         List<LogicalPlanNode> logicalPlanNodes = new ArrayList<>();
         logicalPlanNodes.add(current.dataset().datasetReference());
         logicalPlanNodes.add(current.dataset().schema());
+        current.dataset().datasetAdditionalProperties().ifPresent(logicalPlanNodes::add);
 
         if (current.ifNotExists())
         {

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/common/ExternalVolume.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/common/ExternalVolume.java
@@ -1,0 +1,33 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.common;
+
+import org.finos.legend.engine.persistence.components.relational.sqldom.SqlGen;
+
+public class ExternalVolume implements SqlGen
+{
+    private String externalVolume;
+
+    public ExternalVolume(String externalVolume)
+    {
+        this.externalVolume = externalVolume;
+    }
+
+    @Override
+    public void genSql(StringBuilder builder)
+    {
+        builder.append(String.format("with EXTERNAL_VOLUME = '%s'", externalVolume));
+    }
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/schemaops/statements/CreateTable.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/schemaops/statements/CreateTable.java
@@ -1,4 +1,4 @@
-// Copyright 2023 Goldman Sachs
+// Copyright 2022 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.persistence.components.relational.bigquery.sqldom.schemaops.statements;
+package org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.schemaops.statements;
 
+import org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.common.ExternalVolume;
+import org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.tabletypes.IcebergTableType;
 import org.finos.legend.engine.persistence.components.relational.sqldom.SqlDomException;
 import org.finos.legend.engine.persistence.components.relational.sqldom.SqlGen;
 import org.finos.legend.engine.persistence.components.relational.sqldom.common.Clause;
 import org.finos.legend.engine.persistence.components.relational.sqldom.constraints.table.ClusteringKeyConstraint;
-import org.finos.legend.engine.persistence.components.relational.sqldom.constraints.table.PartitionKeyConstraint;
 import org.finos.legend.engine.persistence.components.relational.sqldom.constraints.table.TableConstraint;
 import org.finos.legend.engine.persistence.components.relational.sqldom.modifiers.TableModifier;
 import org.finos.legend.engine.persistence.components.relational.sqldom.schemaops.Column;
@@ -27,23 +28,23 @@ import org.finos.legend.engine.persistence.components.relational.sqldom.schemaop
 import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.TableType;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils.CLOSING_PARENTHESIS;
-import static org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils.COMMA;
-import static org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils.EMPTY;
-import static org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils.OPEN_PARENTHESIS;
-import static org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils.WHITE_SPACE;
+import static org.finos.legend.engine.persistence.components.relational.sqldom.utils.SqlGenUtils.*;
 
 public class CreateTable implements DDLStatement
 {
     private Table table;
     private final List<TableModifier> modifiers; // dataset
+
+    private ExternalVolume externalVolume;
     private final List<Column> columns; // schema
     private final List<TableConstraint> tableConstraints; // table level
     private final List<TableType> types; // dataset
     private final List<ClusteringKeyConstraint> clusterKeys;
-    private final List<PartitionKeyConstraint> partitionKeys;
+    private Map<String, String> tags;
 
     public CreateTable()
     {
@@ -52,14 +53,12 @@ public class CreateTable implements DDLStatement
         this.tableConstraints = new ArrayList<>();
         this.types = new ArrayList<>();
         this.clusterKeys = new ArrayList<>();
-        this.partitionKeys = new ArrayList<>();
+        this.tags = new HashMap<>();
     }
 
     /*
      CREATE GENERIC PLAN:
      CREATE [TABLE TYPE] TABLE [IF NOT EXISTS] {FULLY_QUALIFIED_TABLE_NAME}( {COLUMNS}{CONSTRAINTS} )
-     PARTITION BY <>
-     CLUSTER BY <>
      */
     @Override
     public void genSql(StringBuilder builder) throws SqlDomException
@@ -79,24 +78,45 @@ public class CreateTable implements DDLStatement
         builder.append(WHITE_SPACE);
         table.genSqlWithoutAlias(builder);
 
+        // External Volume
+        if (externalVolume != null)
+        {
+            builder.append(WHITE_SPACE);
+            externalVolume.genSql(builder);
+            builder.append(WHITE_SPACE);
+        }
+
         // Columns + table constraints
         builder.append(OPEN_PARENTHESIS);
         SqlGen.genSqlList(builder, columns, EMPTY, COMMA);
         SqlGen.genSqlList(builder, tableConstraints, COMMA, COMMA);
         builder.append(CLOSING_PARENTHESIS);
 
-        // Partition Key Expression
-        if (!partitionKeys.isEmpty())
-        {
-            builder.append(WHITE_SPACE + Clause.PARTITION_BY.get() + WHITE_SPACE);
-            SqlGen.genSqlList(builder, partitionKeys, EMPTY, COMMA);
-        }
-
         // Clustering keys
         if (!clusterKeys.isEmpty())
         {
             builder.append(WHITE_SPACE + Clause.CLUSTER_BY.get() + WHITE_SPACE);
+            builder.append(OPEN_PARENTHESIS);
             SqlGen.genSqlList(builder, clusterKeys, EMPTY, COMMA);
+            builder.append(CLOSING_PARENTHESIS);
+        }
+
+        // Tags
+        if (!tags.isEmpty())
+        {
+            builder.append(WHITE_SPACE + "WITH TAG" + WHITE_SPACE);
+            builder.append(OPEN_PARENTHESIS);
+            int i = 0;
+            for (Map.Entry<String, String> tag: tags.entrySet())
+            {
+                builder.append(String.format("%s = '%s'", tag.getKey(), tag.getValue()));
+                if (i < (tags.size() - 1))
+                {
+                    builder.append(COMMA + WHITE_SPACE);
+                }
+                i++;
+            }
+            builder.append(CLOSING_PARENTHESIS);
         }
     }
 
@@ -128,9 +148,13 @@ public class CreateTable implements DDLStatement
         {
             clusterKeys.add((ClusteringKeyConstraint) node);
         }
-        else if (node instanceof PartitionKeyConstraint)
+        else if (node instanceof ExternalVolume)
         {
-            partitionKeys.add((PartitionKeyConstraint) node);
+            externalVolume = (ExternalVolume) node;
+        }
+        else if (node instanceof Map)
+        {
+            tags = (Map<String, String>) node;
         }
     }
 
@@ -144,9 +168,9 @@ public class CreateTable implements DDLStatement
         {
             throw new SqlDomException("Columns list is mandatory for Create Table Command");
         }
-        if (!partitionKeys.isEmpty() && partitionKeys.size() != 1)
+        if (types.stream().anyMatch(tableType -> tableType instanceof IcebergTableType) && externalVolume == null)
         {
-            throw new SqlDomException("Only one Partition Key expression is allowed for BigQuery Create Table Command");
+            throw new SqlDomException("External Volume is mandatory for Iceberg Table");
         }
     }
 }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/tabletypes/ExternalTableType.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/tabletypes/ExternalTableType.java
@@ -1,0 +1,27 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.tabletypes;
+
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.TableType;
+
+public class ExternalTableType extends TableType
+{
+
+    @Override
+    public void genSql(StringBuilder builder)
+    {
+        builder.append("EXTERNAL");
+    }
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/tabletypes/IcebergTableType.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sqldom/tabletypes/IcebergTableType.java
@@ -1,0 +1,27 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.relational.snowflake.sqldom.tabletypes;
+
+import org.finos.legend.engine.persistence.components.relational.sqldom.tabletypes.TableType;
+
+public class IcebergTableType extends TableType
+{
+
+    @Override
+    public void genSql(StringBuilder builder)
+    {
+        builder.append("ICEBERG");
+    }
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaMergeTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/test/java/org/finos/legend/engine/persistence/components/ingestmode/NontemporalDeltaMergeTest.java
@@ -55,6 +55,7 @@ public class NontemporalDeltaMergeTest extends NontemporalDeltaTest
             "VALUES (stage.\"id\",stage.\"name\",stage.\"amount\",stage.\"biz_date\",stage.\"digest\")";
 
         Assertions.assertEquals(AnsiTestArtifacts.expectedBaseTablePlusDigestCreateQuery, preActionsSqlList.get(0));
+        Assertions.assertEquals(AnsiTestArtifacts.expectedStagingTableWithDigestCreateQuery, preActionsSqlList.get(1));
         Assertions.assertEquals(mergeSql, milestoningSqlList.get(0));
 
         // Stats

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromAndThroughTestCases.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromAndThroughTestCases.java
@@ -40,6 +40,7 @@ public abstract class BitemporalDeltaSourceSpecifiesFromAndThroughTestCases exte
                 .relationalSink(getRelationalSink())
                 .executionTimestampClock(fixedClock_2000_01_01)
                 .collectStatistics(true)
+                .createStagingDataset(true)
                 .build();
         GeneratorResult operations = generator.generateOperations(scenario.getDatasets());
         verifyBitemporalDeltaBatchIdBasedNoDeleteIndNoDataSplits(operations);

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromTestCases.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/bitemporal/BitemporalDeltaSourceSpecifiesFromTestCases.java
@@ -38,6 +38,7 @@ public abstract class BitemporalDeltaSourceSpecifiesFromTestCases extends BaseTe
                 .relationalSink(getRelationalSink())
                 .executionTimestampClock(fixedClock_2000_01_01)
                 .collectStatistics(true)
+                .createStagingDataset(true)
                 .build();
         GeneratorResult operations = generator.generateOperations(scenario.getDatasets());
         verifyBitemporalDeltaBatchIdBasedNoDeleteIndNoDataSplits(operations);

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/nontemporal/AppendOnlyTestCases.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/nontemporal/AppendOnlyTestCases.java
@@ -44,6 +44,7 @@ public abstract class AppendOnlyTestCases extends BaseTest
                 .ingestMode(scenario.getIngestMode())
                 .relationalSink(getRelationalSink())
                 .collectStatistics(true)
+                .createStagingDataset(true)
                 .build();
         GeneratorResult operations = generator.generateOperations(scenario.getDatasets());
         verifyAppendOnlyAllowDuplicatesNoAuditing(operations);
@@ -57,6 +58,7 @@ public abstract class AppendOnlyTestCases extends BaseTest
                 .ingestMode(scenario.getIngestMode())
                 .relationalSink(getRelationalSink())
                 .collectStatistics(true)
+                .createStagingDataset(true)
                 .build();
         GeneratorResult operations = generator.generateOperations(scenario.getDatasets());
         verifyAppendOnlyAllowDuplicatesNoAuditing(operations);

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/nontemporal/NontemporalDeltaTestCases.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/nontemporal/NontemporalDeltaTestCases.java
@@ -43,6 +43,7 @@ public abstract class NontemporalDeltaTestCases extends BaseTest
             .ingestMode(testScenario.getIngestMode())
             .relationalSink(getRelationalSink())
             .collectStatistics(true)
+            .createStagingDataset(true)
             .build();
 
         GeneratorResult operations = generator.generateOperations(testScenario.getDatasets());

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/nontemporal/NontemporalSnapshotTestCases.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/nontemporal/NontemporalSnapshotTestCases.java
@@ -48,6 +48,7 @@ public abstract class NontemporalSnapshotTestCases extends BaseTest
             .ingestMode(testScenario.getIngestMode())
             .relationalSink(getRelationalSink())
             .collectStatistics(true)
+            .createStagingDataset(true)
             .build();
 
         GeneratorResult operations = generator.generateOperations(testScenario.getDatasets());

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/unitemporal/UnitmemporalDeltaBatchIdBasedTestCases.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/unitemporal/UnitmemporalDeltaBatchIdBasedTestCases.java
@@ -47,6 +47,7 @@ public abstract class UnitmemporalDeltaBatchIdBasedTestCases extends BaseTest
                 .relationalSink(getRelationalSink())
                 .executionTimestampClock(fixedClock_2000_01_01)
                 .collectStatistics(true)
+                .createStagingDataset(true)
                 .build();
         GeneratorResult operations = generator.generateOperations(scenario.getDatasets());
         verifyUnitemporalDeltaNoDeleteIndNoAuditing(operations);

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/unitemporal/UnitmemporalSnapshotBatchIdBasedTestCases.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/src/test/java/org/finos/legend/engine/persistence/components/testcases/ingestmode/unitemporal/UnitmemporalSnapshotBatchIdBasedTestCases.java
@@ -44,6 +44,7 @@ public abstract class UnitmemporalSnapshotBatchIdBasedTestCases extends BaseTest
                 .relationalSink(getRelationalSink())
                 .executionTimestampClock(fixedClock_2000_01_01)
                 .collectStatistics(true)
+                .createStagingDataset(true)
                 .build();
         GeneratorResult operations = generator.generateOperations(scenario.getDatasets());
         verifyUnitemporalSnapshotWithoutPartitionNoDataSplits(operations);


### PR DESCRIPTION
#### What type of PR is this?
- Improvement

#### What does this PR do / why is it needed ?
1) Config for enabling/disabling Table creation
2) API for extracting staging filters & related tests
3) Support for Dataset Additional Properties - table type/origin, ext-volume, tags etc
4) Support for Iceberg Table creation 
5) Support for Staging table creation in all milestoning schemes & related tests

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
NO
