### PR TITLE
Proper streaming of results + consume all composite buckets during aggregation

### DIFF
--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
@@ -266,7 +266,7 @@ function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(vs: 
     |
       // with group by fields, we need to wrap it on composite
       let composite = ^CompositeAggregation(
-        size = 100->literal(), // todo deal with pagination
+        size = [], // todo allow to set limit?
         sources = $groupByTdsESDetails->map(x | newMap(pair($x.name, ^CompositeAggregationSource( terms = ^TermsAggregation(field = $x.path()->literal(), missing_bucket = true->literal())))))
       );
       newMap(pair('groupByComposite', ^AggregationContainer(composite = $composite, aggregations = $aggregations)));
@@ -433,38 +433,41 @@ function <<access.private>> meta::external::store::elasticsearch::v7::pureToEs::
   compositeSources : Pair<String, CompositeAggregationSource>[*]
 ): Map<String, AggregationContainer>[1]
 {
-  let bucketSize = 500->literal();// up to 500 buckets for now
-
   let compositeSourcesToSort = $toSort->map(x | $compositeSources->filter(m | $m.first == $x.first));
-  let compositeSourcesNotToSort = $compositeSources->removeAll($compositeSourcesToSort);
-  let aggSorts = $toSort->filter(x | $x.first->in($compositeSources.first)->not());
 
-  let aggToComputeAllLevels = $aggSorts->map(s | $aggregations->map(m | $m->get($s.first)->map(v | pair($s.first, $v))));
+  if ($compositeSources->size() == 1,
+    |
+      let aggSorts = $toSort->filter(x | $x.first->in($compositeSources.first)->not());
+      let sorts = $toSort->map(s | pair(if($s->in($aggSorts)->not(), |'_key', |$s.first), $s.second));
 
-  let notSortedAgg = $compositeSourcesNotToSort->fold({x, agg |
-      let terms = $x.second.terms->toOne();
+      let terms = $compositeSources->toOne().second.terms->toOne();
       let sortedTerms = ^$terms(
-        size = $bucketSize,
+        size = [], // todo allow to set limit?
         missing_bucket = [],
-        order = ^TermsAggregationSortOrder(orderMap = $aggSorts->map(s | $s->newMap()))
-      );
-      pair($x.first, ^AggregationContainer(terms = $sortedTerms, aggregations = $agg->putAll($aggToComputeAllLevels)))->newMap();
-    },
-    $aggregations->orElse(newMap([]))
-  );
-
-  let termsAggregation = $compositeSourcesToSort->reverse()->fold({x, agg |
-      let sorts = $toSort->filter(s | $s->in($aggSorts) || $s.first == $x.first)->map(s | pair(if($s.first == $x.first, |'_key', |$s.first), $s.second));
-      let terms = $x.second.terms->toOne();
-      let sortedTerms = ^$terms(
-        size = $bucketSize, 
-        missing_bucket = [],
+        missing = [], /*todo handle null / missing*/
         order = ^TermsAggregationSortOrder(orderMap = $sorts->map(s | $s->newMap()))
       );
-      pair($x.first, ^AggregationContainer(terms = $sortedTerms, aggregations = $agg->putAll($aggToComputeAllLevels)))->newMap();
-    },
-    $notSortedAgg
-  );
+      let sortedContainer = ^AggregationContainer(terms = $sortedTerms, aggregations = $aggregations);
+      pair($compositeSources->toOne().first, $sortedContainer);
+    ,
+    |
+      assertEmpty($compositeSourcesToSort,
+        | 'No supported: multiple sort fields, where the source of these fields is mixed between aggregate fields and group by fields.  Either remove group by fields or aggregate fields from sort' 
+      );
+
+      let terms = $compositeSources.second.terms->map(x | ^MultiTermLookup(field = $x.field->toOne(), missing = [] /*todo handle null / missing*/));
+
+      let aggregationSorted = ^MultiTermsAggregation(
+        size = [], // todo allow to set limit?
+        terms = $terms->toOneMany(),
+        order = $toSort->map(x | $x->newMap())
+      );
+
+      let sortedContainer = ^AggregationContainer(multi_terms = $aggregationSorted, aggregations = $aggregations);
+      pair($compositeSources.first->joinStrings('~'), $sortedContainer);
+  )->newMap();
+
+
 }
 
 function meta::external::store::elasticsearch::v7::pureToEs::process(vs : ValueSpecification[1], req: State[1]): State[1]

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test.pure
@@ -39,7 +39,8 @@ function meta::external::store::elasticsearch::executionTest::test::collectTest(
     tag: String[1],
     extension: Extension[1],
     modelFile: String[1],
-    indexRecordRequest: Function<{String[1], Any[*]->Any[*]}>[1]
+    indexRecordRequest: Function<{String[1], Any[*]->Any[*]}>[1],
+    testFilter: Function<{FunctionDefinition<Any>[1] -> Boolean[1]}>[0..1]
   ): PureTestCollection[1]
 {
   meta::pure::test::collectParameterizedTests(
@@ -52,7 +53,7 @@ function meta::external::store::elasticsearch::executionTest::test::collectTest(
         indexRecordRequest = $indexRecordRequest
       ),
     [],
-    []
+    $testFilter
   );
 }
 

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_7.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_7.pure
@@ -110,22 +110,32 @@ function <<access.private>> meta::external::store::elasticsearch::executionTest:
   ];
 }
 
-function <<access.private>> meta::external::store::elasticsearch::executionTest::test::v7::collectTest(tag: String[1]): PureTestCollection[1]
+function <<access.private>> meta::external::store::elasticsearch::executionTest::test::v7::collectTest(tag: String[1], testFilter: Function<{FunctionDefinition<Any>[1] -> Boolean[1]}>[0..1]): PureTestCollection[1]
 {
   collectTest(
     $tag,
     elasticsearchV7Extension(),
     '/core_elasticsearch_execution_test/engineGrammar_7._pure_',
-    index_String_1__Any_MANY__Any_MANY_
+    index_String_1__Any_MANY__Any_MANY_,
+    $testFilter
   );
 }
 
 function <<test.TestCollection>> meta::external::store::elasticsearch::executionTest::test::v7::test_7_8_0(): PureTestCollection[1]
 {
-  '7.8.0'->collectTest();  
+  let testToIgnore = [
+    // start multi_term ignore - not supported until 7.12
+    meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleAggFields_multipleGroupByFields_TestConfig_1__Boolean_1_,
+    meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleAggFields_multipleGroupByFields_withRename_TestConfig_1__Boolean_1_,
+    meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleAggFields_TestConfig_1__Boolean_1_,
+    meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleAggFields_withRename_TestConfig_1__Boolean_1_
+    // end multi_term ignore - not supported until 7.12
+  ];
+
+  '7.8.0'->collectTest(x | $x->in($testToIgnore)->not());  
 }
 
 function <<test.TestCollection>> meta::external::store::elasticsearch::executionTest::test::v7::test_7_17_0(): PureTestCollection[1]
 {
-  '7.17.0'->collectTest();
+  '7.17.0'->collectTest([]);
 }

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_sort.pure
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation_sort.pure
@@ -29,6 +29,18 @@ meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sor
 
 function
   <<paramTest.Test>>
+  {doc.doc = 'Test sort on group by column on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnGroupByOneField_withRename(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->project([
+      col(y: TDSRow[1] | $y.getString('Director'), 'Dir'),
+      col(y: TDSRow[1] | $y.getInteger('Budget'), 'Budget')
+    ]
+  )->groupBy('Dir', agg('max', r | $r.getInteger('Budget'), agg | $agg->max()))->sort([asc('Dir')]));
+}
+
+function
+  <<paramTest.Test>>
   {doc.doc = 'Test sort on multiple group by columns on Elasticsearch'} 
 meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleGroupByFields(config:TestConfig[1]):Boolean[1]
 {
@@ -37,10 +49,36 @@ meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sor
 
 function
   <<paramTest.Test>>
+  {doc.doc = 'Test sort on multiple group by columns on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleGroupByFields_withRename(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->project([
+      col(y: TDSRow[1] | $y.getString('Director'), 'Dir'),
+      col(y: TDSRow[1] | $y.getString('MainActor.Name'), 'MainActor'),
+      col(y: TDSRow[1] | $y.getInteger('Budget'), 'Budget')
+    ]
+  )->groupBy(['Dir', 'MainActor'], agg('max', r | $r.getInteger('Budget'), agg | $agg->max()))->sort([desc('Dir'), asc('MainActor')]));
+}
+
+function
+  <<paramTest.Test>>
   {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
 meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleGroupByAndSingleAggFields(config:TestConfig[1]):Boolean[1]
 {
   $config->testTdsExpression(x|$x->groupBy('Director', agg('sum', r | $r.getInteger('Budget'), agg | $agg->sum()))->sort([asc('Director'), asc('sum')]));
+}
+
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleGroupByAndSingleAggFields_withRename(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->project([
+      col(y: TDSRow[1] | $y.getString('Director'), 'Dir'),
+      col(y: TDSRow[1] | $y.getInteger('Budget'), 'Budget')
+    ]
+  )->groupBy('Dir', agg('sum', r | $r.getInteger('Budget'), agg | $agg->sum()))->sort([asc('Dir'), asc('sum')]));
 }
 
 function
@@ -54,6 +92,18 @@ meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sor
 function
   <<paramTest.Test>>
   {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleGroupByAndSingleAggFields_aggFirst_withRename(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->project([
+      col(y: TDSRow[1] | $y.getInteger('Budget'), 'Bud'),
+      col(y: TDSRow[1] | $y.getString('Director'), 'Dir')
+    ]
+  )->groupBy('Dir', agg('max', r | $r.getInteger('Bud'), agg | $agg->max()))->sort([asc('max'), asc('Dir')]));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
 meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleGroupByAndMultipleAggFields(config:TestConfig[1]):Boolean[1]
 {
   $config->testTdsExpression(x|$x->groupBy('Budget', [agg('max', r | $r.getFloat('Revenue'), agg | $agg->max()), agg('min', r | $r.getFloat('Revenue'), agg | $agg->min())])->sort([asc('max'), asc('Budget'), asc('min')]));
@@ -62,31 +112,53 @@ meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sor
 function
   <<paramTest.Test>>
   {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
-meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleGroupByAndSingleAggFields(config:TestConfig[1]):Boolean[1]
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleGroupByAndMultipleAggFields_withRename(config:TestConfig[1]):Boolean[1]
 {
-  $config->testTdsExpression(x|$x->groupBy(['Director', 'MainActor.Name'], agg('max', r | $r.getInteger('Budget'), agg | $agg->max()))->sort([desc('Director'), asc('MainActor.Name'), asc('max')]));
+  $config->testTdsExpression(x|$x->project([
+      col(y: TDSRow[1] | $y.getInteger('Budget'), 'Bud'),
+      col(y: TDSRow[1] | $y.getFloat('Revenue'), 'Rev')
+    ]
+  )->groupBy('Bud', [agg('max', r | $r.getFloat('Rev'), agg | $agg->max()), agg('min', r | $r.getFloat('Rev'), agg | $agg->min())])->sort([asc('max'), asc('Bud'), asc('min')]));
 }
 
 function
   <<paramTest.Test>>
   {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
-meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleGroupByAndSingleAggFields_multipleGroupByFields(config:TestConfig[1]):Boolean[1]
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleAggFields_multipleGroupByFields(config:TestConfig[1]):Boolean[1]
 {
-  $config->testTdsExpression(x|$x->groupBy(['Director', 'MPAA'], agg('max', r | $r.getInteger('Budget'), agg | $agg->max()))->sort([desc('Director'), asc('max')]));
+  $config->testTdsExpression(x|$x->groupBy(['Director', 'MainActor.Name'], agg('max', r | $r.getInteger('Budget'), agg | $agg->max()))->sort([asc('max')]));
 }
 
 function
   <<paramTest.Test>>
   {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
-meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleGroupByAndMultipleAggFields(config:TestConfig[1]):Boolean[1]
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnSingleAggFields_multipleGroupByFields_withRename(config:TestConfig[1]):Boolean[1]
 {
-  $config->testTdsExpression(x|$x->groupBy(['Director', 'MainActor.Name', 'MPAA'], [ agg('sum', r | $r.getInteger('Budget'), agg | $agg->sum()), agg('max', r | $r.getInteger('Budget'), agg | $agg->max())])->sort([desc('Director'), asc('MainActor.Name'), asc('sum'), desc('max')]));
+  $config->testTdsExpression(x|$x->project([
+      col(y: TDSRow[1] | $y.getString('Director'), 'Dir'),
+      col(y: TDSRow[1] | $y.getString('MainActor.Name'), 'MainActor.Name'),
+      col(y: TDSRow[1] | $y.getInteger('Budget'), 'Budget')
+    ]
+  )->groupBy(['Dir', 'MainActor.Name'], agg('max', r | $r.getInteger('Budget'), agg | $agg->max()))->sort([asc('max')]));
 }
 
 function
   <<paramTest.Test>>
   {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
-meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleGroupByAndMultipleAggFields_aggFieldFirst(config:TestConfig[1]):Boolean[1]
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleAggFields(config:TestConfig[1]):Boolean[1]
 {
-  $config->testTdsExpression(x|$x->groupBy(['Director', 'MainActor.Name'], [ agg('sum', r | $r.getInteger('Budget'), agg | $agg->sum()), agg('max', r | $r.getInteger('Budget'), agg | $agg->max())])->sort([asc('sum'), desc('max'), desc('Director'), asc('MainActor.Name')]));
+  $config->testTdsExpression(x|$x->groupBy(['Director', 'MainActor.Name'], [ agg('sum', r | $r.getInteger('Budget'), agg | $agg->sum()), agg('max', r | $r.getInteger('Budget'), agg | $agg->max())])->sort([asc('sum'), desc('max')]));
+}
+
+function
+  <<paramTest.Test>>
+  {doc.doc = 'Test sort on group by and aggregate columns on Elasticsearch'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::sort::testSortOnMultipleAggFields_withRename(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->project([
+      col(y: TDSRow[1] | $y.getString('Director'), 'Dir'),
+      col(y: TDSRow[1] | $y.getString('MainActor.Name'), 'MainActor.Name'),
+      col(y: TDSRow[1] | $y.getInteger('Budget'), 'Budget')
+    ]
+  )->groupBy(['Dir', 'MainActor.Name'], [ agg('sum', r | $r.getInteger('Budget'), agg | $agg->sum()), agg('max', r | $r.getInteger('Budget'), agg | $agg->max())])->sort([asc('sum'), desc('max')]));
 }

--- a/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-protocol-utils/src/main/java/org/finos/legend/engine/protocol/store/elasticsearch/specification/utils/ExternalTaggedUnionMap.java
+++ b/legend-engine-xt-elasticsearch/legend-engine-xt-elasticsearch-protocol-utils/src/main/java/org/finos/legend/engine/protocol/store/elasticsearch/specification/utils/ExternalTaggedUnionMap.java
@@ -1,0 +1,26 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.protocol.store.elasticsearch.specification.utils;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.HashMap;
+
+@JsonSerialize(using = ExternalTaggedUnionSerializer.class)
+@JsonDeserialize(using = ExternalTaggedUnionDeserializer.class)
+public class ExternalTaggedUnionMap<K, V> extends HashMap<K, V>
+{
+}


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

- Proper streaming of result to prevent data from been fully in memory.  This is done using JsonParser and JsonPathFiler
- Composite Bucket aggregation - use search after to consume all buckets (data could change given no PIT is use)
- Changes to aggregation sorting to match streaming requirements 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
