### PR TITLE
Fix Lateral Joins in Snowflake

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/semiStructured/TestSemiStructuredFlattening.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/semiStructured/TestSemiStructuredFlattening.java
@@ -18,6 +18,8 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
 {
     private static final String snowflakeMapping = "flatten::mapping::SnowflakeMapping";
@@ -32,7 +34,7 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
                 "    (\n" +
                 "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n" +
                 "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\"), (\"Firm Other Name\", \"\")]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value::varchar as \"Firm Other Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join lateral flatten(input => \"root\".FIRM_DETAILS['otherNames']::varchar, outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1)\n" +
+                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value::varchar as \"Firm Other Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" inner join lateral flatten(input => \"root\".FIRM_DETAILS['otherNames']::varchar, outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\"\n" +
                 "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
                 "    )\n";
         String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n";
@@ -48,7 +50,7 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
                 "    (\n" +
                 "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Name, String, \"\", \"\")]\n" +
                 "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\"), (\"Firm Address Name\", \"\")]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value['name']::varchar as \"Firm Address Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1)\n" +
+                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value['name']::varchar as \"Firm Address Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" inner join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\"\n" +
                 "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
                 "    )\n";
         String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Name, String, \"\", \"\")]\n";
@@ -96,7 +98,7 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
                 "    (\n" +
                 "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Line 0 Line No, Integer, \"\", \"\")]\n" +
                 "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\"), (\"Firm Address Line 0 Line No\", \"\")]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value['lines'][0]['lineno'] as \"Firm Address Line 0 Line No\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1)\n" +
+                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value['lines'][0]['lineno'] as \"Firm Address Line 0 Line No\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" inner join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\"\n" +
                 "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
                 "    )\n";
         String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Line 0 Line No, Integer, \"\", \"\")]\n";
@@ -128,7 +130,7 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
                 "    (\n" +
                 "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\")]\n" +
                 "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\")]\n" +
-                "      sql = select distinct \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join lateral flatten(input => \"root\".FIRM_DETAILS['otherNames']::varchar, outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1) where \"ss_flatten_0\".value::varchar = 'A'\n" +
+                "      sql = select distinct \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" inner join lateral flatten(input => \"root\".FIRM_DETAILS['otherNames']::varchar, outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" where \"ss_flatten_0\".value::varchar = 'A'\n" +
                 "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
                 "    )\n";
         String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\")]\n";
@@ -138,17 +140,11 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
     @Test
     public void testSemiStructuredPrimitivePropertyFilteringInProject()
     {
-        String snowflakePlan = this.buildExecutionPlanString("flatten::semiStructuredPrimitivePropertyFilteringInProject__TabularDataSet_1_", snowflakeMapping, snowflakeRuntime);
-        String snowflakeExpected =
-                "    Relational\n" +
-                "    (\n" +
-                "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n" +
-                "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\"), (\"Firm Other Name\", \"\")]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value::varchar as \"Firm Other Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join lateral flatten(input => \"root\".FIRM_DETAILS['otherNames']::varchar, outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1 and \"ss_flatten_0\".value::varchar like 'A%')\n" +
-                "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
-                "    )\n";
-        String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n";
-        Assert.assertEquals(wrapPreAndFinallyExecutionSqlQuery(TDSType, snowflakeExpected), snowflakePlan);
+        Exception e = assertThrows(RuntimeException.class, () ->
+        {
+            this.buildExecutionPlanString("flatten::semiStructuredPrimitivePropertyFilteringInProject__TabularDataSet_1_", snowflakeMapping, snowflakeRuntime);
+        });
+        Assert.assertTrue(e.getMessage().contains("Filter in column projections is not supported. Use a Post Filter if filtering is necessary"));
     }
 
     @Test
@@ -163,17 +159,11 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
     @Test
     public void testSemiStructuredComplexPropertyFilteringInProject()
     {
-        String snowflakePlan = this.buildExecutionPlanString("flatten::semiStructuredComplexPropertyFilteringInProject__TabularDataSet_1_", snowflakeMapping, snowflakeRuntime);
-        String snowflakeExpected =
-                "    Relational\n" +
-                "    (\n" +
-                "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Name 1, String, \"\", \"\"), (Firm Address Name 2, String, \"\", \"\")]\n" +
-                "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\"), (\"Firm Address Name 1\", \"\"), (\"Firm Address Name 2\", \"\")]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"ss_flatten_0\".value['name']::varchar as \"Firm Address Name 1\", \"ss_flatten_1\".value['name']::varchar as \"Firm Address Name 2\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1 and \"ss_flatten_0\".value['name']::varchar = 'A') left outer join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_1\" on (1 = 1 and \"ss_flatten_1\".value['name']::varchar = 'B')\n" +
-                "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
-                "    )\n";
-        String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Name 1, String, \"\", \"\"), (Firm Address Name 2, String, \"\", \"\")]\n";
-        Assert.assertEquals(wrapPreAndFinallyExecutionSqlQuery(TDSType, snowflakeExpected), snowflakePlan);
+        Exception e = assertThrows(RuntimeException.class, () ->
+        {
+            this.buildExecutionPlanString("flatten::semiStructuredComplexPropertyFilteringInProject__TabularDataSet_1_", snowflakeMapping, snowflakeRuntime);
+        });
+        Assert.assertTrue(e.getMessage().contains("Filter in column projections is not supported. Use a Post Filter if filtering is necessary"));
     }
 
     @Test
@@ -185,7 +175,7 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
                 "    (\n" +
                 "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Names, String, \"\", \"\")]\n" +
                 "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\"), (\"Firm Address Names\", INT)]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"person_table_1\".aggCol as \"Firm Address Names\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join (select \"person_table_2\".ID as ID, listagg(\"ss_flatten_0\".value['name']::varchar, ';') as aggCol from PERSON_SCHEMA.PERSON_TABLE as \"person_table_2\" left outer join lateral flatten(input => \"person_table_2\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1) group by \"person_table_2\".ID) as \"person_table_1\" on (\"root\".ID = \"person_table_1\".ID)\n" +
+                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"person_table_1\".aggCol as \"Firm Address Names\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join (select \"person_table_2\".ID as ID, listagg(\"ss_flatten_0\".value['name']::varchar, ';') as aggCol from PERSON_SCHEMA.PERSON_TABLE as \"person_table_2\" inner join lateral flatten(input => \"person_table_2\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" group by \"person_table_2\".ID) as \"person_table_1\" on (\"root\".ID = \"person_table_1\".ID)\n" +
                 "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
                 "    )\n";
         String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Names, String, \"\", \"\")]\n";
@@ -201,7 +191,7 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
                 "    (\n" +
                 "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Line No Sum, Integer, \"\", \"\")]\n" +
                 "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Name\", \"\"), (\"Firm Address Line No Sum\", INT)]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"person_table_1\".aggCol as \"Firm Address Line No Sum\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join (select \"person_table_2\".ID as ID, sum(\"ss_flatten_1\".value['lineno']) as aggCol from PERSON_SCHEMA.PERSON_TABLE as \"person_table_2\" left outer join lateral flatten(input => \"person_table_2\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1) left outer join lateral flatten(input => \"ss_flatten_0\".value['lines'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_1\" on (1 = 1) group by \"person_table_2\".ID) as \"person_table_1\" on (\"root\".ID = \"person_table_1\".ID)\n" +
+                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"root\".FIRM_DETAILS['legalName']::varchar as \"Firm Name\", \"person_table_1\".aggCol as \"Firm Address Line No Sum\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join (select \"person_table_2\".ID as ID, sum(\"ss_flatten_1\".value['lineno']) as aggCol from PERSON_SCHEMA.PERSON_TABLE as \"person_table_2\" inner join lateral flatten(input => \"person_table_2\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" inner join lateral flatten(input => \"ss_flatten_0\".value['lines'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_1\" group by \"person_table_2\".ID) as \"person_table_1\" on (\"root\".ID = \"person_table_1\".ID)\n" +
                 "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
                 "    )\n";
         String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Name, String, \"\", \"\"), (Firm Address Line No Sum, Integer, \"\", \"\")]\n";
@@ -215,12 +205,12 @@ public class TestSemiStructuredFlattening extends AbstractTestSemiStructured
         String snowflakeExpected =
                 "    Relational\n" +
                 "    (\n" +
-                "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Address Name, String, \"\", \"\"), (Firm Address Line 0 No, Integer, \"\", \"\"), (Firm Address Name A, String, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n" +
-                "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Address Name\", \"\"), (\"Firm Address Line 0 No\", \"\"), (\"Firm Address Name A\", \"\"), (\"Firm Other Name\", \"\")]\n" +
-                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"ss_flatten_0\".value['name']::varchar as \"Firm Address Name\", \"ss_flatten_0\".value['lines'][0]['lineno'] as \"Firm Address Line 0 No\", \"ss_flatten_1\".value['name']::varchar as \"Firm Address Name A\", \"ss_flatten_2\".value::varchar as \"Firm Other Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" left outer join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" on (1 = 1) left outer join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_1\" on (1 = 1 and \"ss_flatten_1\".value['name']::varchar = 'A') left outer join lateral flatten(input => \"root\".FIRM_DETAILS['otherNames']::varchar, outer => true, recursive => false, mode => 'array') as \"ss_flatten_2\" on (1 = 1)\n" +
+                "      type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Address Name, String, \"\", \"\"), (Firm Address Line 0 No, Integer, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n" +
+                "      resultColumns = [(\"First Name\", VARCHAR(100)), (\"Firm Address Name\", \"\"), (\"Firm Address Line 0 No\", \"\"), (\"Firm Other Name\", \"\")]\n" +
+                "      sql = select \"root\".FIRSTNAME as \"First Name\", \"ss_flatten_0\".value['name']::varchar as \"Firm Address Name\", \"ss_flatten_0\".value['lines'][0]['lineno'] as \"Firm Address Line 0 No\", \"ss_flatten_1\".value::varchar as \"Firm Other Name\" from PERSON_SCHEMA.PERSON_TABLE as \"root\" inner join lateral flatten(input => \"root\".FIRM_DETAILS['addresses'], outer => true, recursive => false, mode => 'array') as \"ss_flatten_0\" inner join lateral flatten(input => \"root\".FIRM_DETAILS['otherNames']::varchar, outer => true, recursive => false, mode => 'array') as \"ss_flatten_1\"\n" +
                 "      connection = RelationalDatabaseConnection(type = \"Snowflake\")\n" +
                 "    )\n";
-        String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Address Name, String, \"\", \"\"), (Firm Address Line 0 No, Integer, \"\", \"\"), (Firm Address Name A, String, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n";
+        String TDSType = "  type = TDS[(First Name, String, VARCHAR(100), \"\"), (Firm Address Name, String, \"\", \"\"), (Firm Address Line 0 No, Integer, \"\", \"\"), (Firm Other Name, String, \"\", \"\")]\n";
         Assert.assertEquals(wrapPreAndFinallyExecutionSqlQuery(TDSType, snowflakeExpected), snowflakePlan);
 
         Assert.assertEquals("[PERSON_TABLE.FIRM_DETAILS <TableAliasColumn>, PERSON_TABLE.FIRSTNAME <TableAliasColumn>]", this.scanColumns("flatten::semiStructuredMultiFlatten__TabularDataSet_1_", snowflakeMapping));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/resources/org/finos/legend/engine/plan/execution/stores/relational/test/semiStructured/semiStructuredFlattening.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/resources/org/finos/legend/engine/plan/execution/stores/relational/test/semiStructured/semiStructuredFlattening.pure
@@ -281,7 +281,6 @@ function flatten::semiStructuredMultiFlatten(): TabularDataSet[1]
         col(x | $x.firstName, 'First Name'),
         col(x | $x.firm.addresses.name, 'Firm Address Name'),
         col(x | $x.firm.addresses->subType(@flatten::model::AddressWithLines).lines->at(0).lineno, 'Firm Address Line 0 No'),
-        col(x | $x.firm.addresses->filter(a |  $a.name == 'A').name, 'Firm Address Name A'),
         col(x | $x.firm.otherNames, 'Firm Other Name')
     ])
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -1,3 +1,4 @@
+import meta::relational::metamodel::join::*;
 import meta::relational::functions::sqlQueryToString::*;
 import meta::relational::functions::pureToSqlQuery::metamodel::*;
 import meta::relational::runtime::*;
@@ -69,6 +70,11 @@ Class meta::relational::functions::sqlQueryToString::DbConfig
    {
      assert($this.dbExtension.semiStructuredElementProcessor->isNotEmpty(), '[unsupported-api] Semi structured array element processing not supported for Database Type: ' + $this.dbType->toString());
      $this.dbExtension.semiStructuredElementProcessor->toOne()->eval($s, $sgc);
+   }: String[1];
+
+   lateralJoinProcessor(j:JoinTreeNode[1], dbConfig : DbConfig[1], format:Format[1], extensions:Extension[*])
+   {
+     if($this.dbExtension.lateralJoinProcessor->isEmpty(), |meta::relational::functions::sqlQueryToString::default::processJoinTreeNodeWithLateralJoinDefault($j, $dbConfig, $format, $extensions), |$this.dbExtension.lateralJoinProcessor->toOne()->eval($j, $dbConfig, $format, $extensions));
    }: String[1];
 
    joinStringsProcessor(j:JoinStrings[1], sgc:SqlGenerationContext[1])
@@ -197,6 +203,7 @@ Class meta::relational::functions::sqlQueryToString::DbExtension
    literalProcessor: meta::pure::metamodel::function::Function<{Type[1] -> LiteralProcessor[1]}>[1];
    windowColumnProcessor: meta::pure::metamodel::function::Function<{WindowColumn[1], SqlGenerationContext[1] -> String[1]}>[0..1];
    semiStructuredElementProcessor: meta::pure::metamodel::function::Function<{RelationalOperationElement[1], SqlGenerationContext[1] -> String[1]}>[0..1];
+   lateralJoinProcessor : meta::pure::metamodel::function::Function<{JoinTreeNode[1], DbConfig[1], Format[1], Extension[*] -> String[1]}>[0..1];
    joinStringsProcessor: meta::pure::metamodel::function::Function<{JoinStrings[1], SqlGenerationContext[1] -> String[1]}>[0..1];
    selectSQLQueryProcessor: meta::pure::metamodel::function::Function<{SelectSQLQuery[1], SqlGenerationContext[1], Boolean[1] -> String[1]}>[1];
    upsertSQLQueryProcessor: meta::pure::metamodel::function::Function<{UpsertSQLQuery[1], SqlGenerationContext[1] -> String[1]}>[0..1];

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/snowflake/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/snowflake/snowflakeExtension.pure
@@ -1,3 +1,4 @@
+import meta::relational::metamodel::join::*;
 import meta::pure::alloy::connections::*;
 import meta::relational::functions::sqlQueryToString::snowflake::*;
 import meta::relational::functions::sqlQueryToString::default::*;
@@ -31,6 +32,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
       literalProcessor = $literalProcessor,
       windowColumnProcessor = processWindowColumn_WindowColumn_1__SqlGenerationContext_1__String_1_,
       semiStructuredElementProcessor = processSemiStructuredElementForSnowflake_RelationalOperationElement_1__SqlGenerationContext_1__String_1_,
+      lateralJoinProcessor = processJoinTreeNodeWithLateralJoinForSnowflake_JoinTreeNode_1__DbConfig_1__Format_1__Extension_MANY__String_1_,
       joinStringsProcessor = processJoinStringsOperationForSnowflake_JoinStrings_1__SqlGenerationContext_1__String_1_,
       selectSQLQueryProcessor = processSelectSQLQueryForSnowflake_SelectSQLQuery_1__SqlGenerationContext_1__Boolean_1__String_1_,
       columnNameToIdentifier = columnNameToIdentifierDefault_String_1__DbConfig_1__String_1_,
@@ -287,6 +289,20 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
   if (eq($havingStr, ''), |'', | ' ' + $format.separator + 'having ' + $havingStr) +
   if ($s.orderBy->isEmpty(),|'',| ' ' + $format.separator + 'order by '+ $s.orderBy->processOrderBy($dbConfig, $format->indent(), $config, $extensions)->makeString(','))+
   + processLimit($s, $format, processTakeDefault_SelectSQLQuery_1__Format_1__String_1_, processSliceOrDropForSnowflake_SelectSQLQuery_1__Format_1__Any_1__String_1_);
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::processJoinTreeNodeWithLateralJoinForSnowflake(j:JoinTreeNode[1], dbConfig : DbConfig[1], format:Format[1], extensions:Extension[*]):String[1]
+{
+   // https://docs.snowflake.com/release-notes/bcr-bundles/2023_04/bcr-1057
+   assert(processOperation($j.join.operation, $dbConfig, $format->indent(), ^Config(), $extensions) == '1 = 1', | 'Filter in column projections is not supported. Use a Post Filter if filtering is necessary');
+
+   assert($j.alias.relationalElement->instanceOf(SemiStructuredArrayFlatten), | 'Lateral join in Snowflake should be followed by flatten operation');
+
+   // https://docs.snowflake.com/en/sql-reference/constructs/join-lateral#usage-notes
+   ' ' + $format.separator() + 'inner join lateral '
+   + $j.alias
+         ->map(a|^$a(name = '"' + $a.name + '"'))
+         ->toOne()->processOperation($dbConfig, $format->indent(), $extensions) + $format.separator();
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::processSliceOrDropForSnowflake(s:SelectSQLQuery[1], format:Format[1], size:Any[1]):String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -280,6 +280,15 @@ function meta::relational::functions::sqlQueryToString::default::processSelectCo
        );
 }
 
+function meta::relational::functions::sqlQueryToString::default::processJoinTreeNodeWithLateralJoinDefault(j:JoinTreeNode[1], dbConfig : DbConfig[1], format:Format[1], extensions:Extension[*]):String[1]
+{
+   if($j.joinType == JoinType.INNER,| ' ' + $format.separator() + 'inner join ',|if($j.joinType == JoinType.LEFT_OUTER,| ' ' + $format.separator() + 'left outer join ',| ' ' + $format.separator() + 'right outer join ')) + 'lateral '
+   + $j.alias
+       ->map(a|^$a(name = '"' + $a.name + '"')) //Not sure why this is necessary, but it's retained to keep the generated SQL the same as previously (and does no real harm)
+       ->toOne()->processOperation($dbConfig, $format->indent(), $extensions) + $format.separator()
+   + ' ' + 'on (' + processOperation($j.join.operation, $dbConfig, $format->indent(), ^Config(), $extensions) + ')';
+}
+
 function meta::relational::functions::sqlQueryToString::default::processJoinTreeNode(joinTreeNode:RelationalTreeNode[1], parent:TableAlias[0..1], dbConfig : DbConfig[1], format:Format[1], joinOrder:JoinType[*], extensions:Extension[*]):String[1]
 {
    let tableAlias = $joinTreeNode->match(
@@ -295,12 +304,14 @@ function meta::relational::functions::sqlQueryToString::default::processJoinTree
                                                 ->map(a|^$a(name = '"' + $a.name + '"')) //Not sure why this is necessary, but it's retained to keep the generated SQL the same as previously (and does no real harm)
                                                 ->processOperation($dbConfig, $format->indent(), $extensions),
                                        j:JoinTreeNode[1] |
-                                             if($j.joinType == JoinType.INNER,| ' ' + $format.separator() + 'inner join ',|if($j.joinType == JoinType.LEFT_OUTER,| ' ' + $format.separator() + 'left outer join ',| ' ' + $format.separator() + 'right outer join '))
-                                                + if ($j.lateral == true, | 'lateral ', | '')
-                                                + $j.alias
-                                                      ->map(a|^$a(name = '"' + $a.name + '"')) //Not sure why this is necessary, but it's retained to keep the generated SQL the same as previously (and does no real harm)
-                                                      ->toOne()->processOperation($dbConfig, $format->indent(), $extensions) + $format.separator()
-                                                + ' ' + 'on (' + processOperation($j.join.operation, $dbConfig, $format->indent(), ^Config(), $extensions) + ')';,
+                                             if($j.lateral == true,
+                                             | $dbConfig.lateralJoinProcessor($j, $dbConfig, $format, $extensions),
+                                             | if($j.joinType == JoinType.INNER,| ' ' + $format.separator() + 'inner join ',|if($j.joinType == JoinType.LEFT_OUTER,| ' ' + $format.separator() + 'left outer join ',| ' ' + $format.separator() + 'right outer join '))
+                                               + $j.alias
+                                                   ->map(a|^$a(name = '"' + $a.name + '"')) //Not sure why this is necessary, but it's retained to keep the generated SQL the same as previously (and does no real harm)
+                                                   ->toOne()->processOperation($dbConfig, $format->indent(), $extensions) + $format.separator()
+                                               + ' ' + 'on (' + processOperation($j.join.operation, $dbConfig, $format->indent(), ^Config(), $extensions) + ')';
+                                             );,
                                        a:Any[1] | ''
                                     ]
                                     );


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?

This PR fixes lateral join syntax in snowflake extension.

Previously, ON clause could be specified for a lateral table function (other than SQL UDTFs) or an outer lateral join to a table function (other than SQL UDTF).

Now, ON clause for a lateral table function (other than SQL UDTFs) or an outer lateral join to a table function (other than SQL UDTF) is not allowed.

This has been notified in Snowflake 2023_04 Behaviour Change Release

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
