### PR TITLE
Add pool connection metrics in synchronized housekeeper (2)

### DIFF
--- a/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/prometheus/MetricsHandler.java
+++ b/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/prometheus/MetricsHandler.java
@@ -67,6 +67,9 @@ public class MetricsHandler
     private static final Counter DATASTORE_SPEC_COUNT = Counter.build("legend_engine_datastore_spec_count", "Count datastore specifications").register(getMetricsRegistry());
     private static final Counter JAVA_COMPILATION_COUNT = Counter.build("legend_engine_java_compilation_count", "Count java compilations").register(getMetricsRegistry());
     private static final Gauge TEMP_FILE_COUNT = Gauge.build("legend_engine_temp_file_count", "Measure how many temporary files are being currently created").register(getMetricsRegistry());
+    private static final Gauge ACTIVE_CONNECTIONS =  Gauge.build("active_connections", "Active Connections in Pool").labelNames("poolName").register();
+    private static final Gauge TOTAL_CONNECTIONS = Gauge.build("total_connections", "total Connections in Pool").labelNames("poolName").register();
+    private static final Gauge IDLE_CONNECTIONS = Gauge.build("idle_connections", "Idle Connections in Pool").labelNames("poolName").register();
 
     public static CollectorRegistry getMetricsRegistry()
     {
@@ -110,6 +113,38 @@ public class MetricsHandler
     public static void incrementDatastoreSpecCount()
     {
         DATASTORE_SPEC_COUNT.inc();
+    }
+
+    public static void setActiveConnections(String poolName, double value)
+    {
+        ACTIVE_CONNECTIONS.labels(poolName).set(value);
+    }
+
+    public static void setTotalConnections(String poolName, double value)
+    {
+        TOTAL_CONNECTIONS.labels(poolName).set(value);
+    }
+
+    public static void setIdleConnections(String poolName, double value)
+    {
+        IDLE_CONNECTIONS.labels(poolName).set(value);
+    }
+
+    public static void setConnectionMetrics(String poolName, double activeCount, double totalCount, double idleCount)
+    {
+        if (!poolName.contains("DefaultH2"))
+        {
+            setActiveConnections(poolName, activeCount);
+            setTotalConnections(poolName, totalCount);
+            setIdleConnections(poolName, idleCount);
+        }
+    }
+
+    public static void removeConnectionMetrics(String poolName)
+    {
+        ACTIVE_CONNECTIONS.remove(poolName);
+        TOTAL_CONNECTIONS.remove(poolName);
+        IDLE_CONNECTIONS.remove(poolName);
     }
 
     public static void incrementJavaCompilationCount()

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
@@ -202,6 +202,14 @@
         </dependency>
         <!-- METRICS -->
 
+        <!-- PROMETHEUS -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- PROMETHEUS -->
+
         <!-- DRIVERS -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceWithStatistics.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceWithStatistics.java
@@ -146,6 +146,31 @@ public class DataSourceWithStatistics
         return this.dataSource != null && ((HikariDataSource) dataSource).getHikariPoolMXBean().getActiveConnections() > 0;
     }
 
+    public boolean hasTotalConnections()
+    {
+        return this.dataSource != null && ((HikariDataSource) dataSource).getHikariPoolMXBean().getTotalConnections() > 0;
+    }
+
+    public boolean hasIdleConnections()
+    {
+        return this.dataSource != null && ((HikariDataSource) dataSource).getHikariPoolMXBean().getIdleConnections()> 0;
+    }
+
+    public double getActiveConnections()
+    {
+        return hasActiveConnections() ? ((HikariDataSource) dataSource).getHikariPoolMXBean().getActiveConnections() : (long) 0.00;
+    }
+
+    public double getTotalConnections()
+    {
+        return hasTotalConnections() ? ((HikariDataSource) dataSource).getHikariPoolMXBean().getTotalConnections() : 0.00;
+    }
+
+    public double getIdleConnections()
+    {
+        return hasIdleConnections() ? ((HikariDataSource) dataSource).getHikariPoolMXBean().getIdleConnections() : 0.00;
+    }
+
     public Properties getProperties()
     {
         return ((HikariDataSource) this.dataSource).getDataSourceProperties();

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceWithStatistics.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceWithStatistics.java
@@ -153,7 +153,7 @@ public class DataSourceWithStatistics
 
     public boolean hasIdleConnections()
     {
-        return this.dataSource != null && ((HikariDataSource) dataSource).getHikariPoolMXBean().getIdleConnections()> 0;
+        return this.dataSource != null && ((HikariDataSource) dataSource).getHikariPoolMXBean().getIdleConnections() > 0;
     }
 
     public double getActiveConnections()


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
--> fixes metric accuracy for connection pools. 

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> creating metrics of active, total and idle connections for every active connection pool instance that is updated every 10 minutes 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> No 
