### PR TITLE
Persistence V2: Allow user to specify schema name under table field

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/antlr4/org/finos/legend/pure/grammar/from/antlr4/PersistenceRelationalParserGrammar.g4
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/antlr4/org/finos/legend/pure/grammar/from/antlr4/PersistenceRelationalParserGrammar.g4
@@ -30,7 +30,7 @@ definition:                                 (
                                             )*
                                             EOF
 ;
-table:                                      TARGET_RELATIONAL_TABLE COLON identifier SEMI_COLON
+table:                                      TARGET_RELATIONAL_TABLE COLON identifier (DOT identifier)? SEMI_COLON
 ;
 database:                                   TARGET_RELATIONAL_DATABASE COLON qualifiedName SEMI_COLON
 ;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/from/PersistenceRelationalParseTreeWalker.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/from/PersistenceRelationalParseTreeWalker.java
@@ -68,7 +68,7 @@ public class PersistenceRelationalParseTreeWalker
 
         // table
         PersistenceRelationalParserGrammar.TableContext tableContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.table(), "table", persistenceTarget.sourceInformation);
-        persistenceTarget.table = PureGrammarParserUtility.fromIdentifier(tableContext.identifier());
+        persistenceTarget.table = tableContext.identifier().size() == 1 ? PureGrammarParserUtility.fromIdentifier(tableContext.identifier(0)) : PureGrammarParserUtility.fromIdentifier(tableContext.identifier(0)) + "." + PureGrammarParserUtility.fromIdentifier(tableContext.identifier(1));
 
         // database
         PersistenceRelationalParserGrammar.DatabaseContext databaseContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.database(), "database", persistenceTarget.sourceInformation);

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/test/TestPersistenceRelationalGrammarRoundTrip.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/test/TestPersistenceRelationalGrammarRoundTrip.java
@@ -84,7 +84,7 @@ public class TestPersistenceRelationalGrammarRoundTrip extends TestGrammarRoundt
             "    ->\n" +
             "    Relational\n" +
             "    #{\n" +
-            "      table: TableB;\n" +
+            "      table: schemaA.TableB;\n" +
             "      database: test::Database;\n" +
             "      temporality: None\n" +
             "      {\n" +
@@ -126,7 +126,7 @@ public class TestPersistenceRelationalGrammarRoundTrip extends TestGrammarRoundt
             "    ->\n" +
             "    Relational\n" +
             "    #{\n" +
-            "      table: TableA;\n" +
+            "      table: someSchema.TableA;\n" +
             "      database: test::Database;\n" +
             "      temporality: Unitemporal\n" +
             "      {\n" +


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

This allows user to specify target table name with the schema name (optionally). Hence user can specify table name by either "TABLE_NAME" or "SCHEMA_NAME.TABLE_NAME"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
