### PR TITLE
Remove SingleStore dbtype to use MemSQL

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/DatabaseType.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/DatabaseType.java
@@ -17,5 +17,5 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.
 public enum DatabaseType
 {
     DB2, H2, MemSQL, Sybase, SybaseIQ, Composite, Postgres, SqlServer, Hive,
-    Snowflake, Presto, Trino, BigQuery, Redshift, Databricks, Spanner, Athena, SingleStore
+    Snowflake, Presto, Trino, BigQuery, Redshift, Databricks, Spanner, Athena
 }


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?
SingleStore Managed services will reuse MemSQL DatabaseType

#### Does this PR introduce a user-facing change?
No
