### PR TITLE
Resolve Variable Conflict in Java Generation

### DIFF
--- a/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -413,7 +413,37 @@ public class TestServiceRunner
         RuntimeException e1 = Assert.assertThrows(RuntimeException.class, () -> new SimpleM2MServiceRunnerForDateTimeSerialization("test::serializeInvalidDateTimeFormat__String_1_"));
         Assert.assertEquals("Assert failure at (resource:/platform/pure/basics/tests/assert.pure line:26 column:5), \"yyyy-MM-dd\"T\"HH:mmm:ss.SSSZ is not a valid dateTime format in SerializationConfig\"", e1.getMessage());
     }
-    
+
+    private static class SimpleM2MServiceRunnerForVarConflict extends AbstractServicePlanExecutor
+    {
+        SimpleM2MServiceRunnerForVarConflict(String function)
+        {
+            super("test::Service", buildPlanForFetchFunction("/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure", function), true);
+        }
+
+        @Override
+        public List<ServiceVariable> getServiceVariables()
+        {
+            return Collections.emptyList();
+        }
+    }
+
+    private void testServiceExecutionWithVarConflict(String fetchFunction, String expectedResult)
+    {
+        SimpleM2MServiceRunnerForVarConflict serviceRunner = new SimpleM2MServiceRunnerForVarConflict(fetchFunction);
+        ServiceRunnerInput serviceRunnerInputWithVarConflict = ServiceRunnerInput
+                .newInstance()
+                .withSerializationFormat(SerializationFormat.PURE);
+        String result = serviceRunner.run(serviceRunnerInputWithVarConflict);
+        Assert.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void SimpleM2MServiceRunnerWithVarConflict()
+    {
+        this.testServiceExecutionWithVarConflict("test::VarConflict__String_1_", "{\"settlementDates\":[\"2022-05-05\"]}");
+    }
+
     private static class EnumParamServiceRunner extends AbstractServicePlanExecutor
     {
         private String argName;

--- a/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure
+++ b/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/simpleM2MService.pure
@@ -47,6 +47,40 @@ Class test::targetPerson
   birthDate: DateTime[0..1];
 }
 
+Class test::SettlementDatesResult
+{
+  settlementDates: StrictDate[*];
+}
+
+Class test::ContractualTerms
+{
+  financialTerms: test::FinancialTerms[1];
+}
+
+Class test::FinancialTerms
+{
+}
+
+Class test::CommodityForward extends test::FinancialTerms
+{
+  financialLeg: test::CommodityLeg[1];
+}
+
+Class test::CommoditySwap extends test::FinancialTerms
+{
+  commoditySwapLegs: test::CommodityLeg[*];
+}
+
+Class test::CommodityLeg
+{
+  paymentDates: test::AbstractCommodityPaymentDates[1];
+}
+
+Class test::AbstractCommodityPaymentDates
+{
+  paymentDates: StrictDate[*];
+}
+
 function test::serializeDateTimeWithoutFormat(): String[1]
 {
    test::targetPerson.all()->graphFetch(#{test::targetPerson{birthDate}}#)->serialize(#{test::targetPerson{birthDate}}#)
@@ -112,6 +146,32 @@ function test::wheelsSum2(arg: Integer[1]): Integer[1]
   if($arg <= 1, |3, |4 + test::wheelsSum($arg));
 }
 
+function test::settlementDateFinancialTerms(t: test::FinancialTerms[1]): StrictDate[*]
+{
+  $t->match(
+    [
+      commoditySwap: test::CommoditySwap[1]|$commoditySwap->test::getPaymentDates(),
+      commodityForward: test::CommodityForward[1]|$commodityForward.financialLeg.paymentDates->test::getPaymentDatesFromAbstractPaymentDates(),
+      default: Any[1]|[]
+    ]
+  )
+}
+
+function test::getPaymentDates(s: test::CommoditySwap[1]): StrictDate[*]
+{
+  let paymentDates = $s.commoditySwapLegs->map( a|$a.paymentDates->toOne()->test::getPaymentDatesFromAbstractPaymentDates());
+}
+
+function test::getPaymentDatesFromAbstractPaymentDates(a: test::AbstractCommodityPaymentDates[1]): StrictDate[*]
+{
+  $a.paymentDates
+}
+
+
+function test::VarConflict(): String[1]
+{
+  test::SettlementDatesResult.all()->graphFetch(#{test::SettlementDatesResult{settlementDates}}#)->serialize(#{test::SettlementDatesResult{settlementDates}}#)
+}
 
 ###Mapping
 Mapping test::Map
@@ -136,6 +196,12 @@ Mapping test::Map
       age: $src.age,
       birthDate: $src.birthDate
    }
+
+  *test::SettlementDatesResult: Pure
+  {
+    ~src test::ContractualTerms
+    settlementDates: $src.financialTerms->test::settlementDateFinancialTerms()
+  }
 )
 
 ###Runtime
@@ -171,6 +237,14 @@ Runtime test::Runtime
          {
            class: test::sourcePerson;
            url: 'data:application/json,{"age":25, "birthDate":"2014-12-27T10:01:35.231-0500"}';
+         }
+       }#,
+      connection_4:
+       #{
+         JsonModelConnection
+         {
+           class: test::ContractualTerms;
+           url: 'data:application/json,{"financialTerms":[{"@type":"CommoditySwap","commoditySwapLegs":[{"@type":"CommodityLeg","paymentDates":{"@type":"CommodityPaymentDates","paymentDates":["2022-05-05"]}}]}]}';
          }
        }#
     ]

--- a/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -101,16 +101,38 @@ function meta::external::language::java::transform::getUnitConversionFunctionVar
 
 function <<access.private>> meta::external::language::java::transform::processVariableExpression(v: VariableExpression[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]
 {
-   print(if($debug.debug,|$debug.space+'VariableExpression: \''+($v.name)+'\'\n',|''));
-   let varName = if($v.name == 'this', |$v.name, |$conventions->identifier($v.name));
-   
-   if($conventions->isProvidedVariable($varName), 
+  print(if($debug.debug,|$debug.space+'VariableExpression: \''+($v.name)+'\'\n',|''));
+  let varName = if($v.name == 'this', |$v.name, |$conventions->identifier($v.name));
+
+  if($conventions->isProvidedVariable($varName) && validateVarType($conventions->getProvidedVariable($varName), $conventions->pureTypeToJavaType($v.genericType, $v.multiplicity), $conventions),
       | $conventions->getProvidedVariable($varName),
       {|
-         let type = $conventions->pureTypeToJavaType($v.genericType, $v.multiplicity);
-         j_variable($type, $varName)->debugAndReturn($debug);
+        let type = $conventions->pureTypeToJavaType($v.genericType, $v.multiplicity);
+        j_variable($type, $varName)->debugAndReturn($debug);
       }
-   );
+    );
+}
+
+function <<access.private>> meta::external::language::java::transform::extractTypeName(type:meta::external::language::java::metamodel::Type[1]):String[*]
+{
+  if($type->instanceOf(meta::external::language::java::metamodel::ParameterizedType), 
+      | let clazz = $type->cast(@meta::external::language::java::metamodel::ParameterizedType);
+        if($clazz.typeArguments->at(0)->instanceOf(meta::external::language::java::metamodel::ParameterizedType),
+            | $clazz.typeArguments->at(0)->cast(@meta::external::language::java::metamodel::ParameterizedType).typeArguments->cast(@meta::external::language::java::metamodel::Class).simpleName,
+            | $clazz.typeArguments->cast(@meta::external::language::java::metamodel::Class).simpleName;
+          );,
+      | if($type->instanceOf(meta::external::language::java::metamodel::PrimitiveType), 
+            | $type->cast(@meta::external::language::java::metamodel::PrimitiveType).simpleName,
+            | $type->cast(@meta::external::language::java::metamodel::Class).simpleName
+          )
+    )
+}
+
+function meta::external::language::java::transform::validateVarType(v:Code[1], t:meta::external::language::java::metamodel::Type[1], conventions: Conventions[1]): Boolean[1]
+{
+  if($t->instanceOf(meta::external::language::java::metamodel::PrimitiveType) || $t->instanceOf(meta::external::language::java::metamodel::Class),
+      | equalIgnoreCase(extractTypeName($v.type)->toOne(), extractTypeName($t)->toOne()),
+      | true)
 }
 
 function <<access.private>> meta::external::language::java::transform::processVariableExpressionAsParameter(v: VariableExpression[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
Multiple uses of the same function for different paths in the same "match" statement with common variable names causes a conflict. Change is to compare the type and not just name to reuse the variables.

#### Does this PR introduce a user-facing change?
No
