### PR TITLE
Update set Connection Metrics to exclude LocalH2 connection pools

### DIFF
--- a/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/prometheus/MetricsHandler.java
+++ b/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/prometheus/MetricsHandler.java
@@ -132,7 +132,7 @@ public class MetricsHandler
 
     public static void setConnectionMetrics(String poolName, double activeCount, double totalCount, double idleCount)
     {
-        if (!poolName.contains("DefaultH2"))
+        if (!poolName.contains("DefaultH2") && !poolName.contains("LocalH2"))
         {
             setActiveConnections(poolName, activeCount);
             setTotalConnections(poolName, totalCount);


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
--> exclude another instance of H2 connections from pool metrics 

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2042 

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> No 
