### PR TITLE
Add Iceberg test support

### DIFF
--- a/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/pom.xml
+++ b/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xts-iceberg</artifactId>
+        <version>4.20.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Legend Engine - XT - Table Format - Iceberg - Test Support</name>
+    <artifactId>legend-engine-xt-iceberg-test-support</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-core</artifactId>
+            <version>${iceberg.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-api</artifactId>
+            <version>${iceberg.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+        </dependency>
+
+        <!-- S3 - iceberg storage-->
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-aws</artifactId>
+            <version>${iceberg.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+        <!-- S3 - iceberg storage-->
+
+        <!-- Trino - iceberg SQL execution engine-->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>trino</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-jdbc</artifactId>
+            <version>422</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Trino - iceberg SQL execution engine-->
+
+        <!-- Postgres - iceberg catalog -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <!-- Postgres - iceberg catalog -->
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/src/main/java/org/finos/legend/tableformat/iceberg/testsupport/Icebox.java
+++ b/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/src/main/java/org/finos/legend/tableformat/iceberg/testsupport/Icebox.java
@@ -1,0 +1,225 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.tableformat.iceberg.testsupport;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.junit.Assert;
+import org.junit.runner.Description;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.FailureDetectingExternalResource;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.TrinoContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+public class Icebox extends FailureDetectingExternalResource implements AutoCloseable
+{
+    private static final String LOCALSTACK_DOCKER_IMAGE = "localstack/localstack:2.2.0";
+    private static final String TRINO_DOCKER_IMAGE = "trinodb/trino:422";
+    private static final String POSTGRES_DOCKER_IMAGE = "postgres:12.15";
+
+    private Network network;
+    private LocalStackContainer localstack;
+    private PostgreSQLContainer<?> postgres;
+    private TrinoContainer trino;
+    private JdbcCatalog catalog;
+    private S3Client s3;
+    private Path trinoFile;
+
+    public Icebox()
+    {
+
+    }
+
+    public String getBucketName()
+    {
+        return "iceberg";
+    }
+
+    public String getBucketLocation()
+    {
+        return "s3://" + this.getBucketName() + "/";
+    }
+
+    public TrinoContainer getTrino()
+    {
+        return this.trino;
+    }
+
+    public Catalog getCatalog()
+    {
+        return this.catalog;
+    }
+
+    public S3Client getS3()
+    {
+        return this.s3;
+    }
+
+    public void start() throws Exception
+    {
+        Assert.assertTrue("Docker environment not properly setup", DockerClientFactory.instance().isDockerAvailable());
+
+        this.trinoFile = Files.createTempFile("trino_catalog", ".properties");
+        this.network = Network.newNetwork();
+        this.initLocalStack();
+        this.intPostgres();
+
+        Startables.deepStart(this.localstack, this.postgres).join();
+
+        this.initS3();
+        this.initIcebergCatalog();
+
+        this.initTrino();
+        this.trino.start();
+    }
+
+    @Override
+    protected void starting(Description description)
+    {
+        try
+        {
+            this.start();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(description.toString() + " - failed to start", e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        try (
+                Network ignored = this.network;
+                LocalStackContainer ignored1 = this.localstack;
+                PostgreSQLContainer<?> ignored2 = this.postgres;
+                TrinoContainer ignored3 = this.trino;
+                JdbcCatalog ignored4 = this.catalog;
+                S3Client ignored5 = this.s3
+        )
+        {
+            Files.deleteIfExists(this.trinoFile);
+        }
+    }
+
+    private void initLocalStack()
+    {
+        this.localstack = new LocalStackContainer(DockerImageName.parse(LOCALSTACK_DOCKER_IMAGE))
+                .withServices(LocalStackContainer.Service.S3)
+                .withNetwork(this.network)
+                .withNetworkAliases("s3_aws");
+    }
+
+    private void initTrino() throws Exception
+    {
+        this.prepareTrinoIcebergCatalog();
+
+        this.trino = new TrinoContainer(TRINO_DOCKER_IMAGE)
+                .withCopyFileToContainer(MountableFile.forHostPath(this.trinoFile), "/etc/trino/catalog/iceberg.properties")
+                .withNetwork(this.network)
+                .withNetworkAliases("trino");
+    }
+
+    public String getTrinoConnectorName()
+    {
+        return this.catalog.name();
+    }
+
+    private void prepareTrinoIcebergCatalog() throws Exception
+    {
+        try (
+                OutputStream os = Files.newOutputStream(this.trinoFile)
+        )
+        {
+            Properties props = new Properties();
+
+            props.setProperty("connector.name", getTrinoConnectorName());
+
+            props.setProperty("fs.native-s3.enabled", "true");
+
+            props.setProperty("s3.aws-secret-key", this.localstack.getSecretKey());
+            props.setProperty("s3.aws-access-key", this.localstack.getAccessKey());
+            props.setProperty("s3.region", this.localstack.getRegion());
+            props.setProperty("s3.endpoint", "http://" + this.localstack.getContainerInfo().getNetworkSettings().getNetworks().entrySet().iterator().next().getValue().getIpAddress() + ":4566/");
+
+            props.setProperty("iceberg.catalog.type", "jdbc");
+
+            props.setProperty("iceberg.jdbc-catalog.catalog-name", this.catalog.name());
+            props.setProperty("iceberg.jdbc-catalog.connection-url", "jdbc:postgresql://postgres:5432/test?loggerLevel=OFF");
+            props.setProperty("iceberg.jdbc-catalog.default-warehouse-dir", getBucketLocation());
+            props.setProperty("iceberg.jdbc-catalog.connection-password", this.postgres.getPassword());
+            props.setProperty("iceberg.jdbc-catalog.connection-user", this.postgres.getUsername());
+            props.setProperty("iceberg.jdbc-catalog.driver-class", "org.postgresql.Driver");
+
+            props.store(os, "Iceberg Trino Properties");
+        }
+    }
+
+    private void intPostgres()
+    {
+        this.postgres = new PostgreSQLContainer<>(POSTGRES_DOCKER_IMAGE)
+                .withNetwork(this.network)
+                .withNetworkAliases("postgres");
+    }
+
+    private void initS3()
+    {
+        this.s3 = S3Client
+                .builder()
+                .endpointOverride(this.localstack.getEndpoint())
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(this.localstack.getAccessKey(), this.localstack.getSecretKey())
+                        )
+                )
+                .region(Region.of(this.localstack.getRegion()))
+                .build();
+
+        this.s3.createBucket(CreateBucketRequest.builder().bucket(getBucketName()).build());
+    }
+
+    private void initIcebergCatalog() throws Exception
+    {
+        Class.forName(this.postgres.getDriverClassName()); // ensure JDBC driver is at runtime classpath
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CatalogProperties.CATALOG_IMPL, JdbcCatalog.class.getName());
+        properties.put(CatalogProperties.URI, this.postgres.getJdbcUrl());
+        properties.put(JdbcCatalog.PROPERTY_PREFIX + "user", this.postgres.getUsername());
+        properties.put(JdbcCatalog.PROPERTY_PREFIX + "password", this.postgres.getPassword());
+        properties.put(CatalogProperties.WAREHOUSE_LOCATION, getBucketLocation());
+
+        this.catalog = new JdbcCatalog(x -> new S3FileIO(() -> this.s3), null, true);
+        this.catalog.initialize(getBucketName(), properties);
+    }
+}

--- a/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/src/test/java/org/finos/legend/tableformat/iceberg/testsupport/IceboxTest.java
+++ b/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/src/test/java/org/finos/legend/tableformat/iceberg/testsupport/IceboxTest.java
@@ -1,0 +1,91 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.tableformat.iceberg.testsupport;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+
+public class IceboxTest
+{
+    @ClassRule
+    public static final Icebox ICEBOX = new Icebox();
+
+    @Test
+    public void testCatalogUpdatedThruTrino() throws Exception
+    {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+
+        Catalog catalog = ICEBOX.getCatalog();
+        SupportsNamespaces supportsNamespaces = (SupportsNamespaces) catalog;
+
+        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                .bucket(ICEBOX.getBucketName())
+                .build();
+
+        Assert.assertEquals("Bucket should be empty", 0, ICEBOX.getS3().listObjectsV2(listObjectsV2Request).contents().size());
+
+        Namespace namespace = Namespace.of("example_s3_schema");
+        TableIdentifier table1 = TableIdentifier.of(namespace, "sample_table_1");
+        TableIdentifier table2 = TableIdentifier.of(namespace, "sample_table_2");
+
+        Assert.assertFalse("Namespace should not exists", supportsNamespaces.namespaceExists(namespace));
+        Assert.assertFalse("Table1 should not exist", catalog.tableExists(table1));
+        Assert.assertFalse("Table2 should not exist", catalog.tableExists(table2));
+
+        try (Connection connection = ICEBOX.getTrino().createConnection();
+             Statement statement = connection.createStatement())
+        {
+            // create an Iceberg namespace / schema
+            statement.execute("CREATE SCHEMA " + ICEBOX.getTrinoConnectorName() + "." + namespace + " WITH (location = '" + ICEBOX.getBucketLocation() + "example_s3_schema/')");
+
+            // create an Iceberg table inside namespace
+            statement.execute("CREATE TABLE "  + ICEBOX.getTrinoConnectorName() +  "." + table1 + " (c1 INTEGER)");
+            statement.execute("insert into "   + ICEBOX.getTrinoConnectorName() +  "." + table1 + " values (1), (2), (3)");
+
+            // create an Iceberg table inside namespace
+            statement.execute("CREATE TABLE "  + ICEBOX.getTrinoConnectorName() +  "." + table2 + " (c1 VARCHAR(10))");
+            statement.execute("insert into "   + ICEBOX.getTrinoConnectorName() +  "." + table2 + " values ('hello'), ('world'), ('!')");
+        }
+
+        Assert.assertTrue("Namespace should have been created", supportsNamespaces.namespaceExists(namespace));
+
+        Assert.assertTrue("Table1 should have been created", catalog.tableExists(table1));
+        Assert.assertTrue("Table2 should have been created", catalog.tableExists(table2));
+
+        ListObjectsV2Response listObjectsV2 = ICEBOX.getS3().listObjectsV2(listObjectsV2Request);
+        Assert.assertTrue("S3 iceberg content should exits", listObjectsV2.contents().size() > 0);
+
+//        for(S3Object s3Object : listObjectsV2.contents())
+//        {
+//            System.out.println(s3Object.key() + " - " + s3Object.size());
+//        }
+//
+//        Table table1LLoaded = catalog.loadTable(table1);
+//        String tableS3Key = table1LLoaded.location().substring(ICEBOX.getBucketLocation().length());
+//        String snapshotManifestS3Key = table1LLoaded.currentSnapshot().manifestListLocation().substring(ICEBOX.getBucketLocation().length());
+    }
+}

--- a/legend-engine-xts-iceberg/pom.xml
+++ b/legend-engine-xts-iceberg/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2022 Goldman Sachs
+ Copyright 2023 Goldman Sachs
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,9 +30,11 @@
 
     <properties>
         <top.project>${project.basedir}/../</top.project>
+        <iceberg.version>1.3.0</iceberg.version>
     </properties>
 
     <modules>
         <module>legend-engine-xt-iceberg-pure</module>
+        <module>legend-engine-xt-iceberg-test-support</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <build-helper.maven.plugin.version>3.2.0</build-helper.maven.plugin.version>
         <dockerfile.maven.plugin.version>1.4.13</dockerfile.maven.plugin.version>
         <maven.plugin.puppycrawl.version>8.25</maven.plugin.puppycrawl.version>
-        <testcontainers.version>1.17.6</testcontainers.version>
+        <testcontainers.version>1.18.3</testcontainers.version>
     </properties>
 
     <scm>
@@ -2648,23 +2648,20 @@
             <!-- Test Containers -->
             <dependency>
                 <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>jdbc</artifactId>
-                <version>${testcontainers.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>mssqlserver</artifactId>
-                <version>${testcontainers.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${testcontainers.version}</version>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>3.3.0</version>
             </dependency>
             <!-- Test Containers -->
 


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

This adds a class that to help test Iceberg integration.  The class, Icebox, uses Testcontainer to create the required resources to test these:
- LocalStack container for Iceberg storage on S3 
- Postgres container used for an Iceberg JDBC Catalog
- Trino container used as SQL engine to read/write Iceberg tables

The Icebox allow to interact with the Iceberg files thru any of the axis:
- Using the Catalog to navigate namespaces, tables, and snapshots
- Using SQL thru Trino
- Direct inspection of S3 objects 