### PR TITLE
Allow routing of root router unions in m2m graphfetch

### DIFF
--- a/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
+++ b/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
@@ -192,6 +192,8 @@ function meta::pure::mapping::modelToModel::modelToModelConnectionToString(c:Con
 // Strategic in memory graph fetch flow
 
 ###Pure
+import meta::pure::router::metamodel::clustering::*;
+import meta::pure::router::platform::metamodel::clustering::*;
 import meta::pure::dataQuality::*;
 import meta::pure::executionPlan::*;
 import meta::pure::executionPlan::toString::*;
@@ -497,7 +499,11 @@ function <<access.private>> meta::pure::mapping::modelToModel::graphFetch::execu
                     );
    let routed     = $newFunction->routeFunction($mcc.mappings->at(0), $newRuntime, $exeCtx, $extensions, $debug);
    let routedFn   = $routed->evaluateAndDeactivate();
-   let clusters   = $routedFn.expressionSequence->evaluateAndDeactivate()->cast(@StoreMappingClusteredValueSpecification)->map(c | $c->updateClusterWithChainProcessingInfo($ext, $setsProcessed));
+   let clusters   = $routedFn.expressionSequence->evaluateAndDeactivate()->match([
+     sm: StoreMappingClusteredValueSpecification[*] | $sm->map(c | $c->updateClusterWithChainProcessingInfo($ext, $setsProcessed)),
+     p : PlatformClusteredValueSpecification[1]     | $p,
+     c : ClusteredValueSpecification[*]             | fail('Unsupported model chain connection element %s in graph fetch execution', [$c]); $c;
+   ]);
 
    let fnParams   = $newFunction->stubFuncParameters();
    let varsFromXStoreProperties = $populatedXStorePropertiesInScope->map(prop | let varName = $prop->propertyToVarName();

--- a/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
+++ b/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
@@ -502,7 +502,7 @@ function <<access.private>> meta::pure::mapping::modelToModel::graphFetch::execu
    let clusters   = $routedFn.expressionSequence->evaluateAndDeactivate()->match([
      sm: StoreMappingClusteredValueSpecification[*] | $sm->map(c | $c->updateClusterWithChainProcessingInfo($ext, $setsProcessed)),
      p : PlatformClusteredValueSpecification[1]     | $p,
-     c : ClusteredValueSpecification[*]             | fail('Unsupported model chain connection element %s in graph fetch execution', [$c]); $c;
+     c : ClusteredValueSpecification[*]             | fail('Unsupported model chain connection element %s in graph fetch execution', [$c->type()->elementToPath()]); $c;
    ]);
 
    let fnParams   = $newFunction->stubFuncParameters();

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/tests/union/testUnionRootLevel_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/tests/union/testUnionRootLevel_relational.pure
@@ -530,3 +530,226 @@ function <<test.ToFix, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::re
       $result
    );
 }
+
+
+// ================================================================================
+//        Special Union M2M2R
+// Tests M2M2R with a Relational special union
+// ==================================================================================
+
+###Relational
+Database meta::relational::graphFetch::tests::union::rootLevel::BasicDB 
+(
+  Schema TEST_SCHEMA
+  (
+    Table PEOPLE
+    (
+      ID INT PRIMARY KEY,
+      NAME VARCHAR(200),
+      AGE INT,
+      FIRM_ID INT
+    )
+    Table PEOPLE2
+    (
+      ID INT PRIMARY KEY,
+      NAME VARCHAR(200),
+      AGE INT,
+      FIRM_ID INT
+    )
+
+    Table FIRMS
+    (
+      ID INT PRIMARY KEY,
+      NAME VARCHAR(200)
+    )
+  )
+
+  Join FirmEmployees(TEST_SCHEMA.PEOPLE.FIRM_ID = TEST_SCHEMA.FIRMS.ID)
+  Join FirmEmployees2(TEST_SCHEMA.PEOPLE2.FIRM_ID = TEST_SCHEMA.FIRMS.ID)
+)
+
+
+###Pure
+import meta::relational::graphFetch::tests::union::rootLevel::*;
+
+Class meta::relational::graphFetch::tests::union::rootLevel::Person 
+{
+  name: String[1];
+  age: Integer[1];
+}
+
+Class meta::relational::graphFetch::tests::union::rootLevel::Firm 
+{
+  name: String[1];
+} 
+
+Class meta::relational::graphFetch::tests::union::rootLevel::VettedEmployer 
+{
+  name: String[1];
+}
+
+Class meta::relational::graphFetch::tests::union::rootLevel::RestrictedPerson
+{
+  name: String[1];
+}
+
+Association meta::relational::graphFetch::tests::union::rootLevel::Employment 
+{
+  firm: Firm[1];
+  employees: Person[*];
+}
+
+Association meta::relational::graphFetch::tests::union::rootLevel::BadEmployers
+{
+  firm: VettedEmployer[1];
+  employees: RestrictedPerson[*];
+}
+
+
+###Mapping
+import meta::relational::graphFetch::tests::union::rootLevel::*;
+
+Mapping meta::relational::graphFetch::tests::union::rootLevel::FirmsAndEmployees_Relational
+(
+  *Person: Operation
+  {                                              
+    meta::pure::router::operations::special_union_OperationSetImplementation_1__SetImplementation_MANY_(p1, p2)   
+  }
+
+  Person[p1]: Relational {
+    name: [BasicDB]TEST_SCHEMA.PEOPLE.NAME,
+    age: [BasicDB]TEST_SCHEMA.PEOPLE.AGE,
+
+    firm: [BasicDB]@FirmEmployees
+  }
+
+  Person[p2]: Relational {
+    name: [BasicDB]TEST_SCHEMA.PEOPLE2.NAME,
+    age: [BasicDB]TEST_SCHEMA.PEOPLE2.AGE,
+
+    firm: [BasicDB]@FirmEmployees2
+  }
+
+
+  *Firm: Relational {
+    name: [BasicDB]TEST_SCHEMA.FIRMS.NAME
+  }
+)
+
+Mapping meta::relational::graphFetch::tests::union::rootLevel::FirmsAndEmployees_M2M
+(
+  *meta::relational::graphFetch::tests::union::rootLevel::VettedEmployer: Pure
+  {
+    ~src meta::relational::graphFetch::tests::union::rootLevel::Firm
+    
+    name: $src.name
+  }
+
+  *meta::relational::graphFetch::tests::union::rootLevel::RestrictedPerson: Pure
+  {
+    ~src meta::relational::graphFetch::tests::union::rootLevel::Person
+    
+    name: $src.name,
+    firm: $src.firm
+  }
+)
+
+###Pure
+import meta::pure::executionPlan::toString::*;
+import meta::pure::graphFetch::execution::*;
+import meta::pure::mapping::*;
+import meta::pure::mapping::modelToModel::*;
+import meta::relational::runtime::*;
+import meta::pure::runtime::*;
+import meta::pure::executionPlan::profiles::*;
+import meta::relational::graphFetch::tests::union::rootLevel::*;
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+meta::relational::graphFetch::tests::union::rootLevel::testSpecialUnion_m2m2r(): Boolean[1]
+{
+  let tree = #{
+    RestrictedPerson {
+      name,
+      firm {
+        name
+      }
+    }
+  }#;
+
+  let mapping = FirmsAndEmployees_M2M;
+  let runtime = ^EngineRuntime(
+    mappings = $mapping,
+    connections = [
+      ^meta::pure::alloy::connections::RelationalDatabaseConnection(
+        type = DatabaseType.H2,
+        datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(
+          testDataSetupCsv = 
+            'TEST_SCHEMA\n' +
+            'PEOPLE\n' +
+            'ID,NAME,AGE,FIRM_ID\n' +
+            '0,Alice,20,0\n' +
+            '1,Bob,22,2\n' +
+            '2,Charlie,24,1\n' +
+            '---\n' +
+            'TEST_SCHEMA\n' +
+            'PEOPLE2\n' +
+            'ID,NAME,AGE,FIRM_ID\n' +
+            '3,Dan,26,2\n' +
+            '4,Eve,28,1\n' +
+            '5,Frank,30,1\n' +
+            '---\n' +
+            'TEST_SCHEMA\n' +
+            'FIRMS\n' +
+            'ID,NAME\n' +
+            '0,Toyota\n' +
+            '1,Ford\n' +
+            '2,Cadillac\n' +
+            '---\n'
+        ),
+        authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::TestDatabaseAuthenticationStrategy(),
+        element = BasicDB
+      ),
+      ^ModelChainConnection(element = ^ModelStore(), mappings = [FirmsAndEmployees_Relational])
+    ]
+  );
+  let extensions = meta::relational::extension::relationalExtensions();
+
+  let executionResults = meta::legend::executeLegendQuery(
+    {| 
+      RestrictedPerson.all()
+      ->graphFetch($tree)->serialize($tree)
+      ->from($mapping, $runtime)
+    },
+    [],
+    $extensions
+  );
+  
+  let expected = '{"builder":{"_type":"json"},"values":[' +
+    '{"name":"Alice","firm":{"name":"Toyota"}},' +
+    '{"name":"Bob","firm":{"name":"Cadillac"}},' +
+    '{"name":"Charlie","firm":{"name":"Ford"}},' + 
+    '{"name":"Dan","firm":{"name":"Cadillac"}},' +
+    '{"name":"Eve","firm":{"name":"Ford"}},' + 
+    '{"name":"Frank","firm":{"name":"Ford"}}' + 
+    ']}';
+  
+  assertJsonStringsEqual($expected, $executionResults);
+
+  let executionResults2 = meta::legend::executeLegendQuery(
+    {| 
+      RestrictedPerson.all()
+      ->filter(x | $x.name->in(['Bob', 'Eve']))
+      ->graphFetch($tree)->serialize($tree)
+      ->from($mapping, $runtime)
+    },
+    [],
+    $extensions
+  );
+
+  let expected2 = '{"builder":{"_type":"json"},"values":[' +
+    '{"name":"Bob","firm":{"name":"Cadillac"}},' +
+    '{"name":"Eve","firm":{"name":"Ford"}}' +
+    ']}';
+  
+  assertJsonStringsEqual($expected2, $executionResults2);
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
Bug fix

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->
Allows Platform Execution nodes to be used in model chain/m2m graph fetch flows. 
These occur for example when a ROUTER_UNION is selected as the root of a mapping.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

ROUTER_UNION is an in-memory union as opposed to STORE_UNION which is a Union in the database SQL.

#### Does this PR introduce a user-facing change?
<!--
-->
Yes
