### PR TITLE
Fix netty-codec-http dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2793,6 +2793,11 @@
                 <artifactId>netty-codec</artifactId>
                 <version>${io.netty.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
 
             <!-- Open CSV -->
             <dependency>


### PR DESCRIPTION
Fix netty-code-http dependency. 

This fixes a strange issue with dependency convergence - on some dev environments the lack of version for the codec-http dependency seems to cause the dependency convergence error to fail with multiple versions present in classpath.

