### PR TITLE
Providing execution support as query parameter for MultiExecution Ser…

### DIFF
--- a/legend-engine-core-language-pure/legend-engine-protocol-pure/pom.xml
+++ b/legend-engine-core-language-pure/legend-engine-protocol-pure/pom.xml
@@ -94,6 +94,10 @@
             <artifactId>json-unit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/CompositeExecutionPlan.java
+++ b/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/CompositeExecutionPlan.java
@@ -15,7 +15,9 @@
 package org.finos.legend.engine.protocol.pure.v1.model.executionPlan;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.Assert;
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.impl.list.mutable.FastList;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,10 +45,23 @@ public class CompositeExecutionPlan extends ExecutionPlan
     }
 
     @Override
-    public SingleExecutionPlan getSingleExecutionPlan(Function<? super String, ?> parameterValueAccessor)
+    public SingleExecutionPlan getSingleExecutionPlan(Function<? super String, ?> parameterValueAccessor, Map<String, ?> params)
     {
-        Object planKey = parameterValueAccessor.apply(this.executionKeyName);
-        SingleExecutionPlan singleExecutionPlan = this.executionPlans.get(planKey);
+        SingleExecutionPlan singleExecutionPlan;
+        Object planKey;
+        try
+        {
+             planKey = parameterValueAccessor.apply(this.executionKeyName);
+        }
+        catch (IllegalArgumentException e)
+        {
+            Object pk = params.get(this.executionKeyName);
+            Assert.assertNotNull("No key was passed to service pattern for execution. Please ensure you are providing " + this.executionKeyName + " and its value as part of a query parameter or path parameter to service pattern", pk);
+            planKey = ((FastList) pk).get(0).toString();
+        }
+
+        singleExecutionPlan = this.executionPlans.get(planKey);
+
         if (singleExecutionPlan == null)
         {
             throw new RuntimeException("No plan exists for key: " + planKey + ". Available keys are : " + this.executionPlans.keySet().stream().sorted().collect(Collectors.joining(", ")) + ".");

--- a/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/ExecutionPlan.java
+++ b/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/ExecutionPlan.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.protocol.pure.v1.model.executionPlan;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.eclipse.collections.api.factory.Maps;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -32,5 +33,11 @@ public abstract class ExecutionPlan
         return getSingleExecutionPlan(params::get);
     }
 
-    public abstract SingleExecutionPlan getSingleExecutionPlan(Function<? super String, ?> parameterValueAccessor);
+    public  SingleExecutionPlan getSingleExecutionPlan(Function<? super String, ?> parameterValueAccessor)
+    {
+        return getSingleExecutionPlan(parameterValueAccessor, Maps.mutable.empty());
+    }
+
+
+    public abstract SingleExecutionPlan getSingleExecutionPlan(Function<? super String, ?> parameterValueAccessor, Map<String, ?> params);
 }

--- a/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/SingleExecutionPlan.java
+++ b/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/SingleExecutionPlan.java
@@ -47,6 +47,12 @@ public class SingleExecutionPlan extends ExecutionPlan
         return this;
     }
 
+    @Override
+    public SingleExecutionPlan getSingleExecutionPlan(Function<? super String, ?> parameterValueAccessor, Map<String, ?> params)
+    {
+        return this;
+    }
+
     @JsonIgnore
     @BsonIgnore
     public MutableMap<String, Object> getExecutionStateParams(MutableMap<String, Object> inputState)

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service-pure/src/main/resources/core_service/service/metamodel.pure
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service-pure/src/main/resources/core_service/service/metamodel.pure
@@ -22,7 +22,6 @@ import meta::pure::runtime::*;
 
 Class meta::legend::service::metamodel::Service extends PackageableElement, meta::pure::test::Testable
 [
-   multiExecutionKeyMustBePartOfPattern: if($this.execution->instanceOf(meta::legend::service::metamodel::PureMultiExecution) && $this.execution->cast(@meta::legend::service::metamodel::PureMultiExecution).executionParameters->isNotEmpty() ,|$this.pattern->contains('{'+ $this.execution->cast(@PureMultiExecution).executionKey+'}'),|true),
 
    executionAndTestTypesMatch: if($this.execution->instanceOf(meta::legend::service::metamodel::PureMultiExecution),
                                   |assert($this.test->isEmpty() || ($this.test->isNotEmpty() && $this.test->toOne()->instanceOf(MultiExecutionTest)),'Service with multiple executions requires a MultiExecution test'),


### PR DESCRIPTION
…vices

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
--> Improvement

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> Relaxing constraint for paramkey to exist in service pattern

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> Yes, users can now execute service against a executionKey by passing the keyname and value as a query parameter