### PR TITLE
Persistence test runner : Fixing the composer for graphFetchPath attribute

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
@@ -271,7 +271,7 @@ public class HelperPersistenceComposer
         // graphFetchPath
         if (persistenceTest.graphFetchPath != null)
         {
-            getTabString(indentLevel + 1);
+            str.append(getTabString(indentLevel + 1));
             str.append("graphFetchPath")
                     .append(": ")
                     .append(ServiceOutputComposer.renderPath(persistenceTest.graphFetchPath))

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
@@ -274,7 +274,7 @@ public class HelperPersistenceComposer
             getTabString(indentLevel + 1);
             str.append("graphFetchPath")
                     .append(": ")
-                    .append(persistenceTest.graphFetchPath)
+                    .append(ServiceOutputComposer.renderPath(persistenceTest.graphFetchPath))
                     .append(";\n");
         }
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarV2Roundtrip.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/test/TestPersistenceGrammarV2Roundtrip.java
@@ -225,6 +225,7 @@ public class TestPersistenceGrammarV2Roundtrip extends TestGrammarRoundtrip.Test
             "        }\n" +
             "      ]\n" +
             "      isTestDataFromServiceOutput: false;\n" +
+            "      graphFetchPath: #/test::example::MyType/hello#;\n" +
             "    }\n" +
             "  ]\n" +
             "}\n");


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What does this PR do / why is it needed ?

fixing the composer for the optional attribute graphFetchPath as part of the persistence test runner. 

#### Which issue(s) this PR fixes:
None

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
