### PR TITLE
feat: backend support for code fix suggestions

### DIFF
--- a/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-compiler-api/src/test/java/org/finos/legend/engine/language/pure/compiler/api/test/TestCompileApi.java
+++ b/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-compiler-api/src/test/java/org/finos/legend/engine/language/pure/compiler/api/test/TestCompileApi.java
@@ -74,7 +74,7 @@ public class TestCompileApi
         try
         {
             PureModelContextData pureModelContextData = objectMapper.readValue(pureModelContextDataJsonStr, PureModelContextData.class);
-            Object response = compileApi.compile(pureModelContextData, null, null).getEntity();
+            Object response = compileApi.compile(pureModelContextData, null, null, false).getEntity();
             actual = objectMapper.writeValueAsString(response);
             if (compilationResult != null)
             {

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/Assert.java
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/Assert.java
@@ -15,8 +15,10 @@
 package org.finos.legend.engine.shared.core.operational;
 
 import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.shared.core.operational.errorManagement.CodeFixException;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 
 public class Assert
@@ -53,5 +55,10 @@ public class Assert
     public static void fail(Function0<String> text)
     {
         throw new EngineException(text.value());
+    }
+
+    public static void fail(Function0<String> text, SourceInformation sourceInformation, EngineErrorType type, MutableList<SourceInformation> candidates)
+    {
+        throw new CodeFixException(text.value(), sourceInformation, type, candidates);
     }
 }

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/CodeFixException.java
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/CodeFixException.java
@@ -1,0 +1,43 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.shared.core.operational.errorManagement;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+
+public class CodeFixException extends EngineException
+{
+    private Boolean isCodeFixSuggestion;
+    private MutableList<SourceInformation> candidates;
+
+    public CodeFixException(String message, SourceInformation sourceInformation, EngineErrorType type, MutableList<SourceInformation> candidates)
+    {
+        super(message, sourceInformation, type);
+        this.isCodeFixSuggestion = true;
+        this.candidates = candidates;
+    }
+
+    public Boolean getIsCodeFixSuggestion()
+    {
+        return this.isCodeFixSuggestion;
+    }
+
+    public MutableList<SourceInformation> getCandidates()
+    {
+        return this.candidates;
+    }
+}

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/CodeFixExceptionError.java
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/CodeFixExceptionError.java
@@ -1,0 +1,45 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.shared.core.operational.errorManagement;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+
+public class CodeFixExceptionError extends ExceptionError
+{
+    private Boolean isCodeFixSuggestion = false;
+    private MutableList<SourceInformation> candidates = Lists.mutable.empty();
+
+    CodeFixExceptionError(int code, Throwable t)
+    {
+        super(code, t);
+        if (t instanceof CodeFixException)
+        {
+            this.isCodeFixSuggestion = ((CodeFixException) t).getIsCodeFixSuggestion();
+            this.candidates = ((CodeFixException) t).getCandidates();
+        }
+    }
+
+    public MutableList<SourceInformation> getCandidates()
+    {
+        return candidates;
+    }
+
+    public Boolean getIsCodeFixSuggestion()
+    {
+        return isCodeFixSuggestion;
+    }
+}

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/ExceptionTool.java
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/operational/errorManagement/ExceptionTool.java
@@ -50,7 +50,7 @@ public class ExceptionTool
 
     public static Response exceptionManager(Exception exception, LoggingEventType eventType, Response.Status status, Iterable<? extends CommonProfile> pm)
     {
-        return manage(eventType, pm, new ExceptionError(-1, exception), status);
+        return manage(eventType, pm, exception instanceof CodeFixException ? new CodeFixExceptionError(-1, exception) : new ExceptionError(-1, exception), status);
     }
 
     public static Response exceptionManager(String message, LoggingEventType eventType, Response.Status status, Iterable<? extends CommonProfile> pm)


### PR DESCRIPTION
#### What type of PR is this?

Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

During code composition, if an element's type cannot be found, then the user is prompted with a code fix suggestion in Studio. In order to support the Studio functionality (described in this [Studio PR](https://github.com/finos/legend-studio/pull/2501) and this [Studio PR](https://github.com/finos/legend-studio/pull/2502)), Engine must return a set of candidates.

This PR creates a new type of exception that extends and EngineException, and it contains a new class variable that contains the candidates that will help users resolve the can't find element error in Studio. This list is populated during composition by the Pure Model class and eventually returned to Studio through the compile API.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:
When changes are released, they should be sent out along with one of the Studio PRs hyperlinked in the summary above.

#### Does this PR introduce a user-facing change?
<!--
-->
