### PR TITLE
Match on ViewSelectSQLQuery for Self Join

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -1584,7 +1584,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testDatabaseConnectionS
 
    let resultConnection = $result.rootExecutionNode->cast(@RelationalInstantiationExecutionNode).executionNodes->at(0)->cast(@SQLExecutionNode).connection->cast(@TestDatabaseConnection);
 
-   assertSize($resultConnection.testDataSetupSqls, 50);
+   assertSize($resultConnection.testDataSetupSqls, 56);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testDatabaseConnectionSQLPopulation():Boolean[1]
@@ -1603,7 +1603,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testDatabaseConnectionS
       .connection->cast(@meta::pure::alloy::connections::RelationalDatabaseConnection).datasourceSpecification
                  ->cast(@meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification);
 
-   assertSize($resultConnection.testDataSetupSqls, 50);
+   assertSize($resultConnection.testDataSetupSqls, 56);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::tdsJoinOneDBOneExpression():Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -2833,19 +2833,27 @@ function meta::relational::functions::pureToSqlQuery::manageAggregation(leftSql:
    );
 }
 
+function meta::relational::functions::pureToSqlQuery::getPksFromAlias(r:RelationalOperationElement[*], mt:Table[*]):List<Column>[1]
+{
+   ^List<Column>(values=$r->cast(@Alias)->filter(a|$a.relationalElement->instanceOf(TableAliasColumn) && $mt.primaryKey->contains($a.relationalElement->cast(@TableAliasColumn).column))->map(a|let col = $a.relationalElement->cast(@TableAliasColumn).column; ^$col(name=$a.name);));
+}
 
 function meta::relational::functions::pureToSqlQuery::addSelfJoin(s:SelectSQLQuery[1], j:RelationalTreeNode[1], newJoinName:String[1], extensions:Extension[*]):Pair<SelectSQLQuery, List<Pair<JoinTreeNode, JoinTreeNode>>>[1]
 {
    let rootJtn = $j;
    let rootJtnAlias = $rootJtn.alias;
 
-   let rootJtnAliasTable = $rootJtnAlias.relationalElement->match([t:Table[1]| pair($t.schema.database, ^List<Column>(values=$t.primaryKey)),
-                                                                   u:Union[1]| let mt = $u.queries.data.alias.relationalElement->cast(@Table);
-                                                                               pair($mt.schema.database->at(0), ^List<Column>(values=$u.queries.columns->cast(@Alias)->filter(a|$a.relationalElement->instanceOf(TableAliasColumn) && $mt.primaryKey->contains($a.relationalElement->cast(@TableAliasColumn).column))->map(a|let col = $a.relationalElement->cast(@TableAliasColumn).column; ^$col(name=$a.name);)));,
-                                                                   select:SelectSQLQuery[1]| assert($select.data.alias.relationalElement->toOne()->instanceOf(Table), 'Add self Join is supported with SelectSQLQuery only when main relationalElement is Table');
-                                                                                             let mt = $select.data.alias.relationalElement->cast(@Table);
-                                                                                             pair($mt.schema.database->at(0), ^List<Column>(values=$select.columns->cast(@Alias)->filter(a|$a.relationalElement->instanceOf(TableAliasColumn) && $mt.primaryKey->contains($a.relationalElement->cast(@TableAliasColumn).column))->map(a|let col = $a.relationalElement->cast(@TableAliasColumn).column; ^$col(name=$a.name);)));
-                                                               ]);
+   let rootJtnAliasTable = $rootJtnAlias.relationalElement->match([ v:ViewSelectSQLQuery[1]| let mt = $v->cast(@ViewSelectSQLQuery).selectSQLQuery->cast(@SelectSQLQuery).data.alias.relationalElement->cast(@Table);
+                                                                                             let pks = getPksFromAlias($v.columns, $mt);
+                                                                                             if($pks->isEmpty(), | fail('There is no primary key defined on the table ' + $mt->toOne().name); false;, | true);
+                                                                                             pair($v.schema.database, $pks);,
+                                                                    t:Table[1]| pair($t.schema.database, ^List<Column>(values=$t.primaryKey)),
+                                                                    u:Union[1]| let mt = $u.queries.data.alias.relationalElement->cast(@Table);
+                                                                                pair($mt.schema.database->at(0), getPksFromAlias($u.queries.columns, $mt));,
+                                                                    select:SelectSQLQuery[1]| assert($select.data.alias.relationalElement->toOne()->instanceOf(Table), 'Add self Join is supported with SelectSQLQuery only when main relationalElement is Table');
+                                                                                              let mt = $select.data.alias.relationalElement->cast(@Table);
+                                                                                              pair($mt.schema.database->at(0), getPksFromAlias($select.columns, $mt));
+                                                                  ]);
 
    let rootJtnAliasTablePks = $rootJtnAliasTable.second.values;
    let database = $rootJtnAliasTable.first;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/query/testView.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/query/testView.pure
@@ -77,14 +77,21 @@ function <<test.Test>> meta::relational::tests::query::view::testViewSimpleExist
   assertSameSQL('select "root".ID as "pk_0", "root".ID as "id", "root".quantity as "quantity", "root".orderDate as "date", "root".settlementDateTime as "settlementDateTime" from orderTable as "root" left outer join (select distinct "salespersontable_1".ACCOUNT_ID from (select "salespersontable_1".ACCOUNT_ID as ACCOUNT_ID, "personfirmview_0".firm_name as firm_name from salesPersonTable as "salespersontable_1" inner join (select "root".ID as PERSON_ID, "root".LASTNAME as lastName, "firmtable_0".LEGALNAME as firm_name from personTable as "root" left outer join firmTable as "firmtable_0" on ("firmtable_0".ID = "root".FIRMID)) as "personfirmview_0" on ("salespersontable_1".PERSON_ID = "personfirmview_0".PERSON_ID)) as "salespersontable_1" where "salespersontable_1".firm_name = \'Johnson\') as "salespersontable_0" on ("root".accountID = "salespersontable_0".ACCOUNT_ID) where "salespersontable_0".ACCOUNT_ID is not null', $result);
 }
 
+function <<test.Test>> meta::relational::tests::query::view::testViewPropertyFilterWithPrimaryKey():Boolean[1]
+{
+   let result = execute(|Employee.all()->filter(x|$x.org == 'A')->project([x|$x.category],['Category']), meta::relational::tests::query::view::EmployeeMappingWithViewAndInnerJoin, testRuntime(), meta::relational::extension::relationalExtensions(), noDebug());
+   let tds = $result.values->at(0);
+   assertEquals('select "dept_2".name as "Category" from (select "root".OrgId as OrgId, "root".name as name from Org as "root") as "root" left outer join (select "orgview_2".OrgId as OrgId, "branch_0".name as name_1, "branch_1".name as name from (select "root".OrgId as OrgId, "root".name as name from Org as "root") as "orgview_2" left outer join Dept as "dept_0" on ("orgview_2".name = "dept_0".name) inner join Branch as "branch_0" on ("dept_0".id = "branch_0".branchId) left outer join Dept as "dept_1" on ("orgview_2".name = "dept_1".name) inner join Branch as "branch_1" on ("dept_1".id = "branch_1".branchId)) as "orgview_1" on ("root".OrgId = "orgview_1".OrgId) left outer join (select "dept_3".name as name_1, "branch_2".name as name from Dept as "dept_3" inner join Branch as "branch_2" on ("dept_3".id = "branch_2".branchId)) as "dept_2" on ("root".name = "dept_2".name_1) where case when 1 = 1 then case when "orgview_1".name_1 is null then \'\' else \'A\' end else case when "orgview_1".name is null then \'\' else \'B\' end end = \'A\'', $result->sqlRemoveFormatting());
+   assertSameElements(['Category'], $tds.columns.name);
+   assertEquals(1, $tds.rows->size());
+   assertEquals(['TX'], $result.values.rows->at(0).values);
+}
 
 ###Mapping
 import meta::relational::tests::*;
 import meta::relational::tests::model::simple::*;
 Mapping meta::relational::tests::query::view::relationalMappingWithViewAndInnerJoin
 (
-   
-
     Person : Relational
             {
                scope([db] PersonFirmView)
@@ -93,7 +100,6 @@ Mapping meta::relational::tests::query::view::relationalMappingWithViewAndInnerJ
                     firm ( legalName:firm_name )
                )
             }
-             
     Order : Relational
              {
                 id : [db]orderTable.ID,
@@ -102,9 +108,18 @@ Mapping meta::relational::tests::query::view::relationalMappingWithViewAndInnerJ
                 settlementDateTime : [db]orderTable.settlementDateTime,
                 pnlContact : [db] @Order_SalesPerson > (INNER) [db] @SalesPerson_PersonView
              }
-             
-   
+)
 
-
-   
+Mapping meta::relational::tests::query::view::EmployeeMappingWithViewAndInnerJoin
+(
+  Employee: Relational
+  {
+    ~primaryKey
+    (
+      [db]OrgView.OrgId
+    )
+    ~mainTable [db]OrgView
+     category: [db]@Org_DeptCat > (INNER) [db]@Dept_Branch | Branch.name,
+     division: [db]@Org_DeptDiv > (INNER) [db]@Dept_Branch | Branch.name
+  }
 )

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/relationalSetUp.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/relationalSetUp.pure
@@ -122,6 +122,10 @@ Database meta::relational::tests::db
 
     Table testClassTable(desks INT PRIMARY KEY, students INT)
 
+    Table Dept(id INT PRIMARY KEY, name VARCHAR(10))
+    Table Branch(branchId INT PRIMARY KEY, name VARCHAR(10))
+    Table Org(OrgId INT PRIMARY KEY, name VARCHAR(10))
+
     View interactionViewMaxTime
     (
        ~filter PositiveInteractionTimeFilter
@@ -179,6 +183,12 @@ Database meta::relational::tests::db
         orderPnl : sum(@OrderPnlTable_Order | orderPnlTable.pnl)
     )
 
+    View OrgView
+    (
+        OrgId: Org.OrgId,
+        name: Org.name
+    )
+
     Schema productSchema
     (
        Table synonymTable(ID INT PRIMARY KEY, PRODID INT, TYPE VARCHAR(200), NAME VARCHAR(200))
@@ -210,6 +220,9 @@ Database meta::relational::tests::db
     Join OrderPnlTable_Order(orderPnlTable.ORDER_ID = orderTable.ID)
     Join AccountPnlView_Account(accountOrderPnlView.accountId = accountTable.ID)
     Join Person_OtherNames(personTable.ID = otherNamesTable.PERSON_ID)
+    Join Org_DeptCat(OrgView.name = Dept.name)
+    Join Org_DeptDiv(OrgView.name = Dept.name)
+    Join Dept_Branch(Dept.id = Branch.branchId)
 )
 
 ###Relational

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/relationalSetUp.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/relationalSetUp.pure
@@ -1348,6 +1348,16 @@ function meta::relational::tests::createTablesAndFillDb():Boolean[1]
    executeInDb('insert into simple.firmTable (ID, LEGALNAME, TYPE) values (1, \'Firm X\', \'LLC\');', $connection);
    executeInDb('insert into simple.firmTable (ID, LEGALNAME, TYPE) values (2, \'Firm Y\', \'CORPORATION\');', $connection);
 
+   executeInDb('Drop table if exists Org;', $connection);
+   executeInDb('Create Table Org(OrgId INT, name VARCHAR(10));', $connection);
+   executeInDb('insert into Org (OrgId, name) values (1, \'simthp\');', $connection);
+   executeInDb('Drop table if exists Dept;', $connection);
+   executeInDb('Create Table Dept(id INT, name VARCHAR(10));', $connection);
+   executeInDb('insert into Dept (id, name) values (1, \'simthp\');', $connection);
+   executeInDb('Drop table if exists Branch;', $connection);
+   executeInDb('Create Table Branch(branchId INT, name VARCHAR(10));', $connection);
+   executeInDb('insert into Branch (branchId, name) values (1, \'TX\');', $connection);
+
    true;
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testModel/simpleTestModel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testModel/simpleTestModel.pure
@@ -666,4 +666,10 @@ Class meta::relational::tests::model::simple::class
   desks: Integer[1];
   students: Integer[1];
 }
- 
+
+Class meta::relational::tests::model::simple::Employee
+{
+  category: String[1];
+  division: String[1];
+  org() {if(1==1,|if($this.category->isEmpty(),|'',|'A'), |if($this.division->isEmpty(),|'',|'B'))}: String[0..1];
+}


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
When we map on views and do a filter operation on lambda, it constructs a self join.
Changes will add a match expression for ViewSelectSQLQuery  and a validation while adding Self Join

#### Does this PR introduce a user-facing change?
No
