### PR TITLE
Log failure of service assert lambdas

### DIFF
--- a/legend-engine-xts-service/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
+++ b/legend-engine-xts-service/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/test/runner/service/ServiceTestRunner.java
@@ -29,6 +29,7 @@ import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.dsl.service.generation.ServicePlanGenerator;
 import org.finos.legend.engine.language.pure.dsl.service.generation.extension.ServiceExecutionExtension;
+import org.finos.legend.engine.language.pure.grammar.to.DEPRECATED_PureGrammarComposerCore;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.execution.nodes.helpers.ExecutionNodeTDSResultHelper;
 import org.finos.legend.engine.plan.execution.nodes.helpers.platform.JavaHelper;
@@ -359,6 +360,11 @@ public class ServiceTestRunner
                         Boolean assertResult = (Boolean) assertsClass.getMethod(testName, Root_meta_pure_mapping_Result.class, ExecutionSupport.class).invoke(null, pureResult, pureModel.getExecutionSupport());
                         testResult = assertResult ? TestResult.SUCCESS : TestResult.FAILURE;
                         scope.span().setTag(testName + "_assert", assertResult);
+                        if (!assertResult)
+                        {
+                            String lambdaGrammar = tc.getOne()._assert.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().build());
+                            LOGGER.error("[{}][{}] - Assertion lambda failed: {}", this.service.getPath(), tc.getTwo(), lambdaGrammar);
+                        }
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
Improvement
-->

#### What does this PR do / why is it needed ?

When running platform regression, services that fail on assertion does not log what the assertion function was.  This makes it complicated to understand what could be the root cause.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
