### PR TITLE
Add Float and Integer transformations

### DIFF
--- a/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/transformer/SetImplTransformers.java
+++ b/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/transformer/SetImplTransformers.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.plan.execution.result.transformer;
 
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.plan.dependencies.domain.date.PureDate;
@@ -84,22 +85,28 @@ public class SetImplTransformers
 
     private <T> Function<Object, Object> buildTransformer(TransformerInput<T> transformerInput)
     {
-        if (transformerInput.type != null && transformerInput.test.valueOf(transformerInput.identifier))
+        if (transformerInput.type != null)
         {
-            return transformerInput.transformer.valueOf(transformerInput.identifier);
-        }
-        else if (transformerInput.type != null && transformerInput.type.equals("Boolean"))
-        {
-            return o -> toBoolean(o);
-        }
-        else if (transformerInput.type != null && (transformerInput.type.equals("StrictDate") || transformerInput.type.equals("DateTime") || transformerInput.type.equals("Date")))
-        {
-            return o -> o instanceof Date ? DateFunctions.fromDate((Date) o) : o;
-        }
-        else
-        {
-            return o -> o;
-        }
-    }
+            if (transformerInput.test.valueOf(transformerInput.identifier))
+            {
+                return transformerInput.transformer.valueOf(transformerInput.identifier);
+            }
 
+            switch (transformerInput.type)
+            {
+                case "Boolean":
+                    return this::toBoolean;
+                case "StrictDate":
+                case "DateTime":
+                case "Date":
+                    return o -> o instanceof Date ? DateFunctions.fromDate((Date) o) : o;
+                case "Float":
+                    return o -> o instanceof Number ? ((Number) o).doubleValue() : o;
+                case "Integer":
+                    return o -> o instanceof Number ? ((Number) o).longValue() : o;
+            }
+        }
+
+        return Functions.identity();
+    }
 }

--- a/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/transformer/TestSetImplTransformers.java
+++ b/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/result/transformer/TestSetImplTransformers.java
@@ -14,17 +14,18 @@
 
 package org.finos.legend.engine.plan.execution.result.transformer;
 
-import org.junit.Test;
-
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TestSetImplTransformers
 {
     public SetImplTransformers testBooleanTransformerSetup()
     {
         List<TransformerInput<Integer>> testTransformerInput = new ArrayList<>();
-        testTransformerInput.add(new TransformerInput<Integer>(1, "Boolean", o -> false, null));
+        testTransformerInput.add(new TransformerInput<>(1, "Boolean", o -> false, null));
         return new SetImplTransformers(testTransformerInput);
     }
 
@@ -33,12 +34,12 @@ public class TestSetImplTransformers
     {
         SetImplTransformers s = testBooleanTransformerSetup();
         Object trueValue = s.transformers.get(0).valueOf(true);
-        assert (trueValue instanceof Boolean);
-        assert ((Boolean) trueValue);
+        Assert.assertTrue(trueValue instanceof Boolean);
+        Assert.assertTrue((Boolean) trueValue);
 
         Object falseValue = s.transformers.get(0).valueOf(false);
-        assert (falseValue instanceof Boolean);
-        assert (!(Boolean) falseValue);
+        Assert.assertTrue(falseValue instanceof Boolean);
+        Assert.assertFalse((Boolean) falseValue);
     }
 
     @Test
@@ -46,12 +47,12 @@ public class TestSetImplTransformers
     {
         SetImplTransformers s = testBooleanTransformerSetup();
         Object trueValue = s.transformers.get(0).valueOf("true");
-        assert (trueValue instanceof Boolean);
-        assert ((Boolean) trueValue);
+        Assert.assertTrue(trueValue instanceof Boolean);
+        Assert.assertTrue((Boolean) trueValue);
 
         Object falseValue = s.transformers.get(0).valueOf("false");
-        assert (falseValue instanceof Boolean);
-        assert (!(Boolean) falseValue);
+        Assert.assertTrue(falseValue instanceof Boolean);
+        Assert.assertFalse((Boolean) falseValue);
     }
 
     @Test
@@ -59,12 +60,12 @@ public class TestSetImplTransformers
     {
         SetImplTransformers s = testBooleanTransformerSetup();
         Object trueValue = s.transformers.get(0).valueOf(1L);
-        assert (trueValue instanceof Boolean);
-        assert ((Boolean) trueValue);
+        Assert.assertTrue(trueValue instanceof Boolean);
+        Assert.assertTrue((Boolean) trueValue);
 
         Object falseValue = s.transformers.get(0).valueOf(0L);
-        assert (falseValue instanceof Boolean);
-        assert (!(Boolean) falseValue);
+        Assert.assertTrue(falseValue instanceof Boolean);
+        Assert.assertFalse((Boolean) falseValue);
     }
 
     @Test
@@ -72,12 +73,12 @@ public class TestSetImplTransformers
     {
         SetImplTransformers s = testBooleanTransformerSetup();
         Object trueValue = s.transformers.get(0).valueOf(1);
-        assert (trueValue instanceof Boolean);
-        assert ((Boolean) trueValue);
+        Assert.assertTrue(trueValue instanceof Boolean);
+        Assert.assertTrue((Boolean) trueValue);
 
         Object falseValue = s.transformers.get(0).valueOf(0);
-        assert (falseValue instanceof Boolean);
-        assert (!(Boolean) falseValue);
+        Assert.assertTrue(falseValue instanceof Boolean);
+        Assert.assertFalse((Boolean) falseValue);
     }
 
     @Test
@@ -85,11 +86,80 @@ public class TestSetImplTransformers
     {
         SetImplTransformers s = testBooleanTransformerSetup();
         Object trueValue = s.transformers.get(0).valueOf(1.0);
-        assert (trueValue instanceof Boolean);
-        assert ((Boolean) trueValue);
+        Assert.assertTrue(trueValue instanceof Boolean);
+        Assert.assertTrue((Boolean) trueValue);
 
         Object falseValue = s.transformers.get(0).valueOf(0.0);
-        assert (falseValue instanceof Boolean);
-        assert (!(Boolean) falseValue);
+        Assert.assertTrue(falseValue instanceof Boolean);
+        Assert.assertFalse((Boolean) falseValue);
+    }
+
+    public SetImplTransformers testFloatTransformerSetup()
+    {
+        List<TransformerInput<Integer>> testTransformerInput = new ArrayList<>();
+        testTransformerInput.add(new TransformerInput<>(1, "Float", o -> false, null));
+        return new SetImplTransformers(testTransformerInput);
+    }
+
+    @Test
+    public void testFloatTransformerFromDouble()
+    {
+        SetImplTransformers s = testFloatTransformerSetup();
+        Object val = s.transformers.get(0).valueOf(1.0d);
+        Assert.assertTrue(val instanceof Double);
+        Assert.assertEquals(1.0,  val);
+    }
+
+    @Test
+    public void testFloatTransformerFromInteger()
+    {
+        SetImplTransformers s = testFloatTransformerSetup();
+        Object val = s.transformers.get(0).valueOf(1L);
+        Assert.assertTrue(val instanceof Double);
+        Assert.assertEquals(1.0,  val);
+    }
+
+    @Test
+    public void testFloatTransformerFromBigDecimal()
+    {
+        SetImplTransformers s = testFloatTransformerSetup();
+        Object val = s.transformers.get(0).valueOf(new BigDecimal("0.000"));
+        Assert.assertTrue(val instanceof Double);
+        Assert.assertEquals(0.0,  val);
+    }
+
+
+    public SetImplTransformers testIntegerTransformerSetup()
+    {
+        List<TransformerInput<Integer>> testTransformerInput = new ArrayList<>();
+        testTransformerInput.add(new TransformerInput<>(1, "Integer", o -> false, null));
+        return new SetImplTransformers(testTransformerInput);
+    }
+
+    @Test
+    public void testIntegerTransformerFromInt()
+    {
+        SetImplTransformers s = testIntegerTransformerSetup();
+        Object val = s.transformers.get(0).valueOf(1);
+        Assert.assertTrue(val instanceof Long);
+        Assert.assertEquals(1L,  val);
+    }
+
+    @Test
+    public void testIntegerTransformerFromLong()
+    {
+        SetImplTransformers s = testIntegerTransformerSetup();
+        Object val = s.transformers.get(0).valueOf(1L);
+        Assert.assertTrue(val instanceof Long);
+        Assert.assertEquals(1L,  val);
+    }
+
+    @Test
+    public void testIntegerTransformerFromBigDecimal()
+    {
+        SetImplTransformers s = testIntegerTransformerSetup();
+        Object val = s.transformers.get(0).valueOf(new BigDecimal("123456"));
+        Assert.assertTrue(val instanceof Long);
+        Assert.assertEquals(123456L,  val);
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
@@ -338,10 +338,10 @@ function <<test.Test>> meta::relational::tests::mapping::sqlFunction::toString::
     assertEquals('select cast("root".int1 as varchar) as "toString" from dataTable as "root" where cast("root".int1 as varchar) = \'1\'',$result->sqlRemoveFormatting());
 }
 
-function <<test.Test>> meta::relational::tests::mapping::sqlFunction::round::testProject():Boolean[1]
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::sqlFunction::round::testProject():Boolean[1]
 {
     let result = execute(|SqlFunctionDemo.all()->project([s | $s.float1Round ], ['round']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
-    assertEquals([1.0,2.0], $result.values->at(0).rows.values);
+    assertEquals([1,2], $result.values->at(0).rows.values);
     assertEquals('select round("root".float1, 0) as "round" from dataTable as "root"',$result->sqlRemoveFormatting());
 }
 
@@ -353,38 +353,38 @@ function <<test.Test>> meta::relational::tests::mapping::sqlFunction::round::tes
    assertEquals('select round("root".float1, 0) as "round" from dataTable as "root"',$prestoSql);
 }
 
-function <<test.Test>> meta::relational::tests::mapping::sqlFunction::round::testFilter():Boolean[1]
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::sqlFunction::round::testFilter():Boolean[1]
 {
     let result = execute(|SqlFunctionDemo.all()->filter(s | $s.float1Round == 1)->project([s | $s.float1Round], ['round']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
-    assertEquals([1.0], $result.values->at(0).rows.values);
+    assertEquals([1], $result.values->at(0).rows.values);
     assertEquals('select round("root".float1, 0) as "round" from dataTable as "root" where round("root".float1, 0) = 1',$result->sqlRemoveFormatting());
 }
 
-function <<test.Test>> meta::relational::tests::mapping::sqlFunction::ceiling::testProject():Boolean[1]
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::sqlFunction::ceiling::testProject():Boolean[1]
 {
     let result = execute(|SqlFunctionDemo.all()->project([s | $s.float1Ceiling ], ['ceiling']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
-    assertEquals([2.0,2.0], $result.values->at(0).rows.values);
+    assertEquals([2,2], $result.values->at(0).rows.values);
     assertEquals('select ceiling("root".float1) as "ceiling" from dataTable as "root"',$result->sqlRemoveFormatting());
 }
 
-function <<test.Test>> meta::relational::tests::mapping::sqlFunction::ceiling::testFilter():Boolean[1]
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::sqlFunction::ceiling::testFilter():Boolean[1]
 {
     let result = execute(|SqlFunctionDemo.all()->filter(s | $s.float1Ceiling == 2)->project([s | $s.float1Ceiling], ['ceiling']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
-    assertEquals([2.0,2.0], $result.values->at(0).rows.values);
+    assertEquals([2,2], $result.values->at(0).rows.values);
     assertEquals('select ceiling("root".float1) as "ceiling" from dataTable as "root" where ceiling("root".float1) = 2',$result->sqlRemoveFormatting());
 }
 
-function <<test.Test>> meta::relational::tests::mapping::sqlFunction::floor::testProject():Boolean[1]
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::sqlFunction::floor::testProject():Boolean[1]
 {
     let result = execute(|SqlFunctionDemo.all()->project([s | $s.float1Floor ], ['floor']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
-    assertEquals([1.0,1.0], $result.values->at(0).rows.values);
+    assertEquals([1,1], $result.values->at(0).rows.values);
     assertEquals('select floor("root".float1) as "floor" from dataTable as "root"',$result->sqlRemoveFormatting());
 }
 
-function <<test.Test>> meta::relational::tests::mapping::sqlFunction::floor::testFilter():Boolean[1]
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::sqlFunction::floor::testFilter():Boolean[1]
 {
     let result = execute(|SqlFunctionDemo.all()->filter(s | $s.float1Floor == 1)->project([s | $s.float1Floor], ['floor']), testMapping, testDataTypeMappingRuntime(), meta::relational::extension::relationalExtensions());
-    assertEquals([1.0,1.0], $result.values->at(0).rows.values);
+    assertEquals([1,1], $result.values->at(0).rows.values);
     assertEquals('select floor("root".float1) as "floor" from dataTable as "root" where floor("root".float1) = 1',$result->sqlRemoveFormatting());
 }
 


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

This ensures that Float and Integer Pure types yield Java double and long, respectively.

For example, the new H2 now yields BigDecimal on some scenarios, when before it was double.  This change ensure valuesa re normalized using Pure types.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

This can impact expected results from users.  Regression is running.