### PR TITLE
Use compiled state classloader for loading extensions

### DIFF
--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-core-extension/pom.xml
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-core-extension/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-code-compiled-core</artifactId>
         </dependency>

--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-core-extension/src/main/java/org/finos/legend/engine/pure/code/core/PureCoreExtension.java
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-core-extension/src/main/java/org/finos/legend/engine/pure/code/core/PureCoreExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -42,7 +43,7 @@ public interface PureCoreExtension
         }
         try
         {
-            Class<?> cl = Class.forName("org.finos.legend.pure.generated." + functionFile().replace("/", "_").replace(".pure", ""));
+            Class<?> cl = ((CompiledExecutionSupport) es).getClassLoader().loadClass("org.finos.legend.pure.generated." + functionFile().replace("/", "_").replace(".pure", ""));
             Method m = cl.getMethod("Root_" + functionSignature().replace("::", "_"), ExecutionSupport.class);
             Object res = m.invoke(null, es);
             return (res instanceof List) ?

--- a/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-execution/pom.xml
+++ b/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-execution/pom.xml
@@ -190,6 +190,11 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>
             <scope>test</scope>
         </dependency>

--- a/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-execution/src/test/resources/testModels.txt
+++ b/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-execution/src/test/resources/testModels.txt
@@ -46,7 +46,7 @@ function <<LocalPlatformBinding.TestPlanBinder>> meta::relational::executionPlan
    (
       overrides = [],
       bindingFunction = {plan: ExecutionPlan[1], extensions: Extension[*] |
-         let extensionsWithPlatformBindings = $extensions->concatenate(platformBindingExtension('PlatformBinding - LegendJava - InMemory', [legendJavaPlatformBinding([meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::inMemoryLegendJavaPlatformBindingExtension()])]));
+         let extensionsWithPlatformBindings = 'meta::pure::extension::runtime::getExtensions__Extension_MANY_'->pathToElement()->cast(@Function<{->Extension[*]}>)->eval();
          generatePlatformCode($plan, legendJavaPlatformBindingId(), ^LegendJavaPlatformBindingConfig(), $extensionsWithPlatformBindings);
       }
    )

--- a/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-extensions/src/main/java/org/finos/legend/engine/pure/runtime/extensions/compiled/natives/LegendExtensions.java
+++ b/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-extensions/src/main/java/org/finos/legend/engine/pure/runtime/extensions/compiled/natives/LegendExtensions.java
@@ -36,6 +36,19 @@ public class LegendExtensions extends AbstractNative
         return this.getClass().getCanonicalName() + ".execute(es)";
     }
 
+    @Override
+    public String buildBody()
+    {
+        return "new SharedPureFunction<Object>()\n" +
+                "        {\n" +
+                "            @Override\n" +
+                "            public Object execute(ListIterable<?> vars, final ExecutionSupport es)\n" +
+                "            {\n" +
+                "                return " + this.getClass().getCanonicalName() + ".execute(es);\n" +
+                "            }\n" +
+                "        }";
+    }
+
     public static RichIterable<? extends Root_meta_pure_extension_Extension> execute(ExecutionSupport es)
     {
         return PureCoreExtensionLoader.extensions().flatCollect(c -> c.extraPureCoreExtensions(es));


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Since compiled mode metadata works only with Java code generated from the same compiled state, using compiled state classLoader to load required class where extension method is defined

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

