### PR TITLE
Legend SQL - Use string-ified date instance as parameter values

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -996,11 +996,9 @@ function meta::external::query::sql::transformation::queryToPure::convertValue(a
 {
 
   $a->match([
-    s:String[1] | if ($type->in([Date, StrictDate, DateTime]),
-                    | parseDate($s),
-                    | if ($type->instanceOf(Enumeration),
-                        | extractEnumValue($type->cast(@Enumeration<Enum>), $s),
-                        | $s)),
+    s:String[1] | if ($type->instanceOf(Enumeration),
+                    | extractEnumValue($type->cast(@Enumeration<Enum>), $s),
+                    | $s),
     a:Any[1] | $a,
     a:Any[*] | $a->map(v | convertValue($v, $type))
   ]);

--- a/legend-engine-xts-sql/legend-engine-xt-sql-query/src/test/java/org/finos/legend/engine/query/sql/api/execute/SqlExecuteTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-query/src/test/java/org/finos/legend/engine/query/sql/api/execute/SqlExecuteTest.java
@@ -58,7 +58,7 @@ public class SqlExecuteTest
     @ClassRule
     public static final ResourceTestRule resources;
     private static final PureModel pureModel;
-
+    private static final ObjectMapper OM = new ObjectMapper();
 
     static
     {
@@ -143,10 +143,22 @@ public class SqlExecuteTest
                 .addRow(FastList.newListWith("Danielle"))
                 .build();
 
-        ObjectMapper OM = new ObjectMapper();
-
         Assert.assertEquals(allExpected, OM.readValue(all, TDSExecuteResult.class));
         Assert.assertEquals(filteredExpected, OM.readValue(filtered, TDSExecuteResult.class));
+    }
+
+    @Test
+    public void testExecuteWithDateParams() throws JsonProcessingException
+    {
+        String all = resources.target("sql/v1/execution/executeQueryString")
+                .request()
+                .post(Entity.text("SELECT Name FROM service('/personServiceForStartDate/{date}', date=>'2023-08-24')")).readEntity(String.class);
+
+        TDSExecuteResult allExpected = TDSExecuteResult.builder(FastList.newListWith("Name"))
+                .addRow(FastList.newListWith("Alice"))
+                .build();
+
+        Assert.assertEquals(allExpected, OM.readValue(all, TDSExecuteResult.class));
     }
 
     @Test

--- a/legend-engine-xts-sql/legend-engine-xt-sql-query/src/test/resources/proj-1.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-query/src/test/resources/proj-1.pure
@@ -26,7 +26,8 @@ Database demo::H2DemoDataBase
     firm_id INTEGER,
     name VARCHAR(200),
     country_id INTEGER,
-    type VARCHAR(25)
+    type VARCHAR(25),
+    start_date DATE
   )
   Table CountryTable
   (
@@ -127,6 +128,35 @@ Service demo::H2PersonServiceParameterized
   }
 }
 
+Service demo::H2PersonServiceDateParameterized
+{
+  pattern: '/personServiceForStartDate/{date}';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {date:Date[1]|demo::employee.all()->filter(p | $p.startDate == $date)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.type
+      ],
+      [
+        'Id',
+        'Name',
+        'Employee Type'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
 
 ###Pure
 Enum demo::employeeType
@@ -140,6 +170,7 @@ Class demo::employee
   id: Integer[1];
   name: String[1];
   type: demo::employeeType[1];
+  startDate: Date[1];
 }
 
 
@@ -155,7 +186,8 @@ Mapping demo::DemoRelationalMapping
     ~mainTable [demo::H2DemoDataBase]EmployeeTable
     id: [demo::H2DemoDataBase]EmployeeTable.id,
     name: [demo::H2DemoDataBase]EmployeeTable.name,
-    type: [demo::H2DemoDataBase]EmployeeTable.type
+    type: [demo::H2DemoDataBase]EmployeeTable.type,
+    startDate: [demo::H2DemoDataBase]EmployeeTable.start_date
   }
 )
 
@@ -168,7 +200,7 @@ RelationalDatabaseConnection demo::H2DemoConnection
   specification: LocalH2
   {
     testDataSetupSqls: [
-      'Drop table if exists EmployeeTable;\nCreate Table EmployeeTable(id INTEGER PRIMARY KEY,firm_id INTEGER,name VARCHAR(200),country_id INTEGER, type VARCHAR(25));\nInsert into EmployeeTable (id, firm_id, name, country_id, type) values (101,202, \'Alice\', 303, \'Type1\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type) values (102,203, \'Bob\', 304, \'Type2\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type) values (103,204, \'Curtis\', 305, \'Type2\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type) values (104,205, \'Danielle\', 306, \'Typ1\');\n'
+      'Drop table if exists EmployeeTable;\nCreate Table EmployeeTable(id INTEGER PRIMARY KEY,firm_id INTEGER,name VARCHAR(200),country_id INTEGER, type VARCHAR(25), start_date DATE);\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (101,202, \'Alice\', 303, \'Type1\', \'2023-08-24\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (102,203, \'Bob\', 304, \'Type2\', \'2022-08-24\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (103,204, \'Curtis\', 305, \'Type2\', \'2022-07-24\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (104,205, \'Danielle\', 306, \'Typ1\', \'2022-07-23\');\n'
       ];
   };
   auth: DefaultH2;


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Legend SQL queries on services that use date parameters are failing due to invalid parameter values. Error :`IllegalArgumentException: Invalid provided parameter(s): [Unable to process 'Date' parameter...`
The validator expects a LocalDate or String value while we are passing an instance of StrictDate.

This PR updates SQL-to-pure to send the string value so that the validator can parse it.
<!--
Describe change being introduced by this PR.
-->

#### Does this PR introduce a user-facing change?
No
