### PR TITLE
Add dependency exclusion in legend-engine-xt-mastery-protocol

### DIFF
--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-protocol/pom.xml
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-protocol/pom.xml
@@ -39,6 +39,12 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-dsl-generation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.finos.legend.pure</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- ENGINE -->
 


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What does this PR do / why is it needed ?

Exclude org.finos.legend.pure:* from legend-engine-language-pure-dsl-generation dependency in legend-engine-xt-mastery-protocol

#### Does this PR introduce a user-facing change?

No