### PR TITLE
Fix pure to sql for filter with distinct and groupBy

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -4242,7 +4242,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::reproce
 function meta::relational::functions::pureToSqlQuery::processGroupBy(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
    let nestedQuery = processValueSpecification($expression.parametersValues->at(0), [], $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
-   let select = $nestedQuery.select->cast(@TdsSelectSqlQuery);
+   let select = $nestedQuery.select->pushExtraFilteringOperation($extensions)->cast(@TdsSelectSqlQuery);
    let groupByColumns = findAliasOrFail($expression, $select,  $vars, $state);
    let noSubSelect = $select.groupBy->isEmpty() && ($select.distinct->isEmpty() || !$select.distinct->toOne()) && $select.orderBy.column->removeAll($groupByColumns)->isEmpty();
    $groupByColumns->map(gc| assert(!$gc.relationalElement->instanceOf(WindowColumn),'Group by columns cannot include window columns'););

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testGroupBy.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tds/tests/testGroupBy.pure
@@ -82,6 +82,23 @@ function <<test.Test>> meta::relational::tests::tds::groupBy::simpleGroupDistinc
    assertEquals('select concat("persontable_0".FIRSTNAME, \' \', "persontable_0".LASTNAME) as "sourceName", count(distinct("root".ID)) as "count" from interactionTable as "root" left outer join personTable as "persontable_0" on ("root".sourceId = "persontable_0".ID) group by "sourceName" order by "count" desc,"sourceName"', $result->sqlRemoveFormatting());
 }
 
+function <<test.Test>> meta::relational::tests::tds::groupBy::simpleFilterWithGroupByWithDistinct():Boolean[1]
+{
+  let result = execute(|Trade.all()
+                        ->filter(t | $t.id < 4)
+                        ->filter(t | $t.quantity > 11)
+                        ->project([ x | $x.quantity ],['quantity' ])
+                        ->meta::pure::tds::distinct()
+                        ->meta::pure::tds::groupBy(['quantity'], [agg( 'qty',  x | $x.getString('quantity'), y | $y->count())])
+                        ,simpleRelationalMapping, testRuntime(), meta::relational::extension::relationalExtensions());
+
+  let tds = $result.values->at(0);
+  assertEquals(2, $tds.rows->size());
+  assertEquals([25.0, 1], $tds.rows->at(0).values);
+  assertEquals([320.0, 1], $tds.rows->at(1).values);
+
+  assertEquals('select "tradetable_0"."quantity" as "quantity", count("quantity") as "qty" from (select distinct "root".quantity as "quantity" from tradeTable as "root" where "root".ID < 4 and "root".quantity > 11) as "tradetable_0" group by "quantity"', $result->sqlRemoveFormatting());
+}
 
 function <<test.Test>> meta::relational::tests::tds::groupBy::simpleGroupBySum():Boolean[1]
 {


### PR DESCRIPTION
#### What type of PR is this?
 Bug Fix

#### What does this PR do / why is it needed ?
Queries containing filters with distinct and groupBy were dropping the filters leading to incorrect sql generation. Hence The solution was to included the dropped filters. 

#### Does this PR introduce a user-facing change?
Yes