### PR TITLE
Fix date literal in sql query to string for dates without seconds and minutes 

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -142,11 +142,17 @@ function meta::relational::functions::sqlQueryToString::default::convertDateToSq
 {
    //Default to UTC, if timezone is not specified. GMT is the same as UTC, UTC is not actually a timezone
    let timeZone = if( $dbTimeZone->isEmpty(), | 'GMT', |  $dbTimeZone->toOne());
-   if($date->hasSecond(),
-      | if ($date->hasSubsecond(),
-            | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}', $date),
-            | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}', $date)),
-      | format('%t{[' + $timeZone + ']yyyy-MM-dd}', $date));
+  
+   if ($date->hasSubsecond(),
+      | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}', $date),
+      | if($date->hasSecond(),
+         | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}', $date),
+         |  if($date->hasMinute(),
+            | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm}:00',$date),
+            | if($date->hasHour(),
+             | format('%t{[' + $timeZone + ']yyyy-MM-dd HH}:00:00', $date),
+             | format('%t{[' + $timeZone + ']yyyy-MM-dd}', $date)
+             ))));
 }
 
 function meta::relational::functions::sqlQueryToString::default::processJoinStringsOperationWithConcatCall(js:JoinStrings[1], sgc:SqlGenerationContext[1]): String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/literals/date.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/literals/date.pure
@@ -1,0 +1,53 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::metamodel::*;
+import meta::relational::dbTestRunner::*;
+import meta::pure::test::*;
+
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::literals::date::testStrictDate(config:DbTestConfig[1]):Boolean[1]
+{
+  let literal = ^Literal(value = %2023-08-23);
+  let expected = ^Literal(value = %2023-08-23);
+  runLiteralDatabaseTest($literal, $expected, $config);
+}
+
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::literals::date::testDateTimeWithSeconds(config:DbTestConfig[1]):Boolean[1]
+{
+  let literal = ^Literal(value = %2023-08-23T01:01:01);
+  let expected = ^Literal(value = %2023-08-23T01:01:01);
+  runLiteralDatabaseTest($literal, $expected, $config);
+}
+
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::literals::date::testDateTimeWithMinutes(config:DbTestConfig[1]):Boolean[1]
+{
+  let literal = ^Literal(value = %2023-08-23T01:01);
+  let expected = ^Literal(value = %2023-08-23T01:01:00);
+  runLiteralDatabaseTest($literal, $expected, $config);
+}
+
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::literals::date::testDateTimeWithHours(config:DbTestConfig[1]):Boolean[1]
+{
+  let literal = ^Literal(value = %2023-08-23T01);
+  let expected = ^Literal(value = %2023-08-23T01:00:00);
+  runLiteralDatabaseTest($literal, $expected, $config);
+}
+
+
+function <<paramTest.Test>> meta::relational::tests::dbSpecificTests::sqlQueryTests::literals::date::testDateTimeWithSubseconds(config:DbTestConfig[1]):Boolean[1]
+{
+  let literal = ^Literal(value = %2023-08-23T01:01:01.000001);
+  let expected = ^Literal(value = %2023-08-23T01:01:01.000001);
+  runLiteralDatabaseTest($literal, $expected, $config);
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
bug fix

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->
this Pr fixes sql query to string translation for pure Dates where no seconds / minutes are present by embedding 00 in seconds/ minutes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
