### PR TITLE
Ignore selectSubClauses and namingTests packages for BigQuery tests

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_BigQuery_UsingPureClientTestSuite.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_BigQuery_UsingPureClientTestSuite.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.server.test.pureClient.stores.dbSpecific;
 
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import junit.framework.Test;
+import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.engine.authentication.BigQueryTestDatabaseAuthenticationFlowProviderConfiguration;
 import org.finos.legend.engine.server.test.shared.Relational_DbSpecific_UsingPureClientTestSuite;
 import org.finos.legend.pure.runtime.java.compiled.testHelper.IgnoreUnsupportedApiPureTestSuiteRunner;
@@ -29,6 +30,7 @@ public class Test_Relational_DbSpecific_BigQuery_UsingPureClientTestSuite extend
         return createSuite(
                 "meta::relational::tests::sqlQueryToString::bigQuery",
                 "org/finos/legend/engine/server/test/userTestConfig_withBigQueryTestConnection.json",
+                Lists.immutable.of("selectSubClauses", "namingTests"),
                 new NamedType(BigQueryTestDatabaseAuthenticationFlowProviderConfiguration.class, "bigQueryTest")
         );
     }


### PR DESCRIPTION
#### What type of PR is this?
Ignore selectSubClauses and namingTests packages for BigQuery tests
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
**What:** Ignore test suites explicitly.

**Why:** In pure IDE light when we run these tests they fail as setup function is called before each test. We have setup checking on DDL support in BQ and fails with unsupported api. However in java run, setup is added as first test case with assumption that it will pass. Though it fails it doesn't stop suite from running. So explicitly ignoring tests for BQ where setup fails.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
<!--
-->
