### PR TITLE
Ensure Maven version is at least 3.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
-        <maven.enforcer.requireJavaVersion>[11.0.10,12)</maven.enforcer.requireJavaVersion>
+	<maven.enforcer.requireJavaVersion>[11.0.10,12)</maven.enforcer.requireJavaVersion>
+	<maven.enforcer.requireMavenVersion>3.6.2</maven.enforcer.requireMavenVersion>
         <project.build.outputTimestamp>1680115922</project.build.outputTimestamp>
         <surefire.vm.params>-XX:SoftRefLRUPolicyMSPerMB=1</surefire.vm.params>
         <surefire.reports.directory />
@@ -482,6 +483,9 @@
                                 <requireJavaVersion>
                                     <version>${maven.enforcer.requireJavaVersion}</version>
                                 </requireJavaVersion>
+				<requireMavenVersion>
+				  <version>${maven.enforcer.requireMavenVersion}</version>
+				</requireMavenVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>
                                     <excludes>


### PR DESCRIPTION
Ensure we use maven version 3.6.2 and above. This is due to a bugfix for exclusions and wildcards for artefact filters (https://issues.apache.org/jira/browse/MNG-6713)

This was fixed in Maven 3.6.2 (https://maven.apache.org/docs/3.6.2/release-notes.html)