### PR TITLE
Add limit offset in output for TotalCountDirective

### DIFF
--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/src/main/java/org/finos/legend/engine/query/graphQL/extension/relational/directives/TotalCountDirective.java
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/src/main/java/org/finos/legend/engine/query/graphQL/extension/relational/directives/TotalCountDirective.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
+import org.finos.legend.engine.plan.execution.result.ConstantResult;
 import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.plan.execution.stores.relational.result.RealizedRelationalResult;
 import org.finos.legend.engine.plan.execution.stores.relational.result.RelationalResult;
@@ -42,6 +43,7 @@ import org.finos.legend.pure.generated.core_external_query_graphql_transformatio
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.pac4j.core.profile.CommonProfile;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -91,6 +93,16 @@ public class TotalCountDirective implements IGraphQLDirectiveExtension
         RealizedRelationalResult realizedResult = ((RealizedRelationalResult) ((result).realizeInMemory()));
         List<List<Object>> resultSetRows = (realizedResult).resultSetRows;
         Long totalCount = (Long)((resultSetRows.get(0)).get(0));
-        return totalCount;
+        HashMap<String, Object> finalResult = new HashMap<>();
+        finalResult.put("value", totalCount);
+        if(parameterMap.containsKey("limit"))
+        {
+            finalResult.put("limit", ((ConstantResult)parameterMap.get("limit")).getValue());
+        }
+        if (parameterMap.containsKey("offset"))
+        {
+            finalResult.put("offset", ((ConstantResult)parameterMap.get("offset")).getValue());
+        }
+        return finalResult;
     }
 }

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/src/main/java/org/finos/legend/engine/query/graphQL/extension/relational/directives/TotalCountDirective.java
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/src/main/java/org/finos/legend/engine/query/graphQL/extension/relational/directives/TotalCountDirective.java
@@ -95,7 +95,7 @@ public class TotalCountDirective implements IGraphQLDirectiveExtension
         Long totalCount = (Long)((resultSetRows.get(0)).get(0));
         HashMap<String, Object> finalResult = new HashMap<>();
         finalResult.put("value", totalCount);
-        if(parameterMap.containsKey("limit"))
+        if (parameterMap.containsKey("limit"))
         {
             finalResult.put("limit", ((ConstantResult)parameterMap.get("limit")).getValue());
         }

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/src/test/java/org/finos/legend/engine/query/graphQL/extension/relational/directives/TestTotalCountDirective.java
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/src/test/java/org/finos/legend/engine/query/graphQL/extension/relational/directives/TestTotalCountDirective.java
@@ -134,18 +134,20 @@ public class TestTotalCountDirective
         Response response = graphQLExecute.executeDev(mockRequest, "Project1", "Workspace1", "simple::model::Query", "simple::mapping::Map", "simple::runtime::Runtime", query, null);
 
         String expected = "{" +
-                "\"data\":{" +
-                "\"allFirms\":[" +
-                "{\"legalName\":\"Firm X\"}," +
-                "{\"legalName\":\"Firm A\"}," +
-                "{\"legalName\":\"Firm B\"}" +
-                "]" +
-                "}," +
-                "\"extensions\":{" +
-                "\"allFirms\":{" +
-                "\"totalCount\":3" +
-                "}" +
-                "}" +
+                    "\"data\":{" +
+                        "\"allFirms\":[" +
+                            "{\"legalName\":\"Firm X\"}," +
+                            "{\"legalName\":\"Firm A\"}," +
+                            "{\"legalName\":\"Firm B\"}" +
+                        "]" +
+                    "}," +
+                    "\"extensions\":{" +
+                        "\"allFirms\":{" +
+                            "\"totalCount\":{" +
+                                "\"value\":3" +
+                            "}" +
+                        "}" +
+                    "}" +
                 "}";
 
         Assert.assertEquals(expected, responseAsString(response));
@@ -167,17 +169,21 @@ public class TestTotalCountDirective
         Response response = graphQLExecute.executeDev(mockRequest, "Project1", "Workspace1", "simple::model::Query", "simple::mapping::Map", "simple::runtime::Runtime", query, null);
 
         String expected = "{" +
-                "\"data\":{" +
-                "\"selectEmployees\":[" +
-                "{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}," +
-                "{\"firstName\":\"John\",\"lastName\":\"Johnson\"}" +
-                "]" +
-                "}," +
-                "\"extensions\":{" +
-                "\"selectEmployees\":{" +
-                "\"totalCount\":7" +
-                "}" +
-                "}" +
+                    "\"data\":{" +
+                        "\"selectEmployees\":[" +
+                            "{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}," +
+                            "{\"firstName\":\"John\",\"lastName\":\"Johnson\"}" +
+                        "]" +
+                    "}," +
+                    "\"extensions\":{" +
+                        "\"selectEmployees\":{" +
+                            "\"totalCount\":{" +
+                                "\"offset\":1,"  +
+                                "\"limit\":2," +
+                                "\"value\":7" +
+                            "}" +
+                        "}" +
+                    "}" +
                 "}";
         Assert.assertEquals(expected, responseAsString(response));
     }
@@ -197,17 +203,21 @@ public class TestTotalCountDirective
                 "  }\n" +
                 "}";
         String expected = "{" +
-                "\"data\":{" +
-                "\"selectEmployees\":[" +
-                "{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}," +
-                "{\"firstName\":\"John\",\"lastName\":\"Johnson\"}" +
-                "]" +
-                "}," +
-                "\"extensions\":{" +
-                "\"selectEmployees\":{" +
-                "\"totalCount\":7" +
-                "}" +
-                "}" +
+                    "\"data\":{" +
+                        "\"selectEmployees\":[" +
+                            "{\"firstName\":\"Peter\",\"lastName\":\"Smith\"}," +
+                            "{\"firstName\":\"John\",\"lastName\":\"Johnson\"}" +
+                        "]" +
+                    "}," +
+                    "\"extensions\":{" +
+                        "\"selectEmployees\":{" +
+                            "\"totalCount\":{" +
+                                "\"offset\":1,"  +
+                                "\"limit\":2," +
+                                "\"value\":7" +
+                            "}" +
+                        "}" +
+                    "}" +
                 "}";
         String projectId = "Project1";
         String workspaceId = "Workspace1";


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
We will be returning limit and offset in output along with total count directive. It also extends totalCount directive to return some metadata in future which could include traceid, sql, etc
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes
<!--
-->
