### PR TITLE
DbSpecific test summary generation - fix surefire reports path in workflow

### DIFF
--- a/.github/workflows/database-athena-sql-generation-integration-test.yml
+++ b/.github/workflows/database-athena-sql-generation-integration-test.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-athena-sql-generation-integration-test.yml
+++ b/.github/workflows/database-athena-sql-generation-integration-test.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-bigquery-sql-generation-integration-test.yml
+++ b/.github/workflows/database-bigquery-sql-generation-integration-test.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-bigquery-sql-generation-integration-test.yml
+++ b/.github/workflows/database-bigquery-sql-generation-integration-test.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-databricks-sql-generation-integration-test.yml
+++ b/.github/workflows/database-databricks-sql-generation-integration-test.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-databricks-sql-generation-integration-test.yml
+++ b/.github/workflows/database-databricks-sql-generation-integration-test.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-h2-sql-generation-integration-test.yml
+++ b/.github/workflows/database-h2-sql-generation-integration-test.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-server/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-server/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-h2-sql-generation-integration-test.yml
+++ b/.github/workflows/database-h2-sql-generation-integration-test.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-server/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
+++ b/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
+++ b/.github/workflows/database-mssqlserver-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-postgresql-integration-test.yml
+++ b/.github/workflows/database-postgresql-integration-test.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-postgresql-integration-test.yml
+++ b/.github/workflows/database-postgresql-integration-test.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-postgresql-sql-generation-integration-test.yml
+++ b/.github/workflows/database-postgresql-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-postgresql-sql-generation-integration-test.yml
+++ b/.github/workflows/database-postgresql-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-redshift-sql-generation-integration-test.yml
+++ b/.github/workflows/database-redshift-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-redshift-sql-generation-integration-test.yml
+++ b/.github/workflows/database-redshift-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-singlestore-integration-test.yml
+++ b/.github/workflows/database-singlestore-integration-test.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-singlestore-integration-test.yml
+++ b/.github/workflows/database-singlestore-integration-test.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-singlestore-sql-generation-integration-test.yml
+++ b/.github/workflows/database-singlestore-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-singlestore-sql-generation-integration-test.yml
+++ b/.github/workflows/database-singlestore-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-snowflake-integration-test.yml
+++ b/.github/workflows/database-snowflake-integration-test.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-snowflake-integration-test.yml
+++ b/.github/workflows/database-snowflake-integration-test.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-snowflake-sql-generation-integration-test.yml
+++ b/.github/workflows/database-snowflake-sql-generation-integration-test.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-snowflake-sql-generation-integration-test.yml
+++ b/.github/workflows/database-snowflake-sql-generation-integration-test.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-spanner-sql-generation-integration-test.yml
+++ b/.github/workflows/database-spanner-sql-generation-integration-test.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-spanner-sql-generation-integration-test.yml
+++ b/.github/workflows/database-spanner-sql-generation-integration-test.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-trino-sql-generation-integration-test.yml
+++ b/.github/workflows/database-trino-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/surefire-reports-aggregate/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-execution-tests/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/database-trino-sql-generation-integration-test.yml
+++ b/.github/workflows/database-trino-sql-generation-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-execution-tests/surefire-reports/*.xml
+          path: legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-execution-tests/target/surefire-reports/*.xml
       - name: Upload CI Event
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
#### What type of PR is this?
Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Right now, the path for finding test results is incorrect. Updating it for each workflow which tries to publish test results to find xml files in relevant module's target/surefire-reports directory.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:
| Repo | Run Link | Has Test Results |
|-------|-----------|-------------------|
|abhishoya-gs/legend-engine|https://github.com/abhishoya-gs/legend-engine/actions/runs/6065331278|:white_check_mark:|
|finos/legend-engine|https://github.com/finos/legend-engine/actions/runs/6067460153|:x:|

#### Does this PR introduce a user-facing change?
No
<!--
-->
