### PR TITLE
Change composite PK not null check generated in graph fetch to AND

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -495,7 +495,7 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::planGra
    let changedDriverQuery  = $nonPrimitiveQuery->changeDriverToTempWithPkProjection(tempTableName($parentIdx), $parentSets, $extensions);
    let pkFilteredQuery     = ^$changedDriverQuery
                              (
-                                filteringOperation = andFilters($changedDriverQuery.filteringOperation->concatenate($changedDriverQuery.columns->cast(@Alias)->filter(x | $x.name->startsWith('"pk_'))->map(x | ^DynaFunction(name = 'isNotNull', parameters =  $x.relationalElement))->orFilters($extensions)), $extensions)
+                                filteringOperation = andFilters($changedDriverQuery.filteringOperation->concatenate($changedDriverQuery.columns->cast(@Alias)->filter(x | $x.name->startsWith('"pk_'))->map(x | ^DynaFunction(name = 'isNotNull', parameters =  $x.relationalElement))->andFilters($extensions)), $extensions)
                              );
    let postProcessorResult = $pkFilteredQuery->postProcessSQLQuery($store, [], $mapping, $runtime, $exeCtx, $extensions);
    let postProcessedQuery  = $postProcessorResult.query->cast(@SelectSQLQuery);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchMilestoning.pure
@@ -90,6 +90,77 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
       '{"id":2,"product(2015-10-16)":[{"name":"ProductName2","classificationTypeStr()":"STOCK","type":"STOCK"}]}]',
       $result
    );
+
+   // Adding plan test to assert on composite PK not null check generated (should be AND)
+   let plan = meta::pure::executionPlan::executionPlan($query, $mapping, $runtime, meta::relational::extension::relationalExtensions())->meta::pure::executionPlan::toString::planToString(meta::relational::extension::relationalExtensions());
+   assertEquals(
+    'PureExp\n' + 
+    '(\n' + 
+    '  type = String\n' + 
+    '  expression =  -> serialize(#{meta::relational::tests::milestoning::Order {id, product(2015-10-16) {name, type, classificationTypeStr()}}}#)\n' + 
+    '  (\n' + 
+    '    StoreMappingGlobalGraphFetch\n' + 
+    '    (\n' + 
+    '      type = PartialClass[impls=[(meta::relational::tests::milestoning::Order | milestoningmap.meta_relational_tests_milestoning_Order)], propertiesWithParameters = [id, product(2015-10-16)]]\n' + 
+    '      resultSizeRange = *\n' + 
+    '      store = meta::relational::tests::milestoning::db\n' + 
+    '      localGraphFetchExecutionNode = \n' + 
+    '         RelationalGraphFetch\n' + 
+    '         (\n' + 
+    '           type = PartialClass[impls=[(meta::relational::tests::milestoning::Order | milestoningmap.meta_relational_tests_milestoning_Order)], propertiesWithParameters = [id, product(2015-10-16)]]\n' + 
+    '           nodeIndex = 0\n' + 
+    '           relationalNode = \n' + 
+    '              SQL\n' + 
+    '              (\n' + 
+    '                type = meta::pure::metamodel::type::Any\n' + 
+    '                resultColumns = [("pk_0", INT), ("id", INT)]\n' + 
+    '                sql = select "root".id as "pk_0", "root".id as "id" from OrderTable as "root"\n' + 
+    '                connection = TestDatabaseConnection(type = "H2")\n' + 
+    '              )\n' + 
+    '           children = [\n' + 
+    '              RelationalGraphFetch\n' + 
+    '              (\n' + 
+    '                type = PartialClass[impls=[(meta::relational::tests::milestoning::Product | milestoningmap.meta_relational_tests_milestoning_Product)], propertiesWithParameters = [classificationTypeStr(), name, type]]\n' + 
+    '                nodeIndex = 2\n' + 
+    '                relationalNode = \n' + 
+    '                   SQL\n' + 
+    '                   (\n' + 
+    '                     type = meta::pure::metamodel::type::Any\n' + 
+    '                     resultColumns = [("parent_key_gen_0", INT), ("pk_0", INT), ("pk_1", VARCHAR(200)), ("name", VARCHAR(200)), ("type", VARCHAR(200)), ("k_businessDate", VARCHAR(10))]\n' + 
+    '                     sql = select distinct "temp_table_node_0_0".pk_0 as "parent_key_gen_0", "producttable_0".id as "pk_0", "producttable_0".name as "pk_1", "producttable_0".name as "name", "producttable_0".type as "type", \'2015-10-16\' as "k_businessDate" from (select * from (${temp_table_node_0}) as "root") as "temp_table_node_0_0" inner join OrderTable as "root" on ("temp_table_node_0_0".pk_0 = "root".id) left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= \'2015-10-16\' and "producttable_0".thru_z > \'2015-10-16\') where "producttable_0".name is not null and "producttable_0".id is not null and "producttable_0".from_z <= \'2015-10-16\' and "producttable_0".thru_z > \'2015-10-16\'\n' + 
+    '                     connection = TestDatabaseConnection(type = "H2")\n' + 
+    '                   )\n' + 
+    '                children = [\n' + 
+    '                   RelationalGraphFetch\n' + 
+    '                   (\n' + 
+    '                     type = String\n' + 
+    '                     nodeIndex = 5\n' + 
+    '                     relationalNode = \n' + 
+    '                        SQL\n' + 
+    '                        (\n' + 
+    '                          type = meta::pure::metamodel::type::Any\n' + 
+    '                          resultColumns = [("parent_key_gen_0", INT), ("parent_key_gen_1", VARCHAR(200)), ("node_5_result", VARCHAR(200))]\n' + 
+    '                          sql = select distinct "temp_table_node_2_0".pk_0 as "parent_key_gen_0", "temp_table_node_2_0".pk_1 as "parent_key_gen_1", "productclassificationtable_0".type as "node_5_result" from (select * from (${temp_table_node_2}) as "root") as "temp_table_node_2_0" inner join ProductTable as "root" on ("temp_table_node_2_0".pk_1 = "root".name and "temp_table_node_2_0".pk_0 = "root".id) left outer join ProductClassificationTable as "productclassificationtable_0" on ("root".type = "productclassificationtable_0".type) where "productclassificationtable_0".type is not null and "productclassificationtable_0".from_z <= \'2015-10-16\' and "productclassificationtable_0".thru_z > \'2015-10-16\'\n' + 
+    '                          connection = TestDatabaseConnection(type = "H2")\n' + 
+    '                        )\n' + 
+    '                     children = [\n' + 
+    '                        \n' + 
+    '                     ]\n' + 
+    '                   )\n\n' + 
+    '                ]\n' + 
+    '              )\n\n' + 
+    '           ]\n' + 
+    '         )\n' + 
+    '      children = [\n' + 
+    '         \n' + 
+    '      ]\n' + 
+    '      localTreeIndices = [0, 1, 2, 3, 4, 5]\n' + 
+    '      dependencyIndices = []\n' + 
+    '    )\n' + 
+    '  )\n' + 
+    ')\n',
+    $plan
+  );
 }
 
 // How to resolve %latest in serialize?


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Change composite PK not null check generated in graph fetch to AND. SQL standard 2003 states that NOT NULL constraint on composite PK columns is implicit (and many relational databases enforce this constraint). Hence, AND check should work and should also improve performance.

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
