### PR TITLE
Add decimal and numeric to dyna function type inference

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -1511,8 +1511,33 @@ function <<access.private>> meta::relational::functions::typeInference::getSafeT
 
    if($safeType->instanceOf(meta::relational::metamodel::datatype::Char) || $safeType->instanceOf(meta::relational::metamodel::datatype::Varchar),
       | ^meta::relational::metamodel::datatype::Varchar(size = [if($type1->instanceOf(meta::relational::metamodel::datatype::Other), | 0, | $type1->getSize()), if($type2->instanceOf(meta::relational::metamodel::datatype::Other), | 0, | $type2->getSize())]->max()),
-      | $safeType
+      | if($safeType->instanceOf(meta::relational::metamodel::datatype::Numeric) || $safeType->instanceOf(meta::relational::metamodel::datatype::Decimal),
+        {| 
+          let scale = max([getDecimalScale($type1), getDecimalScale($type2)]);
+          let precision = max([getDecimalIntegerPrecision($type1), getDecimalIntegerPrecision($type2)]) + $scale;
+          ^meta::relational::metamodel::datatype::Decimal(precision = $precision, scale = $scale);
+        },
+        | $safeType
+      )
    );
+}
+
+function <<access.private>> meta::relational::functions::typeInference::getDecimalScale(t: meta::relational::metamodel::datatype::DataType[1]):Integer[1]
+{
+   $t->match([
+      c:meta::relational::metamodel::datatype::Numeric[1]|$c.scale,
+      c:meta::relational::metamodel::datatype::Decimal[1]|$c.scale,
+      a:Any[1]|0
+   ])
+}
+
+function <<access.private>> meta::relational::functions::typeInference::getDecimalIntegerPrecision(t: meta::relational::metamodel::datatype::DataType[1]):Integer[1]
+{
+   $t->match([
+      c:meta::relational::metamodel::datatype::Numeric[1]|$c.precision - $c.scale,
+      c:meta::relational::metamodel::datatype::Decimal[1]|$c.precision - $c.scale,
+      a:Any[1]|0
+   ])
 }
 
 function <<access.private>> meta::relational::functions::typeInference::getSize(t: meta::relational::metamodel::datatype::DataType[1]):Integer[1]
@@ -1527,18 +1552,20 @@ function <<access.private>> meta::relational::functions::typeInference::getSize(
 function <<access.private>> meta::relational::functions::typeInference::safeTypeMap():Map<Class<Any>, List<Class<Any>>>[1]
 {
    newMap([
-      pair(meta::relational::metamodel::datatype::TinyInt, list([meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double])),
-      pair(meta::relational::metamodel::datatype::SmallInt, list([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double])),
-      pair(meta::relational::metamodel::datatype::Integer, list([meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double])),
-      pair(meta::relational::metamodel::datatype::BigInt, list([meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double])),
-      pair(meta::relational::metamodel::datatype::Float, list([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double])),
-      pair(meta::relational::metamodel::datatype::Double, list([meta::relational::metamodel::datatype::Double])),
+      pair(meta::relational::metamodel::datatype::TinyInt, list([meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double, meta::relational::metamodel::datatype::Numeric, meta::relational::metamodel::datatype::Decimal])),
+      pair(meta::relational::metamodel::datatype::SmallInt, list([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double, meta::relational::metamodel::datatype::Numeric, meta::relational::metamodel::datatype::Decimal])),
+      pair(meta::relational::metamodel::datatype::Integer, list([meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double, meta::relational::metamodel::datatype::Numeric, meta::relational::metamodel::datatype::Decimal])),
+      pair(meta::relational::metamodel::datatype::BigInt, list([meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double, meta::relational::metamodel::datatype::Numeric, meta::relational::metamodel::datatype::Decimal])),
+      pair(meta::relational::metamodel::datatype::Float, list([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double, meta::relational::metamodel::datatype::Numeric, meta::relational::metamodel::datatype::Decimal])),
+      pair(meta::relational::metamodel::datatype::Double, list([meta::relational::metamodel::datatype::Double, meta::relational::metamodel::datatype::Numeric, meta::relational::metamodel::datatype::Decimal])),
+      pair(meta::relational::metamodel::datatype::Numeric, list([meta::relational::metamodel::datatype::Numeric, meta::relational::metamodel::datatype::Decimal])),
+      pair(meta::relational::metamodel::datatype::Decimal, list([meta::relational::metamodel::datatype::Decimal, meta::relational::metamodel::datatype::Numeric])),
       pair(meta::relational::metamodel::datatype::Char, list([meta::relational::metamodel::datatype::Char, meta::relational::metamodel::datatype::Varchar])),
       pair(meta::relational::metamodel::datatype::Varchar, list([meta::relational::metamodel::datatype::Char, meta::relational::metamodel::datatype::Varchar])),
       pair(meta::relational::metamodel::datatype::Date, list([meta::relational::metamodel::datatype::Date])),
       pair(meta::relational::metamodel::datatype::Timestamp, list([meta::relational::metamodel::datatype::Timestamp])),
       pair(meta::relational::metamodel::datatype::Bit, list([meta::relational::metamodel::datatype::Bit])),
-      pair(meta::relational::metamodel::datatype::Other, list([meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double,
-                                                               meta::relational::metamodel::datatype::Char, meta::relational::metamodel::datatype::Varchar, meta::relational::metamodel::datatype::Date, meta::relational::metamodel::datatype::Timestamp, meta::relational::metamodel::datatype::Bit, meta::relational::metamodel::datatype::Other]))
+      pair(meta::relational::metamodel::datatype::Other, list([meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::BigInt, meta::relational::metamodel::datatype::Double, meta::relational::metamodel::datatype::Numeric, 
+                                                               meta::relational::metamodel::datatype::Decimal, meta::relational::metamodel::datatype::Char, meta::relational::metamodel::datatype::Varchar, meta::relational::metamodel::datatype::Date, meta::relational::metamodel::datatype::Timestamp, meta::relational::metamodel::datatype::Bit, meta::relational::metamodel::datatype::Other]))
    ])
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testRelationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testRelationalExtension.pure
@@ -101,6 +101,45 @@ function <<test.Test>> meta::relational::tests::typeInference::testDynaCaseInfer
    assertEquals('VARCHAR(12)', $dType->meta::relational::metamodel::datatype::dataTypeToSqlText());
 }
 
+function <<test.Test>> meta::relational::tests::typeInference::testDynaCaseWithDecimalInference_Decimal_Integer():Boolean[1]
+{
+   let mapping = meta::relational::tests::runtime::typeInference::DecimalCompatibilityMapping1
+      ->rootClassMappingByClass(meta::relational::tests::runtime::typeInference::DecimalCompatibilityModel)->toOne()
+      ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation);
+      
+   let intPropDType = $mapping->propertyMappingsByPropertyName('intProp')
+                  ->cast(@meta::relational::mapping::RelationalPropertyMapping).relationalOperationElement->toOne()
+                  ->meta::relational::functions::typeInference::inferRelationalType()->toOne();
+ 
+   assertEquals('DECIMAL(3, 0)', $intPropDType->meta::relational::metamodel::datatype::dataTypeToSqlText());
+}
+
+function <<test.Test>> meta::relational::tests::typeInference::testDynaCaseWithDecimalInference_Decimal_Double():Boolean[1]
+{
+   let mapping = meta::relational::tests::runtime::typeInference::DecimalCompatibilityMapping1
+      ->rootClassMappingByClass(meta::relational::tests::runtime::typeInference::DecimalCompatibilityModel)->toOne()
+      ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation);
+      
+   let floatPropDType = $mapping->propertyMappingsByPropertyName('floatProp')
+                  ->cast(@meta::relational::mapping::RelationalPropertyMapping).relationalOperationElement->toOne()
+                  ->meta::relational::functions::typeInference::inferRelationalType()->toOne();
+
+   assertEquals('DECIMAL(4, 1)', $floatPropDType->meta::relational::metamodel::datatype::dataTypeToSqlText());
+}
+
+function <<test.Test>> meta::relational::tests::typeInference::testDynaCaseWithDecimalInference_Decimal_Numeric():Boolean[1]
+{
+   let mapping = meta::relational::tests::runtime::typeInference::DecimalCompatibilityMapping1
+      ->rootClassMappingByClass(meta::relational::tests::runtime::typeInference::DecimalCompatibilityModel)->toOne()
+      ->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation);
+      
+   let numericPropDType = $mapping->propertyMappingsByPropertyName('numericProp')
+                  ->cast(@meta::relational::mapping::RelationalPropertyMapping).relationalOperationElement->toOne()
+                  ->meta::relational::functions::typeInference::inferRelationalType()->toOne();                                    
+
+   assertEquals('DECIMAL(7, 4)', $numericPropDType->meta::relational::metamodel::datatype::dataTypeToSqlText());   
+}
+
 function <<test.Test>> meta::relational::tests::typeInference::testDynaComplexInference1():Boolean[1]
 {
    let dType = meta::relational::tests::mapping::propertyfunc::model::mapping::PropertyfuncMappingWithJoin->rootClassMappingByClass(meta::relational::tests::mapping::propertyfunc::model::domain::Person)->toOne()->cast(@meta::relational::mapping::RootRelationalInstanceSetImplementation)->propertyMappingsByPropertyName('firstName')
@@ -205,3 +244,42 @@ function <<test.Test>> meta::relational::tests::runtime::extractDBs::testExtract
    assertSize($dbs, 1);
    assert($dbs->at(0) == meta::relational::tests::runtime::extractDBs::SubstitutionTestDB1);
 }
+
+###Relational
+Database meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB
+(
+  Table DecimalCompatibilityTable(
+    prop1 Decimal(3, 0),
+    prop2 Decimal(4, 1),
+    prop3 Numeric(4, 4),
+    prop4 INTEGER,
+    prop5 DOUBLE
+  )
+)
+
+###Pure
+Class meta::relational::tests::runtime::typeInference::DecimalCompatibilityModel
+{
+  intProp: Integer[1];
+  floatProp: Float[1];
+  numericProp: Decimal[1];
+}
+
+###Mapping
+Mapping meta::relational::tests::runtime::typeInference::DecimalCompatibilityMapping1
+(
+   meta::relational::tests::runtime::typeInference::DecimalCompatibilityModel : Relational {
+      intProp: case(isNotNull([meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop1),
+          [meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop1, 
+          [meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop4
+      ),
+      floatProp: case(isNotNull([meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop2),
+          [meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop2, 
+          [meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop5
+      ),
+      numericProp:  case(isNotNull([meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop2),
+          [meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop2, 
+          [meta::relational::tests::runtime::typeInference::DecimalCompatibilityDB]DecimalCompatibilityTable.prop3
+      )
+   }
+)


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

This add support for numeric/decimal types inside Dyna functions, allowing the code to infer its type.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
