### PR TITLE
Fix an issue with subtype check in M2M property transforms

### DIFF
--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/localPropertyMappingsChain.pure
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/chain/localPropertyMappingsChain.pure
@@ -1,0 +1,152 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::mapping::*;
+import meta::json::*;
+import meta::pure::executionPlan::profiles::*;
+import meta::pure::graphFetch::execution::*;
+import meta::pure::mapping::modelToModel::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::src::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::bridge::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::dest::*;
+import meta::pure::runtime::*;
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> {serverVersion.start='v1_19_0'}
+meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::chainMappingWithLocalPropertyMappings(): Boolean[1]
+{
+   let tree = #{
+      Person {
+         name,
+         dateOfBirth {
+            day,
+            month,
+            year
+         }
+      }
+   }#;
+
+   let sourcePersons = '[{"name":"P1", "dateOfBirth": "2023-01-02"}, {"name":"P2", "dateOfBirth": "2023-06-07"}]';
+   
+   let result = execute(
+      {|Person.all()->graphFetch($tree)->serialize($tree)},
+      BridgeToDestMapping,
+      ^Runtime(
+         connections = [
+            ^ModelChainConnection(element = ^ModelStore(), mappings = [SrcToBridgeMapping]),
+            ^JsonModelConnection(element = ^ModelStore(), class = __Person, url = 'data:application/json,' + $sourcePersons)
+         ]
+      ),
+      meta::pure::extension::defaultExtensions()
+   );
+
+   let expected = '[{"name":"P1","dateOfBirth":{"month":1,"year":2023,"day":2}},{"name":"P2","dateOfBirth":{"month":6,"year":2023,"day":7}}]';
+   assert(jsonEquivalent($expected->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> {serverVersion.start='v1_19_0'}
+meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::chainMappingWithLocalPropertyMappingsChecked(): Boolean[1]
+{
+   let tree = #{
+      Person {
+         name,
+         dateOfBirth {
+            day,
+            month,
+            year
+         }
+      }
+   }#;
+
+   let sourcePersons = '[{"name":"P1", "dateOfBirth": "2023-01-02"}, {"name":"P2", "dateOfBirth": "2023-06-07"}]';
+   
+   let result = execute(
+      {|Person.all()->graphFetchChecked($tree)->serialize($tree)},
+      BridgeToDestMapping,
+      ^Runtime(
+         connections = [
+            ^ModelChainConnection(element = ^ModelStore(), mappings = [SrcToBridgeMapping]),
+            ^JsonModelConnection(element = ^ModelStore(), class = __Person, url = 'data:application/json,' + $sourcePersons)
+         ]
+      ),
+      meta::pure::extension::defaultExtensions()
+   );
+
+   let expected = '['+
+    '{"defects":[],"source":{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"name\\":\\"P1\\",\\"dateOfBirth\\":\\"2023-01-02\\"}"},"value":{"name":"P1","dateOfBirth":"2023-01-02"}},"value":{"name":"P1","dateOfBirth":"2023-01-02"}},"value":{"name":"P1","dateOfBirth":{"month":1,"year":2023,"day":2}}},'+
+    '{"defects":[],"source":{"defects":[],"source":{"defects":[],"source":{"number":2,"record":"{\\"name\\":\\"P2\\",\\"dateOfBirth\\":\\"2023-06-07\\"}"},"value":{"name":"P2","dateOfBirth":"2023-06-07"}},"value":{"name":"P2","dateOfBirth":"2023-06-07"}},"value":{"name":"P2","dateOfBirth":{"month":6,"year":2023,"day":7}}}'+
+  ']';
+   assert(jsonEquivalent($expected->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+###Pure
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::src::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::bridge::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::dest::*;
+
+Class meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::src::__Person
+{
+   name: String[1];
+   dateOfBirth: StrictDate[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::bridge::_Person
+{
+   name: String[1];
+   dateOfBirth: StrictDate[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::dest::Person
+{
+   name: String[1];
+   dateOfBirth: DateOfBirth[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::dest::DateOfBirth
+{
+   day: Integer[1];
+   month: Integer[1];
+   year: Integer[1];
+}
+
+###Mapping
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::src::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::bridge::*;
+import meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::dest::*;
+
+Mapping meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::BridgeToDestMapping
+(
+   Person: Pure {
+      ~src _Person
+      name: $src.name,
+      dateOfBirth: $src
+   }
+
+   DateOfBirth: Pure {
+      ~src _Person
+      day: $src.dateOfBirth->dayOfMonth(),
+      month: $src.dateOfBirth->monthNumber(),
+      year: $src.dateOfBirth->year()
+   }
+)
+
+Mapping meta::pure::mapping::modelToModel::test::alloy::chain::localPropertyMappings::SrcToBridgeMapping
+(
+   _Person: Pure {
+      ~src __Person
+      +localProp: String[1] : '',
+      name: $src.name,
+      dateOfBirth: $src.dateOfBirth
+   }
+)

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchInMemory.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchInMemory.pure
@@ -429,15 +429,12 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
 }
 function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::addFilterForSubtype(input:Code[1],propertyType: Code[1],targetSRCType:meta::external::language::java::metamodel::Type[1], targetSet:InstanceSetImplementation[1],context: GenerationContext[1],extensions: Extension[*]):Code[1]
 { 
-  //if source is a mappingclass skip the filter
   let sourceClass = $targetSet->sourceClass($extensions);
-  let sourceClassMappings = $targetSet.parent->_classMappingByClass($sourceClass)->filter(i|$i->instanceOf(InstanceSetImplementation))->cast(@InstanceSetImplementation);
   let targetSrcJType = $context.conventions->className($sourceClass);
 
-  if($targetSet->instanceOf(PureInstanceSetImplementation) && $sourceClassMappings.mappingClass->isEmpty(),
+  if($targetSet->instanceOf(PureInstanceSetImplementation),
      |let interParam  = j_parameter(javaClassType(), 'interParam');
-      $input->js_filter(j_lambda($propertyType,  j_streamOf( $propertyType->j_invoke('getClass',[],javaClassType())->j_invoke('getInterfaces',[],javaClassType())) 
-          ->j_invoke('anyMatch', j_lambda($interParam,  $interParam->j_invoke('equals',[$targetSrcJType-> j_field('class'  ,$targetSrcJType)])),javaBoolean())));,
+      $input->js_filter(j_lambda($propertyType, $propertyType->j_instanceof($targetSrcJType)));,
      |$input
      );
   


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Subtype check currently used in M2M property transforms only checks for immediate interfaces. Converting that check to use all hierarchical interfaces (which is required when sets have local property mappings)

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
