### PR TITLE
Fix `is not distinct from` sql-to-pure

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -2210,7 +2210,7 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
       sfe(isEmpty_Any_$0_1$__Boolean_1_, $left),
       sfe(isEmpty_Any_$0_1$__Boolean_1_, $right)
     ]),
-    sfe(isTrue_Boolean_$0_1$__Boolean_1_, sfe(equal_Any_MANY__Any_MANY__Boolean_1_, [$left, $right]))
+    sfe(equal_Any_MANY__Any_MANY__Boolean_1_, [$left, $right])
   ]);
 }
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -514,9 +514,9 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
         [ x | $x.booleanIn, x | $x.integerIn, x | $x.floatIn, x | $x.decimalIn, x | $x.strictDateIn, x | $x.dateTimeIn, x | $x.stringIn ],
         [ 'Boolean', 'Integer', 'Float', 'Decimal', 'StrictDate', 'DateTime', 'String' ])
       ->filter(row |
-        !(($row.getString('String')->isEmpty() && 'ABC'->isEmpty()) || (isTrue($row.getString('String') == 'ABC')))
+        !(($row.getString('String')->isEmpty() && 'ABC'->isEmpty()) || ($row.getString('String') == 'ABC'))
         ||
-        (($row.getString('String')->isEmpty() && 'DEF'->isEmpty()) || (isTrue($row.getString('String') == 'DEF')))
+        (($row.getString('String')->isEmpty() && 'DEF'->isEmpty()) || ($row.getString('String') == 'DEF'))
       )
       };
   assertLambdaEquals($expected, $sqlTransformContext.lambda());


### PR DESCRIPTION
Remove redundant `isTrue` for an `or` expression

#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
The generated sql for `is not distinct from` fails to compile snowflake 
Issue does not occur when the redundant `isTrue` is removed from the pure expression for `is not distinct from` 

#### Does this PR introduce a user-facing change?
No