### PR TITLE
Allow Elastic Search Executions to run multiple times

### DIFF
--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/plugin/ElasticsearchV7ExecutionNodeExecutor.java
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/plugin/ElasticsearchV7ExecutionNodeExecutor.java
@@ -24,7 +24,10 @@ import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.Execut
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.ExecutionNodeVisitor;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.metamodel.executionPlan.Elasticsearch7RequestExecutionNode;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.metamodel.runtime.Elasticsearch7StoreConnection;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
+import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.RequestBase;
 import org.finos.legend.engine.shared.core.identity.Identity;
+import java.io.IOException;
 
 public class ElasticsearchV7ExecutionNodeExecutor implements ExecutionNodeVisitor<Result>
 {
@@ -49,7 +52,19 @@ public class ElasticsearchV7ExecutionNodeExecutor implements ExecutionNodeVisito
 
             HttpClientContext httpClientContext = ElasticsearchHttpContextUtil.authToHttpContext(this.identity, this.executionState.getCredentialProviderProvider(), connection.authSpec, this.state.getProviders());
 
-            return esNode.request.accept(new ExecutionRequestVisitor(this.state.getClient(), httpClientContext, connection.sourceSpec.url, esNode, this.executionState));
+            RequestBase request = null;
+            try
+            {
+                ObjectMapper pm = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
+                String readInput = pm.writeValueAsString(esNode.request);
+                request = pm.readValue(readInput, RequestBase.class);
+            }
+            catch (IOException e)
+            {
+                throw new IllegalStateException("RequestBase failed to initialize due to issues in deep-copy");
+            }
+
+            return request.accept(new ExecutionRequestVisitor(this.state.getClient(), httpClientContext, connection.sourceSpec.url, esNode, this.executionState));
         }
 
         throw new IllegalStateException("should not get here");

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/plugin/ElasticsearchV7ExecutionNodeExecutor.java
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/plugin/ElasticsearchV7ExecutionNodeExecutor.java
@@ -15,6 +15,7 @@
 
 package org.finos.legend.engine.plan.execution.stores.elasticsearch.v7.plugin;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.finos.legend.engine.plan.execution.nodes.state.ExecutionState;
 import org.finos.legend.engine.plan.execution.result.Result;

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/test/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/test/TestElasticsearchExecutionPlanFromGrammarIntegration.java
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/test/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/test/TestElasticsearchExecutionPlanFromGrammarIntegration.java
@@ -36,7 +36,6 @@ import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransforme
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.metamodel.executionPlan.Elasticsearch7RequestExecutionNode;
-import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.LiteralOrExpression;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.global.search.SearchRequest;
 import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
@@ -137,7 +136,7 @@ public class TestElasticsearchExecutionPlanFromGrammarIntegration
         {
             SingleExecutionPlan originalPlan = getPlanFromFunctionGrammar("abc::abc::indexToTDSGroupByFunction__TabularDataSet_1_");
 
-            //create a deep copy of the original plan that we pass into the execute call
+            //create a deep copy of the original plan that we pass into the exeucte call
             ObjectMapper objectmapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
             String planJson = objectmapper.writeValueAsString(originalPlan);
             SingleExecutionPlan passedPlan = objectmapper.readValue(planJson, SingleExecutionPlan.class);
@@ -147,14 +146,16 @@ public class TestElasticsearchExecutionPlanFromGrammarIntegration
 
             result.stream(outputStream, SerializationFormat.DEFAULT); //this should trigger tryAdvance -- streaming results in batches
 
+
             //Since passedPlan is a deep-copy of original, our goal is that the plan passed through execute() should remain unchanged post execution
-            LiteralOrExpression<Long> originalCompositeSize = ((SearchRequest) ((Elasticsearch7RequestExecutionNode) originalPlan.rootExecutionNode).request).body.aggregations.get("groupByComposite").composite.size;
+            Object  originalCompositeSize = ((SearchRequest) ((Elasticsearch7RequestExecutionNode) originalPlan.rootExecutionNode).request).body.aggregations.get("groupByComposite").composite.size;
 
-            LiteralOrExpression<Long> postExecutionPlanSize = ((SearchRequest) ((Elasticsearch7RequestExecutionNode) passedPlan.rootExecutionNode).request).body.aggregations.get("groupByComposite").composite.size;
+            Object postExecutionPlanSize = ((SearchRequest) ((Elasticsearch7RequestExecutionNode) passedPlan.rootExecutionNode).request).body.aggregations.get("groupByComposite").composite.size;
 
-            //these two should be equal now
+            //two of these should be equal now
             Assert.assertEquals(originalCompositeSize,postExecutionPlanSize);
-            Assert.assertTrue(((SearchRequest) ((Elasticsearch7RequestExecutionNode) passedPlan.rootExecutionNode).request).body.aggregations.get("groupByComposite").composite.size == null);
+            Assert.assertTrue(originalCompositeSize == null);
+            Assert.assertTrue(postExecutionPlanSize == null);
         }
     }
 }

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/test/resources/grammarForPlanIntegrationTesting.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/test/resources/grammarForPlanIntegrationTesting.pure
@@ -50,3 +50,8 @@ function abc::abc::indexToTdsFunction(): TabularDataSet[1]
 {
     indexToTDS(abc::abc::Store, 'index1')->from(abc::abc::EmptyMapping, abc::abc::Runtime);
 }
+
+function abc::abc::indexToTDSGroupByFunction(): TabularDataSet[1]
+{
+    indexToTDS(abc::abc::Store, 'index1')->from(abc::abc::EmptyMapping, abc::abc::Runtime)->groupBy(['prop1', '_id'], agg('count', r | $r.getString('prop1'), agg | $agg->count()));
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
--> Bug fix 

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> instead of passing the execution node object itself, we pass a cloned object so the actual query is not affected with size updating


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> No
