### PR TITLE
Escape single quote present in values for temp table

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -936,7 +936,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             {
                 return (String) ResultNormalizer.normalizeToSql(v, databaseTimeZone);
             }
-            return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
+            return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone).replace("'", "''") + "'"; // replacing single quotes with two single quotes to escape it in sql
         };
 
         Iterator<List<List<Object>>> rowBatchIterator = Iterators.partition(realizedRelationalResult.resultSetRows.iterator(), batchSize);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -936,7 +936,11 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             {
                 return (String) ResultNormalizer.normalizeToSql(v, databaseTimeZone);
             }
-            return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone).replace("'", "''") + "'"; // replacing single quotes with two single quotes to escape it in sql
+            if (v instanceof String)
+            {
+                return "'" + ((String)ResultNormalizer.normalizeToSql(v, databaseTimeZone)).replace("'", "''") + "'"; // replacing single quotes with two single quotes to escape it in sql
+            }
+            return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
         };
 
         Iterator<List<List<Object>>> rowBatchIterator = Iterators.partition(realizedRelationalResult.resultSetRows.iterator(), batchSize);


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels:
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed?
Escape single quote present in values for temp table by replacing with two single quotes. 

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

From https://docs.snowflake.com/en/sql-reference/data-types-text#single-quoted-string-constants

`To include a single quote character within a string constant, type two adjacent single quotes (e.g. '').`


#### Does this PR introduce a user-facing change?
yes
<!--
-->
