### PR TITLE
Make release workflow input description clearer

### DIFF
--- a/.github/workflows/release-large-runner-serial.yml
+++ b/.github/workflows/release-large-runner-serial.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: "New release version"
+        description: "New release version number"
         required: true
 
 jobs:

--- a/.github/workflows/release-large-runner.yml
+++ b/.github/workflows/release-large-runner.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: "New release version"
+        description: "New release version number"
         required: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: "New release version"
+        description: "New release version number"
         required: true
 
 jobs:


### PR DESCRIPTION
Emphasise input should be a version number in release workflows
