### PR TITLE
Connection equality added for relational database connections

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/main/resources/core_relational_athena.definition.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/main/resources/core_relational_athena.definition.json
@@ -1,6 +1,6 @@
 {
   "name": "core_relational_athena",
-  "pattern": "(meta::relational::functions::sqlQueryToString::athena|meta::relational::tests::sqlQueryToString::athena|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
+  "pattern": "(meta::relational::functions::sqlQueryToString::athena|meta::relational::tests::sqlQueryToString::athena|meta::relational::tests::connEquality|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
   "dependencies": [
     "platform",
     "platform_functions",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/main/resources/core_relational_athena/relational/connection/connectionEqualityTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/main/resources/core_relational_athena/relational/connection/connectionEqualityTest.pure
@@ -1,0 +1,46 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::metamodel::execute::tests::*;
+import meta::pure::alloy::connections::*;
+import meta::pure::runtime::*;
+import meta::relational::translation::*;
+import meta::pure::extension::*;
+import meta::relational::extension::*;
+import meta::relational::runtime::*;
+import meta::relational::tests::csv::*;
+import meta::relational::metamodel::execute::*;
+import meta::relational::metamodel::*;
+import meta::pure::mapping::*;
+
+function <<test.Test>> meta::relational::tests::connEquality::testConnectionEqualityAllSameAthena() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.Athena,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::AthenaDatasourceSpecification(awsRegion='awsR', s3OutputLocation='s3OL', databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.Athena,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::AthenaDatasourceSpecification(awsRegion='awsR', s3OutputLocation='s3OL', databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  assert(runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/main/resources/core_relational_athena/relational/connection/metamodel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/main/resources/core_relational_athena/relational/connection/metamodel.pure
@@ -14,7 +14,7 @@
 
 Class meta::pure::alloy::connections::alloy::specification::AthenaDatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-   awsRegion: String[1];
-   s3OutputLocation: String[1];
-   databaseName: String[1];
+   <<equality.Key>> awsRegion: String[1];
+   <<equality.Key>> s3OutputLocation: String[1];
+   <<equality.Key>> databaseName: String[1];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
@@ -1,0 +1,31 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import junit.framework.TestSuite;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+public class Test_Pure_Relational_ConnectionEquality
+{
+    public static TestSuite suite()
+    {
+        String testPackage = "meta::relational::tests::connEquality";
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+        return PureTestBuilderCompiled.buildSuite(TestCollection.collectTests(testPackage, executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery.definition.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery.definition.json
@@ -1,6 +1,6 @@
 {
   "name": "core_relational_bigquery",
-  "pattern": "(meta::relational::functions::sqlQueryToString::bigQuery|meta::relational::tests::sqlQueryToString::bigQuery|meta::relational::bigQuery::tests|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
+  "pattern": "(meta::relational::functions::sqlQueryToString::bigQuery|meta::relational::tests::connEquality|meta::relational::tests::sqlQueryToString::bigQuery|meta::relational::bigQuery::tests|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
   "dependencies": [
     "platform",
     "platform_functions",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/runtime/connection/bigQuerySpecification.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/runtime/connection/bigQuerySpecification.pure
@@ -14,8 +14,8 @@
 
 Class meta::pure::alloy::connections::alloy::specification::BigQueryDatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-    projectId:String[1];
-    defaultDataset:String[1];
-    proxyHost: String[0..1];
-    proxyPort: String[0..1];
+    <<equality.Key>> projectId:String[1];
+    <<equality.Key>> defaultDataset:String[1];
+    <<equality.Key>> proxyHost: String[0..1];
+    <<equality.Key>> proxyPort: String[0..1];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/runtime/connection/connectionEqualityTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/runtime/connection/connectionEqualityTest.pure
@@ -1,0 +1,47 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::metamodel::execute::tests::*;
+import meta::pure::alloy::connections::*;
+import meta::pure::runtime::*;
+import meta::relational::translation::*;
+import meta::pure::extension::*;
+import meta::relational::extension::*;
+import meta::relational::runtime::*;
+import meta::relational::tests::csv::*;
+import meta::relational::metamodel::execute::*;
+import meta::relational::metamodel::*;
+import meta::pure::mapping::*;
+
+
+function <<test.Test>> meta::relational::tests::connEquality::testConnectionEqualityAllSameBigQuery() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::BigQueryDatasourceSpecification(projectId='project', defaultDataset='defDs', proxyHost='ph', proxyPort='8080'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::BigQueryDatasourceSpecification(projectId='project', defaultDataset='defDs', proxyHost='ph', proxyPort='8080'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  assert(runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
@@ -1,0 +1,31 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import junit.framework.TestSuite;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+public class Test_Pure_Relational_ConnectionEquality
+{
+    public static TestSuite suite()
+    {
+        String testPackage = "meta::relational::tests::connEquality";
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+        return PureTestBuilderCompiled.buildSuite(TestCollection.collectTests(testPackage, executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks.definition.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks.definition.json
@@ -1,5 +1,5 @@
 {
   "name" : "core_relational_databricks",
-  "pattern" : "(meta::relational::functions::sqlQueryToString::databricks|meta::relational::tests::sqlQueryToString::databricks|meta::relational::databricks::tests|meta::relational::tests::functions::sqlstring::databricks|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
+  "pattern" : "(meta::relational::functions::sqlQueryToString::databricks|meta::relational::tests::sqlQueryToString::databricks|meta::relational::tests::connEquality|meta::relational::databricks::tests|meta::relational::tests::functions::sqlstring::databricks|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
   "dependencies" : ["platform", "platform_functions", "platform_store_relational", "platform_dsl_mapping", "core_functions", "core", "core_relational"]
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/connection/connectionEqualityTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/connection/connectionEqualityTest.pure
@@ -1,0 +1,47 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::metamodel::execute::tests::*;
+import meta::pure::alloy::connections::*;
+import meta::pure::runtime::*;
+import meta::relational::translation::*;
+import meta::pure::extension::*;
+import meta::relational::extension::*;
+import meta::relational::runtime::*;
+import meta::relational::tests::csv::*;
+import meta::relational::metamodel::execute::*;
+import meta::relational::metamodel::*;
+import meta::pure::mapping::*;
+
+function <<test.Test>> meta::relational::tests::connEquality::testConnectionEqualityAllSameDataBricks() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.Databricks,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::DatabricksDatasourceSpecification(hostname='host', port='8080', protocol='http', httpPath='http://path'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.Databricks,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::DatabricksDatasourceSpecification(hostname='host', port='8080', protocol='http', httpPath='http://path'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  assert(runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+
+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/connection/metamodel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/connection/metamodel.pure
@@ -14,8 +14,8 @@
 
 Class meta::pure::alloy::connections::alloy::specification::DatabricksDatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-    hostname:String[1];
-    port:String[1];
-    protocol:String[1];
-    httpPath:String[1];
+    <<equality.Key>> hostname:String[1];
+    <<equality.Key>> port:String[1];
+    <<equality.Key>> protocol:String[1];
+    <<equality.Key>> httpPath:String[1];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
@@ -1,0 +1,31 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import junit.framework.TestSuite;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+public class Test_Pure_Relational_ConnectionEquality
+{
+    public static TestSuite suite()
+    {
+        String testPackage = "meta::relational::tests::connEquality";
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+        return PureTestBuilderCompiled.buildSuite(TestCollection.collectTests(testPackage, executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-dbExtension-archetype/src/main/resources/archetype-resources/legend-engine-xt-relationalStore-__dbtype__-pure/src/main/resources/core_relational___dbtype__.definition.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-dbExtension-archetype/src/main/resources/archetype-resources/legend-engine-xt-relationalStore-__dbtype__-pure/src/main/resources/core_relational___dbtype__.definition.json
@@ -1,5 +1,5 @@
 {
   "name" : "core_relational_${dbtype}",
-  "pattern" : "(meta::relational::functions::sqlQueryToString::${dbType}|meta::relational::tests::sqlQueryToString::${dbType}|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
+  "pattern" : "(meta::relational::functions::sqlQueryToString::${dbType}|meta::relational::tests::connEquality|meta::relational::tests::sqlQueryToString::${dbType}|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
   "dependencies" : ["platform", "platform_functions", "platform_store_relational", "core", "core_relational"]
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-dbExtension-archetype/src/main/resources/archetype-resources/legend-engine-xt-relationalStore-__dbtype__-pure/src/main/resources/core_relational___dbtype__/relational/connection/connectionEqualityTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-dbExtension-archetype/src/main/resources/archetype-resources/legend-engine-xt-relationalStore-__dbtype__-pure/src/main/resources/core_relational___dbtype__/relational/connection/connectionEqualityTest.pure
@@ -1,0 +1,47 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::metamodel::execute::tests::*;
+import meta::pure::alloy::connections::*;
+import meta::pure::runtime::*;
+import meta::relational::translation::*;
+import meta::pure::extension::*;
+import meta::relational::extension::*;
+import meta::relational::runtime::*;
+import meta::relational::tests::csv::*;
+import meta::relational::metamodel::execute::*;
+import meta::relational::metamodel::*;
+import meta::pure::mapping::*;
+
+
+function <<test.Test>> meta::relational::tests::connEquality::testConnectionEqualityAllSame__dbtype__() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.__dbtype__,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::__dbtype__DatasourceSpecification(),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::BigQueryDatasourceSpecification(projectId='project', defaultDataset='defDs', proxyHost='ph', proxyPort='8080'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );
+
+  assert(runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-dbExtension-archetype/src/main/resources/archetype-resources/legend-engine-xt-relationalStore-__dbtype__-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-dbExtension-archetype/src/main/resources/archetype-resources/legend-engine-xt-relationalStore-__dbtype__-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
@@ -1,0 +1,31 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import junit.framework.TestSuite;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+public class Test_Pure_Relational_ConnectionEquality
+{
+    public static TestSuite suite()
+    {
+        String testPackage = "meta::relational::tests::connEquality";
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+        return PureTestBuilderCompiled.buildSuite(TestCollection.collectTests(testPackage, executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-pure/src/main/resources/core_relational_redshift/relational/connection/metamodel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-pure/src/main/resources/core_relational_redshift/relational/connection/metamodel.pure
@@ -14,10 +14,10 @@
 
 Class {doc.doc ='Specification for the AWS redshift database'} meta::pure::legend::connections::legend::specification::RedshiftDatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-  {doc.doc ='clusterID'} clusterID:String[1];
-  {doc.doc ='The aws region'} region:String[1];
-  {doc.doc ='the full host url'}  host:String[1];
-  {doc.doc ='database name'} databaseName:String[1];
-  {doc.doc ='port'} port:Integer[1];
-  {doc.doc ='Optional URL used for redshift service execution'}  endpointURL:String[0..1];
+  <<equality.Key>> {doc.doc ='clusterID'} clusterID:String[1];
+  <<equality.Key>> {doc.doc ='The aws region'} region:String[1];
+  <<equality.Key>> {doc.doc ='the full host url'}  host:String[1];
+  <<equality.Key>> {doc.doc ='database name'} databaseName:String[1];
+  <<equality.Key>> {doc.doc ='port'} port:Integer[1];
+  <<equality.Key>> {doc.doc ='Optional URL used for redshift service execution'}  endpointURL:String[0..1];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake.definition.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake.definition.json
@@ -1,5 +1,5 @@
 {
   "name" : "core_relational_snowflake",
-  "pattern" : "(meta::relational::functions::sqlQueryToString::snowflake|meta::relational::tests::sqlQueryToString::snowflake|meta::relational::tests::sqlToString::snowflake|meta::pure::executionPlan::tests::snowflake|meta::relational::tests::projection::snowflake|meta::relational::tests::query::snowflake|meta::relational::tests::tds::snowflake|meta::relational::tests::mapping::function::snowflake|meta::relational::tests::postProcessor::snowflake|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
+  "pattern" : "(meta::relational::functions::sqlQueryToString::snowflake|meta::relational::tests::connEquality|meta::relational::tests::sqlQueryToString::snowflake|meta::relational::tests::sqlToString::snowflake|meta::pure::executionPlan::tests::snowflake|meta::relational::tests::projection::snowflake|meta::relational::tests::query::snowflake|meta::relational::tests::tds::snowflake|meta::relational::tests::mapping::function::snowflake|meta::relational::tests::postProcessor::snowflake|meta::pure::alloy::connections|meta::protocols::pure)(::.*)?",
   "dependencies" : ["platform", "platform_functions", "platform_store_relational", "platform_dsl_mapping", "core_functions", "core", "core_relational"]
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/connection/connectionEqualityTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/connection/connectionEqualityTest.pure
@@ -1,0 +1,48 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::metamodel::execute::tests::*;
+import meta::pure::alloy::connections::*;
+import meta::pure::runtime::*;
+import meta::relational::translation::*;
+import meta::pure::extension::*;
+import meta::relational::extension::*;
+import meta::relational::runtime::*;
+import meta::relational::tests::csv::*;
+import meta::relational::metamodel::execute::*;
+import meta::relational::metamodel::*;
+import meta::pure::mapping::*;
+
+
+
+function <<test.Test>> meta::relational::tests::connEquality::testConnectionEqualityAllSameSnowflake() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceSpecification(accountName='account', region='region', warehouseName='wh', databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::SnowflakePublicAuthenticationStrategy(privateKeyVaultReference='pkvr', publicUserName ='public', passPhraseVaultReference='ppVR')
+  );
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceSpecification(accountName='account', region='region', warehouseName='wh', databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::SnowflakePublicAuthenticationStrategy(privateKeyVaultReference='pkvr', publicUserName ='public', passPhraseVaultReference='ppVR')
+  );
+
+  assert(runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/connection/metamodel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/connection/metamodel.pure
@@ -19,28 +19,28 @@ Enum meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType
 
 Class meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-    accountName:String[1];
-    region:String[1];
-    warehouseName:String[1];
-    databaseName:String[1];
-    role:String[0..1];
+    <<equality.Key>> accountName:String[1];
+    <<equality.Key>> region:String[1];
+    <<equality.Key>> warehouseName:String[1];
+    <<equality.Key>> databaseName:String[1];
+    <<equality.Key>> role:String[0..1];
 
     proxyHost:String[0..1];
     proxyPort:String[0..1];
     nonProxyHosts:String[0..1];
 
-    accountType: meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType[0..1];
-    organization:String[0..1];
-    cloudType:String[0..1];
+    <<equality.Key>> accountType: meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType[0..1];
+    <<equality.Key>> organization:String[0..1];
+    <<equality.Key>> cloudType:String[0..1];
 
-    quotedIdentifiersIgnoreCase:Boolean[0..1];
-    enableQueryTags: Boolean[0..1];
+    <<equality.Key>> quotedIdentifiersIgnoreCase:Boolean[0..1];
+    <<equality.Key>> enableQueryTags: Boolean[0..1];
 }
 
 Class meta::pure::alloy::connections::alloy::authentication::SnowflakePublicAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
 {
-    privateKeyVaultReference:String[1];
-    passPhraseVaultReference:String[1];
-    publicUserName:String[1];
+    <<equality.Key>> privateKeyVaultReference:String[1];
+    <<equality.Key>> passPhraseVaultReference:String[1];
+    <<equality.Key>> publicUserName:String[1];
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/test/java/org/finos/legend/pure/code/core/Test_Pure_Relational_ConnectionEquality.java
@@ -1,0 +1,31 @@
+//  Copyright 2022 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import junit.framework.TestSuite;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+public class Test_Pure_Relational_ConnectionEquality
+{
+    public static TestSuite suite()
+    {
+        String testPackage = "meta::relational::tests::connEquality";
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+        return PureTestBuilderCompiled.buildSuite(TestCollection.collectTests(testPackage, executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-pure/src/main/resources/core_relational_spanner/relational/runtime/connection/spannerSpecification.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-pure/src/main/resources/core_relational_spanner/relational/runtime/connection/spannerSpecification.pure
@@ -14,9 +14,9 @@
 
 Class meta::pure::alloy::connections::alloy::specification::SpannerDatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-    projectId:String[1];
-    instanceId:String[1];
-    databaseId:String[1];
-    proxyHost: String[0..1];
-    proxyPort: Integer[0..1];
+   <<equality.Key>>  projectId:String[1];
+   <<equality.Key>>  instanceId:String[1];
+   <<equality.Key>>  databaseId:String[1];
+   <<equality.Key>>  proxyHost: String[0..1];
+   <<equality.Key>>  proxyPort: Integer[0..1];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/contract/storeContract.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/contract/storeContract.pure
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::relational::contract::*;
 import meta::pure::router::metamodel::*;
 import meta::pure::router::systemMapping::tests::*;
 import meta::relational::mapping::*;
@@ -29,6 +30,7 @@ import meta::pure::executionPlan::toString::*;
 import meta::pure::router::clustering::*;
 import meta::pure::graphFetch::executionPlan::*;
 import meta::pure::graphFetch::routing::*;
+import meta::pure::alloy::connections::*;
 
 function meta::relational::contract::relationalStoreContract():StoreContract[1]
 {
@@ -40,6 +42,20 @@ function meta::relational::contract::relationalStoreContract():StoreContract[1]
      planGraphFetchExecution = meta::relational::contract::planGraphFetchExecution_StoreMappingLocalGraphFetchExecutionNodeGenerationInput_1__LocalGraphFetchExecutionNode_1_,
      planCrossGraphFetchExecution = meta::relational::contract::planCrossGraphFetchExecution_StoreMappingCrossLocalGraphFetchExecutionNodeGenerationInput_1__LocalGraphFetchExecutionNode_1_,
     
+     connectionEquality = { b : Connection [1] |
+                               [
+                                 d: RelationalDatabaseConnection[1]|
+                                 let bAsRDB = $b->cast(@RelationalDatabaseConnection);
+                                 // connection element is the store name and we dont compare those
+                                 let comparison = $d.type == $bAsRDB.type &&
+                                   $d.timeZone == $bAsRDB.timeZone &&
+                                   $d.quoteIdentifiers == $bAsRDB.quoteIdentifiers &&
+                                   $d.datasourceSpecification == $bAsRDB.datasourceSpecification &&
+                                   compareObjectsWithPossiblyNoProperties($d.authenticationStrategy,$bAsRDB.authenticationStrategy) &&
+                                   (($d.postProcessors->isEmpty() && $bAsRDB.postProcessors->isEmpty()) || ($d.postProcessors->isNotEmpty() && $bAsRDB.postProcessors->isNotEmpty() && $d.postProcessors == $bAsRDB.postProcessors));
+                                 ]
+                         },
+
      supports = meta::relational::contract::supports_FunctionExpression_1__Boolean_1_,
      supportsStreamFunction = meta::relational::contract::supportsStream_FunctionExpression_1__Boolean_1_,
      shouldStopRouting = [
@@ -220,6 +236,17 @@ function meta::relational::contract::planExecution(sq:meta::pure::mapping::Store
                           ->generateExecutionNodeForPostProcessedResult($sq, $store, $ext, $m->toOne(), $storeRuntime, $exeCtx, $debug, $extensions);
       );
    );
+}
+
+function meta::relational::contract::compareObjectsWithPossiblyNoProperties(obj1: Any[1], obj2: Any[1]): Boolean[1]
+{
+ let propertyCountForObj1 = $obj1->type()->cast(@Class<Any>)->hierarchicalProperties()->size();
+ let propertyCountForObj2 = $obj2->type()->cast(@Class<Any>)->hierarchicalProperties()->size();
+
+ if($propertyCountForObj1 == 0 && $propertyCountForObj2 == 0
+ ,| true
+ ,| $obj1 == $obj2
+ );
 }
 
 function meta::relational::contract::planGraphFetchExecution(input: StoreMappingLocalGraphFetchExecutionNodeGenerationInput[1]): LocalGraphFetchExecutionNode[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/extensions/extension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/extensions/extension.pure
@@ -15,6 +15,8 @@
 import meta::external::language::java::factory::project::*;
 import meta::external::language::java::metamodel::project::*;
 import meta::pure::alloy::connections::*;
+import meta::pure::alloy::connections::alloy::specification::*;
+import meta::pure::alloy::connections::alloy::authentication::*;
 import meta::pure::executionPlan::*;
 import meta::pure::executionPlan::engine::java::*;
 import meta::pure::executionPlan::toString::*;
@@ -208,10 +210,9 @@ function meta::relational::extension::relationalExtension() : meta::pure::extens
                                     },
       testExtension_testedBy = {allReferenceUses:ReferenceUsage[*], extensions:Extension[*] | {soFarr:TestedByResult[1]| $allReferenceUses.owner->filter(o|$o->instanceOf(Database))->cast(@Database)->fold({db,tbr|$db->testedBy($tbr, $extensions)}, $soFarr)}},
       validTestPackages = 'meta::relational::tests'
-   )
+
+  )
 }
-
-
 
 
 //Helper Functions

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/runtime/connection/authenticationStrategy.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/runtime/connection/authenticationStrategy.pure
@@ -23,23 +23,22 @@ Class  <<typemodifiers.abstract>> meta::pure::alloy::connections::alloy::authent
 
 Class meta::pure::alloy::connections::alloy::authentication::DelegatedKerberosAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
 {
-   serverPrincipal: String[0..1];
+   <<equality.Key>> serverPrincipal: String[0..1];
 }
 
 Class
 {doc.doc = 'Authentication using a middle tier user/password'}
 meta::pure::alloy::connections::alloy::authentication::MiddleTierUserNamePasswordAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
 {
-    {doc.doc = 'Username/pasword vault reference'}
-    vaultReference: String[1];
+   <<equality.Key>> {doc.doc = 'Username/pasword vault reference'} vaultReference: String[1];
 }
 
 
 Class meta::pure::alloy::connections::alloy::authentication::UserNamePasswordAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
 {
-   baseVaultReference: String[0..1];
-   userNameVaultReference: String[1];
-   passwordVaultReference: String[1];
+   <<equality.Key>> baseVaultReference: String[0..1];
+   <<equality.Key>> userNameVaultReference: String[1];
+   <<equality.Key>> passwordVaultReference: String[1];
 }
 
 Class meta::pure::alloy::connections::alloy::authentication::GCPApplicationDefaultCredentialsAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
@@ -52,7 +51,7 @@ Class meta::pure::alloy::connections::alloy::authentication::DefaultH2Authentica
 
 Class meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
 {
-    apiToken:String[1];
+    <<equality.Key>> apiToken:String[1];
 }
 
 Class meta::pure::alloy::connections::alloy::authentication::TestDatabaseAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy
@@ -61,6 +60,6 @@ Class meta::pure::alloy::connections::alloy::authentication::TestDatabaseAuthent
 
 Class meta::pure::alloy::connections::alloy::authentication::GCPWorkloadIdentityFederationAuthenticationStrategy extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
 {
-    serviceAccountEmail : String[1];
-    additionalGcpScopes: String[*];
+    <<equality.Key>> serviceAccountEmail : String[1];
+    <<equality.Key>> additionalGcpScopes: String[*];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/runtime/connection/datasourceSpecification.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/runtime/connection/datasourceSpecification.pure
@@ -18,20 +18,21 @@ Class <<typemodifiers.abstract>> meta::pure::alloy::connections::alloy::specific
 
 Class meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-   host: String[1];
-   port: Integer[1];
-   databaseName: String[1];
+   <<equality.Key>> host: String[1];
+   <<equality.Key>> port: Integer[1];
+   <<equality.Key>> databaseName: String[1];
 }
 
 Class meta::pure::alloy::connections::alloy::specification::EmbeddedH2DatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-    databaseName:String[1];
-    directory:String[1];
-    autoServerMode:Boolean[1];
+    <<equality.Key>> databaseName:String[1];
+    <<equality.Key>> directory:String[1];
+    <<equality.Key>> autoServerMode:Boolean[1];
+
 }
 
 Class meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
 {
-    testDataSetupCsv:String[0..1];
-    testDataSetupSqls:String[*];
+    <<equality.Key>> testDataSetupCsv:String[0..1];
+    <<equality.Key>> testDataSetupSqls:String[*];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testRelationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/tests/testRelationalExtension.pure
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::relational::metamodel::execute::tests::*;
+import meta::pure::alloy::connections::*;
 import meta::pure::runtime::*;
 import meta::relational::translation::*;
 import meta::pure::extension::*;
@@ -22,6 +24,119 @@ import meta::relational::metamodel::execute::*;
 import meta::relational::metamodel::*;
 import meta::pure::mapping::*;
 
+function  meta::relational::metamodel::execute::tests::runRelationalRouterExtensionConnectionEquality(c1: RelationalDatabaseConnection[1],
+    c2: RelationalDatabaseConnection[1]) : Boolean[1]
+{
+  let extensions = meta::relational::extension::relationalExtensions().routerExtensions();
+  $c1->match(
+              $extensions.connectionEquality->map(e | $e->eval($c2))->concatenate([
+                  a:Connection[1]  | true
+              ])->toOneMany());
+}
+
+function <<test.Test>> meta::relational::metamodel::execute::tests::testConnectionEqualityAllSameStatic() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.SybaseIQ,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification(host='host', port=8080, databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy()
+  );   
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.SybaseIQ,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification(host='host', port=8080, databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy()
+  );     
+
+  assert(runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+
+function <<test.Test>> meta::relational::metamodel::execute::tests::testConnectionEqualityAllButOnePropertySame() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification(host='host', port=8090, databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy()
+  );   
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification(host='host', port=8080, databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );      
+
+  assert(!runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+
+function <<test.Test>> meta::relational::metamodel::execute::tests::testConnectionEqualityTypeDiff() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.H2,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy()
+  );   
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.Snowflake,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::StaticDatasourceSpecification(host='host', port=8080, databaseName='db'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );      
+
+
+  assert(!runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+
+
+function <<test.Test>> meta::relational::metamodel::execute::tests::testConnectionEqualityTypeSameSpecDiff() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.H2,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy()
+  );   
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.H2,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(testDataSetupCsv='something'),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy()
+  );      
+
+
+  assert(!runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
+
+function <<test.Test>> meta::relational::metamodel::execute::tests::testConnectionEqualityTypeSpecSameAuthDiff() : Boolean[1]
+{
+  let c1 = ^RelationalDatabaseConnection(
+    element = 'Store1',
+    type = DatabaseType.H2,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::DefaultH2AuthenticationStrategy()
+  );   
+
+  let c2 = ^RelationalDatabaseConnection(
+    element = '',
+    type = DatabaseType.H2,
+    datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(),
+    authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::ApiTokenAuthenticationStrategy(apiToken='token')
+  );      
+
+
+  assert(!runRelationalRouterExtensionConnectionEquality($c1, $c2));
+
+}
 
 function <<test.Test>> meta::relational::metamodel::execute::tests::testExecuteInDbToTDS() : Boolean[1]
 {


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?
Connection equality is not currently implemented for for relational database connections.
This has been introduced in the store contract using equality key based checks.

Tests added for athena, databricks, snowflake, bigquery and generic. More tests for spanner, redshift etc to follow

#### Which issue(s) this PR fixes:
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No