### PR TITLE
Fix milestoned qualified property generation for toOne multiplicity

### DIFF
--- a/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/Milestoning.java
+++ b/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/Milestoning.java
@@ -289,8 +289,19 @@ public class Milestoning
                 ._rawType(context.pureModel.getType("meta::pure::metamodel::function::property::QualifiedProperty"))
                 ._typeArguments(Lists.fixedSize.of(PureModel.buildFunctionType(Lists.mutable.of(thisVar), qualifiedProperty._genericType(), originalProperty._multiplicity(), context.pureModel)));
 
+        SimpleFunctionExpression finalExpression = filterExpression;
+        if (originalProperty._multiplicity() == context.pureModel.getMultiplicity("one"))
+        {
+            finalExpression = new Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::SimpleFunctionExpression"))
+                    ._func(context.pureModel.getFunction("meta::pure::functions::multiplicity::toOne_T_MANY__T_1_", true))
+                    ._functionName("toOne")
+                    ._genericType(qualifiedProperty._genericType())
+                    ._multiplicity(context.pureModel.getMultiplicity("one"))
+                    ._parametersValues(Lists.fixedSize.of(filterExpression));
+        }
+
         qualifiedProperty._classifierGenericType(classifierGenericType);
-        qualifiedProperty._expressionSequence(Lists.fixedSize.of(filterExpression));
+        qualifiedProperty._expressionSequence(Lists.fixedSize.of(finalExpression));
 
         return qualifiedProperty;
     }
@@ -357,12 +368,23 @@ public class Milestoning
                 ._multiplicity(context.pureModel.getMultiplicity("zeromany"))
                 ._parametersValues(Lists.fixedSize.of(filterLhs, filterInstanceValue));
 
+        SimpleFunctionExpression finalExpression = filterExpression;
+        if (originalProperty._multiplicity() == context.pureModel.getMultiplicity("one"))
+        {
+            finalExpression = new Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::SimpleFunctionExpression"))
+                    ._func(context.pureModel.getFunction("meta::pure::functions::multiplicity::toOne_T_MANY__T_1_", true))
+                    ._functionName("toOne")
+                    ._genericType(qualifiedProperty._genericType())
+                    ._multiplicity(context.pureModel.getMultiplicity("one"))
+                    ._parametersValues(Lists.fixedSize.of(filterExpression));
+        }
+
         GenericType classifierGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
                 ._rawType(context.pureModel.getType("meta::pure::metamodel::function::property::QualifiedProperty"))
                 ._typeArguments(Lists.fixedSize.of(PureModel.buildFunctionType(Lists.mutable.of(thisVar).withAll(datesToCompare.collect(Functions.firstOfPair())), qualifiedProperty._genericType(), originalProperty._multiplicity(), context.pureModel)));
 
         qualifiedProperty._classifierGenericType(classifierGenericType);
-        qualifiedProperty._expressionSequence(Lists.fixedSize.of(filterExpression));
+        qualifiedProperty._expressionSequence(Lists.fixedSize.of(finalExpression));
 
         return Lists.mutable.of(qualifiedProperty);
     }

--- a/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -2296,6 +2296,66 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
+    public void testMilestoningPropertiesQualfiedExpressionForToOne()
+    {
+        String grammar = "###Pure\n" +
+                "Class <<temporal.processingtemporal>> test::ProcessingTemporalAddress\n" +
+                "{\n" +
+                "  DunmmyProperty : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class <<temporal.businesstemporal>> test::BusinessTemporalAddress\n" +
+                "{\n" +
+                "  DunmmyProperty : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class <<temporal.bitemporal>> test::BiTemporalAddress\n" +
+                "{\n" +
+                "  DunmmyProperty : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::Person\n" +
+                "{\n" +
+                "  processingTemporalAddress1 : test::ProcessingTemporalAddress[1];\n" +
+                "  businessTemporalAddress1 : test::BusinessTemporalAddress[1];\n" +
+                "  biTemporalAddress1 : test::BiTemporalAddress[1];\n" +
+                "  processingTemporalAddress2 : test::ProcessingTemporalAddress[0..1];\n" +
+                "  businessTemporalAddress2 : test::BusinessTemporalAddress[0..1];\n" +
+                "  biTemporalAddress2 : test::BiTemporalAddress[0..1];\n" +
+                "  processingTemporalAddress3 : test::ProcessingTemporalAddress[*];\n" +
+                "  businessTemporalAddress3 : test::BusinessTemporalAddress[*];\n" +
+                "  biTemporalAddress3 : test::BiTemporalAddress[*];\n" +
+                "}";
+        PureModel pm = test(grammar).getTwo();
+
+        RichIterable<? extends QualifiedProperty<?>> personQualifiedProperties = pm.getClass("test::Person")._qualifiedProperties();
+        boolean checkQualifiedExpressionForprocessingTemporalAddress1 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("processingTemporalAddress1")));
+        boolean checkQualifiedExpressionForbusinessTemporalAddress1 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("businessTemporalAddress1")));
+        boolean checkQualifiedExpressionForbiTemporalAddress1 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress1")));
+        boolean checkQualifiedExpressionForprocessingTemporalAddress2 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("processingTemporalAddress2")));
+        boolean checkQualifiedExpressionForbusinessTemporalAddress2 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("businessTemporalAddress2")));
+        boolean checkQualifiedExpressionForbiTemporalAddress2 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress2")));
+        boolean checkQualifiedExpressionForprocessingTemporalAddress3 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("processingTemporalAddress3")));
+        boolean checkQualifiedExpressionForbusinessTemporalAddress3 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("businessTemporalAddress3")));
+        boolean checkQualifiedExpressionForbiTemporalAddress3 = checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress3")));
+        Assert.assertTrue("Qualfied expression generated for processingTemporalAddress should have toOne() as topLevel functionExpression", checkQualifiedExpressionForprocessingTemporalAddress1);
+        Assert.assertTrue("Qualfied expression generated for BusinessTemporalAddress should have toOne() as topLevel functionExpression", checkQualifiedExpressionForbusinessTemporalAddress1);
+        Assert.assertTrue("Qualfied expression generated for BiTemporalAddress should have toOne() as topLevel functionExpression", checkQualifiedExpressionForbiTemporalAddress1);
+        Assert.assertTrue("Qualfied expression generated for processingTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForprocessingTemporalAddress2);
+        Assert.assertTrue("Qualfied expression generated for BusinessTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbusinessTemporalAddress2);
+        Assert.assertTrue("Qualfied expression generated for BiTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbiTemporalAddress2);
+        Assert.assertTrue("Qualfied expression generated for processingTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForprocessingTemporalAddress3);
+        Assert.assertTrue("Qualfied expression generated for BusinessTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbusinessTemporalAddress3);
+        Assert.assertTrue("Qualfied expression generated for BiTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbiTemporalAddress3);
+    }
+
+    private boolean checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(QualifiedProperty generatedMilestoningClassQualifiedProperty)
+    {
+        FunctionExpression topLevelExpression = ((FunctionExpression) generatedMilestoningClassQualifiedProperty._expressionSequence().getFirst());
+         return topLevelExpression._func()._functionName().equals("toOne");
+    }
+
+    @Test
     public void testMilestoningSimplePropertiesAreNotOverridenByUserProperties()
     {
         String grammar = "###Pure\n" +
@@ -2353,13 +2413,22 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
 
     private boolean generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(Property generatedMilestoningClassSimpleProperty, QualifiedProperty generatedMilestoningClassQualifiedProperty)
     {
-        FunctionExpression topLevelExpression = (FunctionExpression) ((LambdaFunction) ((InstanceValue) ((FunctionExpression) generatedMilestoningClassQualifiedProperty._expressionSequence().getFirst())._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
-        if (topLevelExpression._func()._functionName().equals("and"))
+        FunctionExpression topLevelExpression = ((FunctionExpression) generatedMilestoningClassQualifiedProperty._expressionSequence().getFirst());
+        FunctionExpression simplifiedExpression;
+        if (topLevelExpression._func()._functionName().equals("toOne"))
+        {
+            simplifiedExpression = (FunctionExpression) ((LambdaFunction) ((InstanceValue) ((FunctionExpression) (topLevelExpression._parametersValues().toList().get(0)))._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
+        }
+        else
+        {
+            simplifiedExpression = (FunctionExpression) ((LambdaFunction) ((InstanceValue) topLevelExpression._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
+        }
+        if (simplifiedExpression._func()._functionName().equals("and"))
         {
             int idx = generatedMilestoningClassSimpleProperty.getName().equals("processingDate") ? 0 : 1;
-            topLevelExpression = (FunctionExpression) topLevelExpression._parametersValues().toList().get(idx);
+            simplifiedExpression = (FunctionExpression) simplifiedExpression._parametersValues().toList().get(idx);
         }
-        Property filterMilestoningDateProperty = (Property) ((FunctionExpression) topLevelExpression._parametersValues().toList().get(0))._func();
+        Property filterMilestoningDateProperty = (Property) ((FunctionExpression) simplifiedExpression._parametersValues().toList().get(0))._func();
         return generatedMilestoningClassSimpleProperty.equals(filterMilestoningDateProperty);
     }
 

--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/MilestonedM2M.pure
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/MilestonedM2M.pure
@@ -34,7 +34,7 @@ function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly
                     ' *meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner: Pure\n' +
                     '  {\n' +
                     '    ~src  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::S_VehicleOwner\n' +
-                    '    vehicleName: $src.vehicle.name,\n' +
+                    '    vehicleName: $src.vehicle(%2020-10-15).name,\n' +
                     '    personName : $src.name\n' +
                     '  }\n' +
                     ')\n';

--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/MilestonedM2M.pure
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/MilestonedM2M.pure
@@ -1,0 +1,54 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::executionPlan::profiles::*;
+import meta::pure::executionPlan::*;
+import meta::pure::mapping::*;
+import meta::json::*;
+import meta::pure::mapping::modelToModel::*;
+import meta::pure::graphFetch::execution::*;
+import meta::pure::runtime::*;
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> {serverVersion.start='v1_32_0'}meta::pure::mapping::modelToModel::test::alloy::milestoning::model::testM2MMappingWithMilestonedModelsWithAllVersions():Boolean[1]
+{
+  let tree =  #{ meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner{
+                   vehicleName,
+                   personName
+                 }
+               }#;
+  let query = {|meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner.all(%2020-10-15)->graphFetch($tree)->serialize($tree)};
+  let mappingStr =  '###Mapping\n' +
+                    'Mapping  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::M2MMapping\n' +
+                    '(\n' +
+                    ' *meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner: Pure\n' +
+                    '  {\n' +
+                    '    ~src  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::S_VehicleOwner\n' +
+                    '    vehicleName: $src.vehicle.name,\n' +
+                    '    personName : $src.name\n' +
+                    '  }\n' +
+                    ')\n';
+
+  let mapping = meta::legend::compileLegendGrammar($mappingStr)->at(0)->cast(@Mapping);
+  let runtime = ^Runtime(connections = ^JsonModelConnection(
+                                        element=^ModelStore(), 
+                                        class=meta::pure::mapping::modelToModel::test::alloy::milestoning::model::S_VehicleOwner, 
+                                        url='data:application/json,{"businessDate": "2020-10-15","name" : "Ram", "vehicleAllVersions": [{"name": "Bike", "businessDate" : "2020-10-15", "id" : "1"}]}'
+                                        )
+                        );
+  let result = meta::pure::router::execute($query, $mapping, $runtime, meta::pure::extension::configuration::coreExtensions());
+
+  let json = $result.values->toOne();
+  let expected = '{"personName":"Ram","vehicleName":"Bike"}';
+  assert(jsonEquivalent($expected->parseJSON(), $json->parseJSON())); 
+}

--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/MilestonedM2M.pure
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/MilestonedM2M.pure
@@ -28,27 +28,17 @@ function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly
                  }
                }#;
   let query = {|meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner.all(%2020-10-15)->graphFetch($tree)->serialize($tree)};
-  let mappingStr =  '###Mapping\n' +
-                    'Mapping  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::M2MMapping\n' +
-                    '(\n' +
-                    ' *meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner: Pure\n' +
-                    '  {\n' +
-                    '    ~src  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::S_VehicleOwner\n' +
-                    '    vehicleName: $src.vehicle(%2020-10-15).name,\n' +
-                    '    personName : $src.name\n' +
-                    '  }\n' +
-                    ')\n';
 
-  let mapping = meta::legend::compileLegendGrammar($mappingStr)->at(0)->cast(@Mapping);
+  let mapping = meta::pure::mapping::modelToModel::test::alloy::milestoning::model::M2MMapping;
   let runtime = ^Runtime(connections = ^JsonModelConnection(
                                         element=^ModelStore(), 
                                         class=meta::pure::mapping::modelToModel::test::alloy::milestoning::model::S_VehicleOwner, 
-                                        url='data:application/json,{"businessDate": "2020-10-15","name" : "Ram", "vehicleAllVersions": [{"name": "Bike", "businessDate" : "2020-10-15", "id" : "1"}]}'
+                                        url='data:application/json,{"businessDate": "2020-10-15","name" : "Ram", "vehicleAllVersions": [{"name": "B", "businessDate" : "2020-10-15", "id" : "1"}]}'
                                         )
                         );
   let result = meta::pure::router::execute($query, $mapping, $runtime, meta::pure::extension::configuration::coreExtensions());
 
   let json = $result.values->toOne();
-  let expected = '{"personName":"Ram","vehicleName":"Bike"}';
+  let expected = '{"personName":"Ram","vehicleName":"B"}';
   assert(jsonEquivalent($expected->parseJSON(), $json->parseJSON())); 
 }

--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/model.pure
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/model.pure
@@ -1,0 +1,35 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::graphFetch::execution::*;
+import meta::pure::mapping::modelToModel::test::alloy::milestoning::model::*;
+
+Class <<temporal.businesstemporal>>  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::Vehicle
+{
+   id : Integer[1];
+   description: String[1];
+   name : String[1];
+}
+
+Class <<temporal.businesstemporal>> meta::pure::mapping::modelToModel::test::alloy::milestoning::model::S_VehicleOwner
+{
+   vehicle : Vehicle[1];
+   name : String[1];
+}
+
+Class <<temporal.businesstemporal>>  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner
+{
+   vehicleName : String[1];
+   personName : String[1];
+}

--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/model.pure
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/milestoning/model.pure
@@ -33,3 +33,14 @@ Class <<temporal.businesstemporal>>  meta::pure::mapping::modelToModel::test::al
    vehicleName : String[1];
    personName : String[1];
 }
+
+###Mapping
+Mapping meta::pure::mapping::modelToModel::test::alloy::milestoning::model::M2MMapping
+(
+  *meta::pure::mapping::modelToModel::test::alloy::milestoning::model::T_VehicleOwner: Pure
+  {
+    ~src  meta::pure::mapping::modelToModel::test::alloy::milestoning::model::S_VehicleOwner
+    vehicleName: $src.vehicle(%2020-10-15).name,
+    personName : $src.name
+  }
+)


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
While processing the milestoned property legend compiler creates a qualified property with an expression for filtering milestoned dates, But if that milestoned property is of [1] multiplicity it does not appends toOne() at the end of function expression which causes issues.

#### Does this PR introduce a user-facing change?
Yes
