### PR TITLE
always run drop temp table commands before closing conn in relational graphFetch

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -878,9 +878,10 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
 
     private static void createTempTableFromRealizedRelationalResultUsingTempTableStrategyInBlockConnection(RelationalTempTableGraphFetchExecutionNode node, RealizedRelationalResult realizedRelationalResult, String tempTableName, DatabaseConnection databaseConnection, String databaseType, String databaseTimeZone, ExecutionState threadExecutionState, MutableList<CommonProfile> profiles)
     {
+        RelationalStoreExecutionState relationalStoreExecutionState = null;
         try (Scope ignored = GlobalTracer.get().buildSpan("create temp table").withTag("tempTableName", tempTableName).withTag("databaseType", databaseType).startActive(true))
         {
-            RelationalStoreExecutionState relationalStoreExecutionState = (RelationalStoreExecutionState) threadExecutionState.getStoreExecutionState(StoreType.Relational);
+            relationalStoreExecutionState = (RelationalStoreExecutionState) threadExecutionState.getStoreExecutionState(StoreType.Relational);
             relationalStoreExecutionState.setRetainConnection(true);
 
             if (node.tempTableStrategy instanceof LoadFromSubQueryTempTableStrategy)
@@ -915,12 +916,17 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             {
                 throw new RuntimeException("Unsupported temp table strategy");
             }
-
-            String dropTempTableSqlQuery = ((SQLExecutionNode) node.tempTableStrategy.dropTempTableNode.executionNodes.get(0)).sqlQuery;
-            BlockConnection blockConnection = relationalStoreExecutionState.getBlockConnectionContext().getBlockConnection(relationalStoreExecutionState, databaseConnection, profiles);
-            blockConnection.addCommitQuery(dropTempTableSqlQuery);
-            blockConnection.addRollbackQuery(dropTempTableSqlQuery);
-            blockConnection.close();
+        }
+        finally
+        {
+            if (relationalStoreExecutionState != null)
+            {
+                String dropTempTableSqlQuery = ((SQLExecutionNode) node.tempTableStrategy.dropTempTableNode.executionNodes.get(0)).sqlQuery;
+                BlockConnection blockConnection = relationalStoreExecutionState.getBlockConnectionContext().getBlockConnection(relationalStoreExecutionState, databaseConnection, profiles);
+                blockConnection.addCommitQuery(dropTempTableSqlQuery);
+                blockConnection.addRollbackQuery(dropTempTableSqlQuery);
+                blockConnection.close();
+            }
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
- Bug Fix

#### What does this PR do / why is it needed ?
always run drop temp table commands before returning the connection back to the pool in relational graph fetch.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
No
