### PR TITLE
Update LegendTDSResult parser to handle columns without relationalType

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
@@ -53,7 +53,7 @@ public class LegendTDSResultParserTest
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test(expected = RuntimeException.class)
     public void testParseDataInvalidateResults() throws IOException
     {
         try (InputStream pureProjectInputStream = ClassLoader.getSystemClassLoader().getResourceAsStream("legendTdsInvalidResult.json");)

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
@@ -47,7 +47,33 @@ public class LegendTDSResultParserTest
                     LOGGER.info("Row: {}, Column: {}: Value: {}", row, column, value);
                     column++;
                 }
-                Assert.assertEquals("Verify number of column", 8, column);
+                Assert.assertEquals("Verify number of columns", 8, column);
+            }
+            Assert.assertEquals("Verify number of rows", 2, row);
+        }
+    }
+
+    @Test
+    public void testParseDataNoRelationalTypeValidateResults() throws IOException
+    {
+        try (InputStream pureProjectInputStream = ClassLoader.getSystemClassLoader().getResourceAsStream("legendTdsResultNoRelationalType.json");)
+        {
+            LegendTdsResultParser parser = new LegendTdsResultParser(pureProjectInputStream);
+            List<LegendColumn> legendColumns = parser.getLegendColumns();
+            int row = 0;
+            int column = 0;
+            while (parser.hasNext())
+            {
+                row++;
+                column = 0;
+                List<Object> nextRow = parser.next();
+                for (int i = 0; i < legendColumns.size(); i++)
+                {
+                    Object value = nextRow.get(i);
+                    LOGGER.info("Row: {}, Column: {}: Value: {}", row, column, value);
+                    column++;
+                }
+                Assert.assertEquals("Verify number of columns", 2, column);
             }
             Assert.assertEquals("Verify number of rows", 2, row);
         }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
@@ -53,7 +53,7 @@ public class LegendTDSResultParserTest
         }
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testParseDataInvalidateResults() throws IOException
     {
         try (InputStream pureProjectInputStream = ClassLoader.getSystemClassLoader().getResourceAsStream("legendTdsInvalidResult.json");)

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/handler/legend/LegendTDSResultParserTest.java
@@ -53,7 +53,7 @@ public class LegendTDSResultParserTest
         }
     }
 
-    @Test
+    @Test(expected = IOException.class)
     public void testParseDataInvalidateResults() throws IOException
     {
         try (InputStream pureProjectInputStream = ClassLoader.getSystemClassLoader().getResourceAsStream("legendTdsInvalidResult.json");)

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/resources/legendTdsResultNoRelationalType.json
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/resources/legendTdsResultNoRelationalType.json
@@ -1,0 +1,42 @@
+{
+  "builder": {
+    "_type": "tdsBuilder",
+    "columns": [
+      {
+        "name": "stringColumn1",
+        "type": "String"
+      },
+      {
+        "name": "stringColumn2",
+        "type": "String",
+        "relationalType": "sqlType"
+      }
+    ]
+  },
+  "activities": [
+    {
+      "_type": "relational",
+      "sql": "select ..."
+    }
+  ],
+  "result": {
+    "columns": [
+      "stringColumn1",
+      "stringColumn2"
+    ],
+    "rows": [
+      {
+        "values": [
+          "foo",
+          "bar"
+        ]
+      },
+      {
+        "values": [
+          "foo1",
+          "bar2"
+        ]
+      }
+    ]
+  }
+}

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/resources/logback-test.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/resources/logback-test.xml
@@ -7,14 +7,17 @@
     </contextListener>
 
     <appender name="json-stdout" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+       <!-- <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
             <jsonFormatter
                     class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                 <prettyPrint>false</prettyPrint>
             </jsonFormatter>
             <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
             <appendLineSeparator>true</appendLineSeparator>
-        </layout>
+        </layout>-->
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} -%kvp- %msg %n</pattern>
+        </encoder>
     </appender>
 
     <root level="info">

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/resources/logback-test.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/resources/logback-test.xml
@@ -7,17 +7,14 @@
     </contextListener>
 
     <appender name="json-stdout" class="ch.qos.logback.core.ConsoleAppender">
-       <!-- <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+        <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
             <jsonFormatter
                     class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                 <prettyPrint>false</prettyPrint>
             </jsonFormatter>
             <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
             <appendLineSeparator>true</appendLineSeparator>
-        </layout>-->
-        <encoder>
-            <pattern>%-4relative [%thread] %-5level %logger{35} -%kvp- %msg %n</pattern>
-        </encoder>
+        </layout>
     </appender>
 
     <root level="info">


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Legend response does not provide "relationalType" for derived columns. Update the parser on  Legend SQL Engine to handle the use case. 

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
