### PR TITLE
fix bug while creating temporary tables in snowflake for bit type

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
@@ -50,13 +50,22 @@ public class SnowflakeCommands extends RelationalDatabaseCommands
             optionalCSVFileLocation = optionalCSVFileLocation.substring(1);
         }
         List<String> strings = Arrays.asList(
-                "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + c.type).collect(Collectors.joining(",", "(", ")")),
+                "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + mapColumnTypeToSqlText(c.type)).collect(Collectors.joining(",", "(", ")")),
                 "CREATE OR REPLACE TEMPORARY STAGE " + tempStageName(),
                 "PUT file:///" + optionalCSVFileLocation + " @" + tempStageName() + "/" + optionalCSVFileLocation + " PARALLEL = 16 AUTO_COMPRESS = TRUE",
                 "COPY INTO " + tableName + " FROM @" + tempStageName() + "/" + optionalCSVFileLocation + " file_format = (type = CSV field_optionally_enclosed_by= '\"')",
                 "DROP STAGE " + tempStageName()
         );
         return strings;
+    }
+    
+    private String mapColumnTypeToSqlText(String columnType)
+    {
+        switch (columnType)
+        {
+            case "BIT" : return "BOOLEAN";
+            default: return columnType;
+        }
     }
 
     @Override

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.snowflake;
 
+import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.Column;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.IngestionMethod;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommands;
@@ -21,10 +22,13 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.drive
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SnowflakeCommands extends RelationalDatabaseCommands
 {
+    private static final Map<String, String> columnTypeToSqlTextMap = Maps.mutable.of("BIT", "BOOLEAN");
+
     @Override
     public String processTempTableName(String tempTableName)
     {
@@ -50,22 +54,13 @@ public class SnowflakeCommands extends RelationalDatabaseCommands
             optionalCSVFileLocation = optionalCSVFileLocation.substring(1);
         }
         List<String> strings = Arrays.asList(
-                "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + mapColumnTypeToSqlText(c.type)).collect(Collectors.joining(",", "(", ")")),
+                "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + columnTypeToSqlTextMap.getOrDefault(c.type, c.type)).collect(Collectors.joining(",", "(", ")")),
                 "CREATE OR REPLACE TEMPORARY STAGE " + tempStageName(),
                 "PUT file:///" + optionalCSVFileLocation + " @" + tempStageName() + "/" + optionalCSVFileLocation + " PARALLEL = 16 AUTO_COMPRESS = TRUE",
                 "COPY INTO " + tableName + " FROM @" + tempStageName() + "/" + optionalCSVFileLocation + " file_format = (type = CSV field_optionally_enclosed_by= '\"')",
                 "DROP STAGE " + tempStageName()
         );
         return strings;
-    }
-    
-    private String mapColumnTypeToSqlText(String columnType)
-    {
-        switch (columnType)
-        {
-            case "BIT" : return "BOOLEAN";
-            default: return columnType;
-        }
     }
 
     @Override

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.snowflake;
 
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.Column;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.IngestionMethod;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommands;
@@ -22,12 +23,11 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.drive
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SnowflakeCommands extends RelationalDatabaseCommands
 {
-    private static final Map<String, String> columnTypeToSqlTextMap = Maps.mutable.of("BIT", "BOOLEAN");
+    private static final ImmutableMap<String, String> columnTypeToSqlTextMap = Maps.immutable.of("BIT", "BOOLEAN");
 
     @Override
     public String processTempTableName(String tempTableName)
@@ -54,7 +54,7 @@ public class SnowflakeCommands extends RelationalDatabaseCommands
             optionalCSVFileLocation = optionalCSVFileLocation.substring(1);
         }
         List<String> strings = Arrays.asList(
-                "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + columnTypeToSqlTextMap.getOrDefault(c.type, c.type)).collect(Collectors.joining(",", "(", ")")),
+                "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + columnTypeToSqlTextMap.getIfAbsentValue(c.type, c.type)).collect(Collectors.joining(",", "(", ")")),
                 "CREATE OR REPLACE TEMPORARY STAGE " + tempStageName(),
                 "PUT file:///" + optionalCSVFileLocation + " @" + tempStageName() + "/" + optionalCSVFileLocation + " PARALLEL = 16 AUTO_COMPRESS = TRUE",
                 "COPY INTO " + tableName + " FROM @" + tempStageName() + "/" + optionalCSVFileLocation + " file_format = (type = CSV field_optionally_enclosed_by= '\"')",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/TestSnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/TestSnowflakeCommands.java
@@ -34,12 +34,13 @@ public class TestSnowflakeCommands
 
         ImmutableList<Column> columns = Lists.immutable.of(
                 new Column("a", "VARCHAR(100)"),
-                new Column("b", "VARCHAR(100)")
+                new Column("b", "VARCHAR(100)"),
+                new Column("c", "BIT")
         );
 
         List<String> sqlStatements = snowflakeCommands.createAndLoadTempTable("temp_1", columns.castToList(), "/tmp/temp.csv");
         ImmutableList<String> expectedSQLStatements = Lists.immutable.of(
-                "CREATE TEMPORARY TABLE temp_1 (a VARCHAR(100),b VARCHAR(100))",
+                "CREATE TEMPORARY TABLE temp_1 (a VARCHAR(100),b VARCHAR(100),c BOOLEAN)",
                 "CREATE OR REPLACE TEMPORARY STAGE LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE",
                 "PUT file:///tmp/temp.csv @LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE/tmp/temp.csv PARALLEL = 16 AUTO_COMPRESS = TRUE",
                 "COPY INTO temp_1 FROM @LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE/tmp/temp.csv file_format = (type = CSV field_optionally_enclosed_by= '\"')",


### PR DESCRIPTION
fix bug while creating temporary tables for snowflake for bit type

#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
This PR fixes creating temporary tables in snowflake for bit datatype fields

#### Which issue(s) this PR fixes:
NA

#### Other notes for reviewers:
NA

#### Does this PR introduce a user-facing change?
No
