### PR TITLE
Handle single quotes in values in result set temp table strategy

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -928,7 +928,8 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
         }
     }
 
-    static Function<Object, String> getNormalizer(String quoteCharacterReplacement, String databaseTimeZone) {
+    static Function<Object, String> getNormalizer(String quoteCharacterReplacement, String databaseTimeZone)
+    {
         return v ->
         {
             if (v == null)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -66,7 +66,6 @@ import org.finos.legend.engine.plan.execution.result.object.StreamingObjectResul
 import org.finos.legend.engine.plan.execution.result.serialization.CsvSerializer;
 import org.finos.legend.engine.plan.execution.result.serialization.RequestIdGenerator;
 import org.finos.legend.engine.plan.execution.result.serialization.TemporaryFile;
-import org.finos.legend.engine.plan.execution.stores.StoreExecutor;
 import org.finos.legend.engine.plan.execution.stores.StoreType;
 import org.finos.legend.engine.plan.execution.stores.relational.RelationalDatabaseCommandsVisitorBuilder;
 import org.finos.legend.engine.plan.execution.stores.relational.RelationalExecutor;
@@ -130,7 +129,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.graphF
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.graphFetch.store.inMemory.InMemoryRootGraphFetchExecutionNode;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.graphFetch.store.inMemory.StoreStreamReadingExecutionNode;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.result.ClassResultType;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseConnection;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.graph.GraphFetchTree;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.graph.PropertyGraphFetchTree;
@@ -894,7 +892,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             }
             else if (node.tempTableStrategy instanceof LoadFromResultSetAsValueTuplesTempTableStrategy)
             {
-                loadValuesIntoTempTablesFromRelationalResult(node.tempTableStrategy.loadTempTableNode, realizedRelationalResult, ((LoadFromResultSetAsValueTuplesTempTableStrategy) node.tempTableStrategy).tupleBatchSize, databaseTimeZone, threadExecutionState, profiles);
+                loadValuesIntoTempTablesFromRelationalResult(node.tempTableStrategy.loadTempTableNode, realizedRelationalResult, ((LoadFromResultSetAsValueTuplesTempTableStrategy) node.tempTableStrategy).tupleBatchSize, ((LoadFromResultSetAsValueTuplesTempTableStrategy) node.tempTableStrategy).quoteCharacterReplacement, databaseTimeZone, threadExecutionState, profiles);
             }
             else if (node.tempTableStrategy instanceof LoadFromTempFileTempTableStrategy)
             {
@@ -930,7 +928,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
         }
     }
 
-    private static void loadValuesIntoTempTablesFromRelationalResult(ExecutionNode node, RealizedRelationalResult realizedRelationalResult, int batchSize, String databaseTimeZone, ExecutionState threadExecutionState, MutableList<CommonProfile> profiles)
+    private static void loadValuesIntoTempTablesFromRelationalResult(ExecutionNode node, RealizedRelationalResult realizedRelationalResult, int batchSize, String quoteCharacterReplacement, String databaseTimeZone, ExecutionState threadExecutionState, MutableList<CommonProfile> profiles)
     {
         final Function<Object, String> normalizer = v ->
         {
@@ -941,6 +939,14 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             if (v instanceof Number)
             {
                 return (String) ResultNormalizer.normalizeToSql(v, databaseTimeZone);
+            }
+            if (v instanceof String)
+            {
+                if (quoteCharacterReplacement != null)
+                {
+                    return "'" + ((String)ResultNormalizer.normalizeToSql(v, databaseTimeZone)).replace("'", quoteCharacterReplacement) + "'";
+                }
+                return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
             }
             return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
         };
@@ -1898,7 +1904,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
                                 {
                                 }
                                 node.parentTempTableStrategy.createTempTableNode.accept(new ExecutionNodeExecutor(this.profiles, this.executionState));
-                                loadValuesIntoTempTablesFromRelationalResult(node.parentTempTableStrategy.loadTempTableNode, parentRealizedRelationalResult, ((LoadFromResultSetAsValueTuplesTempTableStrategy) node.parentTempTableStrategy).tupleBatchSize, databaseTimeZone, this.executionState, this.profiles);
+                                loadValuesIntoTempTablesFromRelationalResult(node.parentTempTableStrategy.loadTempTableNode, parentRealizedRelationalResult, ((LoadFromResultSetAsValueTuplesTempTableStrategy) node.parentTempTableStrategy).tupleBatchSize, ((LoadFromResultSetAsValueTuplesTempTableStrategy) node.tempTableStrategy).quoteCharacterReplacement, databaseTimeZone, this.executionState, this.profiles);
                             }
                             else if (node.parentTempTableStrategy instanceof LoadFromTempFileTempTableStrategy)
                             {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -928,9 +928,8 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
         }
     }
 
-    private static void loadValuesIntoTempTablesFromRelationalResult(ExecutionNode node, RealizedRelationalResult realizedRelationalResult, int batchSize, String quoteCharacterReplacement, String databaseTimeZone, ExecutionState threadExecutionState, MutableList<CommonProfile> profiles)
-    {
-        final Function<Object, String> normalizer = v ->
+    static Function<Object, String> getNormalizer(String quoteCharacterReplacement, String databaseTimeZone) {
+        return v ->
         {
             if (v == null)
             {
@@ -950,6 +949,11 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             }
             return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
         };
+    }
+
+    private static void loadValuesIntoTempTablesFromRelationalResult(ExecutionNode node, RealizedRelationalResult realizedRelationalResult, int batchSize, String quoteCharacterReplacement, String databaseTimeZone, ExecutionState threadExecutionState, MutableList<CommonProfile> profiles)
+    {
+        final Function<Object, String> normalizer = getNormalizer(quoteCharacterReplacement, databaseTimeZone);
 
         Iterator<List<List<Object>>> rowBatchIterator = Iterators.partition(realizedRelationalResult.resultSetRows.iterator(), batchSize);
         while (rowBatchIterator.hasNext())

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/TestHelpers.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/TestHelpers.java
@@ -1,0 +1,27 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.plugin;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHelpers
+{
+    @Test
+    public void testNormalizerWithSingleQuotes()
+    {
+        Assert.assertEquals("'There''s a quote'", RelationalExecutionNodeExecutor.getNormalizer("''", "GMT").apply("There's a quote"));
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/graphFetch/LoadFromResultSetAsValueTuplesTempTableStrategy.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/graphFetch/LoadFromResultSetAsValueTuplesTempTableStrategy.java
@@ -17,4 +17,5 @@ package org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.graph
 public class LoadFromResultSetAsValueTuplesTempTableStrategy extends TempTableStrategy
 {
     public Integer tupleBatchSize;
+    public String quoteCharacterReplacement;
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -101,6 +101,7 @@ Class meta::relational::graphFetch::executionPlan::LoadFromSubQueryTempTableStra
 Class meta::relational::graphFetch::executionPlan::LoadFromResultSetAsValueTuplesTempTableStrategy extends meta::relational::graphFetch::executionPlan::TempTableStrategy
 {
   tupleBatchSize : Integer[0..1];
+  quoteCharacterReplacement: String[0..1];
 }
 
 function meta::relational::graphFetch::executionPlan::useTempTableStrategy(dbType: DatabaseType[1]):Boolean[1]
@@ -125,6 +126,14 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::getTupl
       | 100;
       );
     );
+}
+
+function <<access.private>> meta::relational::graphFetch::executionPlan::getQuoteCharacterReplacement(dbType: DatabaseType[1]):String[1]
+{
+   if($dbType->in([DatabaseType.Snowflake, DatabaseType.H2]),
+    | '\'\'',
+    | '\''
+  );
 }
 
 function <<access.private>> meta::relational::graphFetch::executionPlan::dbsUsingLoadFromTempFileTempTableStrategyForRoot():DatabaseType[*]
@@ -318,7 +327,8 @@ function meta::relational::graphFetch::executionPlan::getTempTableStrategyForRoo
         createTempTableNode = $createTempTableNode,
         loadTempTableNode = $loadTempTableNode,
         dropTempTableNode = $dropTempTableNode,
-        tupleBatchSize = getTupleBatchSize($dbType)
+        tupleBatchSize = getTupleBatchSize($dbType),
+        quoteCharacterReplacement = getQuoteCharacterReplacement($dbType)
       );
   );
 }
@@ -330,7 +340,8 @@ function meta::relational::graphFetch::executionPlan::getTempTableStrategyForNon
         createTempTableNode = $createTempTableNode,
         loadTempTableNode = $loadTempTableNode,
         dropTempTableNode = $dropTempTableNode,
-        tupleBatchSize = getTupleBatchSize($dbType)
+        tupleBatchSize = getTupleBatchSize($dbType),
+        quoteCharacterReplacement = getQuoteCharacterReplacement($dbType)
       ),
     | if($dbType->in(dbsUsingLoadFromSubQueryTempTableStrategyForComplexProperty()),
       | ^LoadFromSubQueryTempTableStrategy(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/extension/extension_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/extension/extension_relational.pure
@@ -59,7 +59,8 @@ function meta::protocols::pure::vX_X_X::extension::transformTempTableStrategy(te
         createTempTableNode = if($t.createTempTableNode->isNotEmpty(),|$t.createTempTableNode->toOne()->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::executionPlan::transformNode($mapping, $extensions),|[]),
         loadTempTableNode = if($t.loadTempTableNode->isNotEmpty(),|$t.loadTempTableNode->toOne()->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::executionPlan::transformNode($mapping, $extensions),|[]),
         dropTempTableNode = if($t.dropTempTableNode->isNotEmpty(),|$t.dropTempTableNode->toOne()->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::executionPlan::transformNode($mapping, $extensions),|[]),
-        tupleBatchSize = $t.tupleBatchSize
+        tupleBatchSize = $t.tupleBatchSize,
+        quoteCharacterReplacement = $t.quoteCharacterReplacement
       );
    ])
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/models/executionPlan_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/models/executionPlan_relational.pure
@@ -117,6 +117,7 @@ Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::LoadFromSubQueryT
 Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::LoadFromResultSetAsValueTuplesTempTableStrategy extends meta::protocols::pure::vX_X_X::metamodel::executionPlan::TempTableStrategy
 {
    tupleBatchSize : Integer[0..1];
+   quoteCharacterReplacement: String[0..1];
 }
 
 Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::RelationalBlockExecutionNode extends SequenceExecutionNode


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels:
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed?
We don't handle single quotes in values during temp table population in result set temp table strategy.

For example, in `INSERT INTO TEMP_TABLE (NAME) VALUES ('A'1')` we don't escape the single quote in `A'1`, this PR fixes that.

**What's the solution?**

I am introducing a new quoteCharacterReplacement: String[0..1] field in result set temp table strategy which will carry the information for replacing quote character as per db type. This information will be present in execution plan. For now, we only use this temp table strategy with snowflake.

**Testing**

Adding a unit test in engine. Integration testing with Snowflake can be done internally.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:
Requires protocol cut for enabling it in production

#### Does this PR introduce a user-facing change?
No
<!--
-->
