### PR TITLE
Fix MemSQL Dynafunction dateDiff()

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
@@ -191,6 +191,7 @@ function  <<access.private>> meta::relational::functions::sqlQueryToString::mems
         'timestampdiff(SECOND, %s , %s)'
      ])},
      {| format('(%s)', [
+        // Since SingleStore doesn't support millisecond diff, using microsecond diff to calculate required value (https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/timestampdiff/)
         'floor(timestampdiff(MICROSECOND, %s , %s)/1000)'
      ])}
   ];

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
@@ -81,7 +81,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memsq
     dynaFnToSql('concat',                    $allStates,            ^ToSql(format='concat%s', transform={p:String[*]|$p->joinStrings('(', ', ', ')')})),
     dynaFnToSql('convertDate',               $allStates,            ^ToSql(format='%s', transform={p:String[*] | $p->convertToDateMemSQL()})),
     dynaFnToSql('convertVarchar128',         $allStates,            ^ToSql(format='convert(%s, CHAR)')),
-    dynaFnToSql('dateDiff',                  $allStates,            ^ToSql(format='%s', transform={p:String[*]|generateDateDiffExpressionForMemSQL ([$p->at(1), $p->at(0), $p->at(2)->replace('\'', '')])})),
+    dynaFnToSql('dateDiff',                  $allStates,            ^ToSql(format='%s', transform={p:String[*]|generateDateDiffExpressionForMemSQL ([$p->at(0), $p->at(1), $p->at(2)->replace('\'', '')])})),
     dynaFnToSql('datePart',                  $allStates,            ^ToSql(format='date(%s)')),
     dynaFnToSql('dayOfMonth',                $allStates,            ^ToSql(format='day(%s)')),
     dynaFnToSql('dayOfWeekNumber',           $allStates,            ^ToSql(format='dayofweek(%s)')),
@@ -169,16 +169,26 @@ function  <<access.private>> meta::relational::functions::sqlQueryToString::mems
 
   let dbSpecificUnits = [
 
-     {| fail('The DurationUnit \''+$params->at(2)+'\' is not supported yet!');'';},
-     {| fail('The DurationUnit \''+$params->at(2)+'\' is not supported yet!');'';},
-     {| fail('The DurationUnit \''+$params->at(2)+'\' is not supported yet!');'';},
      {| format('(%s)', [
-        'datediff(%s , %s)'
+        'timestampdiff(YEAR, %s , %s)'
      ])},
-     {| fail('The DurationUnit \''+$params->at(2)+'\' is not supported yet!');'';},
-     {| fail('The DurationUnit \''+$params->at(2)+'\' is not supported yet!');'';},
      {| format('(%s)', [
-        'time_to_sec(timediff(%s , %s))'
+        'timestampdiff(MONTH, %s , %s)'
+     ])},
+     {| format('(%s)', [
+        'timestampdiff(WEEK, %s , %s)'
+     ])},
+     {| format('(%s)', [
+        'timestampdiff(DAY, %s , %s)'
+     ])},
+     {| format('(%s)', [
+        'timestampdiff(HOUR, %s , %s)'
+     ])},
+     {| format('(%s)', [
+        'timestampdiff(MINUTE, %s , %s)'
+     ])},
+     {| format('(%s)', [
+        'timestampdiff(SECOND, %s , %s)'
      ])},
      {| fail('The DurationUnit \''+$params->at(2)+'\' is not supported yet!');'';}
   ];

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
@@ -190,7 +190,9 @@ function  <<access.private>> meta::relational::functions::sqlQueryToString::mems
      {| format('(%s)', [
         'timestampdiff(SECOND, %s , %s)'
      ])},
-     {| fail('The DurationUnit \''+$params->at(2)+'\' is not supported yet!');'';}
+     {| format('(%s)', [
+        'floor(timestampdiff(MICROSECOND, %s , %s)/1000)'
+     ])}
   ];
 
   format($dbSpecificUnits->at($indexOfDiff)->eval(), [$params->at(0), $params->at(1)]);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
@@ -79,7 +79,7 @@ function <<test.Test>> meta::relational::memsql::tests::mapping::sqlFunction::pa
    let s = toSQLString(|SqlFunctionDemo.all()->project([s | dateDiff($da, $db, DurationUnit.DAYS)], ['dateDiff']),
                                                 testMapping,
                                                 meta::relational::runtime::DatabaseType.MemSQL, meta::relational::extension::relationalExtensions());
-   assertEquals('select (datediff(\'2017-04-01\' , \'2017-03-01\')) as `dateDiff` from dataTable as `root`',$s);
+   assertEquals('select (timestampdiff(DAY, \'2017-03-01\' , \'2017-04-01\')) as `dateDiff` from dataTable as `root`',$s);
 }
 
 function <<test.Test>> meta::relational::memsql::tests::mapping::sqlFunction::parseInteger::testToSQLStringDateDiffInSeconds_MemSQL():Boolean[1]
@@ -90,7 +90,7 @@ function <<test.Test>> meta::relational::memsql::tests::mapping::sqlFunction::pa
                                                 testMapping,
                                                 meta::relational::runtime::DatabaseType.MemSQL,
                                                 meta::relational::extension::relationalExtensions());
-   assertEquals('select (time_to_sec(timediff(\'2017-03-01 20:08:08\' , \'2017-03-01 19:09:20\'))) as `dateDiff` from dataTable as `root`',$s);
+   assertEquals('select (timestampdiff(SECOND, \'2017-03-01 19:09:20\' , \'2017-03-01 20:08:08\')) as `dateDiff` from dataTable as `root`',$s);
 }
 
 function <<test.Test>> meta::relational::memsql::tests::mapping::sqlFunction::parseInteger::testToSQLStringConvertVarchar128_MemSQL():Boolean[1]


### PR DESCRIPTION
#### What type of PR is this?

Improvement 

#### What does this PR do / why is it needed ?

dateDiff() now allows DurationUnit YEARS, MONTHS, WEEKS, DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS

We use TIMESTAMPDIFF for all duration units. We were previously using time_to_sec(timediff()) for seconds;
time_to_sec(timediff()) has the TIME limitation. [The TIME object can only express intervals between -838:59:59 and 838:59:59.](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/timediff/)

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

Parameters being passed to generateDateDiffExpressionForMemSQL are changed because timestampdiff does date2 - date1, unlike timediff and datediff that do date1-date2

#### Does this PR introduce a user-facing change?
No
