### PR TITLE
Compare JSON Values for Integral vs Non-Integral

### DIFF
--- a/legend-engine-core/legend-engine-core-test/legend-engine-test-runner-shared/src/main/java/org/finos/legend/engine/test/runner/shared/JsonNodeComparator.java
+++ b/legend-engine-core/legend-engine-core-test/legend-engine-test-runner-shared/src/main/java/org/finos/legend/engine/test/runner/shared/JsonNodeComparator.java
@@ -150,7 +150,7 @@ public class JsonNodeComparator implements Comparator<JsonNode>
     {
         if (node1.isIntegralNumber())
         {
-            if (!node2.isIntegralNumber())
+            if (!node2.isIntegralNumber() && !(node1.asText().equals(node2.asText())))
             {
                 return -1;
             }
@@ -166,7 +166,7 @@ public class JsonNodeComparator implements Comparator<JsonNode>
         }
         if (node1.isFloatingPointNumber())
         {
-            if (!node2.isFloatingPointNumber())
+            if (!node2.isFloatingPointNumber() && !(node1.asText().equals(node2.asText())))
             {
                 return -1;
             }

--- a/legend-engine-core/legend-engine-core-test/legend-engine-testable/src/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
+++ b/legend-engine-core/legend-engine-core-test/legend-engine-testable/src/test/java/org/finos/legend/engine/testable/assertion/TestTestAssertionEvaluator.java
@@ -215,4 +215,17 @@ public class TestTestAssertionEvaluator
         Assert.assertTrue(assertionStatus instanceof AssertPass);
         Assert.assertEquals("assert1", assertionStatus.id);
     }
+    
+    @Test
+    public void testEqualToJsonAssertionWithExponentNotation()
+    {
+        ConstantResult constantResult = new ConstantResult("{\"negExp\":[6.2292853E-8, 6.2292853E-7, 6.2292853E-6, 6.2292853E-1], \"posExp\":[6.2292853E0, 6.2292853E1, 62.529285E6, 6.2292853E7, 6.22928534E8], \"noExp\":[0.62, 62, 6.2]}");
+        ExternalFormatData data = new ExternalFormatData();
+        data.contentType = "application/json";
+        EqualToJson equalToJson = new EqualToJson();
+        equalToJson.expected = data;
+        data.data = "{\"negExp\":[6.2292853E-8, 6.2292853E-7, 0.0000062292853, 0.62292853], \"posExp\":[6.2292853, 62.292853, 62529285, 62292853, 622928534], \"noExp\":[0.62, 62, 6.2]}";
+        AssertionStatus assertionStatus = equalToJson.accept(new TestAssertionEvaluator(constantResult));
+        Assert.assertTrue(assertionStatus instanceof AssertPass);
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
On service test execution when we compare the JSON, the assert fails when there is an Integral Node and a Non-Integral Node even though the actual node value is exactly same (with no decimal value on the Non-Integral node).
The changeset is to also to compare the actual value and not just node types.

We see this issue for values with exponent notation that round of to proper Integral numbers and this is because we are enabling the Deserialization Feature USE_BIG_DECIMAL_FOR_FLOATS.
We can enable the ACCEPT_FLOAT_AS_INT but USE_BIG_DECIMAL_FOR_FLOATS takes precedence over USE_BIG_DECIMAL_FOR_FLOATS and so its of no use.

One approach is to preProcess before Jackson handles but we decided not to do that as it could significantly increase service test execution time.


