### PR TITLE
Fix pure date formatting

### DIFF
--- a/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
+++ b/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
@@ -326,26 +326,19 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                             throw new IllegalArgumentException("Date has no sub-second: " + this);
                         }
                         int count = getCharCountFrom(character, formatString, i);
-                        if (count < 3)
+                         int maxLen = count + 1;
+                        int len = this.subsecond.length();
+                        if (len <= maxLen)
                         {
-                            int maxLen = count + 1;
-                            int len = this.subsecond.length();
-                            if (len <= maxLen)
-                            {
-                                appendable.append(this.subsecond);
-                            }
-                            else
-                            {
-                                int j = 0;
-                                while (j < maxLen)
-                                {
-                                    appendable.append(this.subsecond.charAt(j++));
-                                }
-                            }
+                            appendable.append(this.subsecond);
                         }
                         else
                         {
-                            appendable.append(this.subsecond);
+                            int j = 0;
+                            while (j < maxLen)
+                            {
+                                appendable.append(this.subsecond.charAt(j++));
+                            }
                         }
                         i += count;
                         break;

--- a/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/dependencies/domain/date/test/TestPureDate.java
+++ b/legend-engine-core/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/dependencies/domain/date/test/TestPureDate.java
@@ -48,9 +48,11 @@ public class TestPureDate
         Assert.assertEquals("2014-03-10", date.format("yyyy-MM-d"));
         Assert.assertEquals("2014-03-10", date.format("yyyy-MM-dd"));
         Assert.assertEquals("2014-03-10 4:12:35PM", date.format("yyyy-MM-dd h:mm:ssa"));
-        Assert.assertEquals("2014-03-10 16:12:35.070004235 GMT", date.format("yyyy-MM-dd HH:mm:ss.SSSS z"));
-        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", date.format("yyyy-MM-dd\"T\"HH:mm:ss.SSSSZ"));
+        Assert.assertEquals("2014-03-10 16:12:35.0700 GMT", date.format("yyyy-MM-dd HH:mm:ss.SSSS z"));
+        Assert.assertEquals("2014-03-10T16:12:35.0700+0000", date.format("yyyy-MM-dd\"T\"HH:mm:ss.SSSSZ"));
         Assert.assertEquals("2014-03-10 16:12:35.070Z", date.format("yyyy-MM-dd HH:mm:ss.SSSX"));
+        Assert.assertEquals("2014-03-10 16:12:35.070004", date.format("yyyy-MM-dd HH:mm:ss.SSSSSS"));
+        Assert.assertEquals("2014-03-10 16:12:35.070004235", date.format("yyyy-MM-dd HH:mm:ss.SSSSSSSSS"));
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
Bug Fix

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->
fix pureDate formatting of subseconds of precision > milliseconds
- required when memsql tries to load a csv file with dateTime column into a temp table, where column type is DATETIME (6) and actual data has different number digits in second part eg -2023-07-06 16:56:53.000000123
- only occurs when memsql has strict compatibility checks i.e data_conversion_compatibility_level >= 7.0

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
