### PR TITLE
Fix router to handle dynamic column specifications

### DIFF
--- a/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-pure/legend-engine-pure-code/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -511,7 +511,7 @@ function meta::pure::router::routing::processColSpecParams(fe:FunctionExpression
     ]))->cast(@ValueSpecification);
 
    let nfe = ^$fe(parametersValues = $parametersValues);
-   let colSpec = $nfe->reactivate($inScopeVars)->evaluateAndDeactivate()->cast(@ColumnSpecification<Any>)->toOne();
+   $nfe->reactivate($inScopeVars)->evaluateAndDeactivate()->cast(@ColumnSpecification<Any>);
 }
 
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/projection/testSimple.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/projection/testSimple.pure
@@ -34,6 +34,22 @@ function <<test.Test>> meta::relational::tests::projection::simple::testAllOneSi
    assertEquals('select "root".FIRSTNAME as "firstName" from personTable as "root"', $result->sqlRemoveFormatting());
 }
 
+function meta::relational::tests::projection::simple::getCols():ColumnSpecification<Person>[*]
+{
+  [
+    col(x : Person[1] | $x.firstName, 'firstName'),
+    col(x : Person[1] | $x.lastName, 'lastName')
+  ];
+}
+
+function <<test.Test>> meta::relational::tests::projection::simple::testAllOneSimplePropertyWithColsFromFunction():Boolean[1]
+{
+   let result = execute(|Person.all()->project(meta::relational::tests::projection::simple::getCols()), simpleRelationalMapping, testRuntime(), meta::relational::extension::relationalExtensions());
+   assertSize($result.values.rows, 7 );
+   assertEquals('Allen,Anthony,David,Fabrice,Harris,Hill,Hill,John,John,Johnson,Oliver,Peter,Roberts,Smith', $result.values.rows->map(r|$r.values)->sort()->makeString(','));
+   assertEquals('select "root".FIRSTNAME as "firstName", "root".LASTNAME as "lastName" from personTable as "root"', $result->sqlRemoveFormatting());
+}
+
 function <<test.Test>> meta::relational::tests::projection::simple::testAllOneSimplePropertyUsingVariable():Boolean[1]
 {
    let p = [#/Person/firstName#];


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix


#### What does this PR do / why is it needed ?
Fix toOne() in router_routing when processing column specification parameters

NOTE: this is a PR onto master branch - same commit is being made to current release branch as well https://github.com/finos/legend-engine/pull/2382
