### PR TITLE
Allow parsing sql expressions

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-grammar/src/main/java/org/finos/legend/engine/language/sql/grammar/from/SQLGrammarParser.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-grammar/src/main/java/org/finos/legend/engine/language/sql/grammar/from/SQLGrammarParser.java
@@ -28,6 +28,7 @@ import org.antlr.v4.runtime.dfa.DFA;
 import org.finos.legend.engine.language.sql.grammar.from.antlr4.SqlBaseLexer;
 import org.finos.legend.engine.language.sql.grammar.from.antlr4.SqlBaseParser;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.sql.metamodel.Expression;
 import org.finos.legend.engine.protocol.sql.metamodel.Statement;
 
 import java.util.BitSet;
@@ -49,6 +50,12 @@ public class SQLGrammarParser
     public Statement parseStatement(String query)
     {
         return this.parse(query, "statement");
+    }
+
+    public Expression parseExpression(String expression)
+    {
+        SqlBaseParser parser = getSqlBaseParser(expression, "expression");
+        return (Expression) sqlVisitor.visitSingleExpression(parser.singleExpression());
     }
 
     private Statement parse(String query, String name)

--- a/legend-engine-xts-sql/legend-engine-xt-sql-grammar/src/test/java/org/finos/legend/engine/language/sql/grammar/test/roundtrip/TestSQLRoundTrip.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-grammar/src/test/java/org/finos/legend/engine/language/sql/grammar/test/roundtrip/TestSQLRoundTrip.java
@@ -129,15 +129,33 @@ public class TestSQLRoundTrip
     }
 
     @Test
+    public void testWhereExpression()
+    {
+        checkExpression("col1 = 1");
+    }
+
+    @Test
     public void testCompositeWhere()
     {
         check("SELECT * FROM myTable WHERE col1 = 1 AND col2 = 1");
     }
 
     @Test
+    public void testCompositeWhereExpression()
+    {
+        checkExpression("col1 = 1 AND col2 = 1");
+    }
+
+    @Test
     public void testWhereQualified()
     {
         check("SELECT * FROM myTable WHERE myTable.col1 = 1");
+    }
+
+    @Test
+    public void testWhereQualifiedExpression()
+    {
+        checkExpression("myTable.col1 = 1");
     }
 
     @Test
@@ -150,6 +168,15 @@ public class TestSQLRoundTrip
     public void testCompositeWhereOperators()
     {
         check("SELECT * FROM myTable WHERE col = 1 AND col > 1 AND col < 1 " +
+                "AND col >= 1 AND col <= 1 AND col IN (1, 2, 3) AND col IS NULL AND " +
+                "col IS NOT NULL AND col IS DISTINCT FROM 1 AND col IS NOT DISTINCT FROM 1 AND " +
+                "col BETWEEN 0 AND 1");
+    }
+
+    @Test
+    public void testCompositeWhereOperatorsExpression()
+    {
+        checkExpression("col = 1 AND col > 1 AND col < 1 " +
                 "AND col >= 1 AND col <= 1 AND col IN (1, 2, 3) AND col IS NULL AND " +
                 "col IS NOT NULL AND col IS DISTINCT FROM 1 AND col IS NOT DISTINCT FROM 1 AND " +
                 "col BETWEEN 0 AND 1");
@@ -320,6 +347,21 @@ public class TestSQLRoundTrip
     {
         SQLGrammarParser parser = SQLGrammarParser.newInstance();
         Node node = parser.parseStatement(sql);
+        SQLGrammarComposer composer = SQLGrammarComposer.newInstance();
+        String result = composer.renderNode(node);
+        MatcherAssert.assertThat(result.trim(), IsEqualIgnoringCase.equalToIgnoringCase(expected));
+    }
+
+    private void checkExpression(String expression)
+    {
+        checkExpression(expression, expression);
+        checkExpression(expression.toLowerCase(), expression);
+    }
+
+    private void checkExpression(String expression, String expected)
+    {
+        SQLGrammarParser parser = SQLGrammarParser.newInstance();
+        Node node = parser.parseExpression(expression);
         SQLGrammarComposer composer = SQLGrammarComposer.newInstance();
         String result = composer.renderNode(node);
         MatcherAssert.assertThat(result.trim(), IsEqualIgnoringCase.equalToIgnoringCase(expected));


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Allow SQL parser to just parse expressions.  This will allow grammars to contain partial sql expressions like where clauses
 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
