### PR TITLE
GraphQL - Filter out fields with any type during introspection

### DIFF
--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/introspection/fromPure_Introspection.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/introspection/fromPure_Introspection.pure
@@ -86,7 +86,7 @@ function <<access.private>> meta::external::query::graphQL::binding::fromPure::i
     $t->match(
       [
         c:Class<Any>[1] |
-            let fields = $c->allProperties()->map(p|
+            let fields = $c->allProperties()->filter(p|$p.genericType.rawType != Any)->map(p|
                                       ^__Field
                                       (
                                         name = $p.name->toOne(),

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testIntrospectionQuery.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testIntrospectionQuery.pure
@@ -7,6 +7,7 @@ Class {doc.doc = 'Firm class representing a physical entity of Firm'} meta::exte
   {doc.doc = 'Is firm a public entity?'} isPublicEntity: Boolean[1];
   {doc.doc = 'Type of the firm'} firmType: Firm_Type[1];
   any: Any[1];
+  legalNameWithPrefix() {'LegalName: ' + $this.legalName}: Any[1];
 }
 
 Enum meta::external::query::graphQL::transformation::introspection::tests::Firm_Type

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testIntrospectionQuery.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testIntrospectionQuery.pure
@@ -6,8 +6,8 @@ Class {doc.doc = 'Firm class representing a physical entity of Firm'} meta::exte
   {doc.doc = 'All employees of the firm'} employees : meta::external::query::graphQL::transformation::introspection::tests::Person[*];
   {doc.doc = 'Is firm a public entity?'} isPublicEntity: Boolean[1];
   {doc.doc = 'Type of the firm'} firmType: Firm_Type[1];
-  any: Any[1];
-  legalNameWithPrefix() {'LegalName: ' + $this.legalName}: Any[1];
+  anyProperty: Any[1];
+  anyQualifiedProperty() {'LegalName: ' + $this.legalName}: Any[1];
 }
 
 Enum meta::external::query::graphQL::transformation::introspection::tests::Firm_Type

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testIntrospectionQuery.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/transformation/tests/testIntrospectionQuery.pure
@@ -6,6 +6,7 @@ Class {doc.doc = 'Firm class representing a physical entity of Firm'} meta::exte
   {doc.doc = 'All employees of the firm'} employees : meta::external::query::graphQL::transformation::introspection::tests::Person[*];
   {doc.doc = 'Is firm a public entity?'} isPublicEntity: Boolean[1];
   {doc.doc = 'Type of the firm'} firmType: Firm_Type[1];
+  any: Any[1];
 }
 
 Enum meta::external::query::graphQL::transformation::introspection::tests::Firm_Type


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Fixes introspection for pure models with fields on Any type.

Any type is a programming construct but can occur in models / dependency models. This doesn't carry significance in modelling. So, we can filter out fields with any type in introspection.  
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:
In tests it's a delta change in model but not in assert since code is filtering out such fields.

#### Does this PR introduce a user-facing change?
<!--
-->
