### PR TITLE
Limit the SingleStore max cached blob size to prevent out-of-memory error

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/MemSQLTestContainer.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution-tests/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/MemSQLTestContainer.java
@@ -51,6 +51,7 @@ public class MemSQLTestContainer implements DynamicTestConnection
              Statement statement = connection.createStatement())
         {
             statement.execute("create schema if not exists " + DATABASE_NAME + ";");
+            statement.execute("SET GLOBAL maximum_blob_cache_size_mb = 1024");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Limit the SingleStore max cached blob size to prevent out-of-memory error