### PR TITLE
SybaseIQ SQL generation fixes - Handling boolean operations

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
@@ -249,7 +249,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::sybas
 
   let s = if($isSubSelect && ($sq.fromRow->isNotEmpty() || $sq.toRow->isNotEmpty()), |$sq->rewriteSliceAsWindowFunction(), |$sq);
   let opStr = if($s.filteringOperation->isEmpty(), |'', |$s.filteringOperation->map(s|$s->wrapAsBooleanOperation($extensions)->processOperation($dbConfig, $format->indent(), ^$config(callingFromFilter = true), $extensions))->filter(s|$s != '')->joinStrings(' <||> '));
-  let havingStr = if($s.havingOperation->isEmpty(), |'', |$s.havingOperation->map(s|$s->processOperation($dbConfig, $format->indent(), $config, $extensions))->filter(s|$s != '')->joinStrings(' <||> '));
+  let havingStr = if($s.havingOperation->isEmpty(), |'', |$s.havingOperation->map(s|$s->wrapAsBooleanOperation($extensions)->processOperation($dbConfig, $format->indent(), $config, $extensions))->filter(s|$s != '')->joinStrings(' <||> '));
 
   $format.separator + 'select ' + if($s.distinct == true,|'distinct ',|'') + processTop($s, $format, $dbConfig, $extensions) +
   processSelectColumns($s.columns, $dbConfig, $format->indent(), false, $extensions) +

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/tests/testSybaseIQIsEmpty.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/tests/testSybaseIQIsEmpty.pure
@@ -45,12 +45,12 @@ function <<test.Test>> meta::relational::tests::query::function::sybaseIQ::testD
 {
    let result = execute(|TestClass.all()->groupBy([],[agg(x|$x.isValued(), y | $y->count())],['count']), TestMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    assertEquals('select count("root".value is null) as "count" from testTable as "root"', $result->sqlRemoveFormatting());
-   assertEquals('select count(case when ("root".value is null) then \'true\' else \'false\' end) as "count" from testTable as "root"', meta::relational::functions::sqlstring::toSQLString(|TestClass.all()->groupBy([],[agg(x|$x.isValued(), y | $y->count())],['count']), TestMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions()));
+   assertEquals('select count(case when "root".value is null then \'true\' else \'false\' end) as "count" from testTable as "root"', meta::relational::functions::sqlstring::toSQLString(|TestClass.all()->groupBy([],[agg(x|$x.isValued(), y | $y->count())],['count']), TestMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions()));
 }
 
 function <<test.Test>> meta::relational::tests::query::function::sybaseIQ::testDerivedCountWithIsEmptyNestedInIf():Boolean[1]
 {
    let result = execute(|TestClass.all()->groupBy([],[agg(x|$x.isValuedNested(), y | $y->count())],['count']), TestMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    assertEquals('select count(case when "root".value is null then true else false end) as "count" from testTable as "root"', $result->sqlRemoveFormatting());
-   assertEquals('select count(case when ("root".value is null) then \'true\' else \'false\' end) as "count" from testTable as "root"', meta::relational::functions::sqlstring::toSQLString(|TestClass.all()->groupBy([],[agg(x|$x.isValued(), y | $y->count())],['count']), TestMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions()));
+   assertEquals('select count(case when "root".value is null then \'true\' else \'false\' end) as "count" from testTable as "root"', meta::relational::functions::sqlstring::toSQLString(|TestClass.all()->groupBy([],[agg(x|$x.isValued(), y | $y->count())],['count']), TestMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions()));
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/tests/testSybaseIQTDSFilter.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/tests/testSybaseIQTDSFilter.pure
@@ -30,3 +30,17 @@ function <<test.Test>> meta::relational::tests::tds::sybaseIQ::testFilterOnDates
                               simpleRelationalMapping, DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions());
    assertEquals('select "root".settlementDateTime as "settlementDateTime" from tradeTable as "root" where "root".settlementDateTime < convert(DATETIME, \'2015-01-01 00:00:00.000\', 121)', $sql);
 }
+
+function <<test.Test>> meta::relational::tests::tds::sybaseIQ::testFirstNotNullFunction():Boolean[1]
+{
+   let sql =toSQLString(|Person.all()->project(p|$p.firstName,'firstName')->filter(p | meta::pure::tds::extensions::firstNotNull([$p.getString('firstName')->in(['John','Peter','Anthony']), false]) != false),
+      simpleRelationalMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions());
+   assertEquals('select "root".FIRSTNAME as "firstName" from personTable as "root" where (coalesce(case when "root".FIRSTNAME in (\'John\', \'Peter\', \'Anthony\') then \'true\' else \'false\' end, \'false\') <> \'false\' OR coalesce(case when "root".FIRSTNAME in (\'John\', \'Peter\', \'Anthony\') then \'true\' else \'false\' end, \'false\') is null)', $sql);
+}
+
+function <<test.Test>> meta::relational::tests::tds::sybaseIQ::testFirstNotNullFunctionWithinWhenClause():Boolean[1]
+{
+   let sql =toSQLString(|Person.all()->project(p|$p.firstName,'firstName')->filter(p | 
+    if(meta::pure::tds::extensions::firstNotNull([$p.getString('firstName')->in(['John','Peter','Anthony']),false ])->toOne(), | true,| false)), simpleRelationalMapping, meta::relational::runtime::DatabaseType.SybaseIQ, meta::relational::extension::relationalExtensions());
+   assertEquals('select "root".FIRSTNAME as "firstName" from personTable as "root" where case when coalesce(case when "root".FIRSTNAME in (\'John\', \'Peter\', \'Anthony\') then \'true\' else \'false\' end, \'false\') = \'true\' then \'true\' else \'false\' end = \'true\'', $sql);
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -609,6 +609,19 @@ function meta::relational::functions::sqlQueryToString::wrapAsBooleanOperation(e
    if ($e->isBooleanOperation($extensions), | $e, | ^DynaFunction(name ='equal', parameters=[$e, ^Literal(value=true)]););
 }
 
+function meta::relational::functions::sqlQueryToString::maybeWrapAsBooleanCaseOperation(e:RelationalOperationElement[1], sgc:SqlGenerationContext[1]):RelationalOperationElement[1]
+{
+   if ($sgc.dbConfig.dbExtension.isBooleanLiteralSupported,
+    |$e,
+    |$e->wrapAsBooleanCaseOperation($sgc.extensions)
+    );
+}
+ 
+function meta::relational::functions::sqlQueryToString::wrapAsBooleanCaseOperation(e:RelationalOperationElement[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   if ($e->isBooleanOperation($extensions), | ^DynaFunction(name='case', parameters = [$e, ^Literal(value=true), ^Literal(value=false)]), | $e);
+}
+
 function meta::relational::functions::sqlQueryToString::isBooleanOperation(relationalElement:RelationalOperationElement[1], extensions:Extension[*]):Boolean[1]
 {
    $relationalElement->match($extensions.moduleExtension('relational')->cast(@RelationalExtension).sqlQueryToString_isBooleanOperation->concatenate([
@@ -690,7 +703,9 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
                         |
                      if($func.name == 'if',
                         | $func.parameters->head()->map(p | $p->maybeWrapAsBooleanOperation($sgc))->concatenate($func.parameters->tail()),
-                        | $func.parameters
+                        | if (!$func->isBooleanOperation($sgc.extensions),
+                            | $func.parameters->map(p | $p->maybeWrapAsBooleanCaseOperation($sgc)),
+                            | $func.parameters)
                      ));
         let config = $sgc.config;
         let generationState = $sgc.generationState;


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

SybaseIQ doesn't support Boolean Literals. This pr includes two changes that are related boolean handling in sybase.

Change in dbExtension (this applies to all the dbs that don't support boolean literals) - 
Scope of this change is dyna functions (that aren't boolean operations) and can take Boolean operations as parameters.
For such functions, we need to explicitly handle the return value of boolean operations. We do that by wrapping the boolean operation parameters in a case statement.

Change in sybaseIqExtension -
The having clause is always expected to return a boolean. We use wrapAsBooleanOperation() on the having string to handle the boolean operations.

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No