### PR TITLE
Extend Precedence Rules Specification to Support Compound Filters and Enums

### DIFF
--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryParserGrammar.g4
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryParserGrammar.g4
@@ -363,7 +363,7 @@ pathExtension:                           subPath filter?
 ;
 subPath:                                '.' validString
 ;
-filter:                                 BRACE_OPEN '$' '.' combinedExpression BRACE_CLOSE
+filter:                                 BRACE_OPEN combinedExpression BRACE_CLOSE
 ;
 predicate:                              PREDICATE COLON
                                             lambdaFunction

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/HelperMasterRecordDefinitionBuilder.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/HelperMasterRecordDefinitionBuilder.java
@@ -47,7 +47,9 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElem
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -303,7 +305,7 @@ public class HelperMasterRecordDefinitionBuilder
             Property<?,?> property = (Property<?,?>) context.resolveProperty(determineFullPath(parentClass), propertyPath.property);
             Type propertyClass = property._genericType()._rawType();
             String propertyClassName;
-            if (propertyClass instanceof Class)
+            if ((propertyClass instanceof Class) || (propertyClass instanceof Enumeration))
             {
                 propertyClassName = determineFullPath(propertyClass);
             }

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
@@ -73,7 +73,9 @@ public class MasteryParseTreeWalker
 
 
     private static final String SIMPLE_PRECEDENCE_LAMBDA = "{input: %s[1]| true}";
-    private static final String PRECEDENCE_LAMBDA_WITH_FILTER = "{input: %s[1]| $input.%s}";
+    private static final String INPUT = "\\$input";
+    private static final String DOLLAR_SIGN = "\\$";
+    private static final String PRECEDENCE_LAMBDA_WITH_FILTER = "{input: %s[1]| %s}";
     private static final String DATA_PROVIDER_STRING = "DataProvider";
 
     public MasteryParseTreeWalker(ParseTreeWalkerSourceInformation walkerSourceInformation,
@@ -373,8 +375,9 @@ public class MasteryParseTreeWalker
 
     private Lambda visitLambdaWithFilter(String propertyName, MasteryParserGrammar.CombinedExpressionContext ctx)
     {
+        String inputFilter = ctx.getText().replaceAll(DOLLAR_SIGN, INPUT);
         return domainParser.parseLambda(
-                format(PRECEDENCE_LAMBDA_WITH_FILTER, propertyName, ctx.getText()),
+                format(PRECEDENCE_LAMBDA_WITH_FILTER, propertyName, inputFilter),
                 "", 0, 0, true);
     }
 

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
@@ -48,6 +48,8 @@ public class HelperMasteryGrammarComposer
 {
 
     private static final String PRECEDENCE_LAMBDA_WITH_FILTER_PREFIX = "\\{?input: .*\\[1]\\|\\$input\\.";
+    private static final String INPUT = "input";
+    private static final String BRACKETS = "\\(|\\)";
     private static final String PRECEDENCE_LAMBDA_WITH_FILTER_SUFFIX = ".*";
 
     private HelperMasteryGrammarComposer()
@@ -402,10 +404,10 @@ public class HelperMasteryGrammarComposer
         private String visitLambda(Lambda lambda)
         {
             StringBuilder builder = new StringBuilder();
-            String lambdaStr = lambda.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(context).build());
+            String lambdaStr = lambda.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(context).build()).replaceAll(BRACKETS, "");
             if (lambdaStr.matches(PRECEDENCE_LAMBDA_WITH_FILTER_PREFIX + PRECEDENCE_LAMBDA_WITH_FILTER_SUFFIX))
             {
-                String filterPath = lambdaStr.replaceAll(PRECEDENCE_LAMBDA_WITH_FILTER_PREFIX, "");
+                String filterPath = lambdaStr.replaceAll(PRECEDENCE_LAMBDA_WITH_FILTER_PREFIX, "").replace(INPUT, "");
                 builder.append("{$.").append(filterPath).append("}");
             }
             return builder.toString();

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
@@ -168,7 +168,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "      path: org::dataeng::Widget.runProfile.authorization;\n" +
             "    },\n" +
             "    SourcePrecedenceRule: {\n" +
-            "      path: org::dataeng::Widget.identifiers{$.identifier == 'XLON'};\n" +
+            "      path: org::dataeng::Widget.identifiers{$.identifier == 'XLON' || $.identifier == 'LSE'};\n" +
             "      action: Overwrite;\n" +
             "      ruleScope: [\n" +
             "        RecordSourceScope {widget-file-source-sftp, precedence: 1},\n" +
@@ -670,10 +670,25 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
                 Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl complexLambda = getComplexLambda(firstPropertyPath._filter());
                 List<? extends ValueSpecification> lambdaParameters = complexLambda._parametersValues().toList();
 
-                assertEquals("MilestonedIdentifier", getFunctionProperty(lambdaParameters.get(0))._owner()._name());
-                assertEquals("identifier", getFunctionProperty(lambdaParameters.get(0))._name());
-                assertEquals("equal", complexLambda._functionName());
-                assertEquals("XLON", getInstanceValue(lambdaParameters.get(1)));
+                assertEquals("or", complexLambda._functionName());
+
+                // first Part of filter
+                Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl firstFilter = (Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl) lambdaParameters.get(0);
+                List<? extends ValueSpecification> firstFilterLambdaParameters = firstFilter._parametersValues().toList();
+
+                assertEquals("MilestonedIdentifier", getFunctionProperty(firstFilterLambdaParameters.get(0))._owner()._name());
+                assertEquals("identifier", getFunctionProperty(firstFilterLambdaParameters.get(0))._name());
+                assertEquals("equal", firstFilter._functionName());
+                assertEquals("XLON", getInstanceValue(firstFilterLambdaParameters.get(1)));
+
+                // second Part of filter
+                Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl secondFilter = (Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl) lambdaParameters.get(1);
+                List<? extends ValueSpecification> secondFilterLambdaParameters = secondFilter._parametersValues().toList();
+
+                assertEquals("MilestonedIdentifier", getFunctionProperty(secondFilterLambdaParameters.get(0))._owner()._name());
+                assertEquals("identifier", getFunctionProperty(secondFilterLambdaParameters.get(0))._name());
+                assertEquals("equal", secondFilter._functionName());
+                assertEquals("LSE", getInstanceValue(secondFilterLambdaParameters.get(1)));
 
                 //masterRecordFilter
                 assertEquals("true", getSimpleLambdaValue(source._masterRecordFilter()));
@@ -702,10 +717,25 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
                 Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl complexLambda = getComplexLambda(firstPropertyPath._filter());
                 List<? extends ValueSpecification> lambdaParameters = complexLambda._parametersValues().toList();
 
-                assertEquals("MilestonedIdentifier", getFunctionProperty(lambdaParameters.get(0))._owner()._name());
-                assertEquals("identifier", getFunctionProperty(lambdaParameters.get(0))._name());
-                assertEquals("equal", complexLambda._functionName());
-                assertEquals("XLON", getInstanceValue(lambdaParameters.get(1)));
+                assertEquals("or", complexLambda._functionName());
+
+                // first Part of filter
+                Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl firstFilter = (Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl) lambdaParameters.get(0);
+                List<? extends ValueSpecification> firstFilterLambdaParameters = firstFilter._parametersValues().toList();
+
+                assertEquals("MilestonedIdentifier", getFunctionProperty(firstFilterLambdaParameters.get(0))._owner()._name());
+                assertEquals("identifier", getFunctionProperty(firstFilterLambdaParameters.get(0))._name());
+                assertEquals("equal", firstFilter._functionName());
+                assertEquals("XLON", getInstanceValue(firstFilterLambdaParameters.get(1)));
+
+                // second Part of filter
+                Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl secondFilter = (Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl) lambdaParameters.get(1);
+                List<? extends ValueSpecification> secondFilterLambdaParameters = secondFilter._parametersValues().toList();
+
+                assertEquals("MilestonedIdentifier", getFunctionProperty(secondFilterLambdaParameters.get(0))._owner()._name());
+                assertEquals("identifier", getFunctionProperty(secondFilterLambdaParameters.get(0))._name());
+                assertEquals("equal", secondFilter._functionName());
+                assertEquals("LSE", getInstanceValue(secondFilterLambdaParameters.get(1)));
 
                 //masterRecordFilter
                 assertEquals("true", getSimpleLambdaValue(source._masterRecordFilter()));

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
@@ -79,8 +79,14 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "{\n" +
             "  widgetId: String[0..1];\n" +
             "  trigger: String[0..1];\n" +
+            "  modelType: org::dataeng::ModelType[0..1];\n" +
             "  runProfile: org::dataeng::Medium[0..1];\n" +
             "  identifiers: org::dataeng::MilestonedIdentifier[*];\n" +
+            "}\n\n" +
+            "Enum org::dataeng::ModelType\n" +
+            "{\n" +
+            "  modelA,\n" +
+            "  modelB\n" +
             "}\n\n" +
             "Class org::dataeng::Medium\n" +
             "{\n" +
@@ -134,7 +140,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "  }\n" +
             "  precedenceRules: [\n" +
             "    DeleteRule: {\n" +
-            "      path: org::dataeng::Widget.identifiers;\n" +
+            "      path: org::dataeng::Widget.modelType;\n" +
             "      ruleScope: [\n" +
             "        RecordSourceScope {widget-rest-source}\n" +
             "      ];\n" +
@@ -575,7 +581,7 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
 
                 Root_meta_pure_mastery_metamodel_precedence_PropertyPath propertyPath = paths.get(0);
                 //path property
-                assertEquals("identifiers", propertyPath._property()._name());
+                assertEquals("modelType", propertyPath._property()._name());
                 assertEquals("Widget", propertyPath._property()._owner()._name());
                 //path filter
                 assertEquals("true", getSimpleLambdaValue(propertyPath._filter()));


### PR DESCRIPTION
This Pull Request introduces enhancements to the Precedence Rules Specification within the Mastery module. The key improvements include:

1. Support for Compound Filter Expressions:

> - Previous Capability: The system could interpret and capture simple path filters following the structure Widget{$.widgetId == 'value'}.
> - New Capability: It now accommodates compound expressions, allowing for more complex filter definitions. For example, a filter can now include combined conditions such as Widget{$.widgetId == '1234' && $.type == 'woggle'}.

2. Enum Path Specification:
> - Issue: A previously identified bug prevented the system from processing path specifications that pointed to an Enum type. This limitation restricted the rules to only accept paths leading to a Class or Primitive type.
> - Resolution: The bug has been addressed, and the system can now correctly interpret and utilize Enums in path specifications.
