### PR TITLE
Fix mastery composer - extra comma being added when no source precedence rules

### DIFF
--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
@@ -252,7 +252,7 @@ public class HelperMasteryGrammarComposer
         {
             String precedenceRuleString = precedenceRule.accept(new PrecedenceRuleComposer(indentLevel + 1, context, uniqueSourcePrecedenceRules));
             nonSourcePrecedenceRulesBuilder.append(precedenceRuleString);
-            nonSourcePrecedenceRulesBuilder.append(i < precedenceRules.size() && !precedenceRuleString.equals("") ? "," : "");
+            nonSourcePrecedenceRulesBuilder.append(i < precedenceRules.size() - 1 && !precedenceRuleString.equals("") ? "," : "");
         });
         return combinePrecedenceRules(uniqueSourcePrecedenceRules, nonSourcePrecedenceRulesBuilder.toString(), indentLevel);
     }

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
@@ -373,6 +373,60 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "    }#;\n" +
             "}\n";
 
+    public static String MASTERY_MODEL_WITH_ONE_RULE = "###Pure\n" +
+            "Class org::dataeng::Widget\n" +
+            "{\n" +
+            "  widgetId: String[0..1];\n" +
+            "  identifiers: org::dataeng::MilestonedIdentifier[*];\n" +
+            "}\n\n" +
+            "Class org::dataeng::MilestonedIdentifier\n" +
+            "{\n" +
+            "  identifierType: String[1];\n" +
+            "  identifier: String[1];\n" +
+            "  FROM_Z: StrictDate[0..1];\n" +
+            "  THRU_Z: StrictDate[0..1];\n" +
+            "}\n\n\n" +
+            MAPPING_AND_CONNECTION +
+            "###Service\n" +
+            "Service org::dataeng::ParseWidget\n" + WIDGET_SERVICE_BODY + "\n" +
+            "Service org::dataeng::TransformWidget\n" + WIDGET_SERVICE_BODY + "\n" +
+            "\n" +
+            "###Mastery\n" + "MasterRecordDefinition alloy::mastery::WidgetMasterRecord" +
+            "\n" +
+            "{\n" +
+            "  modelClass: org::dataeng::Widget;\n" +
+            "  identityResolution: \n" +
+            "  {\n" +
+            "    resolutionQueries:\n" +
+            "      [\n" +
+            "        {\n" +
+            "          queries: [ {input: org::dataeng::Widget[1]|org::dataeng::Widget.all()->filter(widget|$widget.widgetId == $input.widgetId)}\n" +
+            "                   ];\n" +
+            "          precedence: 1;\n" +
+            "        }\n" +
+            "      ]\n" +
+            "  }\n" +
+            "  precedenceRules: [\n" +
+            "    DeleteRule: {\n" +
+            "      path: org::dataeng::Widget.identifiers.identifier;\n" +
+            "      ruleScope: [\n" +
+            "        RecordSourceScope {widget-producer}\n" +
+            "      ];\n" +
+            "    }\n" +
+            "  ]\n" +
+            "  recordSources:\n" +
+            "  [\n" +
+            "    widget-producer: {\n" +
+            "      description: 'REST Acquisition source.';\n" +
+            "      status: Development;\n" +
+            "      recordService: {\n" +
+            "        acquisitionProtocol: REST;\n" +
+            "      };\n" +
+            "      trigger: Manual;\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}\n";
+
     public static String MINIMUM_CORRECT_MASTERY_MODEL = "###Pure\n" +
             "Class org::dataeng::Widget\n" +
             "{\n" +
@@ -924,6 +978,19 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
         assertTrue(packageableElement instanceof Root_meta_pure_mastery_metamodel_MasterRecordDefinition);
         Root_meta_pure_mastery_metamodel_MasterRecordDefinition masterRecordDefinition = (Root_meta_pure_mastery_metamodel_MasterRecordDefinition) packageableElement;
         assertEquals("Widget", masterRecordDefinition._modelClass()._name());
+    }
+
+    @Test
+    public void testMasteryModelWithOneRule()
+    {
+        Pair<PureModelContextData, PureModel> result = test(MASTERY_MODEL_WITH_ONE_RULE);
+        PureModel model = result.getTwo();
+
+        PackageableElement packageableElement = model.getPackageableElement("alloy::mastery::WidgetMasterRecord");
+        assertNotNull(packageableElement);
+        assertTrue(packageableElement instanceof Root_meta_pure_mastery_metamodel_MasterRecordDefinition);
+        Root_meta_pure_mastery_metamodel_MasterRecordDefinition masterRecordDefinition = (Root_meta_pure_mastery_metamodel_MasterRecordDefinition) packageableElement;
+        assertEquals(1, masterRecordDefinition._precedenceRules().size());
     }
 
     @Test

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/test/TestMasteryGrammarRoundtrip.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/test/TestMasteryGrammarRoundtrip.java
@@ -28,6 +28,12 @@ public class TestMasteryGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
     }
 
     @Test
+    public void masteryRoundTripWithOneRule()
+    {
+        testWithSectionInfoPreserved(TestMasteryCompilationFromGrammar.MASTERY_MODEL_WITH_ONE_RULE);
+    }
+
+    @Test
     public void masteryRoundTripMinimum()
     {
         testWithSectionInfoPreserved(TestMasteryCompilationFromGrammar.MINIMUM_CORRECT_MASTERY_MODEL);


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

When there are precedence rules defined on the master record definition, if none of them are source precedence rules then an extra comma is being added by the composer.
