### PR TITLE
Fix Boolean literal processor for MemSQL

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/executionPlan/tests/executionPlanTest.pure
@@ -36,7 +36,7 @@ function <<test.Test>> meta::relational::memsql::tests::executionPlan::testFilte
                      '    (\n'+
                      '      type = TDS[(Time, Integer, INT, "")]\n'+
                      '      resultColumns = [("Time", INT)]\n'+
-                     '      sql = select `root`.time as `Time` from interactionTable as `root` where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'`root`.ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" {"\\\'" : "\\\'\\\'"} "null")}\', \'`root`.ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "\\\'" "\\\'" {} "null")}\', \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
+                     '      sql = select `root`.time as `Time` from interactionTable as `root` where ((${optionalVarPlaceHolderOperationSelector(optionalID![], \'`root`.ID = ${varPlaceHolderToString(optionalID![] "\\\'" "\\\'" {"\\\'" : "\\\'\\\'"} "null")}\', \'`root`.ID is null\')}) and (${optionalVarPlaceHolderOperationSelector(optionalActive![], \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end = ${varPlaceHolderToString(optionalActive![] "" "" {} "null")}\', \'case when `root`.active = \\\'Y\\\' then \\\'true\\\' else \\\'false\\\' end is null\')}))\n'+
                      '      connection = DatabaseConnection(type = "MemSQL")\n'+
                      '    )\n'+
                      '  )\n'+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
@@ -18,7 +18,7 @@ function <<db.ExtensionLoader>> meta::relational::functions::sqlQueryToString::m
 function <<access.private>> meta::relational::functions::sqlQueryToString::memsql::createDbExtensionForMemSQL():DbExtension[1]
 {
    let reservedWords = memSQLReservedWords();
-   let literalProcessors = getDefaultLiteralProcessors();
+   let literalProcessors = getDefaultLiteralProcessors()->putAll(getLiteralProcessorsForMemSQL());
    let literalProcessor = {type:Type[1]| $literalProcessors->get(if($type->instanceOf(Enumeration), | Enum, | $type))->toOne()};
    let dynaFuncDispatch = getDynaFunctionToSqlDefault($literalProcessor)->groupBy(d| $d.funcName)->putAll(
      getDynaFunctionToSqlForMemSQL()->groupBy(d| $d.funcName))->getDynaFunctionDispatcher();
@@ -40,6 +40,13 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memsq
       ddlCommandsTranslator = getDDLCommandsTranslator(),
       processTempTableName = processTempTableNameDefault_String_1__String_1_
    );
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::memsql::getLiteralProcessorsForMemSQL():Map<Type,LiteralProcessor>[1]
+{
+   newMap([
+      pair(Boolean,    ^LiteralProcessor(format = '%s', transform = toString_Any_1__String_1_->literalTransform()))
+   ])
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::memsql::memSQLReservedWords():String[*]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/semiStructured/TestSemiStructuredMatching.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/semiStructured/TestSemiStructuredMatching.java
@@ -136,7 +136,7 @@ public class TestSemiStructuredMatching extends AbstractTestSemiStructured
                         "    (\n" +
                         "      type = TDS[(Max Amount Flag, Boolean, \"\", \"\")]\n" +
                         "      resultColumns = [(\"Max Amount Flag\", \"\")]\n" +
-                        "      sql = select case when `root`.CUSTOMER::transactionDetails::payment::$@type in ('CashOnDeliveryPayment') then case when `root`.CUSTOMER::transactionDetails::payment::%amountToBePaid < ${maxAmount} then 'true' else 'false' end when `root`.CUSTOMER::transactionDetails::payment::$@type in ('PrepaidPayment', 'WalletPrepaidPayment', 'CardPrepaidPayment') then case when `root`.CUSTOMER::transactionDetails::payment::%amountPaid < ${maxAmount} then 'true' else 'false' end else null end as `Max Amount Flag` from ORDER_SCHEMA.ORDER_TABLE as `root`\n" +
+                        "      sql = select case when `root`.CUSTOMER::transactionDetails::payment::$@type in ('CashOnDeliveryPayment') then case when `root`.CUSTOMER::transactionDetails::payment::%amountToBePaid < ${maxAmount} then true else false end when `root`.CUSTOMER::transactionDetails::payment::$@type in ('PrepaidPayment', 'WalletPrepaidPayment', 'CardPrepaidPayment') then case when `root`.CUSTOMER::transactionDetails::payment::%amountPaid < ${maxAmount} then true else false end else null end as `Max Amount Flag` from ORDER_SCHEMA.ORDER_TABLE as `root`\n" +
                         "      connection = RelationalDatabaseConnection(type = \"MemSQL\")\n" +
                         "    )\n" +
                         "  )\n" +


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed?

Override the default boolean literal processor in the MemSQL extension

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:
testSqlTrue and testSqlFalse in Sql Generation tests of MemSQL should be green after this change

#### Does this PR introduce a user-facing change?
No
