### PR TITLE
change tokens - do not mutate input map, do not cache output object type

### DIFF
--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast2Test.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast2Test.java
@@ -103,7 +103,7 @@ public class GenerateCast2Test extends GenerateCastTestBase
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
@@ -112,7 +112,8 @@ public class GenerateCast2Test extends GenerateCastTestBase
                         "    \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "    \"abc\": \"someValue\"\n" +
                         "  }\n" +
-                        "}\n", Map.class);
+                        "}\n";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
 
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class).invoke(null, jsonNode, "ftdm:abcdefg123");
 
@@ -124,5 +125,6 @@ public class GenerateCast2Test extends GenerateCastTestBase
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}\n" +
                         "}\n", Map.class); // moved 'someValue' to '../existingValue'
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "  \"abc\": true\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": false\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
@@ -64,7 +64,7 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "  \"abc\": true\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+       String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": false\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastChainTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastChainTest.java
@@ -92,7 +92,7 @@ public class GenerateCastChainTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -101,7 +101,8 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -116,13 +117,13 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "  \"abc\": 100, \"def\": 200\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg789\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -132,7 +133,8 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100, \"def\": 200\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -146,13 +148,13 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg789\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -162,9 +164,11 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100, \"def\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
@@ -38,7 +38,7 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -47,7 +47,8 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -62,13 +63,13 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -78,7 +79,8 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -92,13 +94,13 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -108,9 +110,11 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomObjectTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomObjectTest.java
@@ -74,7 +74,7 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -83,7 +83,8 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -98,13 +99,13 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -114,7 +115,8 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -128,13 +130,13 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -144,9 +146,11 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:{@type=Custom, value=1d}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "  \"abc\": 123.45\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 67.89\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
@@ -64,7 +64,7 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "  \"abc\": 123.45\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 67.89\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromJsonTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromJsonTest.java
@@ -65,7 +65,7 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -74,7 +74,8 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -89,13 +90,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -105,7 +106,8 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -119,13 +121,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -135,7 +137,8 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -149,13 +152,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -165,9 +168,11 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromVersionsTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromVersionsTest.java
@@ -56,7 +56,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -65,7 +65,8 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -80,13 +81,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -96,7 +97,8 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -110,13 +112,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -126,7 +128,8 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -140,13 +143,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -156,9 +159,11 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveExtractTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveExtractTest.java
@@ -83,7 +83,7 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -93,7 +93,8 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"names\": {\"@type\":\"NamesClass\", \"first\":\"5d\", \"middle\":\"\", \"last\":\"6d\"}}]\n" +
                         "  ],\n" +
                         "  \"names\": {\"@type\":\"NamesClass\", \"first\":\"7d\", \"middle\":\"\", \"last\":\"8d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -108,13 +109,13 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "  \"firstName\":\"7d\", \"lastName\":\"8d\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -124,7 +125,8 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"firstName\":\"5d\", \"lastName\":\"6d\"}]\n" +
                         "  ],\n" +
                         "  \"firstName\":\"7d\", \"lastName\":\"8d\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -139,5 +141,6 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "  \"names\": {\"@type\":\"NamesClass\", \"first\":\"7d\", \"middle\":\"\", \"last\":\"8d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveNestedTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveNestedTest.java
@@ -65,7 +65,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -75,7 +75,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -90,13 +91,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -106,7 +107,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -121,12 +123,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -136,7 +139,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -151,13 +155,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -167,7 +171,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -182,12 +187,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -197,17 +203,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\", \"value\":\"5d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot overwrite with different value:5d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -217,16 +224,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\", \"value\":\"6d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot overwrite with different value:6d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastInvalidDestination() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -236,17 +245,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": \"invalid\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Destination is not a map: xyz", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastInvalidDestination() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -256,16 +266,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\":  \"invalid\"}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Destination is not a map: abc", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastInvalidSource() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -275,17 +287,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"invalid\", \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Source is not a map: abc", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastInvalidSource() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -295,9 +308,11 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": \"invalid\", \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Source is not a map: xyz", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveTest.java
@@ -75,7 +75,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -85,7 +85,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -100,12 +101,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -115,7 +117,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -130,13 +133,14 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -146,7 +150,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -161,13 +166,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0}, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -177,7 +182,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -192,13 +198,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -208,7 +214,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -223,13 +230,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -239,7 +246,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -254,5 +262,6 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRemoveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRemoveTest.java
@@ -64,7 +64,7 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -74,7 +74,8 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
@@ -87,13 +88,13 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void tesUpcastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -103,7 +104,8 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
@@ -116,13 +118,13 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -132,17 +134,18 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -151,7 +154,8 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -166,5 +170,6 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
    }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameFieldRenamedClassTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameFieldRenamedClassTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertThrows;
 
-public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
+public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBase
 {
     @BeforeClass
     public static void setupSuite() throws IOException, ClassNotFoundException
@@ -47,12 +47,17 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "        {\n" +
                 "          \"@type\": \"meta::pure::changetoken::RenameField\",\n" +
                 "          \"oldFieldName\": [\n" +
-                "            \"value\"\n" +
+                "            \"abc\"\n" +
                 "          ],\n" +
                 "          \"newFieldName\": [\n" +
-                "            \"valueCustom\"\n" +
+                "            \"xyz\"\n" +
                 "          ],\n" +
-                "          \"class\": \"Custom\"\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"@type\": \"meta::pure::changetoken::RenamedClass\",\n" +
+                "          \"newName\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
                 "        }\n" +
                 "      ]\n" +
                 "    }\n" +
@@ -80,13 +85,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -99,12 +104,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -113,12 +118,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -132,12 +137,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -145,13 +150,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -163,13 +168,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -178,12 +183,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -196,12 +201,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -210,12 +215,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -227,11 +232,11 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
@@ -242,10 +247,10 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
@@ -260,12 +265,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -273,13 +278,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -291,13 +296,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -324,19 +329,19 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
@@ -344,18 +349,18 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameNestedPropertyTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameNestedPropertyTest.java
@@ -65,7 +65,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -75,7 +75,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -90,12 +91,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -105,7 +107,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -120,13 +123,14 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -136,7 +140,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -151,13 +156,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -167,7 +172,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -182,13 +188,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -198,7 +204,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -213,13 +220,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -229,7 +236,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -244,12 +252,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -259,7 +268,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -274,13 +284,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -290,7 +300,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -305,12 +316,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -320,17 +332,18 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -340,9 +353,11 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameTest.java
@@ -63,7 +63,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,12 +89,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -103,7 +105,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +121,14 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,7 +138,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -149,13 +154,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -165,7 +170,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -180,13 +186,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -196,7 +202,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -211,13 +218,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -227,7 +234,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -242,12 +250,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -257,7 +266,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -272,13 +282,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -288,7 +298,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -303,12 +314,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -318,17 +330,18 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -338,9 +351,11 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassRenameFieldTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassRenameFieldTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertThrows;
 
-public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
+public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBase
 {
     @BeforeClass
     public static void setupSuite() throws IOException, ClassNotFoundException
@@ -45,14 +45,19 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "      \"prevVersion\": \"ftdm:abcdefg123\",\n" +
                 "      \"changeTokens\": [\n" +
                 "        {\n" +
+                "          \"@type\": \"meta::pure::changetoken::RenamedClass\",\n" +
+                "          \"newName\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                "        },\n" +
+                "        {\n" +
                 "          \"@type\": \"meta::pure::changetoken::RenameField\",\n" +
                 "          \"oldFieldName\": [\n" +
-                "            \"value\"\n" +
+                "            \"abc\"\n" +
                 "          ],\n" +
                 "          \"newFieldName\": [\n" +
-                "            \"valueCustom\"\n" +
+                "            \"xyz\"\n" +
                 "          ],\n" +
-                "          \"class\": \"Custom\"\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::nested::NewSampleClass\"\n" +
                 "        }\n" +
                 "      ]\n" +
                 "    }\n" +
@@ -80,13 +85,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -99,12 +104,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -113,12 +118,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -132,12 +137,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -145,13 +150,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -163,13 +168,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -178,12 +183,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -196,12 +201,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -210,12 +215,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -227,11 +232,11 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
@@ -242,10 +247,10 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
@@ -260,12 +265,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -273,13 +278,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -291,13 +296,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -324,19 +329,19 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
@@ -344,18 +349,18 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassTest.java
@@ -58,7 +58,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -68,7 +68,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -83,12 +84,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -98,7 +100,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -113,13 +116,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -129,7 +132,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -144,13 +148,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -160,7 +164,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -175,6 +180,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }
 

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
@@ -64,7 +64,7 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "  \"abc\": \"one \\\" two\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"two \\\" one\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "  \"abc\": \"one \\\" two\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"two \\\" one\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTest.java
@@ -64,7 +64,7 @@ public class GenerateCastTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,7 +136,8 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -148,13 +151,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -164,9 +167,11 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
@@ -168,5 +168,10 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation.pure
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation.pure
@@ -258,7 +258,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
     j_return($resVar)
   ])));
 
-  let typeVar = j_variable(javaString(), 'type');
+  let typeVar = $resVar->j_invoke('get', [j_string('@type')], javaObject());
   let rootObjVar = j_parameter(objectNode(), 'rootObjectNode');
   let pathVar = j_parameter(javaList(javaObject()), 'path');
   let changeTokenHandlers = $version.changeTokens
@@ -282,13 +282,10 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
         javaRuntimeException()->j_new(j_string('Missing @type'))->j_throw()
       ),
       // Map<String,Object> res = new HashMap<>()
-      $resVar->j_declare(javaHashMap()->j_new([])),
-
-      // String type = (String) objectNode.get("@type")
-      $typeVar->j_declare($objVar->j_invoke('get', [j_string('@type')], javaObject())->j_cast(javaString()))
+      $resVar->j_declare(javaHashMap()->j_new([]))
     ]
-    ->concatenate($changeTokenHandlers)
     ->concatenate($class2->_generateSingleCastObjectRecurseBlock($objRecurseFuncName, $arrRecurseFuncName, $objVar, $pathVar, $rootObjVar, $resVar))
+    ->concatenate($changeTokenHandlers)
     ->concatenate([
       j_return($resVar)
     ]))));
@@ -336,7 +333,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
     j_return($resVar)
   ])));
 
-  let typeVar = j_variable(javaString(), 'type');
+  let typeVar = $resVar->j_invoke('get', [j_string('@type')], javaObject());
   let changeTokenHandlers = $version.changeTokens->reverse()
     ->map(t|$t->match([
       t:AddField[1]|_handleAddFieldDowncast($class2, $t, $objVar, $typeVar, $version.version, $pathVar, $rootObjVar, $resVar),
@@ -358,12 +355,10 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
         javaRuntimeException()->j_new(j_string('Missing @type'))->j_throw()
       ),
       // Map<String,Object> res = new HashMap<>()
-      $resVar->j_declare(javaHashMap()->j_new([])),
-      // String type = (String) objectNode.get("@type")
-      $typeVar->j_declare($objVar->j_invoke('get', [j_string('@type')], javaObject())->j_cast(javaString()))
+      $resVar->j_declare(javaHashMap()->j_new([]))
     ]
-    ->concatenate($changeTokenHandlers)
     ->concatenate($class2->_generateSingleCastObjectRecurseBlock($objRecurseFuncName, $arrRecurseFuncName, $objVar, $pathVar, $rootObjVar, $resVar))
+    ->concatenate($changeTokenHandlers)
     ->concatenate([
       j_return($resVar)
     ]))));
@@ -537,33 +532,33 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleRen
   ):Code[1]
 {
   $oldFieldName->size()->range()->tail()->reverse()->fold({i,r|
-  j_if($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)->j_instanceof(javaRawMap()),$r,
-  j_if(j_ne($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar),j_null()),
+  j_if($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)->j_instanceof(javaRawMap()),$r,
+  j_if(j_ne($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar),j_null()),
   javaRuntimeException()->j_new(j_plus(j_string('Source is not a map: '), j_string($oldFieldName->take($i)->joinStrings('.'))))->j_throw()
   ))},
   j_if(
-  j_ne($oldFieldName->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar),j_null())
+  j_ne($oldFieldName->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar),j_null())
   ,
   j_block(
   $newFieldName->size()->range()->tail()->map({i|
-    j_if($newFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)->j_instanceof(javaRawMap())->j_not(),
+    j_if($newFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)->j_instanceof(javaRawMap())->j_not(),
       javaRuntimeException()->j_new(j_plus(j_string('Destination is not a map: '), j_string($newFieldName->take($i)->joinStrings('.'))))->j_throw()
   )})->concatenate([
-    j_if($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+    j_if($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
      ->j_cast(objectNode())->j_invoke('get', [j_string($newFieldName->last()->toOne())], javaObject())->j_ne(j_null())
-     ->j_and($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+     ->j_and($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
      ->j_cast(objectNode())->j_invoke('get', [j_string($newFieldName->last()->toOne())], javaObject())->j_invoke('equals',
-       $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+       $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
        ->j_cast(objectNode())->j_invoke('get', [j_string($oldFieldName->last()->toOne())], javaVoid()))->j_not()),
           javaRuntimeException()->j_new([j_string('Cannot overwrite with different value:')
-          ->j_plus($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+          ->j_plus($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
           ->j_cast(objectNode())->j_invoke('get', [j_string($newFieldName->last()->toOne())], javaObject()))])->j_throw()),
-    $newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+    $newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
     ->j_cast(objectNode())->j_invoke('put', [j_string($newFieldName->last()->toOne()),
-      $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+      $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
       ->j_cast(objectNode())->j_invoke('get', [j_string($oldFieldName->last()->toOne())], javaVoid())
     ], javaVoid()),
-    $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+    $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
     ->j_cast(objectNode())->j_invoke('remove', [j_string($oldFieldName->last()->toOne())], javaVoid())
   ])
   )
@@ -580,7 +575,7 @@ token:RenamedClass[1], objVar:Code[1], typeVar:Code[1], version:String[1], pathV
   // if (type.equals(token.class))
   j_if(
   $typeVar->j_invoke('equals', [j_string($token.class)]),
-  $objVar->j_invoke('put', [j_string('@type'), j_string($token.newName)])
+  $resVar->j_invoke('put', [j_string('@type'), j_string($token.newName)])
   );
 }
 
@@ -593,7 +588,7 @@ token:RenamedClass[1], objVar:Code[1], typeVar:Code[1], version:String[1], pathV
   // if (type.equals(token.newName))
   j_if(
   $typeVar->j_invoke('equals', [j_string($token.newName)]),
-  $objVar->j_invoke('put', [j_string('@type'), j_string($token.class)])
+  $resVar->j_invoke('put', [j_string('@type'), j_string($token.class)])
   );
 }
 
@@ -614,17 +609,17 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
       df:ConstValue[1] | if(_isPrimitive($token.fieldType) || !_isComplex($df.value),|
       [
         $valVar->j_declare([_getValueAsFieldType($token.fieldType, $df.value)]),
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
-          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
-        $objVar->j_invoke('put', [j_string($token.fieldName), $valVar], javaVoid())
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
+          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        $resVar->j_invoke('put', [j_string($token.fieldName), $valVar], javaVoid())
       ],| j_block([
         $mapVar->j_declare(javaStream()->j_invoke('of',
         $df.value->cast(@String)->parseJSON()->cast(@meta::json::JSONObject).keyValuePairs->map(kv | _inlineJsonValue($kv.key.value, $kv.value)),
         javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()))
       ]->concatenate([
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
-          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
-        $objVar->j_invoke('put', [j_string($token.fieldName), $mapVar], javaVoid())
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
+          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        $resVar->j_invoke('put', [j_string($token.fieldName), $mapVar], javaVoid())
       ]))
       ),
       df:CopyValue[1] |
@@ -636,8 +631,8 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
           j_string($df.source->cast(@RelativeFieldReference).path) // TODO: handle other types of references
         ], javaObject())),
         // res.put("abc", value);
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
-          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
+          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
         $resVar->j_invoke('put', [j_string($token.fieldName), $valVar], javaVoid())
       ]
     ])
@@ -787,7 +782,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleCha
         $class->j_invoke(_getChangeFieldTypeConverter($token.oldFieldType, $token.newFieldType), 
         [
           $pathVar, 
-          $objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
+          $resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
         ], javaObject())
       ], javaVoid())
     ]
@@ -821,11 +816,11 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
         $valVar->j_declare([_getValueAsFieldType($token.fieldType, $df.value)])
       ]->concatenate([
         // if ((Integer)objectNode.get(fieldName) != defaultValue) throw new RuntimeException("Cannot remove non-default value" + objectNode.get("fieldName")) // TODO: handle non-int
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
-            javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
+            javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
 
-        // objectNode.remove(fieldName)
-        $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid()) 
+        // res.remove(fieldName)
+        $resVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
       ])),
       |
       j_block([
@@ -834,11 +829,11 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
         javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()))
       ]->concatenate([
         // if ((Integer)objectNode.get(fieldName) != defaultValue) throw new RuntimeException("Cannot remove non-default value" + objectNode.get("fieldName")) // TODO: handle non-int
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
-        javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
+        javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
 
-        // objectNode.remove(fieldName)
-        $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
+        // res.remove(fieldName)
+        $resVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
       ]))
       ),
       df:CopyValue[1] | 
@@ -848,11 +843,11 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
           $rootObjVar, 
           $pathVar, 
           j_string($df.source->cast(@RelativeFieldReference).path), // TODO: handle other types of references
-          $objVar->j_invoke('get', [j_string($token.fieldName)], javaVoid())
+          $resVar->j_invoke('get', [j_string($token.fieldName)], javaVoid())
         ], javaObject()),
 
-        // objectNode.remove("abc");
-        $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
+        // res.remove("abc");
+        $resVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
       ]
     ])
   );
@@ -874,7 +869,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleCha
         $class->j_invoke(_getChangeFieldTypeConverter($token.newFieldType, $token.oldFieldType), 
         [
           $pathVar, 
-          $objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
+          $resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
         ], javaObject())
       ], javaVoid())
     ]

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/changetoken_test.pure
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/changetoken_test.pure
@@ -64,10 +64,3 @@ function meta::pure::changetoken::tests::getVersionsCustomMap():Versions[1]
             ]
     );
 }
-
-function <<test.Test>> meta::pure::changetoken::tests::testGenerateCast():Boolean[1]
-{
-  let project = generateCast('meta::pure::changetoken:tests::getVersions3', 'TestCastFunction');
-  printProject($project);
-  assertInstanceOf($project, Project);
-}

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/test/java/org/finos/legend/engine/changetoken/test/Test_Pure_Suite.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/test/java/org/finos/legend/engine/changetoken/test/Test_Pure_Suite.java
@@ -1,0 +1,32 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.test;
+
+import junit.framework.TestSuite;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+public class Test_Pure_Suite
+{
+    public static TestSuite suite()
+    {
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+        TestSuite suite = new TestSuite();
+        suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::pure::changetoken", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
+        return suite;
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
1. BugFix
2. Improvement

#### What does this PR do / why is it needed ?
1. Fix the issue with rename class followed by other tokens in the same version of changes
2. Do not mutate input map - create a deep copy and apply change tokens on the fly

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No