### PR TITLE
change tokens - do not mutate input map, do not cache output object type

### DIFF
--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast2Test.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast2Test.java
@@ -103,7 +103,7 @@ public class GenerateCast2Test extends GenerateCastTestBase
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
@@ -112,7 +112,8 @@ public class GenerateCast2Test extends GenerateCastTestBase
                         "    \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "    \"abc\": \"someValue\"\n" +
                         "  }\n" +
-                        "}\n", Map.class);
+                        "}\n";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
 
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class).invoke(null, jsonNode, "ftdm:abcdefg123");
 
@@ -124,5 +125,6 @@ public class GenerateCast2Test extends GenerateCastTestBase
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}\n" +
                         "}\n", Map.class); // moved 'someValue' to '../existingValue'
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast2Test.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast2Test.java
@@ -15,13 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 public class GenerateCast2Test extends GenerateCastTestBase
 {
@@ -63,23 +61,19 @@ public class GenerateCast2Test extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input = "{\n" +
-                "  \"version\": \"ftdm:abcdefg123\",\n" +
-                "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
-                "  \"array\": [\n" +
-                "    {\n" +
-                "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
-                "      \"existingValue\": \"someValue\",\n" +
-                "      \"innerObject\": {\n" +
-                "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+        expect(upcast("{\n" +
+                        "  \"version\": \"ftdm:abcdefg123\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
+                        "  \"array\": [\n" +
+                        "    {\n" +
+                        "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
+                        "      \"existingValue\": \"someValue\",\n" +
+                        "      \"innerObject\": {\n" +
+                        "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  ]\n" +
+                        "}\n"),
                 "{\n" +
                         "  \"version\": \"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
@@ -93,18 +87,13 @@ public class GenerateCast2Test extends GenerateCastTestBase
                         "      }\n" +
                         "    }\n" +
                         "  ]\n" +
-                        "}\n", Map.class); // copied 'someValue' from '../existingValue'
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-
-        // assert that the input is not mutated
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
                         "  \"existingValue\": \"someValue\",\n" +
@@ -112,19 +101,12 @@ public class GenerateCast2Test extends GenerateCastTestBase
                         "    \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "    \"abc\": \"someValue\"\n" +
                         "  }\n" +
-                        "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class).invoke(null, jsonNode, "ftdm:abcdefg123");
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}\n", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
                         "  \"existingValue\": \"someValue\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}\n" +
-                        "}\n", Map.class); // moved 'someValue' to '../existingValue'
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast3Test.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast3Test.java
@@ -15,13 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 public class GenerateCast3Test extends GenerateCastTestBase
 {
@@ -56,24 +54,20 @@ public class GenerateCast3Test extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input = "{\n" +
-                "  \"version\": \"ftdm:abcdefg123\",\n" +
-                "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
-                "  \"array\": [\n" +
-                "    {\n" +
-                "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
-                "      \"existingValue\": \"someValue\",\n" +
-                "      \"innerObject\": {\n" +
-                "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                "        \"abc\": 123\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+        expect(upcast("{\n" +
+                        "  \"version\": \"ftdm:abcdefg123\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
+                        "  \"array\": [\n" +
+                        "    {\n" +
+                        "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
+                        "      \"existingValue\": \"someValue\",\n" +
+                        "      \"innerObject\": {\n" +
+                        "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "        \"abc\": 123\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  ]\n" +
+                        "}\n"),
                 "{\n" +
                         "  \"version\": \"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
@@ -87,36 +81,26 @@ public class GenerateCast3Test extends GenerateCastTestBase
                         "      }\n" +
                         "    }\n" +
                         "  ]\n" +
-                        "}\n", Map.class); // 123 converted to "123"
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-
-        // assert that the input is not mutated
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input = "{\n" +
-                "  \"version\": \"ftdm:abcdefg456\",\n" +
-                "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
-                "  \"array\": [\n" +
-                "    {\n" +
-                "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
-                "      \"existingValue\": \"someValue\",\n" +
-                "      \"innerObject\": {\n" +
-                "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                "        \"abc\": \"123\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class).invoke(null, jsonNode, "ftdm:abcdefg123");
-//        Map<String,Object> jsonNodeOut = TempGenerated.downcast(jsonNode, "ftdm:abcdefg123");
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+        expect(downcast("{\n" +
+                        "  \"version\": \"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
+                        "  \"array\": [\n" +
+                        "    {\n" +
+                        "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
+                        "      \"existingValue\": \"someValue\",\n" +
+                        "      \"innerObject\": {\n" +
+                        "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "        \"abc\": \"123\"\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  ]\n" +
+                        "}\n", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\": \"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
@@ -130,10 +114,6 @@ public class GenerateCast3Test extends GenerateCastTestBase
                         "      }\n" +
                         "    }\n" +
                         "  ]\n" +
-                        "}\n", Map.class); // "123" converted to 123
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-
-        // assert that the input is not mutated
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast4Test.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCast4Test.java
@@ -15,13 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 public class GenerateCast4Test extends GenerateCastTestBase
 {
@@ -56,24 +54,20 @@ public class GenerateCast4Test extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input = "{\n" +
-                "  \"version\": \"ftdm:abcdefg123\",\n" +
-                "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
-                "  \"array\": [\n" +
-                "    {\n" +
-                "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
-                "      \"existingValue\": \"someValue\",\n" +
-                "      \"innerObject\": {\n" +
-                "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                "        \"abc\": 123\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+        expect(upcast("{\n" +
+                        "  \"version\": \"ftdm:abcdefg123\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
+                        "  \"array\": [\n" +
+                        "    {\n" +
+                        "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
+                        "      \"existingValue\": \"someValue\",\n" +
+                        "      \"innerObject\": {\n" +
+                        "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "        \"abc\": 123\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  ]\n" +
+                        "}\n"),
                 "{\n" +
                         "  \"version\": \"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
@@ -87,36 +81,26 @@ public class GenerateCast4Test extends GenerateCastTestBase
                         "      }\n" +
                         "    }\n" +
                         "  ]\n" +
-                        "}\n", Map.class); // 123 converted to 123 optional
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-
-        // assert that the input is not mutated
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input = "{\n" +
-                "  \"version\": \"ftdm:abcdefg456\",\n" +
-                "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
-                "  \"array\": [\n" +
-                "    {\n" +
-                "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
-                "      \"existingValue\": \"someValue\",\n" +
-                "      \"innerObject\": {\n" +
-                "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                "        \"abc\": \"123\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class).invoke(null, jsonNode, "ftdm:abcdefg123");
-//        Map<String,Object> jsonNodeOut = TempGenerated.downcast(jsonNode, "ftdm:abcdefg123");
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+        expect(downcast("{\n" +
+                        "  \"version\": \"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
+                        "  \"array\": [\n" +
+                        "    {\n" +
+                        "      \"@type\": \"meta::pure::changetoken::tests::OuterClass\",\n" +
+                        "      \"existingValue\": \"someValue\",\n" +
+                        "      \"innerObject\": {\n" +
+                        "        \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "        \"abc\": \"123\"\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  ]\n" +
+                        "}\n", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\": \"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
@@ -130,10 +114,6 @@ public class GenerateCast4Test extends GenerateCastTestBase
                         "      }\n" +
                         "    }\n" +
                         "  ]\n" +
-                        "}\n", Map.class); // "123" optional converted to "123"
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-
-        // assert that the input is not mutated
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "  \"abc\": true\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": false\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanStringTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastBooleanStringTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastBooleanStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": false\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:false");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
@@ -64,7 +64,7 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "  \"abc\": true\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+       String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": false\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastBooleanTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastBooleanTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": true\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-       String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastBooleanTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": true}]\n" +
                         "  ],\n" +
                         "  \"abc\": false\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:false", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:false");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastChainTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastChainTest.java
@@ -92,7 +92,7 @@ public class GenerateCastChainTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -101,7 +101,8 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -116,13 +117,13 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "  \"abc\": 100, \"def\": 200\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg789\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -132,7 +133,8 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100, \"def\": 200\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -146,13 +148,13 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg789\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -162,9 +164,11 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100, \"def\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastChainTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastChainTest.java
@@ -15,19 +15,14 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastChainTest extends GenerateCastTestBase
 {
@@ -92,8 +87,7 @@ public class GenerateCastChainTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -101,11 +95,7 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg789\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -115,16 +105,13 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100, \"def\": 200\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg789\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200},\n" +
@@ -133,11 +120,7 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100, \"def\": 200\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -146,16 +129,13 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg789\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200},\n" +
@@ -164,11 +144,7 @@ public class GenerateCastChainTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100, \"def\": 200}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100, \"def\": 300\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:300");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
@@ -38,7 +38,7 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -47,7 +47,8 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -62,13 +63,13 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -78,7 +79,8 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -92,13 +94,13 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -108,9 +110,11 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomMapTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastCustomMapTest extends GenerateCastTestBase
 {
@@ -38,8 +32,7 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -47,11 +40,7 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -61,16 +50,13 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
@@ -79,11 +65,7 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -92,16 +74,13 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
@@ -110,11 +89,7 @@ public class GenerateCastCustomMapTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastCustomNestedTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNestedTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomObjectTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomObjectTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastCustomObjectTest extends GenerateCastTestBase
 {
@@ -74,8 +68,7 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -83,11 +76,7 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -97,16 +86,13 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
@@ -115,11 +101,7 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -128,16 +110,13 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}},\n" +
@@ -146,11 +125,7 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomObjectTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomObjectTest.java
@@ -74,7 +74,7 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -83,7 +83,8 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -98,13 +99,13 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -114,7 +115,8 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -128,13 +130,13 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -144,9 +146,11 @@ public class GenerateCastCustomObjectTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.5}, \"value\":0}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"restricted\":true, \"range\":{\"min\":-1, \"max\":1, \"@type\":\"intMinMax\", \"round\":0.0}, \"value\":1}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, max=1, @type=intMinMax, round=0.0}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, restricted=true, range={min=-1, round=0.0, max=1, @type=intMinMax}, value=1}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:2023-06-22T18:30:01Z");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomPrimitiveStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomPrimitiveTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"1970-01-01T00:00:01Z\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastCustomPrimitiveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"1970-01-01T00:00:01Z\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:2023-06-22T18:30:01Z", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:2023-06-22T18:30:01Z");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastCustomTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:{@type=Custom, value=1d}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:{@type=Custom, value=1d}");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomTest.java
@@ -64,7 +64,7 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastCustomTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"0d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:{@type=Custom, value=1d}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "  \"abc\": 123.45\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 67.89\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleStringTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastDoubleStringTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastDoubleStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 67.89\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:67.89");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
@@ -64,7 +64,7 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "  \"abc\": 123.45\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 67.89\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastDoubleTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastDoubleTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 123.45\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastDoubleTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 123.45}]\n" +
                         "  ],\n" +
                         "  \"abc\": 67.89\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:67.89", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:67.89");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromJsonTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromJsonTest.java
@@ -65,7 +65,7 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -74,7 +74,8 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -89,13 +90,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -105,7 +106,8 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -119,13 +121,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -135,7 +137,8 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -149,13 +152,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -165,9 +168,11 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromJsonTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromJsonTest.java
@@ -15,18 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.finos.legend.pure.generated.*;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastFromJsonTest extends GenerateCastTestBase
 {
@@ -65,8 +58,7 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -74,11 +66,7 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -88,16 +76,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -106,11 +91,7 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -119,16 +100,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
@@ -137,11 +115,7 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -150,16 +124,13 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -168,11 +139,7 @@ public class GenerateCastFromJsonTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:300");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromVersionsTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromVersionsTest.java
@@ -56,7 +56,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -65,7 +65,8 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -80,13 +81,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -96,7 +97,8 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -110,13 +112,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -126,7 +128,8 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -140,13 +143,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -156,9 +159,11 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromVersionsTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastFromVersionsTest.java
@@ -15,18 +15,12 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.finos.legend.pure.generated.*;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastFromVersionsTest extends GenerateCastTestBase
 {
@@ -43,7 +37,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
         addField._fieldName("abc");
         addField._fieldType("Integer[1]");
         addField._safeCast(true);
-        Root_meta_pure_changetoken_ConstValue value =  new Root_meta_pure_changetoken_ConstValue_Impl("Anonymous_NoCounter");
+        Root_meta_pure_changetoken_ConstValue value = new Root_meta_pure_changetoken_ConstValue_Impl("Anonymous_NoCounter");
         value._value(100L);
         addField._defaultValue(value);
         abcdefg456._changeTokensAdd(addField);
@@ -56,8 +50,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -65,11 +58,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -79,16 +68,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -97,11 +83,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -110,16 +92,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
@@ -128,11 +107,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -141,16 +116,13 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -159,11 +131,7 @@ public class GenerateCastFromVersionsTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:300");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastIntegerStringTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastIntegerStringTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastIntegerStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:300");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveExtractTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveExtractTest.java
@@ -15,14 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 public class GenerateCastMoveExtractTest extends GenerateCastTestBase
 {
@@ -83,8 +80,7 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"names\": {\"@type\":\"NamesClass\", \"first\":\"1d\", \"middle\":\"\", \"last\":\"2d\"}},\n" +
@@ -93,11 +89,7 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"names\": {\"@type\":\"NamesClass\", \"first\":\"5d\", \"middle\":\"\", \"last\":\"6d\"}}]\n" +
                         "  ],\n" +
                         "  \"names\": {\"@type\":\"NamesClass\", \"first\":\"7d\", \"middle\":\"\", \"last\":\"8d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String, Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -107,16 +99,13 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"firstName\":\"5d\", \"lastName\":\"6d\"}]\n" +
                         "  ],\n" +
                         "  \"firstName\":\"7d\", \"lastName\":\"8d\"\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"firstName\":\"1d\", \"lastName\":\"2d\"},\n" +
@@ -125,11 +114,7 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"firstName\":\"5d\", \"lastName\":\"6d\"}]\n" +
                         "  ],\n" +
                         "  \"firstName\":\"7d\", \"lastName\":\"8d\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -139,8 +124,6 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"names\": {\"@type\":\"NamesClass\", \"first\":\"5d\", \"middle\":\"\", \"last\":\"6d\"}}]\n" +
                         "  ],\n" +
                         "  \"names\": {\"@type\":\"NamesClass\", \"first\":\"7d\", \"middle\":\"\", \"last\":\"8d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveExtractTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveExtractTest.java
@@ -83,7 +83,7 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -93,7 +93,8 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"names\": {\"@type\":\"NamesClass\", \"first\":\"5d\", \"middle\":\"\", \"last\":\"6d\"}}]\n" +
                         "  ],\n" +
                         "  \"names\": {\"@type\":\"NamesClass\", \"first\":\"7d\", \"middle\":\"\", \"last\":\"8d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -108,13 +109,13 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "  \"firstName\":\"7d\", \"lastName\":\"8d\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -124,7 +125,8 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"firstName\":\"5d\", \"lastName\":\"6d\"}]\n" +
                         "  ],\n" +
                         "  \"firstName\":\"7d\", \"lastName\":\"8d\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -139,5 +141,6 @@ public class GenerateCastMoveExtractTest extends GenerateCastTestBase
                         "  \"names\": {\"@type\":\"NamesClass\", \"first\":\"7d\", \"middle\":\"\", \"last\":\"8d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveNestedTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveNestedTest.java
@@ -65,7 +65,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -75,7 +75,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -90,13 +91,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -106,7 +107,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -121,12 +123,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -136,7 +139,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -151,13 +155,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -167,7 +171,8 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -182,12 +187,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -197,17 +203,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\", \"value\":\"5d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot overwrite with different value:5d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -217,16 +224,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\", \"value\":\"6d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot overwrite with different value:6d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastInvalidDestination() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -236,17 +245,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": \"invalid\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Destination is not a map: xyz", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastInvalidDestination() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -256,16 +266,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\":  \"invalid\"}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Destination is not a map: abc", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastInvalidSource() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -275,17 +287,18 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"invalid\", \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Source is not a map: abc", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastInvalidSource() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -295,9 +308,11 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": \"invalid\", \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Source is not a map: xyz", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveNestedTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveNestedTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastMoveNestedTest extends GenerateCastTestBase
 {
@@ -65,8 +59,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"String\"}},\n" +
@@ -75,11 +68,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String, Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -89,16 +78,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"1d\"}, \"abc\": {\"@type\":\"String\"}},\n" +
@@ -107,11 +93,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -121,16 +103,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"String\"}},\n" +
@@ -139,11 +118,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String, Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -153,16 +128,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"1d\"}, \"abc\": {\"@type\":\"String\"}},\n" +
@@ -171,11 +143,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -185,16 +153,13 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"String\"}},\n" +
@@ -203,19 +168,14 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"String\", \"value\":\"5d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:5d", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}"),
+                "Cannot overwrite with different value:5d");
     }
 
     @Test
     public void testDowncastDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"1d\"}, \"abc\": {\"@type\":\"String\"}},\n" +
@@ -224,19 +184,14 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\": {\"@type\":\"String\", \"value\":\"6d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:6d", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot overwrite with different value:6d");
     }
 
     @Test
     public void testUpcastInvalidDestination() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"String\"}},\n" +
@@ -245,19 +200,14 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"3d\"}, \"xyz\": \"invalid\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Destination is not a map: xyz", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}"),
+                "Destination is not a map: xyz");
     }
 
     @Test
     public void testDowncastInvalidDestination() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"1d\"}, \"abc\": {\"@type\":\"String\"}},\n" +
@@ -266,19 +216,14 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"3d\"}, \"abc\":  \"invalid\"}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Destination is not a map: abc", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Destination is not a map: abc");
     }
 
     @Test
     public void testUpcastInvalidSource() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"String\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"String\"}},\n" +
@@ -287,19 +232,14 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"invalid\", \"xyz\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"String\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Source is not a map: abc", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}"),
+                "Source is not a map: abc");
     }
 
     @Test
     public void testDowncastInvalidSource() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"String\", \"value\":\"1d\"}, \"abc\": {\"@type\":\"String\"}},\n" +
@@ -308,11 +248,7 @@ public class GenerateCastMoveNestedTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": \"invalid\", \"abc\": {\"@type\":\"String\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"String\", \"value\":\"4d\"}, \"abc\": {\"@type\":\"String\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Source is not a map: xyz", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Source is not a map: xyz");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastMoveTest extends GenerateCastTestBase
 {
@@ -75,8 +69,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -85,11 +78,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String, Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -99,16 +88,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -117,11 +103,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -131,17 +113,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
-
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -150,11 +128,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -164,16 +138,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0}, \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0}, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}}},\n" +
@@ -182,11 +153,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -196,16 +163,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -214,11 +178,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -228,16 +188,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -246,11 +203,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -260,8 +213,6 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastMoveTest.java
@@ -75,7 +75,7 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String, Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -85,7 +85,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String, Object> jsonNodeOut = (Map<String, Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String, Object> expectedJsonNodeOut = mapper.readValue(
@@ -100,12 +101,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -115,7 +117,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -130,13 +133,14 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -146,7 +150,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -161,13 +166,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0}, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -177,7 +182,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"SampleNestedClass\", \"active\":true, \"step\":0, \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -192,13 +198,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -208,7 +214,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -223,13 +230,13 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -239,7 +246,8 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -254,5 +262,6 @@ public class GenerateCastMoveTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRemoveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRemoveTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastRemoveTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -74,10 +67,7 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -86,16 +76,13 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void tesUpcastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
@@ -104,10 +91,7 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -116,16 +100,13 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -134,19 +115,14 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}"),
+                "Cannot remove non-default value:300");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -154,11 +130,7 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -168,8 +140,6 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+                        "}\n");
+    }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRemoveTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRemoveTest.java
@@ -64,7 +64,7 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -74,7 +74,8 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
@@ -87,13 +88,13 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void tesUpcastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -103,7 +104,8 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
@@ -116,13 +118,13 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -132,17 +134,18 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -151,7 +154,8 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -166,5 +170,6 @@ public class GenerateCastRemoveTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
    }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameFieldRenamedClassTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameFieldRenamedClassTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertThrows;
 
-public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
+public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBase
 {
     @BeforeClass
     public static void setupSuite() throws IOException, ClassNotFoundException
@@ -47,12 +47,17 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "        {\n" +
                 "          \"@type\": \"meta::pure::changetoken::RenameField\",\n" +
                 "          \"oldFieldName\": [\n" +
-                "            \"value\"\n" +
+                "            \"abc\"\n" +
                 "          ],\n" +
                 "          \"newFieldName\": [\n" +
-                "            \"valueCustom\"\n" +
+                "            \"xyz\"\n" +
                 "          ],\n" +
-                "          \"class\": \"Custom\"\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"@type\": \"meta::pure::changetoken::RenamedClass\",\n" +
+                "          \"newName\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
                 "        }\n" +
                 "      ]\n" +
                 "    }\n" +
@@ -80,13 +85,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -99,12 +104,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -113,12 +118,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -132,12 +137,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -145,13 +150,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -163,13 +168,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -178,12 +183,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -196,12 +201,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -210,12 +215,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -227,11 +232,11 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
@@ -242,10 +247,10 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
@@ -260,12 +265,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -273,13 +278,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -291,13 +296,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -324,19 +329,19 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
@@ -344,18 +349,18 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameFieldRenamedClassTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameFieldRenamedClassTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBase
 {
@@ -68,8 +62,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -78,11 +71,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -92,16 +81,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -110,11 +96,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -124,17 +106,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
-
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -143,11 +121,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -157,16 +131,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -175,11 +146,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -189,16 +156,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -207,11 +171,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -221,16 +181,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -239,11 +196,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -253,16 +206,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -271,11 +221,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -285,16 +231,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
@@ -303,11 +246,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -317,16 +256,13 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -335,19 +271,14 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}"),
+                "Cannot overwrite with different value:{@type=Custom, value=9d}");
     }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
@@ -356,11 +287,7 @@ public class GenerateCastRenameFieldRenamedClassTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot overwrite with different value:{@type=Custom, value=8d}");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameNestedPropertyTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameNestedPropertyTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
 {
@@ -65,8 +59,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -75,11 +68,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -89,16 +78,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
@@ -107,11 +93,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -121,17 +103,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
-
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
@@ -140,11 +118,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -154,16 +128,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}},\n" +
@@ -172,11 +143,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -186,16 +153,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
@@ -204,11 +168,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -218,16 +178,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
@@ -236,11 +193,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -250,16 +203,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
@@ -268,11 +218,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -282,16 +228,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
@@ -300,11 +243,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -314,16 +253,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
@@ -332,19 +268,14 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+                        "}"),
+                "Cannot overwrite with different value:9d");
+    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
@@ -353,11 +284,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot overwrite with different value:8d");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameNestedPropertyTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameNestedPropertyTest.java
@@ -65,7 +65,7 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -75,7 +75,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -90,12 +91,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -105,7 +107,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -120,13 +123,14 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -136,7 +140,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -151,13 +156,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -167,7 +172,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -182,13 +188,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -198,7 +204,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -213,13 +220,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -229,7 +236,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -244,12 +252,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -259,7 +268,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -274,13 +284,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -290,7 +300,8 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -305,12 +316,13 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -320,17 +332,18 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -340,9 +353,11 @@ public class GenerateCastRenameNestedPropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamePropertyTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamePropertyTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
 {
@@ -63,8 +57,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -119,17 +101,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
-
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
@@ -138,11 +116,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -152,16 +126,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}},\n" +
@@ -170,11 +141,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -184,16 +151,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
@@ -202,11 +166,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -216,16 +176,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
@@ -234,11 +191,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -248,16 +201,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
@@ -266,11 +216,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -280,16 +226,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
@@ -298,11 +241,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -312,16 +251,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
@@ -330,19 +266,14 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+                        "}"),
+                "Cannot overwrite with different value:9d");
+    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
@@ -351,11 +282,7 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot overwrite with different value:8d");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastRenameTest extends GenerateCastTestBase
 {
@@ -63,8 +57,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -119,17 +101,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
-
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -138,11 +116,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -152,16 +126,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -170,11 +141,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -184,16 +151,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -202,11 +166,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -216,16 +176,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -234,11 +191,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -248,16 +201,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -266,11 +216,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -280,16 +226,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
@@ -298,11 +241,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -312,16 +251,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -330,19 +266,14 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+                        "}"),
+                "Cannot overwrite with different value:{@type=Custom, value=9d}");
+    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
@@ -351,11 +282,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot overwrite with different value:{@type=Custom, value=8d}");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenameTest.java
@@ -63,7 +63,7 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,12 +89,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -103,7 +105,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +121,14 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,7 +138,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -149,13 +154,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -165,7 +170,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -180,13 +186,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -196,7 +202,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -211,13 +218,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -227,7 +234,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -242,12 +250,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -257,7 +266,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -272,13 +282,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -288,7 +298,8 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -303,12 +314,13 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -318,17 +330,18 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
         Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -338,9 +351,11 @@ public class GenerateCastRenameTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassRenameFieldTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassRenameFieldTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBase
 {
@@ -68,8 +62,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -78,11 +71,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -92,16 +81,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -110,11 +96,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -124,17 +106,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
-
 
     @Test
     public void testUpcastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -143,11 +121,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -157,16 +131,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -175,11 +146,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -189,16 +156,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -207,11 +171,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -221,16 +181,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastMissing() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -239,11 +196,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -253,16 +206,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -271,11 +221,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -285,16 +231,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastExistingTheSame() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
@@ -303,11 +246,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -317,16 +256,13 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -335,19 +271,14 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}"),
+                "Cannot overwrite with different value:{@type=Custom, value=9d}");
     }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
@@ -356,11 +287,7 @@ public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBas
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot overwrite with different value:{@type=Custom, value=8d}");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassRenameFieldTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassRenameFieldTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertThrows;
 
-public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
+public class GenerateCastRenamedClassRenameFieldTest extends GenerateCastTestBase
 {
     @BeforeClass
     public static void setupSuite() throws IOException, ClassNotFoundException
@@ -45,14 +45,19 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "      \"prevVersion\": \"ftdm:abcdefg123\",\n" +
                 "      \"changeTokens\": [\n" +
                 "        {\n" +
+                "          \"@type\": \"meta::pure::changetoken::RenamedClass\",\n" +
+                "          \"newName\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                "        },\n" +
+                "        {\n" +
                 "          \"@type\": \"meta::pure::changetoken::RenameField\",\n" +
                 "          \"oldFieldName\": [\n" +
-                "            \"value\"\n" +
+                "            \"abc\"\n" +
                 "          ],\n" +
                 "          \"newFieldName\": [\n" +
-                "            \"valueCustom\"\n" +
+                "            \"xyz\"\n" +
                 "          ],\n" +
-                "          \"class\": \"Custom\"\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::nested::NewSampleClass\"\n" +
                 "        }\n" +
                 "      ]\n" +
                 "    }\n" +
@@ -80,13 +85,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -99,12 +104,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -113,12 +118,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -132,12 +137,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -145,13 +150,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}\n" +
+                        "  \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -163,13 +168,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -178,12 +183,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -196,12 +201,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -210,12 +215,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
-                        "  \"xyz\": {\"@type\":\"OtherCustom\", \"value\":\"1d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -227,11 +232,11 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}";
@@ -242,10 +247,10 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"4d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"3d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"valueOther\":\"2d\"}}]\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"def\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"def\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
@@ -260,12 +265,12 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
@@ -273,13 +278,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"valueCustom\":\"4d\"}\n" +
+                        "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
@@ -291,13 +296,13 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"8d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"8d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
@@ -324,19 +329,19 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\", \"valueCustom\":\"1d\"}},\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\", \"valueCustom\":\"2d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\", \"valueCustom\":\"3d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"2d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method upcastMethod = compiledClass.getMethod("upcast", Map.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> upcastMethod.invoke(null, jsonNode));
-        Assert.assertEquals("Cannot overwrite with different value:9d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=9d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
-   }
+    }
 
     @Test
     public void testDowncastExistingTheDifferent() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
@@ -344,18 +349,18 @@ public class GenerateCastRenamePropertyTest extends GenerateCastTestBase
         String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
-                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
-                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\", \"valueCustom\":\"5d\"}},\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"5d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"5d\"}},\n" +
                         "  \"innerNestedArray\":[\n" +
-                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\", \"valueCustom\":\"6d\"}},\n" +
-                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\", \"valueCustom\":\"7d\"}}]\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"6d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"6d\"}},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"7d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"7d\"}}]\n" +
                         "  ],\n" +
-                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\", \"valueCustom\":\"9d\"}\n" +
+                        "  \"abc\": {\"@type\":\"Custom\", \"value\":\"8d\"}, \"xyz\": {\"@type\":\"Custom\", \"value\":\"9d\"}\n" +
                         "}";
         Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot overwrite with different value:8d", re.getCause().getMessage());
+        Assert.assertEquals("Cannot overwrite with different value:{@type=Custom, value=8d}", re.getCause().getMessage());
         Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassTest.java
@@ -58,7 +58,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -68,7 +68,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -83,12 +84,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -98,7 +100,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -113,13 +116,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -129,7 +132,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -144,13 +148,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -160,7 +164,8 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -175,6 +180,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }
 

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastRenamedClassTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastRenamedClassTest extends GenerateCastTestBase
 {
@@ -58,8 +52,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -68,11 +61,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
@@ -82,16 +71,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testUpcastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"1d\"}},\n" +
@@ -100,11 +86,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -114,16 +96,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"abc\": {\"@type\":\"Custom\", \"value\":\"3d\"}}]\n" +
                         "  ],\n" +
                         "  \"abc\": {\"@type\":\"Custom\", \"value\":\"4d\"}\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -132,11 +111,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::nested::NewSampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -146,16 +121,13 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastType() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"4d\"}},\n" +
@@ -164,11 +136,7 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::OtherClass\",\n" +
@@ -178,9 +146,6 @@ public class GenerateCastRenamedClassTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::OtherClass\", \"xyz\": {\"@type\":\"Custom\", \"value\":\"2d\"}}]\n" +
                         "  ],\n" +
                         "  \"xyz\": {\"@type\":\"Custom\", \"value\":\"1d\"}\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 }
-

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastStringQuotesTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"two \\\" one\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:two \" one");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringQuotesTest.java
@@ -64,7 +64,7 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "  \"abc\": \"one \\\" two\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastStringQuotesTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"two \\\" one\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastStringTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"two \\\" one\"\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:two \" one");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastStringTest.java
@@ -64,7 +64,7 @@ public class GenerateCastStringTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "  \"abc\": \"one \\\" two\"\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"one \\\" two\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,9 +136,11 @@ public class GenerateCastStringTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": \"one \\\" two\"}]\n" +
                         "  ],\n" +
                         "  \"abc\": \"two \\\" one\"\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:two \" one", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTest.java
@@ -15,17 +15,11 @@
 package org.finos.legend.engine.changetoken.generation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static org.junit.Assert.assertThrows;
 
 public class GenerateCastTest extends GenerateCastTestBase
 {
@@ -64,8 +58,7 @@ public class GenerateCastTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(upcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
@@ -73,11 +66,7 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
-
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -87,16 +76,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class); // updated version and new default value field added
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -105,11 +91,7 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -118,16 +100,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        String input =
-                "{\n" +
+        expect(downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
@@ -136,11 +115,7 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
-                .invoke(null, jsonNode, "ftdm:abcdefg123");
-        Map<String,Object> expectedJsonNodeOut = mapper.readValue(
+                        "}", "ftdm:abcdefg123"),
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -149,16 +124,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class); // remove default values
-        Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}\n");
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        String input =
-                "{\n" +
+        exception(() -> downcast("{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
                         "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100},\n" +
@@ -167,11 +139,7 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-        Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
-        InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
-        Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
-        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:300");
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastTest.java
@@ -64,7 +64,7 @@ public class GenerateCastTest extends GenerateCastTestBase
     @Test
     public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg123\", \n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -73,7 +73,8 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
                         "  ]\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("upcast", Map.class).invoke(null, jsonNode);
 
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -88,13 +89,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "  \"abc\": 100\n" +
                         "}", Map.class); // updated version and new default value field added
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -104,7 +105,8 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 100\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -118,13 +120,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNull() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -134,7 +136,8 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
                         "  ],\n" +
                         "  \"abc\": null\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Map<String,Object> jsonNodeOut = (Map<String,Object>) compiledClass.getMethod("downcast", Map.class, String.class)
                 .invoke(null, jsonNode, "ftdm:abcdefg123");
         Map<String,Object> expectedJsonNodeOut = mapper.readValue(
@@ -148,13 +151,13 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "  ]\n" +
                         "}", Map.class); // remove default values
         Assert.assertEquals(expectedJsonNodeOut, jsonNodeOut);
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 
     @Test
     public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
     {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> jsonNode = mapper.readValue(
+        String input =
                 "{\n" +
                         "  \"version\":\"ftdm:abcdefg456\",\n" +
                         "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
@@ -164,9 +167,11 @@ public class GenerateCastTest extends GenerateCastTestBase
                         "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": 100}]\n" +
                         "  ],\n" +
                         "  \"abc\": 300\n" +
-                        "}", Map.class);
+                        "}";
+        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
         Method downcastMethod = compiledClass.getMethod("downcast", Map.class, String.class);
         InvocationTargetException re = assertThrows("non-default", InvocationTargetException.class, () -> downcastMethod.invoke(null, jsonNode, "ftdm:abcdefg123"));
         Assert.assertEquals("Cannot remove non-default value:300", re.getCause().getMessage());
+        Assert.assertEquals(mapper.readValue(input, Map.class), jsonNode);
     }
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastUtilTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastUtilTest.java
@@ -62,12 +62,10 @@ public class GenerateCastUtilTest extends GenerateCastTestBase
     public void testResolvePath() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
         Method m = compiledClass.getMethod("resolvePath", List.class, String.class);
-
         // note that "0" is cast to int in resolveRelativeReference or setRelativeReference
         Assert.assertArrayEquals(
                 Arrays.asList("a", "b", 1, "c", "0").toArray(),
-                ((List<Object>)m.invoke(null, Arrays.asList("a", "b", 1, "c", 2), "../0")).toArray());
-
+                ((List<Object>) m.invoke(null, Arrays.asList("a", "b", 1, "c", 2), "../0")).toArray());
         InvocationTargetException ex = Assert.assertThrows(InvocationTargetException.class,
                 () -> m.invoke(null, Arrays.asList("a", "b", 1, "c", 2), "../../../../../../x"));
         Assert.assertEquals("Relative reference escapes root (a/b/1/c/2) at index 5 of ../../../../../../x", ex.getCause().getMessage());
@@ -77,7 +75,6 @@ public class GenerateCastUtilTest extends GenerateCastTestBase
     public void testResolveRelativeReference() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
         Method m = compiledClass.getMethod("resolveRelativeReference", Map.class, List.class, String.class);
-
         ObjectMapper mapper = new ObjectMapper();
         String input = "{\n" +
                 "  \"version\": \"ftdm:abcdefg123\",\n" +
@@ -92,18 +89,15 @@ public class GenerateCastUtilTest extends GenerateCastTestBase
                 "    }\n" +
                 "  ]\n" +
                 "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-
+        Map<String, Object> jsonNode = parse(input);
         Assert.assertEquals("someValue",
                 m.invoke(null, jsonNode,
                         Arrays.asList("array", 0, "innerObject", "@type"),
                         "../../existingValue"));
-
         Assert.assertEquals("meta::pure::changetoken::tests::SampleClass",
                 m.invoke(null, jsonNode,
                         Collections.emptyList(),
                         "array/0/innerObject/@type"));
-
         InvocationTargetException ex = Assert.assertThrows(InvocationTargetException.class,
                 () -> m.invoke(null, jsonNode,
                         Collections.emptyList(),
@@ -115,8 +109,7 @@ public class GenerateCastUtilTest extends GenerateCastTestBase
     public void testSetRelativeReference() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
     {
         Method m = compiledClass.getMethod("setRelativeReference", Map.class, List.class, String.class, Object.class);
-        
-        ObjectMapper mapper = new ObjectMapper();
+
         String input = "{\n" +
                 "  \"version\": \"ftdm:abcdefg123\",\n" +
                 "  \"@type\": \"meta::pure::changetoken::tests::SomeClassWithAnArray\",\n" +
@@ -130,15 +123,13 @@ public class GenerateCastUtilTest extends GenerateCastTestBase
                 "    }\n" +
                 "  ]\n" +
                 "}\n";
-        Map<String,Object> jsonNode = mapper.readValue(input, Map.class);
-
+        Map<String, Object> jsonNode = parse(input);
         m.invoke(null, jsonNode,
                 Arrays.asList("array", 0, "innerObject", "@type"), "../newValue", 123);
         Assert.assertEquals(123,
                 compiledClass.getMethod("resolveRelativeReference", Map.class, List.class, String.class).invoke(null, jsonNode,
                         Arrays.asList("array", 0, "innerObject", "@type"),
                         "../newValue"));
-
         {
             InvocationTargetException ex = Assert.assertThrows(InvocationTargetException.class,
                     () -> m.invoke(null, jsonNode,
@@ -146,7 +137,6 @@ public class GenerateCastUtilTest extends GenerateCastTestBase
                             "array/blah", 456));
             Assert.assertEquals("java.lang.NumberFormatException: For input string: \"blah\": at index 1 of array/blah", ex.getCause().getMessage());
         }
-
         {
             InvocationTargetException ex = Assert.assertThrows(InvocationTargetException.class,
                     () -> m.invoke(null, jsonNode,

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
@@ -168,5 +168,10 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
@@ -30,6 +30,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dependency-analyze</id>
+                        <configuration>
+                            <!-- The dependency plugin analyzer raises these as false positives -->
+                            <ignoredUnusedDeclaredDependencies>
+                                <dependency>junit:junit</dependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.finos.legend.pure</groupId>
                 <artifactId>legend-pure-maven-generation-par</artifactId>
                 <configuration>

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation.pure
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation.pure
@@ -258,7 +258,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
     j_return($resVar)
   ])));
 
-  let typeVar = j_variable(javaString(), 'type');
+  let typeVar = $resVar->j_invoke('get', [j_string('@type')], javaObject());
   let rootObjVar = j_parameter(objectNode(), 'rootObjectNode');
   let pathVar = j_parameter(javaList(javaObject()), 'path');
   let changeTokenHandlers = $version.changeTokens
@@ -282,13 +282,10 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
         javaRuntimeException()->j_new(j_string('Missing @type'))->j_throw()
       ),
       // Map<String,Object> res = new HashMap<>()
-      $resVar->j_declare(javaHashMap()->j_new([])),
-
-      // String type = (String) objectNode.get("@type")
-      $typeVar->j_declare($objVar->j_invoke('get', [j_string('@type')], javaObject())->j_cast(javaString()))
+      $resVar->j_declare(javaHashMap()->j_new([]))
     ]
-    ->concatenate($changeTokenHandlers)
     ->concatenate($class2->_generateSingleCastObjectRecurseBlock($objRecurseFuncName, $arrRecurseFuncName, $objVar, $pathVar, $rootObjVar, $resVar))
+    ->concatenate($changeTokenHandlers)
     ->concatenate([
       j_return($resVar)
     ]))));
@@ -336,7 +333,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
     j_return($resVar)
   ])));
 
-  let typeVar = j_variable(javaString(), 'type');
+  let typeVar = $resVar->j_invoke('get', [j_string('@type')], javaObject());
   let changeTokenHandlers = $version.changeTokens->reverse()
     ->map(t|$t->match([
       t:AddField[1]|_handleAddFieldDowncast($class2, $t, $objVar, $typeVar, $version.version, $pathVar, $rootObjVar, $resVar),
@@ -358,12 +355,10 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_generateS
         javaRuntimeException()->j_new(j_string('Missing @type'))->j_throw()
       ),
       // Map<String,Object> res = new HashMap<>()
-      $resVar->j_declare(javaHashMap()->j_new([])),
-      // String type = (String) objectNode.get("@type")
-      $typeVar->j_declare($objVar->j_invoke('get', [j_string('@type')], javaObject())->j_cast(javaString()))
+      $resVar->j_declare(javaHashMap()->j_new([]))
     ]
-    ->concatenate($changeTokenHandlers)
     ->concatenate($class2->_generateSingleCastObjectRecurseBlock($objRecurseFuncName, $arrRecurseFuncName, $objVar, $pathVar, $rootObjVar, $resVar))
+    ->concatenate($changeTokenHandlers)
     ->concatenate([
       j_return($resVar)
     ]))));
@@ -537,33 +532,33 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleRen
   ):Code[1]
 {
   $oldFieldName->size()->range()->tail()->reverse()->fold({i,r|
-  j_if($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)->j_instanceof(javaRawMap()),$r,
-  j_if(j_ne($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar),j_null()),
+  j_if($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)->j_instanceof(javaRawMap()),$r,
+  j_if(j_ne($oldFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar),j_null()),
   javaRuntimeException()->j_new(j_plus(j_string('Source is not a map: '), j_string($oldFieldName->take($i)->joinStrings('.'))))->j_throw()
   ))},
   j_if(
-  j_ne($oldFieldName->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar),j_null())
+  j_ne($oldFieldName->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar),j_null())
   ,
   j_block(
   $newFieldName->size()->range()->tail()->map({i|
-    j_if($newFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)->j_instanceof(javaRawMap())->j_not(),
+    j_if($newFieldName->take($i)->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)->j_instanceof(javaRawMap())->j_not(),
       javaRuntimeException()->j_new(j_plus(j_string('Destination is not a map: '), j_string($newFieldName->take($i)->joinStrings('.'))))->j_throw()
   )})->concatenate([
-    j_if($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+    j_if($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
      ->j_cast(objectNode())->j_invoke('get', [j_string($newFieldName->last()->toOne())], javaObject())->j_ne(j_null())
-     ->j_and($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+     ->j_and($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
      ->j_cast(objectNode())->j_invoke('get', [j_string($newFieldName->last()->toOne())], javaObject())->j_invoke('equals',
-       $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+       $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
        ->j_cast(objectNode())->j_invoke('get', [j_string($oldFieldName->last()->toOne())], javaVoid()))->j_not()),
           javaRuntimeException()->j_new([j_string('Cannot overwrite with different value:')
-          ->j_plus($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+          ->j_plus($newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
           ->j_cast(objectNode())->j_invoke('get', [j_string($newFieldName->last()->toOne())], javaObject()))])->j_throw()),
-    $newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+    $newFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
     ->j_cast(objectNode())->j_invoke('put', [j_string($newFieldName->last()->toOne()),
-      $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+      $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
       ->j_cast(objectNode())->j_invoke('get', [j_string($oldFieldName->last()->toOne())], javaVoid())
     ], javaVoid()),
-    $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $objVar)
+    $oldFieldName->init()->fold({t,res | $res->j_cast(objectNode())->j_invoke('get', [j_string($t)], javaObject()) }, $resVar)
     ->j_cast(objectNode())->j_invoke('remove', [j_string($oldFieldName->last()->toOne())], javaVoid())
   ])
   )
@@ -580,7 +575,7 @@ token:RenamedClass[1], objVar:Code[1], typeVar:Code[1], version:String[1], pathV
   // if (type.equals(token.class))
   j_if(
   $typeVar->j_invoke('equals', [j_string($token.class)]),
-  $objVar->j_invoke('put', [j_string('@type'), j_string($token.newName)])
+  $resVar->j_invoke('put', [j_string('@type'), j_string($token.newName)])
   );
 }
 
@@ -593,7 +588,7 @@ token:RenamedClass[1], objVar:Code[1], typeVar:Code[1], version:String[1], pathV
   // if (type.equals(token.newName))
   j_if(
   $typeVar->j_invoke('equals', [j_string($token.newName)]),
-  $objVar->j_invoke('put', [j_string('@type'), j_string($token.class)])
+  $resVar->j_invoke('put', [j_string('@type'), j_string($token.class)])
   );
 }
 
@@ -614,17 +609,17 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
       df:ConstValue[1] | if(_isPrimitive($token.fieldType) || !_isComplex($df.value),|
       [
         $valVar->j_declare([_getValueAsFieldType($token.fieldType, $df.value)]),
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
-          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
-        $objVar->j_invoke('put', [j_string($token.fieldName), $valVar], javaVoid())
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
+          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        $resVar->j_invoke('put', [j_string($token.fieldName), $valVar], javaVoid())
       ],| j_block([
         $mapVar->j_declare(javaStream()->j_invoke('of',
         $df.value->cast(@String)->parseJSON()->cast(@meta::json::JSONObject).keyValuePairs->map(kv | _inlineJsonValue($kv.key.value, $kv.value)),
         javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()))
       ]->concatenate([
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
-          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
-        $objVar->j_invoke('put', [j_string($token.fieldName), $mapVar], javaVoid())
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
+          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        $resVar->j_invoke('put', [j_string($token.fieldName), $mapVar], javaVoid())
       ]))
       ),
       df:CopyValue[1] |
@@ -636,8 +631,8 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
           j_string($df.source->cast(@RelativeFieldReference).path) // TODO: handle other types of references
         ], javaObject())),
         // res.put("abc", value);
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
-          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
+          javaRuntimeException()->j_new([j_string('Cannot overwrite existing non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
         $resVar->j_invoke('put', [j_string($token.fieldName), $valVar], javaVoid())
       ]
     ])
@@ -787,7 +782,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleCha
         $class->j_invoke(_getChangeFieldTypeConverter($token.oldFieldType, $token.newFieldType), 
         [
           $pathVar, 
-          $objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
+          $resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
         ], javaObject())
       ], javaVoid())
     ]
@@ -821,11 +816,11 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
         $valVar->j_declare([_getValueAsFieldType($token.fieldType, $df.value)])
       ]->concatenate([
         // if ((Integer)objectNode.get(fieldName) != defaultValue) throw new RuntimeException("Cannot remove non-default value" + objectNode.get("fieldName")) // TODO: handle non-int
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
-            javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $valVar)->j_not()),
+            javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
 
-        // objectNode.remove(fieldName)
-        $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid()) 
+        // res.remove(fieldName)
+        $resVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
       ])),
       |
       j_block([
@@ -834,11 +829,11 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
         javaVoid())->j_invoke('collect', [javaCollectors()->j_invoke('toMap', [j_methodReference(AbstractMap_SimpleEntry(), 'getKey', javaFunctionType([], javaObject())), j_methodReference(AbstractMap_SimpleEntry(), 'getValue', javaFunctionType([], javaObject()))], javaVoid())], javaVoid()))
       ]->concatenate([
         // if ((Integer)objectNode.get(fieldName) != defaultValue) throw new RuntimeException("Cannot remove non-default value" + objectNode.get("fieldName")) // TODO: handle non-int
-        j_if($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
-        javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($objVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
+        j_if($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_ne(j_null())->j_and($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())->j_invoke('equals', $mapVar)->j_not()),
+        javaRuntimeException()->j_new([j_string('Cannot remove non-default value:')->j_plus($resVar->j_invoke('get', [j_string($token.fieldName)], javaObject()))])->j_throw()),
 
-        // objectNode.remove(fieldName)
-        $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
+        // res.remove(fieldName)
+        $resVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
       ]))
       ),
       df:CopyValue[1] | 
@@ -848,11 +843,11 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleAdd
           $rootObjVar, 
           $pathVar, 
           j_string($df.source->cast(@RelativeFieldReference).path), // TODO: handle other types of references
-          $objVar->j_invoke('get', [j_string($token.fieldName)], javaVoid())
+          $resVar->j_invoke('get', [j_string($token.fieldName)], javaVoid())
         ], javaObject()),
 
-        // objectNode.remove("abc");
-        $objVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
+        // res.remove("abc");
+        $resVar->j_invoke('remove', [j_string($token.fieldName)], javaVoid())
       ]
     ])
   );
@@ -874,7 +869,7 @@ function <<access.private>> meta::pure::changetoken::cast_generation::_handleCha
         $class->j_invoke(_getChangeFieldTypeConverter($token.newFieldType, $token.oldFieldType), 
         [
           $pathVar, 
-          $objVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
+          $resVar->j_invoke('get', [j_string($token.fieldName)], javaObject())
         ], javaObject())
       ], javaVoid())
     ]

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/changetoken_test.pure
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/changetoken_test.pure
@@ -64,10 +64,3 @@ function meta::pure::changetoken::tests::getVersionsCustomMap():Versions[1]
             ]
     );
 }
-
-function <<test.Test>> meta::pure::changetoken::tests::testGenerateCast():Boolean[1]
-{
-  let project = generateCast('meta::pure::changetoken:tests::getVersions3', 'TestCastFunction');
-  printProject($project);
-  assertInstanceOf($project, Project);
-}

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/test/java/org/finos/legend/engine/changetoken/test/Test_Pure_Suite.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/test/java/org/finos/legend/engine/changetoken/test/Test_Pure_Suite.java
@@ -1,0 +1,32 @@
+//  Copyright 2023 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.test;
+
+import junit.framework.TestSuite;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+public class Test_Pure_Suite
+{
+    public static TestSuite suite()
+    {
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+        TestSuite suite = new TestSuite();
+        suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::pure::changetoken", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
+        return suite;
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
BugFix and Improvements

#### What does this PR do / why is it needed ?
1. Fix the issue with rename class followed by other tokens in the same version of changes
2. Do not mutate input map - create a deep copy and apply change tokens on the fly
3. Refactored test cases, so implementation details are only in base class

#### Other notes for reviewers:
Fixed issue with dependency plugin analyzer in changetoken pure module

#### Does this PR introduce a user-facing change?
No