### PR TITLE
Improve efficiency on some elasticsearch queries grouping by computed if/else fields

### DIFF
--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/result/ExecutionRequestVisitor.java
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/result/ExecutionRequestVisitor.java
@@ -273,11 +273,16 @@ public class ExecutionRequestVisitor extends AbstractRequestBaseVisitor<Result>
 
         for (Map.Entry<String, FiltersBucket> bucketEntry : buckets.keyed.entrySet())
         {
+            FiltersBucket value = bucketEntry.getValue();
+
+            if (value.doc_count.getLiteral() == 0)
+            {
+                continue;
+            }
+
             MutableMap<String, Object> result = Maps.mutable.empty();
 
             result.put(key, bucketEntry.getKey());
-
-            FiltersBucket value = bucketEntry.getValue();
 
             for (Map.Entry<String, Aggregate> aggregateEntry : value.__additionalProperties.entrySet())
             {

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/result/ExecutionRequestVisitor.java
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/elasticsearch/v7/result/ExecutionRequestVisitor.java
@@ -81,8 +81,11 @@ import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.typ
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.AggregateBase;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.AggregationContainer;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.AvgAggregate;
+import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.Buckets;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.CompositeBucket;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.DoubleTermsBucket;
+import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.FiltersAggregate;
+import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.FiltersBucket;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.LongTermsBucket;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.MaxAggregate;
 import org.finos.legend.engine.protocol.store.elasticsearch.v7.specification.types.aggregations.MinAggregate;
@@ -229,6 +232,15 @@ public class ExecutionRequestVisitor extends AbstractRequestBaseVisitor<Result>
                 Iterator<MultiTermsBucket> bucketsIterator = bucketsParser.readValuesAs(MultiTermsBucket.class);
                 objectNodeStream = processMultiTermsBucket(aggregationContainerEntry.getKey(), aggregateTDSResultVisitor, bucketsIterator, lastBucket);
             }
+            else if (aggregationContainer.filters != null)
+            {
+                String key = aggregationContainerEntry.getKey();
+                FilteringParserDelegate filtersParser = new FilteringParserDelegate(aggsParser, new JsonPointerBasedFilter("/filters#" + key), false, false);
+                filtersParser.nextToken();
+                filtersParser.clearCurrentToken();
+                FiltersAggregate filtersAggregate = filtersParser.readValueAs(FiltersAggregate.class);
+                objectNodeStream = processFiltersBucket(aggregateTDSResultVisitor, key, filtersAggregate);
+            }
         }
 
         if (objectNodeStream == null)
@@ -251,6 +263,30 @@ public class ExecutionRequestVisitor extends AbstractRequestBaseVisitor<Result>
         }
 
         return new CollectIterator<>(objectNodeStream, h -> extractors.stream().map(x -> x.apply(h)).toArray());
+    }
+
+    private static Iterator<ObjectNode> processFiltersBucket(AggregateTDSResultVisitor aggregateTDSResultVisitor, String key, FiltersAggregate filtersAggregate)
+    {
+        Buckets<FiltersBucket> buckets = filtersAggregate.buckets;
+
+        List<ObjectNode> bucketResults = Lists.mutable.empty();
+
+        for (Map.Entry<String, FiltersBucket> bucketEntry : buckets.keyed.entrySet())
+        {
+            MutableMap<String, Object> result = Maps.mutable.empty();
+
+            result.put(key, bucketEntry.getKey());
+
+            FiltersBucket value = bucketEntry.getValue();
+
+            for (Map.Entry<String, Aggregate> aggregateEntry : value.__additionalProperties.entrySet())
+            {
+                result.put(aggregateEntry.getKey(), ((AggregateBase) aggregateEntry.getValue().unionValue()).accept(aggregateTDSResultVisitor));
+            }
+
+            bucketResults.add(ElasticsearchObjectMapperProvider.OBJECT_MAPPER.valueToTree(result));
+        }
+        return bucketResults.iterator();
     }
 
     private static Iterator<ObjectNode> processComposite(AggregateTDSResultVisitor aggregateTDSResultVisitor, Iterator<CompositeBucket> buckets, Procedure<MultiBucketBase> lastBucket)
@@ -577,11 +613,12 @@ public class ExecutionRequestVisitor extends AbstractRequestBaseVisitor<Result>
                 }
                 else
                 {
-                    if (!this.activities.isEmpty())
-                    {
-                        return false;
-                    }
                     processor = ExecutionRequestVisitor.this::processNotAggregateResponse;
+                }
+
+                if (!next && !this.activities.isEmpty())
+                {
+                    return false;
                 }
 
                 HttpUriRequest request = this.searchRequest.accept(new ElasticsearchV7RequestToHttpRequestVisitor(ExecutionRequestVisitor.this.url, ExecutionRequestVisitor.this.executionState));

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
@@ -376,14 +376,15 @@ function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(grou
     | 
       if ($doFilterBucket,
       | 
-        let buckets = $filterBuckets.second.values;
+        let buckets = $filterBuckets.second.values->filter(x | $x.query->isNotEmpty());
+        let elseBucket = $filterBuckets.second.values->filter(x | $x.query->isEmpty())->toOne();
         let bucketsMap = $buckets->toIndexed()->map({bucket | 
             let prevBuckets = $buckets->slice(0, $bucket.first);
             let notPrevQuery = $prevBuckets->isNotEmpty()->if(|^QueryContainer(bool = ^BoolQuery(must_not = ^QueryContainer(bool = ^BoolQuery(should = $prevBuckets.query)))), |[]);        
             pair($bucket.second.name->toOne(), ^QueryContainer(bool = ^BoolQuery(must = $notPrevQuery->concatenate($bucket.second.query))));
         })->newMap();
 
-        let filtersAggregation = ^FiltersAggregation(filters = ^Buckets<QueryContainer>(keyed = $bucketsMap));
+        let filtersAggregation = ^FiltersAggregation(filters = ^Buckets<QueryContainer>(keyed = $bucketsMap), other_bucket = true->literal(), other_bucket_key = $elseBucket.name->literal());
         newMap(pair($groupByTdsESDetails->at(0).path(), ^AggregationContainer(filters = $filtersAggregation, aggregations = $aggregations)));
       ,  
       |

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
@@ -1535,16 +1535,11 @@ function meta::external::store::elasticsearch::v7::pureToEs::processPainlessBool
       ]);
 
       let paramScript = $newValue->match([
-        pv: PlanVarPlaceHolder[1] |
-          if($pv.type == StrictDate,
-            |'LocalDate.parse(params[\'%s\']).atTime(0, 0).toInstant(ZoneOffset.UTC).toEpochMilli()',
-            | if($pv.type == DateTime,
-              |'ZonedDateTime.parse(params[\'%s\']).toInstant().toEpochMilli()',
-              | fail('Type not supported on variable - %s:%s'->format([$pv.name, $pv.type->elementToPath()]))->cast(@String)
-            )
-          ),
-        any: Any[*] | 'params[\'%s\']'
-      ])->format($param.first);
+        pv: PlanVarPlaceHolder[1] | 
+            '(params[\'%s\'].length() <= 10 ? LocalDate.parse(params[\'%s\']).atTime(0, 0) : LocalDateTime.parse(params[\'%s\'])).toInstant(ZoneOffset.UTC).toEpochMilli()'
+                      ->format([$param.first, $param.first, $param.first]),
+        any: Any[*] | 'params[\'%s\']'->format($param.first)
+      ]);
 
       let script = '(%s && %s.toInstant().toEpochMilli() %s %s)'->format([painlessIsNotEmpty($tdsESDetail), painlessExtractField($tdsESDetail), $operation, $paramScript]);
       let literalOrExpression = $newValue->literalOrExpression(true)->toOne();

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
@@ -81,6 +81,8 @@ Class meta::external::store::elasticsearch::v7::pureToEs::TDSESDetail
   path(){
     $this.resultPath.path()
   }:String[1];
+  runtimeMappingVS: ValueSpecification[0..1];
+  runtimeMappingVSTDSDetails: TDSESDetail[*];
   format: String[0..1];
 }
 
@@ -223,9 +225,10 @@ function meta::external::store::elasticsearch::v7::pureToEs::processProjectColum
   $expr->extractSimpleValue($initReq).first.values->match([
     tdsDetail: TDSESDetail[1] | pair(^$tdsDetail(name = $name, type = $type), $initReq),
     {vs: ValueSpecification[1] |
-      let resultPath = ^DocValueResultPath(fieldPath = $name, property = $type->defaultRuntimePropertyForPureType());
-      let scripted = $vs->toRuntimeMapping($resultPath, $initReq);
-      pair(^TDSESDetail(type = $type, name = $name, resultPath = $resultPath, format = $scripted.search.runtime_mappings->toOne()->get($name).format.value), $scripted);
+      let withCounter = ^$initReq(counter = $initReq.counter + 1);
+      let resultPath = ^DocValueResultPath(fieldPath = 'runtime_mapping_' + $initReq.counter->toString(), property = $type->defaultRuntimePropertyForPureType());
+      let scripted = $vs->toRuntimeMapping($resultPath, $withCounter);
+      pair(^TDSESDetail(type = $type, name = $name, resultPath = $resultPath, runtimeMappingVS = $vs, runtimeMappingVSTDSDetails = $scripted.tdsESDetails, format = $scripted.search.runtime_mappings->toOne()->get($resultPath.path()).format.value), $scripted);
     },
     {any: Any[*] | 
       $any->type()->match([
@@ -233,7 +236,7 @@ function meta::external::store::elasticsearch::v7::pureToEs::processProjectColum
           let resultPath = ^DocValueResultPath(fieldPath = $name, property = $pt->defaultRuntimePropertyForPureType());
           let iv = ^InstanceValue(multiplicity = $vs.func->functionReturnMultiplicity(), genericType = ^GenericType(rawType = $type), values=$any)->evaluateAndDeactivate();
           let scripted = $iv->toRuntimeMapping($resultPath, $initReq);
-          pair(^TDSESDetail(type = $type, name = $name, resultPath = $resultPath, format = $scripted.search.runtime_mappings->toOne()->get($name).format.value), $scripted);
+          pair(^TDSESDetail(type = $type, name = $name, resultPath = $resultPath, runtimeMappingVS = $iv, runtimeMappingVSTDSDetails = $scripted.tdsESDetails, format = $scripted.search.runtime_mappings->toOne()->get($resultPath.path()).format.value), $scripted);
         },
         other: Any[*] | fail(|'Cannot project column - %s:%s'->format([$name,$any->type()->elementToPath()]))->cast(@Pair<TDSESDetail, State>)
       ])
@@ -328,15 +331,15 @@ function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(vs: 
   processGroupBy($groupByTdsESDetails, $aggregateValues, $groupedReq);
 }
 
-function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(groupByTdsESDetails: TDSESDetail[*], aggregateValues: meta::pure::tds::AggregateValue<Any, Any>[*], groupedReq: State[1]): State[1]
+function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(groupByTdsESDetails: TDSESDetail[*], aggregateValues: meta::pure::tds::AggregateValue<Any, Any>[*], initReq: State[1]): State[1]
 {
   let aggPairs = $aggregateValues->map({x |
-    let rawToAggregate = processProjectColumn(^BasicColumnSpecification<TDSRow>(func = $x.mapFn, name = $x.name), $groupedReq).first;
+    let rawToAggregate = processProjectColumn(^BasicColumnSpecification<TDSRow>(func = $x.mapFn, name = $x.name), $initReq).first;
     let aggFunc = $x.aggregateFn->deepByPassRouterInfo()->cast(@FunctionDefinition<Any>).expressionSequence->toOne('tds aggregation only supports simple expressions: max, min, sum, etc.');
 
     let container = if ($aggFunc->instanceOf(FunctionExpression),
       |
-        $groupedReq.supportedAggregationFunctions->findAndEvalSupportedFunction($aggFunc->cast(@FunctionExpression), $rawToAggregate.path(), $groupedReq)
+        $initReq.supportedAggregationFunctions->findAndEvalSupportedFunction($aggFunc->cast(@FunctionExpression), $rawToAggregate.path(), $initReq)
       ,
       |
         fail('Unsupported aggregation functions: ' + $aggFunc->printValueSpecification(''));
@@ -344,10 +347,25 @@ function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(grou
     );
 
     let aggReturnType = $x.aggregateFn->functionReturnType().rawType->toOne()->cast(@DataType);
-    let resultPath = ^AggregateResultPath(fieldPath = $rawToAggregate.name, property = $rawToAggregate.resultPath.property);
+    let resultPath = ^AggregateResultPath(fieldPath = $rawToAggregate.name, property = $rawToAggregate.resultPath.property, fieldToAggregate = $rawToAggregate.resultPath);
     let toAggregate = ^$rawToAggregate(type = $aggReturnType, resultPath = $resultPath);
     pair($toAggregate, $container);
   });
+
+  let filterBuckets = if($groupByTdsESDetails->size() == 1 && $groupByTdsESDetails->at(0).path()->in($aggPairs.first.resultPath->cast(@AggregateResultPath).fieldToAggregate.path())->not(), 
+                        |
+                          let detailsAtRutimeMappingTime = $groupByTdsESDetails->at(0).runtimeMappingVSTDSDetails;
+                          let result = $groupByTdsESDetails->at(0).runtimeMappingVS->optimizeForFiltersAggregation(false, ^$initReq(tdsESDetails = $detailsAtRutimeMappingTime)); 
+                          let reqResult = $result.first;
+                          pair(^$reqResult(tdsESDetails = $initReq.tdsESDetails), $result.second);
+                        ,  
+                        |
+                          pair($initReq, list(^BucketsForFiltersAggregation()))
+                      );
+
+  let doFilterBucket = $filterBuckets.second.values->forAll(x | $x.name->isNotEmpty());  
+
+  let groupedReq = $filterBuckets.first;
 
   let aggregations = newMap($aggPairs->map(x | pair($x.first.name, $x.second)));
   let aggregationsForSearch = if ($groupByTdsESDetails->isEmpty(),
@@ -355,26 +373,41 @@ function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(grou
       // no group by field - just run the aggregations
       $aggregations
     ,
-    |
-      // with group by fields, we need to wrap it on composite
-      let composite = ^CompositeAggregation(
-        size = [], // todo allow to set limit?
-        sources = $groupByTdsESDetails->map(x | newMap(pair($x.name, ^CompositeAggregationSource( terms = ^TermsAggregation(field = $x.path()->literal(), missing_bucket = true->literal())))))
-      );
-      newMap(pair('groupByComposite', ^AggregationContainer(composite = $composite, aggregations = $aggregations)));
-  );
+    | 
+      if ($doFilterBucket,
+      | 
+        let buckets = $filterBuckets.second.values;
+        let bucketsMap = $buckets->toIndexed()->map({bucket | 
+            let prevBuckets = $buckets->slice(0, $bucket.first);
+            let notPrevQuery = $prevBuckets->isNotEmpty()->if(|^QueryContainer(bool = ^BoolQuery(must_not = ^QueryContainer(bool = ^BoolQuery(should = $prevBuckets.query)))), |[]);        
+            pair($bucket.second.name->toOne(), ^QueryContainer(bool = ^BoolQuery(must = $notPrevQuery->concatenate($bucket.second.query))));
+        })->newMap();
+
+        let filtersAggregation = ^FiltersAggregation(filters = ^Buckets<QueryContainer>(keyed = $bucketsMap));
+        newMap(pair($groupByTdsESDetails->at(0).path(), ^AggregationContainer(filters = $filtersAggregation, aggregations = $aggregations)));
+      ,  
+      |
+        // with group by fields, we need to wrap it on composite
+        let composite = ^CompositeAggregation(
+          size = [], // todo allow to set limit?
+          sources = $groupByTdsESDetails->map(x | newMap(pair($x.path(), ^CompositeAggregationSource( terms = ^TermsAggregation(field = $x.path()->literal(), missing_bucket = true->literal())))))
+        );
+        newMap(pair('groupByComposite', ^AggregationContainer(composite = $composite, aggregations = $aggregations)));
+  ));
 
   let groupByTdsESDetailsAsAgg = $groupByTdsESDetails->map({x |
-    let resultPath = ^AggregateResultPath(fieldPath = $x.name, property = $x.resultPath.property);
+    let resultPath = ^AggregateResultPath(fieldPath = $x.resultPath.fieldPath, property = $x.resultPath.property);
     let toAggregate = ^$x(resultPath = $resultPath);
   });
 
   let search = $groupedReq.search;
+  // $search.runtime_mappings = // todo remove runtime mapping if optmized
   let newSearch = ^$search(
      size = 0->literal() // avoiding reading all the matches, we just want the aggregate results
     ,aggregations = $aggregationsForSearch
     ,docvalue_fields = []
     ,_source = ^SourceConfig(fetch = false->literal())
+    ,runtime_mappings = if($doFilterBucket, | $search.runtime_mappings->toOne()->keyValues()->filter(x | $x.first != $groupByTdsESDetails->at(0).path())->newMap(), |$search.runtime_mappings)
   );
 
   ^$groupedReq(
@@ -383,6 +416,56 @@ function meta::external::store::elasticsearch::v7::pureToEs::processGroupBy(grou
   );
 }
 
+function meta::external::store::elasticsearch::v7::pureToEs::optimizeForFiltersAggregation(vs: ValueSpecification[*], elseBlock: Boolean[1], state: State[1]): Pair<State, List<BucketsForFiltersAggregation>>[1]
+{
+  $vs->match([
+    fe: FunctionExpression[1] | 
+      if($fe.func == if_Boolean_1__Function_1__Function_1__T_m_ && $fe.genericType.rawType == String,
+        | $fe->bucketsForFiltersAggregation($state),
+        | pair($state, list(^BucketsForFiltersAggregation()))          
+      ),
+    iv: InstanceValue[1] | 
+      $iv.values->filter(x | $elseBlock)->match([
+        elseBucketName: String[1] | pair($state, list(^BucketsForFiltersAggregation(name = $elseBucketName))),
+        other: Any[*] | pair($state, list(^BucketsForFiltersAggregation()))
+      ]),
+    any: Any[*] | pair($state, list(^BucketsForFiltersAggregation()))
+  ]);
+}
+
+function meta::external::store::elasticsearch::v7::pureToEs::bucketsForFiltersAggregation(fe: FunctionExpression[1], state: State[1]): Pair<State, List<BucketsForFiltersAggregation>>[1]
+{
+  let ifTrue = $fe.parametersValues->at(1)->cast(@InstanceValue).values->cast(@FunctionDefinition<Any>)->toOne();
+
+  $ifTrue.expressionSequence->match([
+    iv: InstanceValue[1] |
+          $iv.values->match([
+            {bucketName: String[1] | 
+                let expr = $fe.parametersValues->at(0); // convert to query contaier
+                let subState = ^$state(inFilter = true, inProject = false, aggregationQuery = false, search = ^SearchRequestBody());
+                // todo hmmm tds details are wrong here :(
+                let reqWithFilter = processFilterLambda($expr, $subState);
+                let filterQuery = $reqWithFilter.search.query;
+                let newState = ^$reqWithFilter(inFilter = $state.inFilter, inProject = $state.inProject, aggregationQuery = $state.aggregationQuery, search = $state.search);
+
+                let ifTrueBucket = ^BucketsForFiltersAggregation(name = $bucketName, query = $filterQuery);
+
+                let ifFalse =$fe.parametersValues->at(2);
+                let ifFalseBuckets = optimizeForFiltersAggregation($ifFalse->cast(@InstanceValue).values->cast(@FunctionDefinition<Any>)->toOne().expressionSequence, true, $newState);
+
+                pair($ifFalseBuckets.first, list($ifTrueBucket->concatenate($ifFalseBuckets.second.values)));
+            },
+            any: Any[*] | pair($state, list(^BucketsForFiltersAggregation()))
+        ]),
+    any: Any[*] | pair($state, list(^BucketsForFiltersAggregation()))
+  ]);
+}
+
+Class meta::external::store::elasticsearch::v7::pureToEs::BucketsForFiltersAggregation
+{
+  name: String[0..1];
+  query: QueryContainer[0..1];
+}
 
 function meta::external::store::elasticsearch::v7::pureToEs::processFilter(vs : FunctionExpression[1], initReq: State[1]): State[1]
 {
@@ -464,9 +547,9 @@ function meta::external::store::elasticsearch::v7::pureToEs::processSort(vs : Fu
           // but cannot sort values from the actual aggregations
           // for that, we switch to limiting TermsAggregation
 
-          let sortOnAggregatedValues = $columnsToSort->filter(x | $x->in($compositeSources.first)->not());
+          let sortOnAggregatedValues = $toSort.first->filter(x | $x.path()->in($compositeSources.first)->not());
 
-          let toSortByName = $toSort->map(x | pair($x.first.name, $x.second));
+          let toSortByName = $toSort->map(x | pair($x.first.path(), $x.second));
 
           let sortedContainer = if ($sortOnAggregatedValues->isEmpty(),
             | sortOnCompositeAggregationContainer($toSortByName, $container.aggregations, $composite, $compositeSources)

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/tds_utils.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/tds_utils.pure
@@ -89,5 +89,5 @@ Class meta::external::store::elasticsearch::v7::metamodel::tds::FieldResultPath 
 
 Class meta::external::store::elasticsearch::v7::metamodel::tds::AggregateResultPath extends meta::external::store::elasticsearch::v7::metamodel::tds::ResultPath
 {
-  
+  fieldToAggregate: meta::external::store::elasticsearch::v7::metamodel::tds::ResultPath[0..1];
 }

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test.pure
@@ -284,10 +284,10 @@ function meta::external::store::elasticsearch::executionTest::testCase::assertTd
   );
 
   let zipped = if ($description->contains('sort('),
-    | $expected.rows->map(r | $expected.columns.name->map(c | $r.get($c)))
-        ->zip($actual.rows->map(r | $actual.columns.name->map(c | $r.get($c)))),
-    | $expected->sort($expected.columns.name).rows->map(r | $expected.columns.name->map(c | $r.get($c)))
-        ->zip($actual->sort($actual.columns.name).rows->map(r | $actual.columns.name->map(c | $r.get($c))))
+    | $expected.rows->map(r | $expected.columns->map(c | $r.get($c)))
+        ->zip($actual.rows->map(r | $actual.columns->map(c | $r.get($c)))),
+    | $expected->sort($expected.columns.name).rows->map(r | $expected.columns->map(c | $r.get($c)))
+        ->zip($actual->sort($actual.columns.name).rows->map(r | $actual.columns->map(c | $r.get($c))))
   );
 
   $zipped->forAll(x | assert(comparePrimitives($x.first, $x.second)));

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation.pure
@@ -135,3 +135,64 @@ meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::tes
                 |'Newer',
                 |'Newest'))), 'ReleaseDate'), col(x: TDSRow[1] | $x.getInteger('Budget'), 'Budget')])->groupBy('ReleaseDate', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
 }
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByIfExpressionOnAdjustTodayFunctions(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->extend([col(x: TDSRow[1] | 
+          if($x.getDate('ReleaseDate') < today()->adjust(-15, DurationUnit.YEARS), 
+            |'Oldest', 
+            |if($x.getDate('ReleaseDate') < today()->adjust(-10, DurationUnit.YEARS), 
+              |'Older',
+              |if($x.getDate('ReleaseDate') < today()->adjust(-5, DurationUnit.YEARS), 
+                |'Newer',
+                |'Newest'))), 'Bucket')])->groupBy('Bucket', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByExpressionOnAdjustTodayFunctions(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->extend([col(x: TDSRow[1] | 
+        $x.getDate('ReleaseDate') < today()->adjust(-15, DurationUnit.YEARS), 
+          'Is Old?')])->groupBy('Is Old?', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}
+
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByIfExpressionOnAdjustNowFunctions(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->extend([col(x: TDSRow[1] | 
+          if($x.getDate('ReleaseDate') < now()->adjust(-15, DurationUnit.YEARS), 
+            |'Oldest', 
+            |if($x.getDate('ReleaseDate') < now()->adjust(-10, DurationUnit.YEARS), 
+              |'Older',
+              |if($x.getDate('ReleaseDate') < now()->adjust(-5, DurationUnit.YEARS), 
+                |'Newer',
+                |'Newest'))), 'Bucket')])->groupBy('Bucket', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByExpressionOnAdjustNowFunctions(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->extend([col(x: TDSRow[1] | 
+        $x.getDate('ReleaseDate') < now()->adjust(-15, DurationUnit.YEARS), 
+          'Is Old?')])->groupBy('Is Old?', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByExpressionOnAdjustNowFunctions2(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->extend([col(x: TDSRow[1] | 
+        $x.getDate('ReleaseDate') < now(), 
+          'Is Old?')])->groupBy('Is Old?', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_aggregation.pure
@@ -90,3 +90,48 @@ meta::external::store::elasticsearch::executionTest::testCase::tds::restrict::te
 {
   $config->testTdsExpression(x|$x->groupBy(['Director', 'MPAA'], [ agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum()), agg('avgBudget', r | $r.getInteger('Budget'), agg | $agg->average()) ])->restrict(['Director', 'avgBudget']));
 }
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByExpressionNestedIf(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->extend([col(x: TDSRow[1] | 
+          if($x.getDate('ReleaseDate') < %1990-01-01, 
+            |'Oldest', 
+            |if($x.getDate('ReleaseDate') < %2000-01-01, 
+              |'Older',
+              |if($x.getDate('ReleaseDate') < %2010-01-01, 
+                |'Newer',
+                |'Newest'))), 'Bucket')])->groupBy('Bucket', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByExpressionNestedIfAggregateOnExpression(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->extend([col(x: TDSRow[1] | 
+          if($x.getDate('ReleaseDate') < %1990-01-01, 
+            |'Oldest', 
+            |if($x.getDate('ReleaseDate') < %2000-01-01, 
+              |'Older',
+              |if($x.getDate('ReleaseDate') < %2010-01-01, 
+                |'Newer',
+                |'Newest'))), 'Bucket')])->groupBy('Bucket', agg('countBuckets', r | $r.getString('Bucket'), agg | $agg->count())));
+}
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test projection on Elasticsearch with pure nested if expressions'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::groupBy::testGroupByExpressionOverridesExistingColumnName(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x|$x->project([col(x: TDSRow[1] | 
+          if($x.getDate('ReleaseDate') < %1990-01-01, 
+            |'Oldest', 
+            |if($x.getDate('ReleaseDate') < %2000-01-01, 
+              |'Older',
+              |if($x.getDate('ReleaseDate') < %2010-01-01, 
+                |'Newer',
+                |'Newest'))), 'ReleaseDate'), col(x: TDSRow[1] | $x.getInteger('Budget'), 'Budget')])->groupBy('ReleaseDate', agg('sumBudget', r | $r.getInteger('Budget'), agg | $agg->sum())));
+}

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_filter_date.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/src/main/resources/core_elasticsearch_execution_test/elasticsearch_plan_test_filter_date.pure
@@ -187,3 +187,19 @@ meta::external::store::elasticsearch::executionTest::testCase::tds::filter::date
   let var = %2010-04-26T00:00:00.200+0000;
   $config->testTdsExpression(x | $x->filter(x | $var <= $x.getDate('ReleaseDate')));
 }
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test less than equal filter on Elasticsearch Integer property mapping with variable'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::filter::date::testFilterUsingValueFromAdjustNowFunctions(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x | $x->filter(x | $x.getDate('ReleaseDate') >= now()->adjust(-15, DurationUnit.YEARS)));
+}
+
+function 
+  <<paramTest.Test>>
+  {doc.doc = 'Test less than equal filter on Elasticsearch Integer property mapping with variable'} 
+meta::external::store::elasticsearch::executionTest::testCase::tds::filter::date::testFilterUsingValueFromAdjustTodayFunctions(config:TestConfig[1]):Boolean[1]
+{
+  $config->testTdsExpression(x | $x->filter(x | $x.getDate('ReleaseDate') >= today()->adjust(-15, DurationUnit.YEARS)));
+}


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

When grouping by fields that are bucketing using if/else, is more efficient to use filters bucket aggregation rather than scripting a runtime field to group by after.  This will avoid the scripting, which can be resource intensive.   

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
