### PR TITLE
Improve Postgres SQL support - RegExp matching, Hashing

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/PostgresTestContainers.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/tests/api/dynamicTestConnections/PostgresTestContainers.java
@@ -52,6 +52,7 @@ public class PostgresTestContainers implements DynamicTestConnection
         System.out.println("Starting setup of dynamic connection for database: Postgres ");
 
         long start = System.currentTimeMillis();
+        this.postgreSQLContainer.withInitScript("postgres/init.sql");
         this.postgreSQLContainer.start();
         String containerHost = this.postgreSQLContainer.getHost();
         int containerPort = this.postgreSQLContainer.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/src/test/resources/postgres/init.sql
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution-tests/src/test/resources/postgres/init.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION pgcrypto;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-pure/src/main/resources/core_relational_postgres/relational/sqlQueryToString/postgresExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-pure/src/main/resources/core_relational_postgres/relational/sqlQueryToString/postgresExtension.pure
@@ -190,6 +190,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::postg
     dynaFnToSql('joinStrings',            $allStates,            ^ToSql(format='string_agg(%s, %s)')),
     dynaFnToSql('length',                 $allStates,            ^ToSql(format='char_length(%s)')),
     dynaFnToSql('log10',                  $allStates,            ^ToSql(format='log(%s)')),
+    dynaFnToSql('matches',                $allStates,            ^ToSql(format=regexpMatchPostgres('%s'), transform={p:String[2]|$p->transformRegexpParams()})),
     dynaFnToSql('minute',                 $allStates,            ^ToSql(format='date_part(\'minute\', %s)')),
     dynaFnToSql('month',                  $allStates,            ^ToSql(format='date_part(\'month\', %s)')),
     dynaFnToSql('monthName',              $allStates,            ^ToSql(format='to_char(%s, \'FMMonth\')')),
@@ -203,6 +204,8 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::postg
     dynaFnToSql('quarterNumber',          $allStates,            ^ToSql(format='date_part(\'quarter\', %s)')),
     dynaFnToSql('round',                  $allStates,            ^ToSql(format='round((%s)::numeric, %s)', transform=transformRound_String_MANY__String_MANY_)),
     dynaFnToSql('second',                 $allStates,            ^ToSql(format='date_part(\'second\', %s)')),
+    dynaFnToSql('sha1',                   $allStates,            ^ToSql(format='encode(digest(%s, \'sha1\'), \'hex\')')),
+    dynaFnToSql('sha256',                 $allStates,            ^ToSql(format='encode(digest(%s, \'sha256\'), \'hex\')')),
     dynaFnToSql('substring',              $allStates,            ^ToSql(format='substring%s', transform={p:String[*]|$p->joinStrings('(', ', ', ')')})),
     dynaFnToSql('stdDevPopulation',       $allStates,            ^ToSql(format='stddev_pop(%s)')),
     dynaFnToSql('stdDevSample',           $allStates,            ^ToSql(format='stddev_samp(%s)')),
@@ -308,4 +311,9 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::postg
   if ($dropSchemaSQL.schema.name == 'default', 
     |  [], 
     | 'Drop schema if exists ' + $dropSchemaSQL.schema.name + ';')
+}
+
+function meta::relational::functions::sqlQueryToString::postgres::regexpMatchPostgres(query: String[1]): String[1]
+{
+   '%s ~ \'^' + $query + '$\''
 }


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Add dyna function support for functions - matches, sha1, sha256 for Postgres DB

References:
1. RegExp matching: https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP
2. Hashing: https://www.postgresql.org/docs/current/pgcrypto.html

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
