### PR TITLE
Upgrade resultset normalizer - temp table creation for snowflake in GraphFetch

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -943,7 +943,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             }
             if (v instanceof PureDate)
             {
-                return (String) ResultNormalizer.normalizeToSql(v, databaseTimeZone);
+                return "'" + (String) ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
             }
             if (v instanceof String && quoteCharacterReplacement != null)
             {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -30,6 +30,7 @@ import org.eclipse.collections.impl.map.mutable.MapAdapter;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.plan.dependencies.domain.dataQuality.BasicChecked;
+import org.finos.legend.engine.plan.dependencies.domain.date.PureDate;
 import org.finos.legend.engine.plan.dependencies.domain.graphFetch.IGraphInstance;
 import org.finos.legend.engine.plan.dependencies.store.relational.IRelationalCreateAndPopulateTempTableExecutionNodeSpecifics;
 import org.finos.legend.engine.plan.dependencies.store.relational.IRelationalResult;
@@ -935,6 +936,14 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             if (v == null)
             {
                 return "null";
+            }
+            if (v instanceof Number)
+            {
+                return v.toString();
+            }
+            if (v instanceof PureDate)
+            {
+                ResultNormalizer.normalizeToSql(v, databaseTimeZone);
             }
             if (v instanceof String && quoteCharacterReplacement != null)
             {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -949,6 +949,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             {
                 return "'" + ((String) v).replace("'", quoteCharacterReplacement) + "'";
             }
+            // TODO - Implement db specific processing for boolean type
             return "'" + v.toString() + "'";
         };
     }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -936,19 +936,11 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             {
                 return "null";
             }
-            if (v instanceof Number)
+            if (v instanceof String && quoteCharacterReplacement != null)
             {
-                return (String) ResultNormalizer.normalizeToSql(v, databaseTimeZone);
+                return "'" + ((String) v).replace("'", quoteCharacterReplacement) + "'";
             }
-            if (v instanceof String)
-            {
-                if (quoteCharacterReplacement != null)
-                {
-                    return "'" + ((String)ResultNormalizer.normalizeToSql(v, databaseTimeZone)).replace("'", quoteCharacterReplacement) + "'";
-                }
-                return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
-            }
-            return "'" + ResultNormalizer.normalizeToSql(v, databaseTimeZone) + "'";
+            return "'" + v.toString() + "'";
         };
     }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -943,7 +943,7 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             }
             if (v instanceof PureDate)
             {
-                ResultNormalizer.normalizeToSql(v, databaseTimeZone);
+                return (String) ResultNormalizer.normalizeToSql(v, databaseTimeZone);
             }
             if (v instanceof String && quoteCharacterReplacement != null)
             {


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

Fixes Graphfetch executions in Snowflake when the data has a special character(\)

In graphfetch executions, we create temp tables using insert statements for Snowflake. 
The tuples for insert statements are created from the resultset. They go through the ResultSetNormalizer in FreeMarkerExecutor, so we shouldn't be doing it again in the graphfetch normalizer. (The ResultSetNormalizer.normalizeToSql() isn't idempotent)

#### Which issue(s) this PR fixes:

Fixes # 

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
