### PR TITLE
Add support to specify a filter in mastery resolution key spec

### DIFF
--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryLexerGrammar.g4
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryLexerGrammar.g4
@@ -57,6 +57,7 @@ RESOLUTION_QUERY_KEY_TYPE_GENERATED_PRIMARY_KEY:'GeneratedPrimaryKey'; //Validat
 RESOLUTION_QUERY_KEY_TYPE_SUPPLIED_PRIMARY_KEY: 'SuppliedPrimaryKey'; //Validated against equality key to ensure an actuial PK and create if don't find match
 RESOLUTION_QUERY_KEY_TYPE_ALTERNATE_KEY:        'AlternateKey'; //AlternateKey (In an AlternateKey is specified then at least one required in the input record or fail resolution). AlternateKey && (CurationModel field == Create) then the input source is attempting to create a new record (e.g. from UI) block if existing record found
 RESOLUTION_QUERY_KEY_TYPE_OPTIONAL:             'Optional';
+RESOLUTION_QUERY_FILTER:                        'filter';
 
 // -------------------------------------- PRECEDENCE RULES --------------------------------------
 PRECEDENCE_RULES:                               'precedenceRules';

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryParserGrammar.g4
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/MasteryParserGrammar.g4
@@ -277,6 +277,7 @@ resolutionQuery:                            BRACE_OPEN
                                              | resolutionQueryKeyType
                                              | resolutionQueryOptional
                                              | resolutionQueryPrecedence
+                                             | resolutionQueryFilter
                                             )*
                                             BRACE_CLOSE
 ;
@@ -299,6 +300,8 @@ resolutionQueryKeyType:                  RESOLUTION_QUERY_KEY_TYPE COLON (
 resolutionQueryOptional:                 RESOLUTION_QUERY_OPTIONAL COLON boolean_value SEMI_COLON
 ;
 resolutionQueryPrecedence:               PRECEDENCE COLON INTEGER SEMI_COLON
+;
+resolutionQueryFilter:                   RESOLUTION_QUERY_FILTER COLON lambdaFunction SEMI_COLON
 ;
 // -------------------------------------- PRECEDENCE RULES--------------------------------------
 

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/MasteryCompilerExtension.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/toPureGraph/MasteryCompilerExtension.java
@@ -76,7 +76,7 @@ public class MasteryCompilerExtension implements IMasteryCompilerExtension
                 (masterRecordDefinition, context) ->
                 {
                     Root_meta_pure_mastery_metamodel_MasterRecordDefinition pureMasteryMetamodelMasterRecordDefinition = (Root_meta_pure_mastery_metamodel_MasterRecordDefinition) context.pureModel.getOrCreatePackage(masterRecordDefinition._package)._children().detect(c -> masterRecordDefinition.name.equals(c._name()));
-                    pureMasteryMetamodelMasterRecordDefinition._identityResolution(HelperMasterRecordDefinitionBuilder.buildIdentityResolution(masterRecordDefinition.identityResolution, context));
+                    pureMasteryMetamodelMasterRecordDefinition._identityResolution(HelperMasterRecordDefinitionBuilder.buildIdentityResolution(masterRecordDefinition.identityResolution, masterRecordDefinition.modelClass, context));
                     pureMasteryMetamodelMasterRecordDefinition._sources(HelperMasterRecordDefinitionBuilder.buildRecordSources(masterRecordDefinition.sources, context));
                     pureMasteryMetamodelMasterRecordDefinition._postCurationEnrichmentService(BuilderUtil.buildService(masterRecordDefinition.postCurationEnrichmentService, context, masterRecordDefinition.sourceInformation));
                     pureMasteryMetamodelMasterRecordDefinition._exceptionWorkflowTransformService(BuilderUtil.buildService(masterRecordDefinition.exceptionWorkflowTransformService, context, masterRecordDefinition.sourceInformation));

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/from/MasteryParseTreeWalker.java
@@ -736,6 +736,13 @@ public class MasteryParseTreeWalker
         MasteryParserGrammar.ResolutionQueryPrecedenceContext resolutionQueryPrecedenceContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.resolutionQueryPrecedence(), "precedence", sourceInformation);
         resolutionQuery.precedence = Integer.parseInt(resolutionQueryPrecedenceContext.INTEGER().getText());
 
+        //filter
+        MasteryParserGrammar.ResolutionQueryFilterContext resolutionQueryFilterContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.resolutionQueryFilter(), "filter", sourceInformation);
+        if (resolutionQueryFilterContext != null)
+        {
+            resolutionQuery.filter = visitLambda(resolutionQueryFilterContext.lambdaFunction());
+        }
+
         return resolutionQuery;
     }
 

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/mastery/grammar/to/HelperMasteryGrammarComposer.java
@@ -458,6 +458,10 @@ public class HelperMasteryGrammarComposer
                 builder.append(getTabString(indentLevel + 4)).append("optional: ").append(resolutionQuery.optional).append(";\n");
             }
             builder.append(getTabString(indentLevel + 4)).append("precedence: ").append(resolutionQuery.precedence).append(";\n");
+            if (resolutionQuery.filter != null)
+            {
+                builder.append(getTabString(indentLevel + 4)).append("filter: ").append(lambdaToString(resolutionQuery.filter, context)).append(";\n");
+            }
             builder.append(getTabString(indentLevel + 3)).append("}");
         });
         builder.append("\n").append(getTabString(indentLevel + 2)).append("]");

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/mastery/compiler/test/TestMasteryCompilationFromGrammar.java
@@ -128,6 +128,15 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
             "          keyType: AlternateKey;\n" +
             "          optional: true;\n" +
             "          precedence: 2;\n" +
+            "          filter: {input: org::dataeng::Widget[1]|$input.trigger == 'A'};\n" +
+            "        },\n" +
+            "        {\n" +
+            "          queries: [ {input: org::dataeng::Widget[1],EFFECTIVE_DATE: StrictDate[1]|org::dataeng::Widget.all()->filter(widget|((($widget.identifiers.identifierType == 'CUSIP') && ($input.identifiers->filter(idType|$idType.identifierType == 'CUSIP').identifier == $widget.identifiers->filter(idType|$idType.identifierType == 'CUSIP').identifier)) && ($widget.identifiers.FROM_Z->toOne() <= $EFFECTIVE_DATE)) && ($widget.identifiers.THRU_Z->toOne() > $EFFECTIVE_DATE))}\n" +
+            "                   ];\n" +
+            "          keyType: AlternateKey;\n" +
+            "          optional: true;\n" +
+            "          precedence: 2;\n" +
+            "          filter: {input: org::dataeng::Widget[1]|$input.trigger == 'B'};\n" +
             "        },\n" +
             "        {\n" +
             "          queries: [ {input: org::dataeng::Widget[1]|org::dataeng::Widget.all()->filter(widget|$widget.trigger == $input.trigger)}\n" +
@@ -1396,6 +1405,126 @@ public class TestMasteryCompilationFromGrammar extends TestCompilationFromGramma
                 "ExchangeDataProvider alloy::mastery::dataprovider::LSE;\n\n\n";
 
         TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(model, "COMPILATION error at [23:5-29:5]: ConditionalRule with ruleScope is currently unsupported");
+    }
+
+    @Test
+    public void testCompilationErrorWhenResolutionFilterHasMoreThanOneParameter()
+    {
+        String model = "###Pure\n" +
+                "Class org::dataeng::Widget\n" +
+                "{\n" +
+                "  widgetId: String[0..1];\n" +
+                "}\n\n" +
+                "###Mastery\n" + "MasterRecordDefinition alloy::mastery::WidgetMasterRecord" +
+                "\n" +
+                "{\n" +
+                "  modelClass: org::dataeng::Widget;\n" +
+                "  identityResolution: \n" +
+                "  {\n" +
+                "    resolutionQueries:\n" +
+                "      [\n" +
+                "        {\n" +
+                "          queries: [ {input: org::dataeng::Widget[1]|org::dataeng::Widget.all()->filter(widget|$widget.widgetId == $input.widgetId)}\n" +
+                "                   ];\n" +
+                "          precedence: 1;\n" +
+                "          filter: {input:org::dataeng::Widget[1],current:org::dataeng::Widget[1]| $input.widgetId == $current.widget};\n" +
+                "        }\n" +
+                "      ]\n" +
+                "  }\n" +
+                "  recordSources:\n" +
+                "  [\n" +
+                "    widget-producer: {\n" +
+                "      description: 'REST Acquisition source.';\n" +
+                "      status: Development;\n" +
+                "      recordService: {\n" +
+                "        acquisitionProtocol: REST;\n" +
+                "      };\n" +
+                "      trigger: Manual;\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n\n";
+
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(model, "COMPILATION error at [8:1-34:1]: Error in 'alloy::mastery::WidgetMasterRecord': The resolution query filter must have exactly one parameter specified in the lambda function - found 2");
+    }
+
+    @Test
+    public void testCompilationErrorWhenResolutionFilterHasWrongParameterType()
+    {
+        String model = "###Pure\n" +
+                "Class org::dataeng::Widget\n" +
+                "{\n" +
+                "  widgetId: String[0..1];\n" +
+                "}\n\n" +
+                "###Mastery\n" + "MasterRecordDefinition alloy::mastery::WidgetMasterRecord" +
+                "\n" +
+                "{\n" +
+                "  modelClass: org::dataeng::Widget;\n" +
+                "  identityResolution: \n" +
+                "  {\n" +
+                "    resolutionQueries:\n" +
+                "      [\n" +
+                "        {\n" +
+                "          queries: [ {input: org::dataeng::Widget[1]|org::dataeng::Widget.all()->filter(widget|$widget.widgetId == $input.widgetId)}\n" +
+                "                   ];\n" +
+                "          precedence: 1;\n" +
+                "          filter: {input:String[1]| $input == 'A'};\n" +
+                "        }\n" +
+                "      ]\n" +
+                "  }\n" +
+                "  recordSources:\n" +
+                "  [\n" +
+                "    widget-producer: {\n" +
+                "      description: 'REST Acquisition source.';\n" +
+                "      status: Development;\n" +
+                "      recordService: {\n" +
+                "        acquisitionProtocol: REST;\n" +
+                "      };\n" +
+                "      trigger: Manual;\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n\n";
+
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(model, "COMPILATION error at [8:1-34:1]: Error in 'alloy::mastery::WidgetMasterRecord': Input Class for the resolution key filter should be org::dataeng::Widget, however found String");
+    }
+
+    @Test
+    public void testCompilationErrorWhenResolutionFilterHasWrongParameterMultiplicity()
+    {
+        String model = "###Pure\n" +
+                "Class org::dataeng::Widget\n" +
+                "{\n" +
+                "  widgetId: String[0..1];\n" +
+                "}\n\n" +
+                "###Mastery\n" + "MasterRecordDefinition alloy::mastery::WidgetMasterRecord" +
+                "\n" +
+                "{\n" +
+                "  modelClass: org::dataeng::Widget;\n" +
+                "  identityResolution: \n" +
+                "  {\n" +
+                "    resolutionQueries:\n" +
+                "      [\n" +
+                "        {\n" +
+                "          queries: [ {input: org::dataeng::Widget[1]|org::dataeng::Widget.all()->filter(widget|$widget.widgetId == $input.widgetId)}\n" +
+                "                   ];\n" +
+                "          precedence: 1;\n" +
+                "          filter: {input:org::dataeng::Widget[0..1]| $input.widgetId == 'A'};\n" +
+                "        }\n" +
+                "      ]\n" +
+                "  }\n" +
+                "  recordSources:\n" +
+                "  [\n" +
+                "    widget-producer: {\n" +
+                "      description: 'REST Acquisition source.';\n" +
+                "      status: Development;\n" +
+                "      recordService: {\n" +
+                "        acquisitionProtocol: REST;\n" +
+                "      };\n" +
+                "      trigger: Manual;\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n\n";
+
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(model, "COMPILATION error at [8:1-34:1]: Error in 'alloy::mastery::WidgetMasterRecord': Expected input for resolution key filter to have multiplicity 1");
     }
 
     private void assertDataProviders(PureModel model)

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/mastery/identity/ResolutionQuery.java
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/mastery/identity/ResolutionQuery.java
@@ -24,4 +24,5 @@ public class ResolutionQuery
     public ResolutionKeyType keyType;
     public Boolean optional;
     public Integer precedence;
+    public Lambda filter;
 }

--- a/legend-engine-xts-mastery/legend-engine-xt-mastery-pure/src/main/resources/core_mastery/mastery/metamodel.pure
+++ b/legend-engine-xts-mastery/legend-engine-xt-mastery-pure/src/main/resources/core_mastery/mastery/metamodel.pure
@@ -178,6 +178,9 @@ meta::pure::mastery::metamodel::identity::ResolutionQuery
 
   {doc.doc='The query precedence applied when there are more than one ResoultionQuery definitions on an IdentityResolution, 1 is hiughest.'}
   precedence : Integer[1];
+
+  {doc.doc='An optional filter that when specified will determine whether the input should execute this resolution query or not.'}
+  filter: meta::pure::metamodel::function::LambdaFunction<{Any[*]->Boolean[1]}>[0..1];
 }
 
 Enum {doc.doc = 'Types of resolution keys.'}


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

This PR allows users to specify an optional filter in the MasterRecordDefinition resolution keys specification.

#### Other notes for reviewers:

This is an optional field so changes are completely backwards compatible.

