### PR TITLE
Support variable expressions in MongoDB plan generation

### DIFF
--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan-test/src/main/resources/core_mongodb_execution_test/mongodb_execution_tests.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan-test/src/main/resources/core_mongodb_execution_test/mongodb_execution_tests.pure
@@ -150,10 +150,32 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::equal::testSelectEqualStringParam(config:meta::external::store::mongodb::executionTest::TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeFull();
+
+  let personQuery = {firstName:String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firstName == $firstName})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firstName', 'Gelya')], '/core_mongodb_execution_test/expected_execution_results/equal/testSelectEqualString.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::equal::testSelectEqualNumber(config:meta::external::store::mongodb::executionTest::TestConfig[1]):Boolean[1]
 {
-  let filterLambda = { x: Person[1] |  $x.age == 45};
+  let filterLambda = { x: Person[1] | $x.age == 45};
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/equal/testSelectEqualNumber.json');
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::equal::testSelectEqualNumberParam(config:meta::external::store::mongodb::executionTest::TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeFull();
+
+  let personQuery = {age: Integer[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.age == $age})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('age', 45)], '/core_mongodb_execution_test/expected_execution_results/equal/testSelectEqualNumber.json');
 }
 
 
@@ -162,6 +184,17 @@ function <<paramTest.Test>>
 {
   let filterLambda = { x: Person[1] | $x.firm.legalName == 'Yodoo'};
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/equal/testSelectEqualNested.json');
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::equal::testSelectEqualNestedParam(config:meta::external::store::mongodb::executionTest::TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeFull();
+
+  let personQuery = {firmLegalName: String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firm.legalName == 'Yodoo'})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firmLegalName', 'Yodoo')], '/core_mongodb_execution_test/expected_execution_results/equal/testSelectEqualNested.json');
 }
 
 
@@ -185,6 +218,17 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::notEqual::testSelectNotEqualStringParam(config:meta::external::store::mongodb::executionTest::TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {firstName:String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firstName != $firstName})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firstName', 'Coralie')], '/core_mongodb_execution_test/expected_execution_results/not_equal/testSelectNotEqualString.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::notEqual::testSelectNotEqualNumber(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | $x.age != 23};
@@ -192,10 +236,32 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::notEqual::testSelectNotEqualNumberParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {age:Integer[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.age != $age})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('age', 23)], '/core_mongodb_execution_test/expected_execution_results/not_equal/testSelectNotEqualNumber.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::notEqual::testSelectNotEqualAndString(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | !($x.firstName == 'Coralie' && $x.lastName == 'Batie')};
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/not_equal/testSelectNotEqualString.json', personTreeSmall());
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::notEqual::testSelectNotEqualAndStringParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {firstName:String[1], lastName: String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| !($x.firstName == $firstName && $x.lastName == $lastName)})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firstName', 'Coralie'), pair('lastName', 'Batie')], '/core_mongodb_execution_test/expected_execution_results/not_equal/testSelectNotEqualString.json');
 }
 
 
@@ -209,10 +275,32 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::lessThanEqual::testLessThanEqualStringParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {firstName:String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firstName <= $firstName})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firstName', 'Jefferey')], '/core_mongodb_execution_test/expected_execution_results/less_than_equal/testLessThanEqualString.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::lessThanEqual::testLessThanEqualNumber(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | $x.age <= 25 };
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/less_than_equal/testLessThanEqualNumber.json', personTreeSmall());
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::lessThanEqual::testLessThanEqualNumberParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {age:Integer[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.age <= $age})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('age', 25)], '/core_mongodb_execution_test/expected_execution_results/less_than_equal/testLessThanEqualNumber.json');
 }
 
 // Filters - LessThan
@@ -225,10 +313,32 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::lessThan::testLessThanNumberParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {age:Integer[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.age < $age})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('age', 25)], '/core_mongodb_execution_test/expected_execution_results/less_than/testLessThanNumber.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::lessThan::testLessThanString(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | $x.firstName < 'Jefferey' };
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/less_than/testLessThanString.json', personTreeSmall());
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::lessThan::testLessThanStringParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {firstName:String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firstName < $firstName})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firstName', 'Jefferey')], '/core_mongodb_execution_test/expected_execution_results/less_than/testLessThanString.json');
 }
 
 function
@@ -250,12 +360,33 @@ function <<paramTest.Test>>
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/greater_than/testGreaterThanString.json', personTreeSmall());
 }
 
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThan::testGreaterThanStringParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {firstName:String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firstName > $firstName})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firstName', 'Coralie')], '/core_mongodb_execution_test/expected_execution_results/greater_than/testGreaterThanString.json');
+}
 
 function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThan::testGreaterThanNumber(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | $x.age > 45 };
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/greater_than/testGreaterThanNumber.json', personTreeSmall());
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThan::testGreaterThanNumberParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {age:Integer[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.age > $age})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('age', 45)], '/core_mongodb_execution_test/expected_execution_results/greater_than/testGreaterThanNumber.json');
 }
 
 function
@@ -279,6 +410,17 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThanEqual::testGreaterThanEqualStringParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {firstName:String[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firstName >= $firstName})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firstName', 'Coralie')], '/core_mongodb_execution_test/expected_execution_results/greater_than_equal/testGreaterThanEqualString.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThanEqual::testGreaterThanEqualNumber(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | $x.age >= 45 };
@@ -286,10 +428,32 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThanEqual::testGreaterThanEqualNumberParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {age:Integer[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.age >= $age})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('age', 45)], '/core_mongodb_execution_test/expected_execution_results/greater_than_equal/testGreaterThanEqualNumber.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThanEqual::testGreaterThanEqualNestedNumber(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | $x.firm.numberOfEmployees >= 100 };
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/greater_than_equal/testGreaterThanEqualNestedNumber.json', personTreeSmall());
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::greaterThanEqual::testGreaterThanEqualNestedNumberParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {firmNumberOfEmployees:Integer[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| $x.firm.numberOfEmployees >= $firmNumberOfEmployees})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('firmNumberOfEmployees', 100)], '/core_mongodb_execution_test/expected_execution_results/greater_than_equal/testGreaterThanEqualNestedNumber.json');
 }
 
 // Filters - Dates
@@ -302,6 +466,17 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::dates::testDateBetweenWithGTandLTParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {minBirthDate:StrictDate[1], maxBirthDate:DateTime[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| ($x.birthDate > $minBirthDate) && ($x.birthDate < $maxBirthDate)})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('minBirthDate', %1969-01-01), pair('maxBirthDate', %1971-04-04T18:09:35+0000)], '/core_mongodb_execution_test/expected_execution_results/combinations/testDatesBetweenWithGTandLT.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::dates::testDateBetweenWithGTEandLTE(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | ($x.birthDate >= %1980-04-04T07:12:12) && ($x.birthDate <= %1983-05-06T00:12:12)};
@@ -309,10 +484,32 @@ function <<paramTest.Test>>
 }
 
 function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::dates::testDateBetweenWithGTEandLTEParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {minBirthDate:DateTime[1], maxBirthDate:DateTime[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| ($x.birthDate >= $minBirthDate) && ($x.birthDate <= $maxBirthDate)})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('minBirthDate', %1980-04-04T07:12:12+0000), pair('maxBirthDate', %1983-05-06T00:12:12+0000)], '/core_mongodb_execution_test/expected_execution_results/combinations/testDatesBetweenWithGTEandLTE.json');
+}
+
+function <<paramTest.Test>>
  meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::dates::testNestedDateBetweenWithGTEandLTE(config:TestConfig[1]):Boolean[1]
 {
   let filterLambda = { x: Person[1] | ($x.firm.dateFounded >= %2014-04-04T07:12:12) };
   testFilterExecution($config, $filterLambda, '/core_mongodb_execution_test/expected_execution_results/greater_than_equal/testGreaterThanEqualNestedDate.json', personTreeSmall());
+}
+
+function <<paramTest.Test>>
+ meta::external::store::mongodb::executionTest::testCase::graphfetch::filter::dates::testNestedDateBetweenWithGTEandLTEParam(config:TestConfig[1]):Boolean[1]
+{
+  let mapping = $config.mapping;
+  let runtime = $config.runtime;
+  let graphFetch = personTreeSmall();
+
+  let personQuery = {minFoundingDate:DateTime[1] | Person.all()->from($mapping, $runtime)->filter({x:Person[1]| ($x.firm.dateFounded >= $minFoundingDate)})->graphFetch($graphFetch)->serialize($graphFetch)};
+  testFilterExecutionWithParam($config, $personQuery, [pair('minFoundingDate', %2014-04-04T07:12:12+0000)], '/core_mongodb_execution_test/expected_execution_results/greater_than_equal/testGreaterThanEqualNestedDate.json');
 }
 
 // GraphFetch
@@ -411,6 +608,11 @@ function <<paramTest.Test>>
 // UTILS
 
 function meta::external::store::mongodb::executionTest::executeAndAssert(f: FunctionDefinition<Any>[1], expectedResult: String[1]):Boolean[1]
+{
+  meta::external::store::mongodb::executionTest::executeAndAssert($f, $expectedResult, []);
+}
+
+function meta::external::store::mongodb::executionTest::executeAndAssert(f: FunctionDefinition<Any>[1], expectedResult: String[1], vars: Pair<String, Any>[*]):Boolean[1]
  {
   let extensions = [
     meta::external::store::mongodb::extension::mongoDBExtensions('mongoDB'),
@@ -421,7 +623,7 @@ function meta::external::store::mongodb::executionTest::executeAndAssert(f: Func
 
    let result = meta::legend::execute(
     $f,
-    [],
+    $vars,
     $executionContext,
     $extensions
   )->meta::json::parseJSON()->meta::json::toPrettyJSONString();
@@ -450,6 +652,11 @@ function meta::external::store::mongodb::executionTest::testCase::utils::testFil
   executeAndAssert($personQuery, $expectedResult);
 }
 
+function meta::external::store::mongodb::executionTest::testCase::utils::testFilterExecutionWithParam(config:TestConfig[1], query:FunctionDefinition<Any>[1], vars: Pair<String, Any>[*], expectedResultFileLoc: String[1]):Boolean[1]
+{
+  let expectedResult = readFile($expectedResultFileLoc)->toOne();
+  executeAndAssert($query, $expectedResult, $vars);
+}
 
 function <<paramTest.AfterPackage>> meta::external::store::mongodb::executionTest::testCase::cleanupTestSuite(config:TestConfig[1]):Boolean[1]
 {

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/plugin/MongoDBExecutionNodeExecutor.java
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/mongodb/plugin/MongoDBExecutionNodeExecutor.java
@@ -28,6 +28,7 @@ import org.finos.legend.engine.plan.dependencies.domain.dataQuality.EnforcementL
 import org.finos.legend.engine.plan.dependencies.domain.dataQuality.IChecked;
 import org.finos.legend.engine.plan.dependencies.domain.dataQuality.IDefect;
 import org.finos.legend.engine.plan.execution.nodes.ExecutionNodeExecutor;
+import org.finos.legend.engine.plan.execution.nodes.helpers.freemarker.FreeMarkerExecutor;
 import org.finos.legend.engine.plan.execution.nodes.helpers.platform.ExecutionNodeJavaPlatformHelper;
 import org.finos.legend.engine.plan.execution.nodes.helpers.platform.JavaHelper;
 import org.finos.legend.engine.plan.execution.nodes.state.ExecutionState;
@@ -107,11 +108,12 @@ public class MongoDBExecutionNodeExecutor implements ExecutionNodeVisitor<Result
             DatabaseCommand dbCommand = objectMapper.readValue(databaseCommand, DatabaseCommand.class);
             MongoDBQueryJsonComposer mongoDBQueryJsonComposer = new MongoDBQueryJsonComposer(false);
             String composedDbCommand = mongoDBQueryJsonComposer.parseDatabaseCommand(dbCommand);
+            String placeholderReplacedDbCommand = FreeMarkerExecutor.process(composedDbCommand, this.executionState);
 
             CredentialProviderProvider credentialProviderProvider = this.executionState.getCredentialProviderProvider();
             Identity identity = IdentityFactoryProvider.getInstance().makeIdentity(profiles);
 
-            return new MongoDBExecutor(credentialProviderProvider).executeMongoDBQuery(composedDbCommand, mongoDBConnection, identity);
+            return new MongoDBExecutor(credentialProviderProvider).executeMongoDBQuery(placeholderReplacedDbCommand, mongoDBConnection, identity);
         }
         catch (IOException e)
         {

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/visitors/BaseTypeValueVisitorImpl.java
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/visitors/BaseTypeValueVisitorImpl.java
@@ -20,6 +20,7 @@ import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.Bas
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.BoolTypeValue;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.DateTypeValue;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.DecimalTypeValue;
+import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.FloatTypeValue;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.IntTypeValue;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.KeyValuePair;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.LongTypeValue;
@@ -66,6 +67,12 @@ public class BaseTypeValueVisitorImpl implements BaseTypeValueVisitor<String>
     {
         // not used
         return String.valueOf(val);
+    }
+
+    @Override
+    public String visit(FloatTypeValue val)
+    {
+        return String.valueOf(val.value);
     }
 
     @Override

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/visitors/BaseTypeValueVisitorImpl.java
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/visitors/BaseTypeValueVisitorImpl.java
@@ -26,6 +26,7 @@ import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.Lon
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.NullTypeValue;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.ObjectTypeValue;
 import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.StringTypeValue;
+import org.finos.legend.engine.protocol.mongodb.schema.metamodel.aggregation.VariableTypeValue;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -85,6 +86,12 @@ public class BaseTypeValueVisitorImpl implements BaseTypeValueVisitor<String>
     public String visit(StringTypeValue val)
     {
         return convertToStringWithQuotes(String.valueOf(val.value));
+    }
+
+    @Override
+    public String visit(VariableTypeValue val)
+    {
+        return String.valueOf(val.value);
     }
 
     @Override

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/metamodel/mongodbStore.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/metamodel/mongodbStore.pure
@@ -409,6 +409,11 @@ Class meta::external::store::mongodb::metamodel::aggregation::BaseTypeValue
 {
 }
 
+Class meta::external::store::mongodb::metamodel::aggregation::VariableTypeValue extends BaseTypeValue
+{
+  value: String[1];
+}
+
 Class meta::external::store::mongodb::metamodel::aggregation::StringTypeValue extends BaseTypeValue
 {
   value: String[1];

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/metamodel/mongodbStore.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/metamodel/mongodbStore.pure
@@ -438,6 +438,11 @@ Class meta::external::store::mongodb::metamodel::aggregation::LongTypeValue exte
   value: Integer[1];
 }
 
+Class meta::external::store::mongodb::metamodel::aggregation::FloatTypeValue extends BaseTypeValue
+{
+  value: Float[1];
+}
+
 Class meta::external::store::mongodb::metamodel::aggregation::DecimalTypeValue extends BaseTypeValue
 {
   value: Decimal[1];

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/pureToDatabaseCommand/pureToDatabaseCommand.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/pureToDatabaseCommand/pureToDatabaseCommand.pure
@@ -190,6 +190,8 @@ function meta::external::store::mongodb::functions::pureToDatabaseCommand::proce
     s: String[1]      | ^LiteralValue(value=^StringTypeValue(value=$s)),
     i: Integer[1]     | ^LiteralValue(value=^IntTypeValue(value=$i)),
     b: Boolean[1]     | ^LiteralValue(value=^BoolTypeValue(value=$b)),
+    f: Float[1]       | ^LiteralValue(value=^FloatTypeValue(value=$f)),
+    d: Decimal[1]     | ^LiteralValue(value=^DecimalTypeValue(value=$d)),
     sd: StrictDate[1] | ^LiteralValue(value=^DateTypeValue(value=meta::pure::functions::date::date(year($sd), monthNumber($sd), dayOfMonth($sd), 0, 0 ,0)->toString()));,                 // type cast StrictDate to dateTime,(as strictdates in expected value are converted to datetime,to retain timezone info)
     dt: DateTime[1]   | ^LiteralValue(value=^DateTypeValue(value=$dt->toString()));,
     l: LambdaFunction<Any>[1] |
@@ -206,11 +208,11 @@ function meta::external::store::mongodb::functions::pureToDatabaseCommand::proce
   let var = $inScopeVars->get($v.name->toOne()).values->cast(@PlanVarPlaceHolder)->toOne();
   let varType = $var.type;
 
-  if($varType == String,                                   | ^LiteralValue(value=^VariableTypeValue(value='\"${'+$var->toOne().name+'}\"')),
-  | if($varType == Boolean,                                | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'?c}')),
-      | if($varType == Integer,                            | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'}')),
-        | if($varType->in([Float, Number, Decimal]),       | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'}')),
-          | if($varType->in([Date, DateTime, StrictDate]), | ^LiteralValue(value=^VariableTypeValue(value='new ISODate(\"${'+$var->toOne().name+'}\")')),
+  if($varType == String,                                    | ^LiteralValue(value=^VariableTypeValue(value='\"${'+$var->toOne().name+'}\"')),
+  | if($varType == Boolean,                                 | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'?c}')),
+      | if($varType->in([Integer, Float, Number, Decimal]), | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'}')),
+        | if($varType == StrictDate,                        | ^LiteralValue(value=^VariableTypeValue(value='new ISODate(\"${'+$var->toOne().name+'}\")')),
+          | if($varType->in([Date, DateTime]),              | ^LiteralValue(value=^VariableTypeValue(value='new ISODate(\"${'+$var->toOne().name+'}Z\")')),
             {|
               fail('Type of variable \'%s: %s[%s]\' not supported'->format([$var.name, $var.type->printType(), $var.multiplicity->toOne()->printMultiplicity()]));
               ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'}'));

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/pureToDatabaseCommand/pureToDatabaseCommand.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/pureToDatabaseCommand/pureToDatabaseCommand.pure
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::pure::executionPlan::*;
 import meta::json::*;
 import meta::pure::router::printer::*;
 import meta::pure::metamodel::serialization::grammar::*;
@@ -134,7 +135,7 @@ function meta::external::store::mongodb::functions::pureToDatabaseCommand::proce
   let fieldPath = '$' + $path;
 
   let leftSide = ^FieldPathExpression(fieldPath=$fieldPath);
-  let rightSide = processValueSpecification($functionExpression.parametersValues->at(1)->cast(@InstanceValue), $databaseCommand, $mapping, $inScopeVars, $debug)->cast(@LiteralValue);
+  let rightSide = processValueSpecification($functionExpression.parametersValues->at(1), $databaseCommand, $mapping, $inScopeVars, $debug)->cast(@LiteralValue);
   ^EqOperatorExpression(expressions=[$leftSide, $rightSide]);
 }
 
@@ -169,7 +170,7 @@ function meta::external::store::mongodb::functions::pureToDatabaseCommand::proce
   let fieldPath = '$' + $path->toOne();
 
   let leftSide = ^FieldPathExpression(fieldPath=$fieldPath);
-  let rightSide = processValueSpecification($functionExpression.parametersValues->at(1)->cast(@InstanceValue), $databaseCommand, $mapping, $inScopeVars, $debug)->cast(@LiteralValue);
+  let rightSide = processValueSpecification($functionExpression.parametersValues->at(1), $databaseCommand, $mapping, $inScopeVars, $debug)->cast(@LiteralValue);
   meta::external::store::mongodb::functions::pureToDatabaseCommand::processComparisonFunction($functionExpression, $leftSide, $rightSide);
 }
 
@@ -188,12 +189,37 @@ function meta::external::store::mongodb::functions::pureToDatabaseCommand::proce
   $i.values->match([
     s: String[1]      | ^LiteralValue(value=^StringTypeValue(value=$s)),
     i: Integer[1]     | ^LiteralValue(value=^IntTypeValue(value=$i)),
-    sd :StrictDate[1] | ^LiteralValue(value=^DateTypeValue(value=meta::pure::functions::date::date(year($sd), monthNumber($sd), dayOfMonth($sd), 0, 0 ,0)->toString()));,                 // type cast StrictDate to dateTime,(as strictdates in expected value are converted to datetime,to retain timezone info)
+    b: Boolean[1]     | ^LiteralValue(value=^BoolTypeValue(value=$b)),
+    sd: StrictDate[1] | ^LiteralValue(value=^DateTypeValue(value=meta::pure::functions::date::date(year($sd), monthNumber($sd), dayOfMonth($sd), 0, 0 ,0)->toString()));,                 // type cast StrictDate to dateTime,(as strictdates in expected value are converted to datetime,to retain timezone info)
     dt: DateTime[1]   | ^LiteralValue(value=^DateTypeValue(value=$dt->toString()));,
     l: LambdaFunction<Any>[1] |
-      let fe = $i.values->cast(@LambdaFunction<Any>).expressionSequence->cast(@SimpleFunctionExpression);
-      processFunctionExpression($fe->toOne(), $databaseCommand, $mapping, $inScopeVars, $debug);
+      $i.values->cast(@LambdaFunction<Any>).expressionSequence->match(
+          [
+              s:StoreMappingRoutedValueSpecification[1] | $s.value->cast(@SimpleFunctionExpression)->toOne()->processFunctionExpression($databaseCommand, $mapping, $inScopeVars, $debug),
+              f:SimpleFunctionExpression[1]             | $f->toOne()->processFunctionExpression($databaseCommand, $mapping, $inScopeVars, $debug)
+          ]);
   ]);
+}
+
+function meta::external::store::mongodb::functions::pureToDatabaseCommand::processVariableExpression(v: VariableExpression[1], databaseCommand: DatabaseCommand[1], mapping: Mapping[1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1]): MongoDBOperationElement[1]
+{
+  let var = $inScopeVars->get($v.name->toOne()).values->cast(@PlanVarPlaceHolder)->toOne();
+  let varType = $var.type;
+
+  if($varType == String,                                   | ^LiteralValue(value=^VariableTypeValue(value='\"${'+$var->toOne().name+'}\"')),
+  | if($varType == Boolean,                                | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'?c}')),
+      | if($varType == Integer,                            | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'}')),
+        | if($varType->in([Float, Number, Decimal]),       | ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'}')),
+          | if($varType->in([Date, DateTime, StrictDate]), | ^LiteralValue(value=^VariableTypeValue(value='new ISODate(\"${'+$var->toOne().name+'}\")')),
+            {|
+              fail('Type of variable \'%s: %s[%s]\' not supported'->format([$var.name, $var.type->printType(), $var.multiplicity->toOne()->printMultiplicity()]));
+              ^LiteralValue(value=^VariableTypeValue(value='${'+$var->toOne().name+'}'));
+            }
+          )
+        )
+      )
+    )
+  );
 }
 
 function meta::external::store::mongodb::functions::pureToDatabaseCommand::processValueSpecification(vs:ValueSpecification[1], databaseCommand:DatabaseCommand[1], mapping: Mapping[1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1]): MongoDBOperationElement[1]
@@ -204,7 +230,8 @@ function meta::external::store::mongodb::functions::pureToDatabaseCommand::proce
                  r:ExtendedRoutedValueSpecification[1]     | $r.value->processValueSpecification($databaseCommand, $mapping, $inScopeVars, $debug),
                  r:FunctionRoutedValueSpecification[1]     | $r.value->processValueSpecification($databaseCommand, $mapping, $inScopeVars, $debug),
                  f:FunctionExpression[1]                   | $f->processFunctionExpression($databaseCommand, $mapping, $inScopeVars, $debug),
-                 i:InstanceValue[1]                        | $i->processInstanceValue($databaseCommand, $mapping, $inScopeVars, $debug)
+                 i:InstanceValue[1]                        | $i->processInstanceValue($databaseCommand, $mapping, $inScopeVars, $debug),
+                 v:VariableExpression[1]                   | $v->processVariableExpression($databaseCommand, $mapping, $inScopeVars, $debug)
              ]);
 }
 


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Enables MongoDB plan generation/execution to work with parameters/variables
- Add VariableTypeValue to represent a variable placeholder
- Use existing FreeMarker processor to replace plan variable placeholders during execution
- Handle VariableExpressions and remove cast to InstanceValue within equals/comparison expression processors

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
