### PR TITLE
Allow negative numbers for default value

### DIFF
--- a/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainParserGrammar.g4
+++ b/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainParserGrammar.g4
@@ -92,7 +92,7 @@ aggregationType:                                AGGREGATION_TYPE_COMPOSITE | AGG
 defaultValue: EQUAL defaultValueExpression
 ;
 
-defaultValueExpression: (instanceReference)(propertyExpression) | expressionInstance | instanceLiteralToken | defaultValueExpressionsArray
+defaultValueExpression: (instanceReference)(propertyExpression) | expressionInstance | instanceLiteral | defaultValueExpressionsArray
 ;
 
 defaultValueExpressionsArray: BRACKET_OPEN ( defaultValueExpression (COMMA defaultValueExpression)* )? BRACKET_CLOSE

--- a/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/domain/DomainParseTreeWalker.java
+++ b/legend-engine-core/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/domain/DomainParseTreeWalker.java
@@ -246,9 +246,9 @@ public class DomainParseTreeWalker
         {
             result = this.newFunction(ctx.expressionInstance(), Lists.mutable.empty(), null, false, " ");
         }
-        else if (ctx.instanceLiteralToken() != null)
+        else if (ctx.instanceLiteral() != null)
         {
-            result = this.instanceLiteralToken(ctx.instanceLiteralToken(), false);
+            result = this.instanceLiteral(ctx.instanceLiteral(), "", Lists.mutable.empty(), null, " ", false, false);
         }
 
         if (ctx.propertyExpression() != null)


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed?
Allow numeric primitives properties to have a negative value.

To reproduce:
Setup:
```
curl https://legend.finos.org/omnibus/start.sh | bash
```

The following:
```
curl http://localhost:6900/engine/api/pure/v1/grammar/grammarToJson/model -X POST -H "Content-Type: text/plain" -d "Class domain::Error { description: String[1]; code: Integer[1]; }"
curl http://localhost:6900/engine/api/pure/v1/grammar/grammarToJson/model -X POST -H "Content-Type: text/plain" -d "Class domain::Error { description: String[1] = 'OK'; code: Integer[1] = 0; }"
curl http://localhost:6900/engine/api/pure/v1/grammar/grammarToJson/model -X POST -H "Content-Type: text/plain" -d "Class domain::Error { description: String[1] = 'Description'; code: Integer[1] = 1; }"
```
works fine, however
```
curl http://localhost:6900/engine/api/pure/v1/grammar/grammarToJson/model -X POST -H "Content-Type: text/plain" -d "Class domain::Error { description: String[1] = 'Unknown'; code: Integer[1] = -1; }"
```
gives error, while

```
curl http://localhost:6900/engine/api/pure/v1/grammar/grammarToJson/model -X POST -H "Content-Type: text/plain" -d "Class domain::Error { description: String[1]; code: Integer[1]; } Class domain::ErrorMessage { error: domain::Error[1] = ^domain::Error(description = 'Unknown', code = -1); }"
```
works fine.

So, as it is possible to set negative value on property in nested class, it should be also possible to set negative value on property of primitive type.

#### Other notes for reviewers:
#### Does this PR introduce a user-facing change?
Default values are not commonly used yet, but user should be able to define a default value in range supported by type.
