### PR TITLE
Engine server: switch deps to runtime scope for cli execution

### DIFF
--- a/legend-engine-config/legend-engine-server/pom.xml
+++ b/legend-engine-config/legend-engine-server/pom.xml
@@ -1024,7 +1024,7 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -1034,7 +1034,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- TEST -->


### PR DESCRIPTION
Engine server: switch deps to runtime scope for cli execution so that mvn exec:java works to launch the engine server

For example the following fails if the dependencies changed in this PR are only set to test scope

`mvn -pl legend-engine-config/legend-engine-server exec:java -Dexec.mainClass="org.finos.legend.engine.server.Server" -Dexec.args="server ${CONFIG_LOC}"`