### PR TITLE
Handle null for optional field

### DIFF
--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomArrayEmbeddedTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomArrayEmbeddedTest.java
@@ -1,0 +1,121 @@
+//  Copyright 2024 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+public class GenerateCastCustomArrayEmbeddedTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuiteFromJson("{\n" +
+                "  \"@type\": \"meta::pure::changetoken::Versions\",\n" +
+                "  \"versions\": [\n" +
+                "    {\n" +
+                "      \"@type\": \"meta::pure::changetoken::Version\",\n" +
+                "      \"version\": \"ftdm:abcdefg123\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"@type\": \"meta::pure::changetoken::Version\",\n" +
+                "      \"version\": \"ftdm:abcdefg456\",\n" +
+                "      \"prevVersion\": \"ftdm:abcdefg123\",\n" +
+                "      \"changeTokens\": [\n" +
+                "        {\n" +
+                "          \"@type\": \"meta::pure::changetoken::AddField\",\n" +
+                "          \"fieldName\": \"abc\",\n" +
+                "          \"fieldType\": \"Integer[*]\",\n" +
+                "          \"defaultValue\": {\n" +
+                "            \"@type\": \"meta::pure::changetoken::ConstValue\",\n" +
+                "            \"value\": \"[1,2,3]\"\n" +
+                "          },\n" +
+                "          \"safeCast\": true,\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        expect(upcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}"),
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": [1,2,3]\n" +
+                        "}\n");
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        expect(downcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": [1,2,3]\n" +
+                        "}", "ftdm:abcdefg123"),
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}\n");
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        exception(() -> downcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": [1,2,3]}]\n" +
+                        "  ],\n" +
+                        "  \"abc\":[5,6,7]\n" +
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:[5, 6, 7]");
+    }
+}

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNullKeywordTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNullKeywordTest.java
@@ -1,0 +1,121 @@
+//  Copyright 2024 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+public class GenerateCastCustomNullKeywordTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuiteFromJson("{\n" +
+                "  \"@type\": \"meta::pure::changetoken::Versions\",\n" +
+                "  \"versions\": [\n" +
+                "    {\n" +
+                "      \"@type\": \"meta::pure::changetoken::Version\",\n" +
+                "      \"version\": \"ftdm:abcdefg123\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"@type\": \"meta::pure::changetoken::Version\",\n" +
+                "      \"version\": \"ftdm:abcdefg456\",\n" +
+                "      \"prevVersion\": \"ftdm:abcdefg123\",\n" +
+                "      \"changeTokens\": [\n" +
+                "        {\n" +
+                "          \"@type\": \"meta::pure::changetoken::AddField\",\n" +
+                "          \"fieldName\": \"abc\",\n" +
+                "          \"fieldType\": \"Custom[0..1]\",\n" +
+                "          \"defaultValue\": {\n" +
+                "            \"@type\": \"meta::pure::changetoken::ConstValue\",\n" +
+                "            \"value\": \"null\"\n" +
+                "          },\n" +
+                "          \"safeCast\": true,\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        expect(upcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}"),
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": null\n" +
+                        "}\n");
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        expect(downcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": null\n" +
+                        "}", "ftdm:abcdefg123"),
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}\n");
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        exception(() -> downcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:2023-06-22T18:30:01Z");
+    }
+}

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNullStringTest.java
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/src/test/java/org/finos/legend/engine/changetoken/generation/GenerateCastCustomNullStringTest.java
@@ -1,0 +1,121 @@
+//  Copyright 2024 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.changetoken.generation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+public class GenerateCastCustomNullStringTest extends GenerateCastTestBase
+{
+    @BeforeClass
+    public static void setupSuite() throws IOException, ClassNotFoundException
+    {
+        setupSuiteFromJson("{\n" +
+                "  \"@type\": \"meta::pure::changetoken::Versions\",\n" +
+                "  \"versions\": [\n" +
+                "    {\n" +
+                "      \"@type\": \"meta::pure::changetoken::Version\",\n" +
+                "      \"version\": \"ftdm:abcdefg123\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"@type\": \"meta::pure::changetoken::Version\",\n" +
+                "      \"version\": \"ftdm:abcdefg456\",\n" +
+                "      \"prevVersion\": \"ftdm:abcdefg123\",\n" +
+                "      \"changeTokens\": [\n" +
+                "        {\n" +
+                "          \"@type\": \"meta::pure::changetoken::AddField\",\n" +
+                "          \"fieldName\": \"abc\",\n" +
+                "          \"fieldType\": \"Custom[0..1]\",\n" +
+                "          \"defaultValue\": {\n" +
+                "            \"@type\": \"meta::pure::changetoken::ConstValue\",\n" +
+                "            \"value\": \"\"\n" +
+                "          },\n" +
+                "          \"safeCast\": true,\n" +
+                "          \"class\": \"meta::pure::changetoken::tests::SampleClass\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n");
+    }
+
+    @Test
+    public void testUpcast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        expect(upcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}"),
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": null\n" +
+                        "}\n");
+    }
+
+    @Test
+    public void testDowncast() throws JsonProcessingException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+    {
+        expect(downcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": null\n" +
+                        "}", "ftdm:abcdefg123"),
+                "{\n" +
+                        "  \"version\":\"ftdm:abcdefg123\", \n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}, \n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\"}]\n" +
+                        "  ]\n" +
+                        "}\n");
+    }
+
+    @Test
+    public void testDowncastNonDefault() throws JsonProcessingException, NoSuchMethodException
+    {
+        exception(() -> downcast("{\n" +
+                        "  \"version\":\"ftdm:abcdefg456\",\n" +
+                        "  \"@type\": \"meta::pure::changetoken::tests::SampleClass\",\n" +
+                        "  \"innerObject\": {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "  \"innerNestedArray\":[\n" +
+                        "    {\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null},\n" +
+                        "    [{\"@type\": \"meta::pure::changetoken::tests::SampleClass\", \"abc\": null}]\n" +
+                        "  ],\n" +
+                        "  \"abc\": \"2023-06-22T18:30:01Z\"\n" +
+                        "}", "ftdm:abcdefg123"),
+                "Cannot remove non-default value:2023-06-22T18:30:01Z");
+    }
+}

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation_util.pure
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation_util.pure
@@ -23,11 +23,12 @@ function <<access.private>> meta::pure::changetoken::cast_generation::getValueAs
     let typeMultiplicity = $typeMultiplicityString->extractTypeMultiplicity();
     let type = $typeMultiplicity.first;
     let multiplicity = $typeMultiplicity.second;
+    let isOptional = if($multiplicity->getLowerBound() == 0, | true, | false);
     let isSingle = $multiplicity == PureOne || $multiplicity == PureZero || $multiplicity == ZeroOne;
     let oneValue = if ($anyValue->size() == 0, | if($isSingle, | ^JSONNull(), | ^JSONArray()), | $anyValue->toOne());
     let jsonValue = if ($oneValue->instanceOf(JSONElement), | $oneValue->cast(@JSONElement), | $oneValue->expandValue($typeKeyName));
     if($obsoleteJsonAsString,
-        | inlineJsonValueWithUnescaping($type, $isSingle, $jsonValue),
+        | inlineJsonValueWithUnescaping($type, $isOptional, $isSingle, $jsonValue),
         | inlineJsonValue($jsonValue)
     );
 }

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation_util_deprecated.pure
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/src/main/resources/core_pure_changetoken/cast_generation_util_deprecated.pure
@@ -17,14 +17,17 @@ import meta::external::language::java::metamodel::*;
 import meta::json::*;
 import meta::pure::changetoken::cast_generation::*;
 
-function <<access.private>> meta::pure::changetoken::cast_generation::inlineJsonValueWithUnescaping(type: String[1], isSingle: Boolean[1], jsonValue: JSONElement[1]): Code[1]
+function <<access.private>> meta::pure::changetoken::cast_generation::inlineJsonValueWithUnescaping(type: String[1], isOptional: Boolean[1], isSingle: Boolean[1], jsonValue: JSONElement[1]): Code[1]
 {
     let value = expandComplexString($jsonValue);
+    if($value->instanceOf(JSONNull) || $value->instanceOf(JSONString) && ($value->cast(@JSONString).value->length() == 0 || $value->cast(@JSONString).value->equalIgnoreCase('null')) && $isOptional,
+        | j_null(),
+        |
     if($type->equalIgnoreCase('Boolean') && $isSingle,
         | $value->match([b:JSONBoolean[1] | j_boolean($b.value), s:JSONString[1] | j_boolean($s.value)]),
         |
     if($type->equalIgnoreCase('Float') && $isSingle || $type->equalIgnoreCase('Double') && $isSingle,
-        | $value->match([f:JSONNumber[1] | j_double($f.value->cast(@Float)), s:JSONString[1] | j_double($s.value)]),
+        | $value->match([f:JSONNumber[1] | $f.value->match([i:Integer[1] | j_int($i), f:Float[1] | j_double($f)]), s:JSONString[1] | j_double($s.value)]),
         |
     if($type->equalIgnoreCase('Integer') && $isSingle,
         | $value->match([i:JSONNumber[1] | j_int($i.value->cast(@Integer)), s:JSONString[1] | j_int($s.value)]),
@@ -32,12 +35,13 @@ function <<access.private>> meta::pure::changetoken::cast_generation::inlineJson
     if($value->instanceOf(JSONString),
         | j_string(stripMatchingQuotes($value->match([s:JSONString[1] | $s.value]))),
         | inlineJsonValue($value);
-    ))));
+    )))));
 }
 
 function <<access.private>> meta::pure::changetoken::cast_generation::expandComplexString(value: JSONElement[1]): JSONElement[1]
 {
-    if($value->instanceOf(JSONString) && $value->cast(@JSONString).value->startsWith('{') && $value->cast(@JSONString).value->endsWith('}'),
+    if($value->instanceOf(JSONString) && (($value->cast(@JSONString).value->startsWith('{') && $value->cast(@JSONString).value->endsWith('}'))
+        || ($value->cast(@JSONString).value->startsWith('[') && $value->cast(@JSONString).value->endsWith(']'))),
         | $value->cast(@JSONString).value->parseJSON(),
         | $value
     );


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
If change-tokens customer is still using deprecated format (with JSON serialized as string) it should provide full functionality. Fix null handling, etc.

#### Other notes for reviewers:
cast_generation_util_deprecated will be removed as soon as deprecated format is not needed anymore.

#### Does this PR introduce a user-facing change?
No