### PR TITLE
Make EngineUrlStreamHandlerFactory safe wrt to changes in JDK15+

### DIFF
--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/url/EngineUrlStreamHandlerFactory.java
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/url/EngineUrlStreamHandlerFactory.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class EngineUrlStreamHandlerFactory implements URLStreamHandlerFactory
 {
@@ -60,7 +60,7 @@ public class EngineUrlStreamHandlerFactory implements URLStreamHandlerFactory
         }
     }
 
-    private final Map<String, URLStreamHandler> handlers = new TreeMap<>();
+    private final Map<String, URLStreamHandler> handlers = new ConcurrentHashMap<>();
 
     @Override
     public URLStreamHandler createURLStreamHandler(String protocol)


### PR DESCRIPTION
TreeMap implementation has been changed in Java 15 to optimize some functions. As a result running embedded service executions concurrently in the same JVM can now throw concurrent modification exceptions when running on JVM 15 onwards. 
Note that TreeMap has never been threadsafe - just that exceptions are now thrown on Java 15 onwards. 

Switching to a threadsafe map implementation to avoid exceptions being thrown for concurrent executions of the same service on the same JVM. 

References:
https://www.oracle.com/java/technologies/javase/15-relnote-issues.html
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8227666
https://hg.openjdk.org/jdk/jdk/rev/65b345254ca3

