### PR TITLE
Use native git with git-commit-id-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,7 @@
                             <includeOnlyProperty>^git.(commit.time|closest.tag.name|branch|tags)$</includeOnlyProperty>
                             <includeOnlyProperty>^git.(commit.time|branch|tags)$</includeOnlyProperty>
                         </includeOnlyProperties>
+                        <useNativeGit>true</useNativeGit>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Support development flow for using git work-tree on this project. 
We use the git-commit-id Maven plugin which by default uses jgit. When using legend-engine with git work-tree the build fails because jgit does not support git work-trees and cannot identify a commit when running. 

This fixes the project to instead use the git command line rather than jgit in this plugin. 
This will have potential impact downstream, particularly in build pipelines which will need to have git installed. 
The Github runners we use have git installed by default but other build infrastructure will have to ensure they have git installed. 
