### PR TITLE
[Legend SQL] Add ability to externalize in arrow format

### DIFF
--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/pom.xml
@@ -110,6 +110,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-shared-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <dependency>
@@ -217,6 +221,31 @@
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-extension-compiled-store-relational</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- TEST -->

--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/src/main/java/org/finos/legend/engine/external/format/json/JsonSchemaRuntimeExtension.java
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/src/main/java/org/finos/legend/engine/external/format/json/JsonSchemaRuntimeExtension.java
@@ -19,6 +19,7 @@ import org.finos.legend.engine.external.format.json.read.IJsonDeserializeExecuti
 import org.finos.legend.engine.external.format.json.read.IJsonInternalizeExecutionNodeSpecifics;
 import org.finos.legend.engine.external.format.json.write.IJsonExternalizeExecutionNodeSpecifics;
 import org.finos.legend.engine.external.format.json.write.JsonDataWriter;
+import org.finos.legend.engine.external.format.json.write.JsonTDSWriter;
 import org.finos.legend.engine.external.shared.runtime.ExternalFormatRuntimeExtension;
 import org.finos.legend.engine.external.shared.runtime.write.ExternalFormatSerializeResult;
 import org.finos.legend.engine.plan.dependencies.store.shared.IExecutionNodeContext;
@@ -31,8 +32,10 @@ import org.finos.legend.engine.plan.execution.result.ConstantResult;
 import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.plan.execution.result.object.StreamingObjectResult;
 import org.finos.legend.engine.plan.execution.stores.inMemory.plugin.StoreStreamReadingObjectsIterator;
+import org.finos.legend.engine.plan.execution.stores.relational.result.RelationalResult;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.JavaPlatformImplementation;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.externalFormat.ExternalFormatExternalizeExecutionNode;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.externalFormat.ExternalFormatExternalizeTDSExecutionNode;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.externalFormat.ExternalFormatInternalizeExecutionNode;
 import org.finos.legend.engine.shared.core.identity.Identity;
 
@@ -122,6 +125,19 @@ public class JsonSchemaRuntimeExtension implements ExternalFormatRuntimeExtensio
         catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e)
         {
             throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Result executeExternalizeTDSExecutionNode(ExternalFormatExternalizeTDSExecutionNode node, Result result, Identity identity, ExecutionState executionState)
+    {
+        if (result instanceof RelationalResult)
+        {
+            return new ExternalFormatSerializeResult(new JsonTDSWriter((RelationalResult) result), result, CONTENT_TYPE);
+        }
+        else
+        {
+            throw new RuntimeException("JSON external format only supported on relational execution");
         }
     }
 

--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/src/main/java/org/finos/legend/engine/external/format/json/write/JsonTDSWriter.java
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/src/main/java/org/finos/legend/engine/external/format/json/write/JsonTDSWriter.java
@@ -1,0 +1,37 @@
+//  Copyright 2024 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.external.format.json.write;
+
+import org.finos.legend.engine.external.shared.runtime.write.ExternalFormatWriter;
+import org.finos.legend.engine.plan.execution.stores.relational.result.RelationalResult;
+import org.finos.legend.engine.plan.execution.stores.relational.serialization.RelationalResultToJsonDefaultSerializer;
+
+import java.io.OutputStream;
+
+public class JsonTDSWriter extends ExternalFormatWriter
+{
+    private final RelationalResultToJsonDefaultSerializer serializer;
+
+    public JsonTDSWriter(RelationalResult result)
+    {
+        this.serializer = new RelationalResultToJsonDefaultSerializer(result);
+    }
+
+    @Override
+    public void writeData(OutputStream outputStream)
+    {
+        this.serializer.stream(outputStream);
+    }
+}

--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/java/org/finos/legend/engine/external/format/json/JsonSchemaRuntimeExtensionTest.java
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/java/org/finos/legend/engine/external/format/json/JsonSchemaRuntimeExtensionTest.java
@@ -1,0 +1,135 @@
+//  Copyright 2024 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.external.format.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.javacrumbs.jsonunit.JsonAssert;
+import net.javacrumbs.jsonunit.core.Configuration;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.finos.legend.engine.external.shared.runtime.test.TestExternalFormatQueries;
+import org.finos.legend.engine.external.shared.runtime.write.ExternalFormatSerializeResult;
+import org.finos.legend.engine.language.pure.compiler.Compiler;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
+import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
+import org.finos.legend.engine.plan.execution.stores.relational.activity.RelationalExecutionActivity;
+import org.finos.legend.engine.plan.execution.stores.relational.result.RelationalResult;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.RelationalExecutionNode;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes.externalFormat.ExternalFormatExternalizeTDSExecutionNode;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.result.TDSColumn;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.result.TDSResultType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseConnection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.result.SQLResultColumn;
+import org.finos.legend.engine.shared.core.api.request.RequestContext;
+import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
+import org.finos.legend.engine.shared.core.identity.factory.IdentityFactoryProvider;
+import org.finos.legend.pure.generated.core_relational_relational_extensions_extension;
+import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import static org.finos.legend.pure.generated.core_relational_java_platform_binding_legendJavaPlatformBinding_relationalLegendJavaPlatformBindingExtension.Root_meta_relational_executionPlan_platformBinding_legendJava_relationalExtensionJavaPlatformBinding__Extension_1_;
+import static org.mockito.ArgumentMatchers.any;
+
+public class JsonSchemaRuntimeExtensionTest extends TestExternalFormatQueries
+{
+    private PureModelContextData modelData;
+
+    @Before
+    public void setUp()
+    {
+        String pureCode = resourceAsString("tdsTest/proj-1.pure");
+        this.modelData = PureGrammarParser.newInstance().parseModel(pureCode);
+        ExecutionSupport executionSupport = Compiler.compile(modelData, DeploymentMode.TEST, IdentityFactoryProvider.getInstance().getAnonymousIdentity().getName()).getExecutionSupport();
+        formatExtensions = FastList.newListWith(
+                Root_meta_relational_executionPlan_platformBinding_legendJava_relationalExtensionJavaPlatformBinding__Extension_1_(executionSupport),
+                core_relational_relational_extensions_extension.Root_meta_relational_extension_relationalExtension__Extension_1_(executionSupport)
+        );
+    }
+
+    @Test
+    public void testExternalize()
+    {
+        String actualResult = runTest(this.modelData,
+                "|demo::employee.all()" +
+                        "->project([x|$x.id, x|$x.startDate, x|$x.name],['id', 'startDate', 'name'])" +
+                        "->externalize('application/json')" +
+                        "->from(demo::DemoRelationalMapping, demo::H2DemoRuntime)");
+        String expected = resourceAsString("tdsTest/testExternalizeExpected.json");
+
+        Configuration configuration = JsonAssert.whenIgnoringPaths("activities[0].comment"); // ignore comments such as executionTraceID
+        JsonAssert.assertJsonEquals(expected, actualResult, configuration);
+
+    }
+
+    @Test
+    public void executeExternalizeTDSExecutionNodeTest() throws Exception
+    {
+        JsonSchemaRuntimeExtension extension = new JsonSchemaRuntimeExtension();
+        ExternalFormatExternalizeTDSExecutionNode node = new ExternalFormatExternalizeTDSExecutionNode();
+        //create a real result from H2
+        RelationalExecutionNode mockExecutionNode = Mockito.mock(RelationalExecutionNode.class);
+        DatabaseConnection mockDatabaseConnection = Mockito.mock(DatabaseConnection.class);
+
+        mockExecutionNode.connection = mockDatabaseConnection;
+        TDSResultType resultType = new TDSResultType();
+        resultType.tdsColumns = FastList.newListWith(
+                new TDSColumn("testInt", "Integer"),
+                new TDSColumn("testStringR", "String"),
+                new TDSColumn("testString", "String"),
+                new TDSColumn("testDate", "DateTime"),
+                new TDSColumn("testBool", "Boolean")
+        );
+
+        mockExecutionNode.resultType = resultType;
+        Mockito.when(mockDatabaseConnection.accept(any())).thenReturn(false);
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:~/test;TIME ZONE=America/New_York", "sa", ""); ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+        {
+            //setup table
+            conn.createStatement().execute("DROP TABLE IF EXISTS testtable");
+            conn.createStatement().execute("DROP TABLE IF EXISTS testtableJoin");
+
+            conn.createStatement().execute("Create Table testtable (testInt INTEGER, testString VARCHAR(255), testDate TIMESTAMP, testBool BOOLEAN)");
+            conn.createStatement().execute("Create Table testtableJoin (testIntR INTEGER, testStringR VARCHAR(255)  PRIMARY KEY )");
+
+            conn.createStatement().execute("INSERT INTO  testtable (testInt, testString, testDate, testBool) VALUES(1,'A', '2020-01-01 00:00:00-05:00',true),( 2,null, '2020-01-01 00:00:00-02:00',false ),( 3,'B', '2020-01-01 00:00:00-05:00',false )");
+            conn.createStatement().execute("INSERT INTO  testtableJoin (testIntR, testStringR) VALUES(6,'A'), (1,'B')");
+
+            RelationalResult relationalResult = new RelationalResult(FastList.newListWith(
+                    new RelationalExecutionActivity("SELECT testInt, testStringR, testString, testDate, testBool FROM testtable left join  testtableJoin on testtable.testInt=testtableJoin.testIntR", null)),
+                    mockExecutionNode,
+                    FastList.newListWith(
+                            new SQLResultColumn("testInt", "INTEGER"),
+                            new SQLResultColumn("testStringR", "VARCHAR"),
+                            new SQLResultColumn("testString", "VARCHAR"),
+                            new SQLResultColumn("testDate", "TIMESTAMP"),
+                            new SQLResultColumn("testBool", "BOOLEAN")
+                    ), null, "America/New_York", conn,
+                    IdentityFactoryProvider.getInstance().getAnonymousIdentity(), null, null, new RequestContext());
+
+            ExternalFormatSerializeResult serializeResult = (ExternalFormatSerializeResult) extension.executeExternalizeTDSExecutionNode(node, relationalResult, IdentityFactoryProvider.getInstance().getAnonymousIdentity(), null);
+
+            serializeResult.stream(outputStream, SerializationFormat.DEFAULT);
+
+            String expected = resourceAsString("tdsTest/executeExternalizeTDSExecutionNodeTestExpected.json");
+            JsonAssert.assertJsonEquals(expected, new ObjectMapper().readValue(new ByteArrayInputStream(outputStream.toByteArray()), Object.class));
+        }
+    }
+}

--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/resources/tdsTest/executeExternalizeTDSExecutionNodeTestExpected.json
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/resources/tdsTest/executeExternalizeTDSExecutionNodeTestExpected.json
@@ -1,0 +1,71 @@
+{
+  "builder": {
+    "_type": "tdsBuilder",
+    "columns": [
+      {
+        "name": "testInt",
+        "type": "Integer"
+      },
+      {
+        "name": "testStringR",
+        "type": "String"
+      },
+      {
+        "name": "testString",
+        "type": "String"
+      },
+      {
+        "name": "testDate",
+        "type": "DateTime"
+      },
+      {
+        "name": "testBool",
+        "type": "Boolean"
+      }
+    ]
+  },
+  "activities": [
+    {
+      "_type": "relational",
+      "sql": "SELECT testInt, testStringR, testString, testDate, testBool FROM testtable left join  testtableJoin on testtable.testInt=testtableJoin.testIntR"
+    }
+  ],
+  "result": {
+    "columns": [
+      "testInt",
+      "testStringR",
+      "testString",
+      "testDate",
+      "testBool"
+    ],
+    "rows": [
+      {
+        "values": [
+          1,
+          "B",
+          "A",
+          "2020-01-01T05:00:00.000000000+0000",
+          true
+        ]
+      },
+      {
+        "values": [
+          2,
+          null,
+          null,
+          "2020-01-01T02:00:00.000000000+0000",
+          false
+        ]
+      },
+      {
+        "values": [
+          3,
+          null,
+          "B",
+          "2020-01-01T05:00:00.000000000+0000",
+          false
+        ]
+      }
+    ]
+  }
+}

--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/resources/tdsTest/proj-1.pure
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/resources/tdsTest/proj-1.pure
@@ -1,0 +1,114 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::H2DemoDataBase
+(
+  Table FirmTable
+  (
+    id INTEGER PRIMARY KEY,
+    legal_name VARCHAR(200)
+  )
+  Table EmployeeTable
+  (
+    id INTEGER PRIMARY KEY,
+    firm_id INTEGER,
+    name VARCHAR(200),
+    country_id INTEGER,
+    type VARCHAR(25),
+    start_date DATE
+  )
+  Table CountryTable
+  (
+    id INTEGER PRIMARY KEY,
+    country_name VARCHAR(200)
+  )
+
+  Join FirmEmployee(EmployeeTable.firm_id = FirmTable.id)
+  Join EmployeeCountry(EmployeeTable.country_id = CountryTable.id)
+)
+
+
+
+###Pure
+Enum demo::employeeType
+{
+  Type1,
+  Type2
+}
+
+Class demo::employee
+{
+  id: Integer[1];
+  name: String[1];
+  type: demo::employeeType[1];
+  startDate: Date[1];
+  derivedName() {$this.name+'_derived'} : String[1];
+}
+
+
+###Mapping
+Mapping demo::DemoRelationalMapping
+(
+  *demo::employee: Relational
+  {
+    ~primaryKey
+    (
+      [demo::H2DemoDataBase]EmployeeTable.id
+    )
+    ~mainTable [demo::H2DemoDataBase]EmployeeTable
+    id: [demo::H2DemoDataBase]EmployeeTable.id,
+    name: [demo::H2DemoDataBase]EmployeeTable.name,
+    type: EnumerationMapping EmployeeType: [demo::H2DemoDataBase]EmployeeTable.type,
+    startDate: [demo::H2DemoDataBase]EmployeeTable.start_date
+  }
+
+   demo::employeeType : EnumerationMapping EmployeeType
+   {
+       Type1: 'Type1',
+       Type2: 'Type2'
+   }
+)
+
+
+###Connection
+RelationalDatabaseConnection demo::H2DemoConnection
+{
+  store: demo::H2DemoDataBase;
+  type: H2;
+  specification: LocalH2
+  {
+    testDataSetupSqls: [
+      'Drop table if exists EmployeeTable;\nCreate Table EmployeeTable(id INTEGER PRIMARY KEY,firm_id INTEGER,name VARCHAR(200),country_id INTEGER, type VARCHAR(25), start_date DATE);\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (101,202, \'Alice\', 303, \'Type1\', \'2023-08-24\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (102,203, \'Bob\', 304, \'Type2\', \'2022-08-24\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (103,204, \'Curtis\', 305, \'Type2\', \'2022-07-24\');\nInsert into EmployeeTable (id, firm_id, name, country_id, type, start_date) values (104,205, \'Danielle\', 306, \'Type1\', \'2022-07-23\');\n'
+      ];
+  };
+  auth: DefaultH2;
+}
+
+
+###Runtime
+Runtime demo::H2DemoRuntime
+{
+  mappings:
+  [
+    demo::DemoRelationalMapping
+  ];
+  connections:
+  [
+    demo::H2DemoDataBase:
+    [
+      connection_1: demo::H2DemoConnection
+    ]
+  ];
+}

--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/resources/tdsTest/testExternalizeExpected.json
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/src/test/resources/tdsTest/testExternalizeExpected.json
@@ -1,0 +1,66 @@
+{
+  "builder": {
+    "_type": "tdsBuilder",
+    "columns": [
+      {
+        "name": "id",
+        "type": "Integer",
+        "relationalType": "INTEGER"
+      },
+      {
+        "name": "startDate",
+        "type": "Date",
+        "relationalType": "DATE"
+      },
+      {
+        "name": "name",
+        "type": "String",
+        "relationalType": "VARCHAR(200)"
+      }
+    ]
+  },
+  "activities": [
+    {
+      "_type": "relational",
+      "comment": "-- \"executionTraceID\" : \"e27392e9-8ec0-4024-bbc0-bf71297a5676\"",
+      "sql": "select \"root\".id as \"id\", \"root\".start_date as \"startDate\", \"root\".name as \"name\" from EmployeeTable as \"root\""
+    }
+  ],
+  "result": {
+    "columns": [
+      "id",
+      "startDate",
+      "name"
+    ],
+    "rows": [
+      {
+        "values": [
+          101,
+          "2023-08-24",
+          "Alice"
+        ]
+      },
+      {
+        "values": [
+          102,
+          "2022-08-24",
+          "Bob"
+        ]
+      },
+      {
+        "values": [
+          103,
+          "2022-07-24",
+          "Curtis"
+        ]
+      },
+      {
+        "values": [
+          104,
+          "2022-07-23",
+          "Danielle"
+        ]
+      }
+    ]
+  }
+}

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -211,7 +211,7 @@ function meta::external::query::sql::transformation::queryToPure::processRootQue
   )->cast(@PositionalParameterExpression);
 
   trace({|
-    let processed = externalizeToArrow(wrapWithFrom($query->processQuery($context)));
+    let processed = externalize(wrapWithFrom($query->processQuery($context)));
     let variables = $processed.lambda->extractPositionals($positionals.index->map(i | positionalName($i)));
 
     ^$processed(positionals = $processed.positionals->concatenate($variables)->removeDuplicatesBy(v | $v.name));
@@ -1281,15 +1281,14 @@ let executionContext = if ($source.executionOptions->isNotEmpty(),
   );
 }
 
-function <<access.private>> meta::external::query::sql::transformation::queryToPure::externalizeToArrow(context:SqlTransformContext[1]):SqlTransformContext[1]
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::externalize(context:SqlTransformContext[1]):SqlTransformContext[1]
 {
-  if ($context.externalizeToArrow, | externalizeToArrow($context.expression->toOne(), $context), | $context);
+  if ($context.externalizeContentType->isEmpty(), | $context, | externalize($context.expression->toOne(), $context));
 }
 
-function <<access.private>> meta::external::query::sql::transformation::queryToPure::externalizeToArrow(expression:FunctionExpression[1], context:SqlTransformContext[1]):SqlTransformContext[1]
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::externalize(expression:FunctionExpression[1], context:SqlTransformContext[1]):SqlTransformContext[1]
 {
-  let format = 'application/x.arrow';
-  let newExp = appendTdsFunc($context.expression->toOne(), externalize_TabularDataSet_1__String_1__String_1_, list($format));
+  let newExp = appendTdsFunc($context.expression->toOne(), externalize_TabularDataSet_1__String_1__String_1_, list($context.externalizeContentType->toOne()));
   ^$context(expression = $newExp);
 }
 
@@ -3313,13 +3312,13 @@ function meta::external::query::sql::transformation::queryToPure::rootContext(so
 function meta::external::query::sql::transformation::queryToPure::context(id:Integer[1], root:Boolean[1], sources: SQLSource[*],
   extensions: meta::pure::extension::Extension[*], scopeWithFrom:Boolean[0..1], debug:DebugContext[1]):SqlTransformContext[1]
 {
-  context($id, $root, $sources, $extensions, $scopeWithFrom, $debug, false);
+  context($id, $root, $sources, $extensions, $scopeWithFrom, $debug, []);
 }
 
 function meta::external::query::sql::transformation::queryToPure::context(id:Integer[1], root:Boolean[1], sources: SQLSource[*],
-  extensions: meta::pure::extension::Extension[*], scopeWithFrom:Boolean[0..1], debug:DebugContext[1], externalizeToArrow: Boolean[1]):SqlTransformContext[1]
+  extensions: meta::pure::extension::Extension[*], scopeWithFrom:Boolean[0..1], debug:DebugContext[1], externalizeContentType: String[0..1]):SqlTransformContext[1]
 {
-  ^SqlTransformContext(id = $id, root = $root, sources = $sources, extensions = $extensions, scopeWithFrom = $scopeWithFrom, debug = $debug, externalizeToArrow = $externalizeToArrow);
+  ^SqlTransformContext(id = $id, root = $root, sources = $sources, extensions = $extensions, scopeWithFrom = $scopeWithFrom, debug = $debug, externalizeContentType = $externalizeContentType);
 }
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::positionalName(i:Integer[1]):String[1]
@@ -3342,7 +3341,7 @@ Class meta::external::query::sql::transformation::queryToPure::SqlTransformConte
   aliases:SQLColumnAlias[*];
   name: String[0..1];
   scopeWithFrom: Boolean[0..1];
-  externalizeToArrow: Boolean[1];
+  externalizeContentType: String[0..1];
   debug: DebugContext[1];
 
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -20,6 +20,7 @@ import meta::legend::service::metamodel::*;
 import meta::pure::executionPlan::*;
 import meta::external::query::sql::transformation::utils::*;
 import meta::external::query::sql::transformation::compile::utils::*;
+import meta::external::format::shared::functions::*;
 
 
 Class meta::external::query::sql::transformation::queryToPure::SQLSourceArgument
@@ -210,7 +211,7 @@ function meta::external::query::sql::transformation::queryToPure::processRootQue
   )->cast(@PositionalParameterExpression);
 
   trace({|
-    let processed = wrapWithFrom($query->cast(@Query)->processQuery($context));
+    let processed = externalizeToArrow(wrapWithFrom($query->processQuery($context)));
     let variables = $processed.lambda->extractPositionals($positionals.index->map(i | positionalName($i)));
 
     ^$processed(positionals = $processed.positionals->concatenate($variables)->removeDuplicatesBy(v | $v.name));
@@ -1280,7 +1281,17 @@ let executionContext = if ($source.executionOptions->isNotEmpty(),
   );
 }
 
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::externalizeToArrow(context:SqlTransformContext[1]):SqlTransformContext[1]
+{
+  if ($context.externalizeToArrow, | externalizeToArrow($context.expression->toOne(), $context), | $context);
+}
 
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::externalizeToArrow(expression:FunctionExpression[1], context:SqlTransformContext[1]):SqlTransformContext[1]
+{
+  let format = 'application/x.arrow';
+  let newExp = appendTdsFunc($context.expression->toOne(), externalize_TabularDataSet_1__String_1__String_1_, list($format));
+  ^$context(expression = $newExp);
+}
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processSelectItems(selectItems: SelectItem[*], context: SqlTransformContext[1], useContextForNameResolve:Boolean[1]): Pair<LambdaFunction<Any>, String>[*]
 {
@@ -3302,7 +3313,13 @@ function meta::external::query::sql::transformation::queryToPure::rootContext(so
 function meta::external::query::sql::transformation::queryToPure::context(id:Integer[1], root:Boolean[1], sources: SQLSource[*],
   extensions: meta::pure::extension::Extension[*], scopeWithFrom:Boolean[0..1], debug:DebugContext[1]):SqlTransformContext[1]
 {
-  ^SqlTransformContext(id = $id, root = $root, sources = $sources, extensions = $extensions, scopeWithFrom = $scopeWithFrom, debug = $debug);
+  context($id, $root, $sources, $extensions, $scopeWithFrom, $debug, false);
+}
+
+function meta::external::query::sql::transformation::queryToPure::context(id:Integer[1], root:Boolean[1], sources: SQLSource[*],
+  extensions: meta::pure::extension::Extension[*], scopeWithFrom:Boolean[0..1], debug:DebugContext[1], externalizeToArrow: Boolean[1]):SqlTransformContext[1]
+{
+  ^SqlTransformContext(id = $id, root = $root, sources = $sources, extensions = $extensions, scopeWithFrom = $scopeWithFrom, debug = $debug, externalizeToArrow = $externalizeToArrow);
 }
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::positionalName(i:Integer[1]):String[1]
@@ -3325,7 +3342,9 @@ Class meta::external::query::sql::transformation::queryToPure::SqlTransformConte
   aliases:SQLColumnAlias[*];
   name: String[0..1];
   scopeWithFrom: Boolean[0..1];
+  externalizeToArrow: Boolean[1];
   debug: DebugContext[1];
+
 
   //failOnUnknown is only set to false when trying to calculate type
   positional(p:PositionalParameterExpression[1], type:Type[0..1], failOnUnknown:Boolean[1]){

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -2440,7 +2440,7 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
         [ 'Boolean', 'Integer', 'Float', 'Decimal', 'StrictDate', 'DateTime', 'String' ])
       ->restrict(['Boolean', 'Integer'])
       ->externalize('application/x.arrow')
-      }, testSources(), false, true, true, true)
+      }, testSources(), false, true, true, 'application/x.arrow')
 }
 
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -25,6 +25,7 @@ import meta::pure::functions::meta::*;
 import meta::pure::mapping::*;
 import meta::pure::metamodel::serialization::grammar::*;
 import meta::external::query::sql::transformation::compile::utils::*;
+import meta::external::format::shared::functions::*;
 
 //SELECT
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testSelectStar():Boolean[1]
@@ -2427,6 +2428,19 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
         ->filter(row:TDSRow[1] | $row.getInteger('Integer') == $_1 && $row.getString('String') == $_2)
       }
   )
+}
+
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testExternalize():Boolean[1]
+{
+  test(
+    'SELECT Boolean, Integer FROM service."/service/service1"',
+
+    {| FlatInput.all()->project(
+        [ x | $x.booleanIn, x | $x.integerIn, x | $x.floatIn, x | $x.decimalIn, x | $x.strictDateIn, x | $x.dateTimeIn, x | $x.stringIn ],
+        [ 'Boolean', 'Integer', 'Float', 'Decimal', 'StrictDate', 'DateTime', 'String' ])
+      ->restrict(['Boolean', 'Integer'])
+      ->externalize('application/x.arrow')
+      }, testSources(), false, true, true, true)
 }
 
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testUtils.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testUtils.pure
@@ -29,13 +29,13 @@ function meta::external::query::sql::transformation::queryToPure::tests::test(sq
 
 function meta::external::query::sql::transformation::queryToPure::tests::test(sqls:String[*], expected:FunctionDefinition<Any>[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], assertLambda:Boolean[1], assertJSON:Boolean[1]):Boolean[1]
 {
-  test($sqls, $expected, $sources, $scopeWithFrom, $assertLambda, $assertJSON, false);
+  test($sqls, $expected, $sources, $scopeWithFrom, $assertLambda, $assertJSON, []);
 }
 
-function meta::external::query::sql::transformation::queryToPure::tests::test(sqls:String[*], expected:FunctionDefinition<Any>[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], assertLambda:Boolean[1], assertJSON:Boolean[1], externalizeToArrow:Boolean[1]):Boolean[1]
+function meta::external::query::sql::transformation::queryToPure::tests::test(sqls:String[*], expected:FunctionDefinition<Any>[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], assertLambda:Boolean[1], assertJSON:Boolean[1], externalizeContentType: String[0..1]):Boolean[1]
 {
   $sqls->forAll(sql |
-    let sqlTransformContext = $sql->processQuery($sources, $scopeWithFrom, $externalizeToArrow);
+    let sqlTransformContext = $sql->processQuery($sources, $scopeWithFrom, $externalizeContentType);
     let actual = $sqlTransformContext.lambda();
 
     if ($assertLambda, | assertLambdaEquals($expected, $actual), | true);
@@ -60,15 +60,15 @@ function meta::external::query::sql::transformation::queryToPure::tests::process
 
 function meta::external::query::sql::transformation::queryToPure::tests::processQuery(sql: String[1], sources:SQLSource[*], scopeWithFrom:Boolean[1]): SqlTransformContext[1]
 {
-  processQuery($sql, $sources, $scopeWithFrom, false);
+  processQuery($sql, $sources, $scopeWithFrom, []);
 }
 
-function meta::external::query::sql::transformation::queryToPure::tests::processQuery(sql: String[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], externalizeToArrow:Boolean[1]): SqlTransformContext[1]
+function meta::external::query::sql::transformation::queryToPure::tests::processQuery(sql: String[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], externalizeContentType: String[0..1]): SqlTransformContext[1]
 {
   let query = meta::legend::compileVS('#SQL{' + $sql + '}#')->cast(@Query);
 
   let extensions = relationalExtensions();
   let context = rootContext($sources, $extensions);
 
-  $query->processRootQuery(^$context(scopeWithFrom = $scopeWithFrom, externalizeToArrow = $externalizeToArrow));
+  $query->processRootQuery(^$context(scopeWithFrom = $scopeWithFrom, externalizeContentType = $externalizeContentType));
 }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testUtils.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testUtils.pure
@@ -29,8 +29,13 @@ function meta::external::query::sql::transformation::queryToPure::tests::test(sq
 
 function meta::external::query::sql::transformation::queryToPure::tests::test(sqls:String[*], expected:FunctionDefinition<Any>[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], assertLambda:Boolean[1], assertJSON:Boolean[1]):Boolean[1]
 {
+  test($sqls, $expected, $sources, $scopeWithFrom, $assertLambda, $assertJSON, false);
+}
+
+function meta::external::query::sql::transformation::queryToPure::tests::test(sqls:String[*], expected:FunctionDefinition<Any>[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], assertLambda:Boolean[1], assertJSON:Boolean[1], externalizeToArrow:Boolean[1]):Boolean[1]
+{
   $sqls->forAll(sql |
-    let sqlTransformContext = $sql->processQuery($sources, $scopeWithFrom);
+    let sqlTransformContext = $sql->processQuery($sources, $scopeWithFrom, $externalizeToArrow);
     let actual = $sqlTransformContext.lambda();
 
     if ($assertLambda, | assertLambdaEquals($expected, $actual), | true);
@@ -55,10 +60,15 @@ function meta::external::query::sql::transformation::queryToPure::tests::process
 
 function meta::external::query::sql::transformation::queryToPure::tests::processQuery(sql: String[1], sources:SQLSource[*], scopeWithFrom:Boolean[1]): SqlTransformContext[1]
 {
+  processQuery($sql, $sources, $scopeWithFrom, false);
+}
+
+function meta::external::query::sql::transformation::queryToPure::tests::processQuery(sql: String[1], sources:SQLSource[*], scopeWithFrom:Boolean[1], externalizeToArrow:Boolean[1]): SqlTransformContext[1]
+{
   let query = meta::legend::compileVS('#SQL{' + $sql + '}#')->cast(@Query);
 
   let extensions = relationalExtensions();
   let context = rootContext($sources, $extensions);
 
-  $query->processRootQuery(^$context(scopeWithFrom = $scopeWithFrom));
+  $query->processRootQuery(^$context(scopeWithFrom = $scopeWithFrom, externalizeToArrow = $externalizeToArrow));
 }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-query/src/main/java/org/finos/legend/engine/query/sql/api/execute/SqlExecute.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-query/src/main/java/org/finos/legend/engine/query/sql/api/execute/SqlExecute.java
@@ -57,6 +57,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
+import java.util.Optional;
 
 import static org.finos.legend.engine.plan.execution.api.result.ResultManager.manageResult;
 
@@ -89,9 +90,10 @@ public class SqlExecute
     @Deprecated
     @Consumes({MediaType.TEXT_PLAIN})
     public Response executeSql(@Context HttpServletRequest request, String sql, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat")SerializationFormat format,
+                               @QueryParam("externalizeContentType") Optional<String> contentType,
                                @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @Context UriInfo uriInfo)
     {
-        return execute(request, new SQLQueryInput(null, sql, null), format, pm, uriInfo);
+        return execute(request, new SQLQueryInput(null, sql, null), format, contentType, pm, uriInfo);
     }
 
     @POST
@@ -100,9 +102,10 @@ public class SqlExecute
     @Deprecated
     @Consumes({MediaType.APPLICATION_JSON})
     public Response executeSql(@Context HttpServletRequest request, Query query, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat") SerializationFormat format,
+                               @QueryParam("externalizeContentType") Optional<String> contentType,
                                @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @Context UriInfo uriInfo)
     {
-        return execute(request, new SQLQueryInput(query, null, null), format, pm, uriInfo);
+        return execute(request, new SQLQueryInput(query, null, null), format, contentType, pm, uriInfo);
     }
 
     @POST
@@ -110,6 +113,7 @@ public class SqlExecute
     @Path("execute")
     @Consumes({MediaType.APPLICATION_JSON})
     public Response execute(@Context HttpServletRequest request, SQLQueryInput query, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat") SerializationFormat format,
+                            @QueryParam("externalizeContentType") Optional<String> contentType,
                             @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @Context UriInfo uriInfo)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
@@ -117,7 +121,7 @@ public class SqlExecute
         Query q = extractQuery(query);
         SQLContext context = new SQLContext(q, query.getPositionalArguments());
 
-        Result result = this.executor.execute(q, query.getPositionalArguments(), request.getRemoteUser(), context, identity);
+        Result result = this.executor.execute(q, query.getPositionalArguments(), request.getRemoteUser(), context, identity, contentType);
 
         try (Scope ignored = GlobalTracer.get().buildSpan("Manage Results").startActive(true))
         {
@@ -130,9 +134,10 @@ public class SqlExecute
     @Path("execute")
     @Consumes({MediaType.TEXT_PLAIN})
     public Response execute(@Context HttpServletRequest request, String sql, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat") SerializationFormat format,
+                            @QueryParam("externalizeContentType") Optional<String> contentType,
                             @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @Context UriInfo uriInfo)
     {
-        return execute(request, new SQLQueryInput(null, sql, null), format, pm, uriInfo);
+        return execute(request, new SQLQueryInput(null, sql, null), format, contentType, pm, uriInfo);
     }
 
     @POST


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Allow Alloy SQL clients to request data externalized to arrow format.

This allows users to use a memory efficient serialization format than JSON.
<!--
Describe change being introduced by this PR.
-->

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
