### PR TITLE
Remove overrideFlag from freemarker processing 

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/freemarker/FreeMarkerExecutor.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/nodes/helpers/freemarker/FreeMarkerExecutor.java
@@ -126,15 +126,7 @@ public class FreeMarkerExecutor
 
     public static String processRecursively(String input, Map<String, ?> variableMap, String templateFunctions)
     {
-        boolean overrideTemplateModelFlag = Boolean.valueOf(System.getProperty(overridePropertyForTemplateModel));
-        if (!overrideTemplateModelFlag)
-        {
-            return process(input, new TemplateHashModelOverride(variableMap, templateFunctions), templateFunctions);
-        }
-        else
-        {
-            return recur(input, variableMap, templateFunctions);
-        }
+        return process(input, new TemplateHashModelOverride(variableMap, templateFunctions), templateFunctions);   
     }
 
     private static String recur(String input, Map<String,?> variableMap, String templateFunctions)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/nodes/helpers/freemarker/TestFreeMarkerExecutor.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/test/java/org/finos/legend/engine/plan/execution/nodes/helpers/freemarker/TestFreeMarkerExecutor.java
@@ -117,9 +117,6 @@ public class TestFreeMarkerExecutor
         rootMap.put("C3", "${C4}");
         rootMap.put("C4", "C4");
         rootMap.put("D", "abcd<@efg");
-        //should fail in the old flow (since old flow processes placeholder with specialcharacter value twice, causing it to fail
-        Assert.assertThrows(RuntimeException.class, () -> processRecursivelyWithFlagSwitching(sql, rootMap, "", "this is A1 and B2 and C4 placeholders and abcd<@efg with special characters."));
-        System.clearProperty(overridePropertyForTemplateModel);
         //processing should pass with new flow since it allows placeholder to process only once and avoid this issue.
         Assert.assertEquals("this is A1 and B2 and C4 placeholders and abcd<@efg with special characters.", processRecursively(sql, rootMap, ""));
     }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/full/functions/in/TestPlanExecutionForIn.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/full/functions/in/TestPlanExecutionForIn.java
@@ -277,12 +277,6 @@ public class TestPlanExecutionForIn extends AlloyTestServer
         //executePlan with freemarker placeholders in sql Query
         String expectedResult = "{\"builder\":{\"_type\":\"tdsBuilder\",\"columns\":[{\"name\":\"fullName\",\"type\":\"String\",\"relationalType\":\"VARCHAR(100)\"}]},\"activities\":[{\"_type\":\"relational\",\"sql\":\"select \\\"root\\\".fullName as \\\"fullName\\\" from PERSON as \\\"root\\\" where ((\\\"root\\\".fullName in ('user1','user2','user3') and \\\"root\\\".firmName = 'abcd<@efg') and (\\\"root\\\".birthTime is null))\"}],\"result\":{\"columns\":[\"fullName\"],\"rows\":[]}}";
         Assert.assertEquals(expectedResult, RelationalResultToJsonDefaultSerializer.removeComment(executePlan(plan, queryParameters)));
-
-        //check if old flow works as expected
-        System.setProperty(overridePropertyForTemplateModel, "true");
-        //in old flow, processing "<@" would fail ideally (this was our status quo)
-        Assert.assertThrows(RuntimeException.class, () -> RelationalResultToJsonDefaultSerializer.removeComment(executePlan(plan, queryParameters)));
-        System.clearProperty(overridePropertyForTemplateModel);
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> Earlier, we had a flag that we could set to true and rollback to old code flow if anything broke with the new flow. Now we are removing this flag and keeping 1 flow after a week in 4.40.0 release 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2564 

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> No
