### PR TITLE
Make all identifiers for enumSourceValue in EnumMappings as single-quoted References

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerUtility.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerUtility.java
@@ -150,7 +150,7 @@ public class PureGrammarComposerUtility
         }
         else
         {
-            return UNQUOTED_IDENTIFIER_PATTERN.matcher(val).matches() ? val : convertString(val, true, doubleQuotes);
+            return convertString(val, true, doubleQuotes);
         }
     }
 


### PR DESCRIPTION
For Enum Mappings, if a user passes enum references as a source value using form Mode like this: 
![image](https://github.com/finos/legend-engine/assets/61725373/b057e104-aa59-4888-a966-c9106c2862cb)
it converts to text mode like this: 
![image](https://github.com/finos/legend-engine/assets/61725373/a761015c-b970-4267-ac21-8c1d207ba386)
And this fails compiling because the latter is unable to parse properly with the existing antlr rules. 

So now, we will make it so we single-quote each identifier in a enum reference, like this: 
![image](https://github.com/finos/legend-engine/assets/61725373/351bf63a-095d-4347-8aef-e2a71d5c0e84)
This compiles properly and fixes the roundtrip issue. 
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
--> Bug fix for studio 

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
--> Described above.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
--> No. 
