### PR TITLE
Java Generation: Generate classes for concrete function parameters 

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/simpleObject.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/simpleObject.pure
@@ -1354,3 +1354,66 @@ Mapping meta::pure::mapping::modelToModel::test::alloy::M
 
 
 )
+
+
+###Pure
+import meta::pure::executionPlan::profiles::*;
+
+Class meta::pure::mapping::modelToModel::test::shared::source::A
+{
+  id : String[1];
+  b : meta::pure::mapping::modelToModel::test::shared::source::B[*];
+}
+
+Class meta::pure::mapping::modelToModel::test::shared::source::B
+{
+  i : Integer[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::shared::dest::Target
+{
+  id : String[1];
+  i : Integer[*];
+}
+
+// Package named so that scanProperties will work
+function meta::pure::mapping::modelToModel::test::alloy::f(a : meta::pure::mapping::modelToModel::test::shared::source::A[1], b : meta::pure::mapping::modelToModel::test::shared::source::B[*]) : String[1]
+{
+  if($a.id != '' && $b->isNotEmpty(), | 'N/A', | 'A/N');
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> { serverVersion.start='v1_19_0' } meta::pure::mapping::modelToModel::test::alloy::simple::testConcreteFunctionCallWithNoPropertyAccess() : Boolean[1]
+{
+  let tree = #{meta::pure::mapping::modelToModel::test::shared::dest::Target { id, i}}#;
+  let query = {| meta::pure::mapping::modelToModel::test::shared::dest::Target.all()->meta::pure::graphFetch::execution::graphFetch($tree)->meta::pure::graphFetch::execution::serialize($tree)};
+  let mapping = meta::pure::mapping::modelToModel::test::shared::dest::MappingWithNoPropertyAccessOnClass;
+  let runtime = ^meta::core::runtime::Runtime(
+    connectionStores = [
+      ^meta::core::runtime::ConnectionStore(
+        element=^meta::external::store::model::ModelStore(),
+        connection = ^meta::external::store::model::JsonModelConnection(
+          class=meta::pure::mapping::modelToModel::test::shared::source::A,
+          url='data:application/json,{"id":"hello", "i" : []}'
+        )
+      )
+    ]
+  );
+
+  let result = execute($query, $mapping, $runtime, meta::pure::extension::defaultExtensions());
+  assert(meta::json::jsonEquivalent('{"id":"A/N","i":[]}'->meta::json::parseJSON(), $result.values->toOne()->meta::json::parseJSON()));
+}
+
+
+
+###Mapping 
+Mapping meta::pure::mapping::modelToModel::test::shared::dest::MappingWithNoPropertyAccessOnClass
+(
+  *meta::pure::mapping::modelToModel::test::shared::dest::Target : Pure 
+  {
+    ~src meta::pure::mapping::modelToModel::test::shared::source::A
+    id : meta::pure::mapping::modelToModel::test::alloy::f($src, [])
+    i : []
+  }
+)
+
+

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
@@ -99,6 +99,11 @@ function meta::external::language::java::transform::usesLibrary(conventions: Con
    $conventions.libraries->exists(l | $l.name == $name);
 }
 
+function meta::external::language::java::transform::isProvidedClass(conventions: Conventions[1], c: meta::external::language::java::metamodel::Class[1]): Boolean[1]
+{
+  $c->in($conventions.providedTypes->values());
+}
+
 function meta::external::language::java::transform::fieldName(conventions: Conventions[1], property: AbstractProperty<Any>[1]): String[1]
 {
    $conventions->identifier($conventions.fieldNameStrategy->eval($property.name->toOne()));

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -279,6 +279,7 @@ function <<access.private>> meta::external::language::java::transform::processCo
             let classesUsed = $signature.method->typesUsed()
                                 ->typesToClasses()
                                 ->filter(c | !meta::external::language::java::factory::isKnownPackage($c.package))
+                                ->filter(c | !meta::external::language::java::transform::isProvidedClass($conventions, $c))
                                 ->map(c | $c->addModifiers(['public'])
                                             ->usingKnownPackages($conventions->knownPackages())
                                             ->imports($conventions->standardImports()));

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -265,8 +265,6 @@ function <<access.private>> meta::external::language::java::transform::processCo
       }
    );
 
-
-
    if(!($conventions.visitedFunctions->contains($fe)),
       |let newCon = ^$conventions(visitedFunctions += $fe->cast(@FunctionExpression));
       let name = $fe.func->elementToPath();
@@ -284,18 +282,7 @@ function <<access.private>> meta::external::language::java::transform::processCo
                                 ->filter(c | !meta::external::language::java::transform::isProvidedClass($conventions, $c))
                                 ->map(c | $c->addModifiers(['public', 'interface'])
                                             ->usingKnownPackages($conventions->knownPackages()));
-                                            //->imports($conventions->standardImports()));
-
-            // println('***********');
-            // println('Classes provided');
-            //    $conventions.providedTypes->values().simpleName->println();
-
-            // println('Classes used');
-            // println($classesUsed.simpleName);
-            // println('***********************');
-            // fail();
             
-
             let withImports = javaClass('public', $signature.class)
                     ->usingKnownPackages($conventions->knownPackages())
                     ->imports($conventions->standardImports());
@@ -313,65 +300,6 @@ function <<access.private>> meta::external::language::java::transform::processCo
       |j_invoke($signature.class, $signature.method.name, $castArgs, $signature.method.returnType);
    );
 }
-
-// function <<access.private>> meta::external::language::java::transform::generateClass(cls : meta::pure::metamodel::type::Class<Any>[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]) : meta::external::language::java::metamodel::Class[*]
-// {
-  
-//    let typeInfo = meta::pure::executionPlan::platformBinding::typeInfo::newTypeInfoSet()->enrichTypeInfos($cls, []);
-    
-//    let props = $typeInfo->meta::pure::executionPlan::platformBinding::typeInfo::allProperties($cls);
-   
-//    let proto = $conventions->implClassName($cls)->addModifiers(['public']);
-
-//    let clsTypeInfo = $typeInfo.typeInfos->filter(t | $t->instanceOf(meta::pure::executionPlan::platformBinding::typeInfo::ClassTypeInfo))
-//                                         ->cast(@meta::pure::executionPlan::platformBinding::typeInfo::ClassTypeInfo)
-//                                         ->filter(c | $c.class() == $cls);
-
-//             assert($clsTypeInfo->size() == 1, 'Error: found multiple type infos for class');
-
-//             //let nestedDeps = generateInterfacesAndEnums($conventions, $typeInfo, $debug);
-
-//             let interface = $clsTypeInfo->toOne()->generateInterfaceForClass($conventions,$debug);
-//             let implementationWithProps = $props->fold({p,c| let var = $conventions->fieldName($p);
-//                                            let javaType = $conventions->pureTypeToJavaType($p);
-//                                            let f = javaField(['private'], $javaType, $var);
-//                                            let param = j_parameter($javaType, $var);
-
-//                                            $c->addField($f)
-//                                              ->addMethod(javaMethod('public', $javaType, $conventions->getterName($p), [], 'return ' + $var+';'))
-//                                              ->addMethod(javaMethod('public', $proto, $conventions->setterName($p),  j_parameter($javaType, $var), 
-//                                                            j_block([j_this($c)->j_field($f)->j_assign($param),
-//                                                                     j_this($c)->j_return()
-//                                                                    ])
-//                                                         ));
-//                                            }, $proto)
-//                               ->addConstructor(javaConstructor(['public'], [], ''))
-//                               // interface generation adds this method, so we need to add to implementation too - TODO This should not happen
-//                               ->addMethod(javaMethod('public', javaString(), $conventions->className(IReferencedObject).methods->toOne().name, [], j_return(j_null())))
-//                               ->implements($interface)
-//                               ->usingKnownPackages($conventions->knownPackages())
-//                               ->imports($conventions->standardImports())
-//                               ->imports($interface);  
-
-//               [$interface, $implementationWithProps];
-
-// }
-
-// function <<access.private>> meta::external::language::java::transform::enrichTypeInfos(infos:meta::pure::executionPlan::platformBinding::typeInfo::TypeInfoSet[1], for:meta::pure::metamodel::type::Class<Any>[1], seen:meta::pure::metamodel::type::Class<Any>[*]): meta::pure::executionPlan::platformBinding::typeInfo::TypeInfoSet[1]
-// {
-//    if($seen->contains($for),
-//       | $infos,
-//       {|
-//          let withCls = $infos
-//             ->meta::pure::executionPlan::platformBinding::typeInfo::addForClassWithAllProperties($for)
-//             ->meta::pure::executionPlan::platformBinding::typeInfo::addForClassWithAllPropertiesViaAssociations($for);
-
-//          let nowSeen = $seen->concatenate($for);
-//          $withCls->meta::pure::executionPlan::platformBinding::typeInfo::forClass($for).supertypes->fold({super, inf| $inf->enrichTypeInfos($super, $nowSeen)}, $withCls);
-//       }
-//    );
-// }
-
 
 function <<access.private>> meta::external::language::java::transform::debugAndReturn(c:Code[1], debug:DebugContext[1]):Code[1]
 {

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -280,7 +280,7 @@ function <<access.private>> meta::external::language::java::transform::processCo
                                 ->typesToClasses()
                                 ->filter(c | !meta::external::language::java::factory::isKnownPackage($c.package))
                                 ->filter(c | !meta::external::language::java::transform::isProvidedClass($conventions, $c))
-                                ->map(c | $c->addModifiers(['public', 'interface'])
+                                ->map(c | $c->addModifiers(['public'])
                                             ->usingKnownPackages($conventions->knownPackages()));
             
             let withImports = javaClass('public', $signature.class)

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -265,6 +265,8 @@ function <<access.private>> meta::external::language::java::transform::processCo
       }
    );
 
+
+
    if(!($conventions.visitedFunctions->contains($fe)),
       |let newCon = ^$conventions(visitedFunctions += $fe->cast(@FunctionExpression));
       let name = $fe.func->elementToPath();
@@ -280,9 +282,19 @@ function <<access.private>> meta::external::language::java::transform::processCo
                                 ->typesToClasses()
                                 ->filter(c | !meta::external::language::java::factory::isKnownPackage($c.package))
                                 ->filter(c | !meta::external::language::java::transform::isProvidedClass($conventions, $c))
-                                ->map(c | $c->addModifiers(['public'])
-                                            ->usingKnownPackages($conventions->knownPackages())
-                                            ->imports($conventions->standardImports()));
+                                ->map(c | $c->addModifiers(['public', 'interface'])
+                                            ->usingKnownPackages($conventions->knownPackages()));
+                                            //->imports($conventions->standardImports()));
+
+            // println('***********');
+            // println('Classes provided');
+            //    $conventions.providedTypes->values().simpleName->println();
+
+            // println('Classes used');
+            // println($classesUsed.simpleName);
+            // println('***********************');
+            // fail();
+            
 
             let withImports = javaClass('public', $signature.class)
                     ->usingKnownPackages($conventions->knownPackages())
@@ -301,6 +313,64 @@ function <<access.private>> meta::external::language::java::transform::processCo
       |j_invoke($signature.class, $signature.method.name, $castArgs, $signature.method.returnType);
    );
 }
+
+// function <<access.private>> meta::external::language::java::transform::generateClass(cls : meta::pure::metamodel::type::Class<Any>[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]) : meta::external::language::java::metamodel::Class[*]
+// {
+  
+//    let typeInfo = meta::pure::executionPlan::platformBinding::typeInfo::newTypeInfoSet()->enrichTypeInfos($cls, []);
+    
+//    let props = $typeInfo->meta::pure::executionPlan::platformBinding::typeInfo::allProperties($cls);
+   
+//    let proto = $conventions->implClassName($cls)->addModifiers(['public']);
+
+//    let clsTypeInfo = $typeInfo.typeInfos->filter(t | $t->instanceOf(meta::pure::executionPlan::platformBinding::typeInfo::ClassTypeInfo))
+//                                         ->cast(@meta::pure::executionPlan::platformBinding::typeInfo::ClassTypeInfo)
+//                                         ->filter(c | $c.class() == $cls);
+
+//             assert($clsTypeInfo->size() == 1, 'Error: found multiple type infos for class');
+
+//             //let nestedDeps = generateInterfacesAndEnums($conventions, $typeInfo, $debug);
+
+//             let interface = $clsTypeInfo->toOne()->generateInterfaceForClass($conventions,$debug);
+//             let implementationWithProps = $props->fold({p,c| let var = $conventions->fieldName($p);
+//                                            let javaType = $conventions->pureTypeToJavaType($p);
+//                                            let f = javaField(['private'], $javaType, $var);
+//                                            let param = j_parameter($javaType, $var);
+
+//                                            $c->addField($f)
+//                                              ->addMethod(javaMethod('public', $javaType, $conventions->getterName($p), [], 'return ' + $var+';'))
+//                                              ->addMethod(javaMethod('public', $proto, $conventions->setterName($p),  j_parameter($javaType, $var), 
+//                                                            j_block([j_this($c)->j_field($f)->j_assign($param),
+//                                                                     j_this($c)->j_return()
+//                                                                    ])
+//                                                         ));
+//                                            }, $proto)
+//                               ->addConstructor(javaConstructor(['public'], [], ''))
+//                               // interface generation adds this method, so we need to add to implementation too - TODO This should not happen
+//                               ->addMethod(javaMethod('public', javaString(), $conventions->className(IReferencedObject).methods->toOne().name, [], j_return(j_null())))
+//                               ->implements($interface)
+//                               ->usingKnownPackages($conventions->knownPackages())
+//                               ->imports($conventions->standardImports())
+//                               ->imports($interface);  
+
+//               [$interface, $implementationWithProps];
+
+// }
+
+// function <<access.private>> meta::external::language::java::transform::enrichTypeInfos(infos:meta::pure::executionPlan::platformBinding::typeInfo::TypeInfoSet[1], for:meta::pure::metamodel::type::Class<Any>[1], seen:meta::pure::metamodel::type::Class<Any>[*]): meta::pure::executionPlan::platformBinding::typeInfo::TypeInfoSet[1]
+// {
+//    if($seen->contains($for),
+//       | $infos,
+//       {|
+//          let withCls = $infos
+//             ->meta::pure::executionPlan::platformBinding::typeInfo::addForClassWithAllProperties($for)
+//             ->meta::pure::executionPlan::platformBinding::typeInfo::addForClassWithAllPropertiesViaAssociations($for);
+
+//          let nowSeen = $seen->concatenate($for);
+//          $withCls->meta::pure::executionPlan::platformBinding::typeInfo::forClass($for).supertypes->fold({super, inf| $inf->enrichTypeInfos($super, $nowSeen)}, $withCls);
+//       }
+//    );
+// }
 
 
 function <<access.private>> meta::external::language::java::transform::debugAndReturn(c:Code[1], debug:DebugContext[1]):Code[1]

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -274,16 +274,22 @@ function <<access.private>> meta::external::language::java::transform::processCo
         if(!$state.visitedFunctions->contains($fe.func->elementToPath()),
            |print(if($debug.debug,|$debug.space+'Implementation of: \''+$fe.func->elementToPath()+'\'\n',|''));
            let updatedState = $state->addDependencyVisitedFunction($fe.func->elementToPath());
-
+            
             let implBody    = $fe.func->cast(@ConcreteFunctionDefinition<Any>).expressionSequence->evaluateAndDeactivate()->generateJavaMethodBody($newCon, $debug->indent());
-            let classesUsed = $signature.method->typesUsed()->concatenate($implBody->typesUsed())->typesToClasses();
+            let classesUsed = $signature.method->typesUsed()
+                                ->typesToClasses()
+                                ->filter(c | !meta::external::language::java::factory::isKnownPackage($c.package))
+                                ->map(c | $c->addModifiers(['public'])
+                                            ->usingKnownPackages($conventions->knownPackages())
+                                            ->imports($conventions->standardImports()));
+
             let withImports = javaClass('public', $signature.class)
                     ->usingKnownPackages($conventions->knownPackages())
                     ->imports($conventions->standardImports());
             let impl             = $withImports->addMethod(javaMethod(['public', 'static'], $signature.method.returnType, $signature.method.name, $signature.method.parameters, $implBody));
             let dependencies     = $implBody->dependencies()->removeDuplicates();
             let withDependencies = $dependencies->resolveProjects($updatedState);
-            let project          = mergeProjects(newProject()->addClass($impl)->concatenate($withDependencies->getProjects($dependencies))->toOneMany());
+            let project          = mergeProjects(newProject()->addClass($impl)->addClasses($classesUsed)->concatenate($withDependencies->getProjects($dependencies))->toOneMany());
             $withDependencies->addDependencyProject($name, $project);
           ,|$state);
         }
@@ -294,6 +300,7 @@ function <<access.private>> meta::external::language::java::transform::processCo
       |j_invoke($signature.class, $signature.method.name, $castArgs, $signature.method.returnType);
    );
 }
+
 
 function <<access.private>> meta::external::language::java::transform::debugAndReturn(c:Code[1], debug:DebugContext[1]):Code[1]
 {

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
@@ -2874,6 +2874,40 @@ function meta::external::language::java::factory::knownPackage(pkg: meta::extern
    )))))))));
 }
 
+function meta::external::language::java::factory::isKnownPackage(pkg: meta::external::language::java::metamodel::Package[1]):Boolean[1]
+{
+     let pkgName = $pkg->packageToString();
+
+   if($pkg->instanceOf(KnownPackage),
+      | true,
+      |
+   if($pkgName == 'java.lang',
+      | true,
+      |
+   if($pkgName == 'java.util',
+      | true,
+      |
+   if($pkgName == 'java.util.function',
+      | true,
+      |
+   if($pkgName == 'java.util.stream',
+      | true,
+      |
+   if($pkgName == 'java.io',
+      | true,
+      |
+   if($pkgName == 'java.net',
+      | true,
+      |
+   if($pkgName == 'java.math',
+      | true,
+      |
+   if($pkgName == 'java.time',
+      | true,
+      | false
+   )))))))));
+}
+
 function meta::external::language::java::factory::javaLangPackage(): meta::external::language::java::factory::KnownPackage[1]
 {
    ^meta::external::language::java::factory::KnownPackage(

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
@@ -3549,7 +3549,9 @@ function <<access.private>> meta::external::language::java::factory::project::me
          });
          let methods = $existing.methods->concatenate($newlyDefinedMethods);
 
-         $base->replaceClass(^$existing(additionalImports=$imports, superType=$superType, interfaces=$interfaces, fields=$fields, methods=$methods));
+         let modifiers = $existing.modifiers->concatenate($class.modifiers)->removeDuplicates();
+
+         $base->replaceClass(^$existing(additionalImports=$imports, superType=$superType, interfaces=$interfaces, fields=$fields, methods=$methods, modifiers=$modifiers));
       }
    );
 }

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
@@ -3511,7 +3511,15 @@ function <<access.private>> meta::external::language::java::factory::project::me
       {| $base->addClass($srcDirPath, $class)},
       {|
          let existing = $base->getClass($srcDirPath, $classFullName)->toOne();
-         
+         if ($existing->instanceOf(meta::external::language::java::metamodel::Enumeration) && $class->instanceOf(meta::external::language::java::metamodel::Class),
+          | $base,
+          | if ($existing->instanceOf(meta::external::language::java::metamodel::Class) && $class->instanceOf(meta::external::language::java::metamodel::Enumeration),
+            | $base->replaceClass($class),
+            |  
+         let x = if($class.simpleName == 'TestEnum', | println('existing'); println($existing); println('class'); println($class); println('======'); '';, |'';);
+
+        // let blah = if($class.simpleName == 'Duration', | println('booyah'); println('class'); println($class,2); println('existing:'); println($existing,2); println('------');   '';, | '';);
+
          let imports = $existing.additionalImports->concatenate($class.additionalImports)->removeDuplicates();
 
          let superType = if($existing.superType->isEmpty(),
@@ -3550,8 +3558,14 @@ function <<access.private>> meta::external::language::java::factory::project::me
          let methods = $existing.methods->concatenate($newlyDefinedMethods);
 
          let modifiers = $existing.modifiers->concatenate($class.modifiers)->removeDuplicates();
+         let f = ^$existing(additionalImports=$imports, superType=$superType, interfaces=$interfaces, fields=$fields, methods=$methods, modifiers=$modifiers);
+        let x1 = if($class.simpleName == 'TestEnum', | println('result'); println($f); println('======'); '';, |'';);
 
-         $base->replaceClass(^$existing(additionalImports=$imports, superType=$superType, interfaces=$interfaces, fields=$fields, methods=$methods, modifiers=$modifiers));
+         $base->replaceClass($f);
+         
+         ));
+
+        
       }
    );
 }

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/metamodel_factories.pure
@@ -3511,61 +3511,54 @@ function <<access.private>> meta::external::language::java::factory::project::me
       {| $base->addClass($srcDirPath, $class)},
       {|
          let existing = $base->getClass($srcDirPath, $classFullName)->toOne();
+         
          if ($existing->instanceOf(meta::external::language::java::metamodel::Enumeration) && $class->instanceOf(meta::external::language::java::metamodel::Class),
           | $base,
           | if ($existing->instanceOf(meta::external::language::java::metamodel::Class) && $class->instanceOf(meta::external::language::java::metamodel::Enumeration),
             | $base->replaceClass($class),
-            |  
-         let x = if($class.simpleName == 'TestEnum', | println('existing'); println($existing); println('class'); println($class); println('======'); '';, |'';);
+            | let imports = $existing.additionalImports->concatenate($class.additionalImports)->removeDuplicates();
 
-        // let blah = if($class.simpleName == 'Duration', | println('booyah'); println('class'); println($class,2); println('existing:'); println($existing,2); println('------');   '';, | '';);
+              let superType = if($existing.superType->isEmpty(),
+                                  {|$class.superType},
+                                  |
+                              if($class.superType->isEmpty(),
+                                  {|$existing.superType},
+                                  {|
+                                    assert($existing.superType == $class.superType, |'Cannot change superType from ' + $existing.superType->toOne()->typeToString() + ' to ' + $class.superType->toOne()->typeToString());
+                                    $existing.superType;
+                                  }
+                              ));
 
-         let imports = $existing.additionalImports->concatenate($class.additionalImports)->removeDuplicates();
+              let interfaces = $existing.interfaces->concatenate($class.interfaces)->removeDuplicates();
+              
+              let newlyDefinedFields = $class.fields->filter({newField |
+                  let existingField = $existing.fields->filter({m | $m.name == $newField.name});
+                  assert($existingField->isEmpty() || (($existingField.type == $newField.type) && ($existingField.value == $newField.value) && ($existingField.valueCode == $newField.valueCode)), | 'Cannot merge field ' + $newField.name + ' in ' + $classFullName);
+                  $existingField->isEmpty();
+              });
+              let fields = $existing.fields->concatenate($newlyDefinedFields);
+              
+              let newlyDefinedMethods = $class.methods->filter({newMethod|
+                  let existingMethod = $existing.methods->filter({m| $m.name == $newMethod.name && $m.parameters.type == $newMethod.parameters.type});
+                  assert($existingMethod->isEmpty() || ($existingMethod.body == $newMethod.body && $existingMethod.bodyCode == $newMethod.bodyCode), {| $existingMethod.bodyCode->match([
+                                                                                                                                                      c:Code[1] | println($c->codeToString()),
+                                                                                                                                                      x:Code[0] | println($existingMethod.body->toOne())
+                                                                                                                                                    ]);
+                                                                                                                                                    $newMethod.bodyCode->match([
+                                                                                                                                                      c:Code[1] | println($c->codeToString()),
+                                                                                                                                                      x:Code[0] | println($newMethod.body->toOne())
+                                                                                                                                                    ]);
+                                                                                                                                                    'Cannot merge implementations of ' + $newMethod->methodSignature() + ' in ' + $classFullName;});
+                  $existingMethod->isEmpty();
+              });
+              let methods = $existing.methods->concatenate($newlyDefinedMethods);
 
-         let superType = if($existing.superType->isEmpty(),
-                            {|$class.superType},
-                            |
-                         if($class.superType->isEmpty(),
-                            {|$existing.superType},
-                            {|
-                               assert($existing.superType == $class.superType, |'Cannot change superType from ' + $existing.superType->toOne()->typeToString() + ' to ' + $class.superType->toOne()->typeToString());
-                               $existing.superType;
-                            }
-                         ));
+              let modifiers = $existing.modifiers->concatenate($class.modifiers)->removeDuplicates();
+              let f = ^$existing(additionalImports=$imports, superType=$superType, interfaces=$interfaces, fields=$fields, methods=$methods, modifiers=$modifiers);
 
-         let interfaces = $existing.interfaces->concatenate($class.interfaces)->removeDuplicates();
-         
-         let newlyDefinedFields = $class.fields->filter({newField |
-            let existingField = $existing.fields->filter({m | $m.name == $newField.name});
-            assert($existingField->isEmpty() || (($existingField.type == $newField.type) && ($existingField.value == $newField.value) && ($existingField.valueCode == $newField.valueCode)), | 'Cannot merge field ' + $newField.name + ' in ' + $classFullName);
-            $existingField->isEmpty();
-         });
-         let fields = $existing.fields->concatenate($newlyDefinedFields);
-         
-         let newlyDefinedMethods = $class.methods->filter({newMethod|
-            let existingMethod = $existing.methods->filter({m| $m.name == $newMethod.name && $m.parameters.type == $newMethod.parameters.type});
-            assert($existingMethod->isEmpty() || ($existingMethod.body == $newMethod.body && $existingMethod.bodyCode == $newMethod.bodyCode), {| $existingMethod.bodyCode->match([
-                                                                                                                                                 c:Code[1] | println($c->codeToString()),
-                                                                                                                                                 x:Code[0] | println($existingMethod.body->toOne())
-                                                                                                                                               ]);
-                                                                                                                                               $newMethod.bodyCode->match([
-                                                                                                                                                 c:Code[1] | println($c->codeToString()),
-                                                                                                                                                 x:Code[0] | println($newMethod.body->toOne())
-                                                                                                                                               ]);
-                                                                                                                                              'Cannot merge implementations of ' + $newMethod->methodSignature() + ' in ' + $classFullName;});
-            $existingMethod->isEmpty();
-         });
-         let methods = $existing.methods->concatenate($newlyDefinedMethods);
-
-         let modifiers = $existing.modifiers->concatenate($class.modifiers)->removeDuplicates();
-         let f = ^$existing(additionalImports=$imports, superType=$superType, interfaces=$interfaces, fields=$fields, methods=$methods, modifiers=$modifiers);
-        let x1 = if($class.simpleName == 'TestEnum', | println('result'); println($f); println('======'); '';, |'';);
-
-         $base->replaceClass($f);
-         
-         ));
-
-        
+              $base->replaceClass($f);
+              
+            ));
       }
    );
 }


### PR DESCRIPTION
M2M execution relies on source fetch tree computation to generate the list of Pure classes to generate Java code for. 
However, if a function is passed an empty argument then there is no property access and hence nothing is present in the source tree informing the platform that Java code should be generated for the corresponding parameter type. As a result the compilation of Java code present in the execution plan fails due to missing classes. 

This change fixes that by processing the parameters and generating code for parameter types that are not part of the Java standard library or engine conventions library.  If we happen to have already generated code for the parameter type earlier in the plan generation (e.g the class is mentioned in the source fetch tree) then the Java generation merging code will handle duplicates that may be generated by this changeset. 