### PR TITLE
add execution context to query

### DIFF
--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/api/QueryStoreManager.java
@@ -165,10 +165,23 @@ public class QueryStoreManager
         validateNonEmptyQueryField(query.groupId, "Query project group ID is missing or empty");
         validateNonEmptyQueryField(query.artifactId, "Query project artifact ID is missing or empty");
         validateNonEmptyQueryField(query.versionId, "Query project version is missing or empty");
-        validateNonEmptyQueryField(query.mapping, "Query mapping is missing or empty");
-        validateNonEmptyQueryField(query.runtime, "Query runtime is missing or empty");
+        if (query.executionContext instanceof QueryExplicitExecutionContext)
+        {
+            QueryExplicitExecutionContext queryExplicitExecutionContext = (QueryExplicitExecutionContext) query.executionContext;
+            validateNonEmptyQueryField(queryExplicitExecutionContext.mapping, "Query mapping is missing or empty");
+            validateNonEmptyQueryField(queryExplicitExecutionContext.runtime, "Query runtime is missing or empty");
+        }
+        else if (query.executionContext instanceof QueryDataSpaceExecutionContext)
+        {
+            QueryDataSpaceExecutionContext queryDataSpaceExecutionContext = (QueryDataSpaceExecutionContext) query.executionContext;
+            validateNonEmptyQueryField(queryDataSpaceExecutionContext.dataSpacePath, "Query data Space execution context dataSpace path is missing or empty");
+        }
+        else
+        {
+            validateNonEmptyQueryField(query.mapping, "Query mapping is missing or empty");
+            validateNonEmptyQueryField(query.runtime, "Query runtime is missing or empty");
+        }
         validateNonEmptyQueryField(query.content, "Query content is missing or empty");
-
         validate(SourceVersion.isName(query.groupId), "Query project group ID is invalid");
         validate(VALID_ARTIFACT_ID_PATTERN.matcher(query.artifactId).matches(), "Query project artifact ID is invalid");
         // TODO: we can potentially create a pattern check for version

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/Query.java
@@ -31,8 +31,11 @@ public class Query
     public String artifactId;
     public String versionId;
     public String originalVersionId;
+    @Deprecated
     public String mapping;
+    @Deprecated
     public String runtime;
+    public QueryExecutionContext executionContext;
     public String content;
     public Long lastUpdatedAt;
     public Long createdAt;

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryDataSpaceExecutionContext.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryDataSpaceExecutionContext.java
@@ -1,0 +1,24 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.application.query.model;
+
+public class QueryDataSpaceExecutionContext extends QueryExecutionContext
+{
+
+    public String dataSpacePath;
+
+    public String executionKey;
+
+}

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryExecutionContext.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryExecutionContext.java
@@ -1,0 +1,28 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.application.query.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type", defaultImpl = QueryExplicitExecutionContext.class)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = QueryExplicitExecutionContext.class, name = "explicitExecutionContext"),
+        @JsonSubTypes.Type(value = QueryDataSpaceExecutionContext.class, name = "dataSpaceExecutionContext"),
+})
+public abstract class QueryExecutionContext
+{
+
+}

--- a/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryExplicitExecutionContext.java
+++ b/legend-engine-application-query/src/main/java/org/finos/legend/engine/application/query/model/QueryExplicitExecutionContext.java
@@ -1,0 +1,23 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.application.query.model;
+
+public class QueryExplicitExecutionContext extends QueryExecutionContext
+{
+    public String mapping;
+
+    public String runtime;
+
+}

--- a/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/utils/TestQuerySerialization.java
+++ b/legend-engine-application-query/src/test/java/org/finos/legend/engine/application/query/utils/TestQuerySerialization.java
@@ -1,0 +1,140 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.application.query.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.finos.legend.engine.application.query.model.Query;
+import org.finos.legend.engine.application.query.model.QueryDataSpaceExecutionContext;
+import org.finos.legend.engine.application.query.model.QueryExplicitExecutionContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestQuerySerialization
+{
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    String LEGACY_QUERY = "{\n" +
+            "  \"_id\": 1242837498375,\n" +
+            "  \"artifactId\": \"test-artifact\",\n" +
+            "  \"content\": \"content\",\n" +
+            "  \"createdAt\": null,\n" +
+            "  \"defaultParameterValues\": [],\n" +
+            "  \"description\": \"description\",\n" +
+            "  \"executionContext\": null,\n" +
+            "  \"gridConfig\": null,\n" +
+            "  \"groupId\": \"test.group\",\n" +
+            "  \"id\": \"1\",\n" +
+            "  \"lastUpdatedAt\": null,\n" +
+            "  \"mapping\": \"my::mapping\",\n" +
+            "  \"name\": \"query1\",\n" +
+            "  \"originalVersionId\": \"0.0.0\",\n" +
+            "  \"owner\": \"testUser\",\n" +
+            "  \"runtime\": \"my::runtime\",\n" +
+            "  \"stereotypes\": [],\n" +
+            "  \"taggedValues\": [],\n" +
+            "  \"versionId\": \"0.0.0\"\n" +
+            "}";
+
+
+    String EXPLICIT_EX_QUERY = "{\n" +
+            "  \"artifactId\": \"test-artifact\",\n" +
+            "  \"content\": \"content\",\n" +
+            "  \"createdAt\": 1713280515492,\n" +
+            "  \"defaultParameterValues\": [],\n" +
+            "  \"description\": \"description\",\n" +
+            "  \"gridConfig\": null,\n" +
+            "  \"groupId\": \"test.group\",\n" +
+            "  \"id\": \"1\",\n" +
+            "  \"lastUpdatedAt\": 1713280515492,\n" +
+            "  \"name\": \"query1\",\n" +
+            "  \"originalVersionId\": \"0.0.0\",\n" +
+            "  \"owner\": \"testUser\",\n" +
+            "  \"executionContext\": \n" +
+            "    {\n" +
+            "      \"_type\": \"explicitExecutionContext\",\n" +
+            "      \"mapping\": \"my::mapping\",\n" +
+            "      \"runtime\": \"my::runtime\"\n" +
+            "    }\n" +
+            "  ,\n" +
+            "  \"versionId\": \"0.0.0\"\n" +
+            "}";
+
+
+    String DATA_SPACE_QUERY = "{\n" +
+            "  \"artifactId\": \"test-artifact\",\n" +
+            "  \"content\": \"content\",\n" +
+            "  \"createdAt\": 1713280515492,\n" +
+            "  \"defaultParameterValues\": [],\n" +
+            "  \"description\": \"description\",\n" +
+            "  \"gridConfig\": null,\n" +
+            "  \"groupId\": \"test.group\",\n" +
+            "  \"id\": \"1\",\n" +
+            "  \"lastUpdatedAt\": 1713280515492,\n" +
+            "  \"name\": \"query1\",\n" +
+            "  \"originalVersionId\": \"0.0.0\",\n" +
+            "  \"owner\": \"testUser\",\n" +
+            "  \"executionContext\": \n" +
+            "    {\n" +
+            "      \"_type\": \"dataSpaceExecutionContext\",\n" +
+            "      \"dataSpacePath\": \"my::dataSpace\",\n" +
+            "      \"executionKey\": \"myKey\"\n" +
+            "    }\n" +
+            "  ,\n" +
+            "  \"versionId\": \"0.0.0\"\n" +
+            "}";
+
+    String DATA_SPACE_QUERY_NO_KEY = "{\n" +
+            "  \"artifactId\": \"test-artifact\",\n" +
+            "  \"content\": \"content\",\n" +
+            "  \"createdAt\": 1713280515492,\n" +
+            "  \"defaultParameterValues\": [],\n" +
+            "  \"description\": \"description\",\n" +
+            "  \"gridConfig\": null,\n" +
+            "  \"groupId\": \"test.group\",\n" +
+            "  \"id\": \"1\",\n" +
+            "  \"lastUpdatedAt\": 1713280515492,\n" +
+            "  \"name\": \"query1\",\n" +
+            "  \"originalVersionId\": \"0.0.0\",\n" +
+            "  \"owner\": \"testUser\",\n" +
+            "  \"executionContext\": \n" +
+            "    {\n" +
+            "      \"_type\": \"dataSpaceExecutionContext\",\n" +
+            "      \"dataSpacePath\": \"my::dataSpace\"\n" +
+            "    }\n" +
+            "  ,\n" +
+            "  \"versionId\": \"0.0.0\"\n" +
+            "}";
+
+    @Test
+    public void testDeserialization() throws Exception
+    {
+        Query legacyQuery = objectMapper.readValue(LEGACY_QUERY, Query.class);
+        Assert.assertNull(legacyQuery.executionContext);
+        Assert.assertEquals(legacyQuery.mapping, "my::mapping");
+        Assert.assertEquals(legacyQuery.runtime, "my::runtime");
+        Query explicitExecutionQuery = objectMapper.readValue(EXPLICIT_EX_QUERY, Query.class);
+        Assert.assertNull(explicitExecutionQuery.runtime);
+        Assert.assertNull(explicitExecutionQuery.mapping);
+        Assert.assertTrue(explicitExecutionQuery.executionContext instanceof QueryExplicitExecutionContext);
+        Query dataSpaceQuery = objectMapper.readValue(DATA_SPACE_QUERY, Query.class);
+        Assert.assertTrue(dataSpaceQuery.executionContext instanceof QueryDataSpaceExecutionContext);
+        QueryDataSpaceExecutionContext dataSpaceExecutionContext = (QueryDataSpaceExecutionContext) dataSpaceQuery.executionContext;
+        Assert.assertEquals(dataSpaceExecutionContext.dataSpacePath, "my::dataSpace");
+        Assert.assertEquals(dataSpaceExecutionContext.executionKey, "myKey");
+        Query dataSpaceQuery2 = objectMapper.readValue(DATA_SPACE_QUERY_NO_KEY, Query.class);
+        Assert.assertNull(((QueryDataSpaceExecutionContext)dataSpaceQuery2.executionContext).executionKey);
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix/Enhancement. 
Deprecates direct proeprties "runtime" and "mapping" as some queries will not provide these directly but implicit resolve them through another execution source.
This include dataSpace with has an executionKey that points to mapping/runtime. 

This fixes some opening bugs with dataSpace
- query does not persist execution key causing failures if user changes runtime/mapping
- if more than one execution key, query will always default to default exec context even if user did not save the query with that. 
- further allows us saving other forms of sources -> Service ? InLine (for usage of from())

Further improvements:

- We can migrate all queries to use new QueryExecutionContext class. Will be in separate PR

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
