### PR TITLE
revert HelperRelationalDatabaseConnectionBuilder.java to previous version

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalDatabaseConnectionBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalDatabaseConnectionBuilder.java
@@ -44,9 +44,13 @@ public class HelperRelationalDatabaseConnectionBuilder
         Root_meta_external_store_relational_runtime_DatabaseConnection connection = pureConnection._type(context.pureModel.getEnumValue("meta::relational::runtime::DatabaseType", connectionType));
         connection._timeZone(timeZone);
         connection._quoteIdentifiers(quoteIdentifiers);
-        if (element != null)
+        try
         {
             HelperRelationalBuilder.resolveDatabase(element, elementSourceInformation, context);
+        }
+        catch (RuntimeException e)
+        {
+            context.pureModel.storesIndex.putIfAbsent(element, new Root_meta_relational_metamodel_Database_Impl(element)._name(element));
         }
     }
 


### PR DESCRIPTION
#### What does this PR do / why is it needed?

We need to catch the exceptions to keep it backward compatible 
