### PR TITLE
IDE Light: specify repositories via runtime configuration

### DIFF
--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
@@ -43,15 +43,16 @@ This is controlled in the sourceLocationConfiguration section:
     "directories" : ["."]
   },
 ```
-The welcomeFileDirectory specifies the directory where the welcome file should be loaded from/stored to allowing you to keep multiple welcome files and load as needed. Note only one welcome file is loaded at startup.
-The directories folder specifies the location to search for code repositories. This directory is traversed and all code repositories are loaded in mutable state allowing you to make edits. 
-By default this location is the current directory in which the Pure IDE Light is executed from. 
+The welcomeFileDirectory specifies the directory where the welcome file should be loaded from/stored to allowing you to keep multiple welcome files on your local file system and choose via configuration which one to use.
+The directories folder specifies locations to search for code repositories. These directories are traversed and all code repositories are loaded in an editable state.
+If no directories are specified this defaults to the current directory in which the Pure IDE Light process is executed from. 
 
 If you specify a specific extension folder (for example legend-engine-xts-java) then the code repositories under this folder will be loaded as mutable *and* all its required dependencies too. 
 All other modules will be loaded via the class loader mechanism (and hence not editable). 
 
 #### Specifying required repositories to load
-You can further control which repositories are loaded in mutable state by using the requiredRepositories configuration:
+You can limit the IDE from loading all classpath repositories dynamically found by the service loader by using the requiredRepositories configuration.
+This will load only the repositories specified and any required dependencies needed. 
 
 ```
   "requiredRepositories" : ["core_external_language_java"]
@@ -68,7 +69,7 @@ In particular:
 3. ShowLocalPlan - print out the execution plan into the console (needs PlanLocal to be enabled)
 4. ExecPlan - when executing a query use the generatePlan/executePlan endpoints on engine server rather than execute. If PlanLocal is true then the plan will be generated in the IDE and then sent to executePlan for execution, if not then the plan is generated via generatePlan before being sent to the executePlan endpoint.
 
-These options can be set at startup via Java VM properties, for example:
+These options can be set at startup via Java VM properties, for example setting the following when starting up the IDE:
 
 ```
 -Dpure.option.PlanLocal
@@ -78,4 +79,4 @@ These options can also be enabled/disabled using REST endpoints that are documen
 
 For example to enable the PlanLocal setting you can execute http://127.0.0.1:9200/pureRuntimeOptions/setPureRuntimeOption/PlanLocal/true
 
-Note that GUI support via the Pure IDE Light to enable/disable/view these options is planned to be supported soon.
+TODO: Add support in UI to set/view these options

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
@@ -1,9 +1,9 @@
-#Pure IDE Light
+# Pure IDE Light
 
 Pure IDE Light is a development environment for Pure, the language underlying the Legend platform.
 
 
-##Running Pure IDE Light
+## Quick Start
 
 From the root of legend-engine, run the following to launch the Pure IDE Light server.
 
@@ -11,4 +11,71 @@ From the root of legend-engine, run the following to launch the Pure IDE Light s
 mvn -pl legend-engine-pure-ide-light exec:java -Dexec.mainClass="org.finos.legend.engine.ide.PureIDELight" -Dexec.args="server ./legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json"
 ```
 
-Then navigate to http://127.0.0.1/ide
+Then navigate to http://127.0.0.1:9200/ide 
+
+# Configuration
+## Configuration file
+### Port 
+The port used by IDE Light is specified in the port option under the server->connection section:
+```
+"server": {
+    "type": "simple",
+    "applicationContextPath": "/",
+    "adminContextPath": "/admin",
+    "connector": {
+      "maxRequestHeaderSize": "32KiB",
+      "type": "http",
+      "port": 9200
+    },
+    "requestLog": {
+      "appenders": [
+      ]
+    }
+```
+
+### Location of repositories
+The configuration file for Pure IDE Light allows you to specify directories containing Pure source code which will be loaded up in an editable state. 
+This is controlled in the sourceLocationConfiguration section:
+
+```
+"sourceLocationConfiguration": {
+    "welcomeFileDirectory": "./",
+    "directories" : ["."]
+  },
+```
+The welcomeFileDirectory specifies the directory where the welcome file should be loaded from/stored to allowing you to keep multiple welcome files and load as needed. Note only one welcome file is loaded at startup.
+The directories folder specifies the location to search for code repositories. This directory is traversed and all code repositories are loaded in mutable state allowing you to make edits. 
+By default this location is the current directory in which the Pure IDE Light is executed from. 
+
+If you specify a specific extension folder (for example legend-engine-xts-java) then the code repositories under this folder will be loaded as mutable *and* all its required dependencies too. 
+All other modules will be loaded via the class loader mechanism (and hence not editable). 
+
+#### Specifying required repositories to load
+You can further control which repositories are loaded in mutable state by using the requiredRepositories configuration:
+
+```
+  "requiredRepositories" : ["core_external_language_java"]
+```
+
+This will load the core_external_language_java in mutable state and all its dependencies. No other repositories will be loaded (e.g. repositories discovered by the service loader)
+
+### Runtime Pure properties
+The platform uses a number of properties to help with debugging of execution plan generation.
+In particular:
+
+1. PlanLocal - during query execution perform execution plan generation in the IDE rather than performing this on engine server
+2. DebugPlatformCodeGen - enable debug output for the platform code generation (currently Java code) 
+3. ShowLocalPlan - print out the execution plan into the console (needs PlanLocal to be enabled)
+4. ExecPlan - when executing a query use the generatePlan/executePlan endpoints on engine server rather than execute. If PlanLocal is true then the plan will be generated in the IDE and then sent to executePlan for execution, if not then the plan is generated via generatePlan before being sent to the executePlan endpoint.
+
+These options can be set at startup via Java VM properties, for example:
+
+```
+-Dpure.option.PlanLocal
+```
+
+These options can also be enabled/disabled using REST endpoints that are documented using Swagger: http://127.0.0.1:9200/swagger#/Pure%20Runtime%20Options/
+
+For example to enable the PlanLocal setting you can execute http://127.0.0.1:9200/pureRuntimeOptions/setPureRuntimeOption/PlanLocal/true
+
+Note that GUI support via the Pure IDE Light to enable/disable/view these options is planned to be supported soon.

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
@@ -45,7 +45,8 @@ sourceLocationConfiguration section:
 ```
 "sourceLocationConfiguration": {
     "welcomeFileDirectory": "./",
-    "directories" : ["."]
+    "directories" : ["."],
+    "pathPatternsToExclude" : "*/**/{archetype-resources,target}"
   },
 ```
 
@@ -63,6 +64,9 @@ folder (for example legend-engine-xts-java) then the code repositories
 under this folder will be loaded as mutable *and* all its required
 dependencies too.  All other modules will be loaded via the class
 loader mechanism (and hence not editable).
+
+The pathPatternsToExclude property specifies a glob pattern of paths to ignore when searching directories for code repositories.
+The example config excludes any paths containing archetype-resources and target. 
 
 #### Specifying required repositories to load
 

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/README.md
@@ -1,11 +1,13 @@
 # Pure IDE Light
 
-Pure IDE Light is a development environment for Pure, the language underlying the Legend platform.
+Pure IDE Light is a development environment for Pure, the language
+underlying the Legend platform.
 
 
 ## Quick Start
 
-From the root of legend-engine, run the following to launch the Pure IDE Light server.
+From the root of legend-engine, run the following to launch the Pure
+IDE Light server.
 
 ```
 mvn -pl legend-engine-pure-ide-light exec:java -Dexec.mainClass="org.finos.legend.engine.ide.PureIDELight" -Dexec.args="server ./legend-engine-pure-ide-light/src/main/resources/ideLightConfig.json"
@@ -34,8 +36,11 @@ The port used by IDE Light is specified in the port option under the server->con
 ```
 
 ### Location of repositories
-The configuration file for Pure IDE Light allows you to specify directories containing Pure source code which will be loaded up in an editable state. 
-This is controlled in the sourceLocationConfiguration section:
+
+The configuration file for Pure IDE Light
+allows you to specify directories containing Pure source code which
+will be loaded up in an editable state.  This is controlled in the
+sourceLocationConfiguration section:
 
 ```
 "sourceLocationConfiguration": {
@@ -43,33 +48,59 @@ This is controlled in the sourceLocationConfiguration section:
     "directories" : ["."]
   },
 ```
-The welcomeFileDirectory specifies the directory where the welcome file should be loaded from/stored to allowing you to keep multiple welcome files on your local file system and choose via configuration which one to use.
-The directories folder specifies locations to search for code repositories. These directories are traversed and all code repositories are loaded in an editable state.
-If no directories are specified this defaults to the current directory in which the Pure IDE Light process is executed from. 
 
-If you specify a specific extension folder (for example legend-engine-xts-java) then the code repositories under this folder will be loaded as mutable *and* all its required dependencies too. 
-All other modules will be loaded via the class loader mechanism (and hence not editable). 
+The welcomeFileDirectory specifies the directory where the welcome
+file should be loaded from/stored to allowing you to keep multiple
+welcome files on your local file system and choose via configuration
+which one to use.
+
+The directories folder specifies locations to search for code
+repositories. These directories are traversed and all code
+repositories are loaded in an editable state.  If no directories are
+specified this defaults to the current directory in which the Pure IDE
+Light process is executed from.  If you specify a specific extension
+folder (for example legend-engine-xts-java) then the code repositories
+under this folder will be loaded as mutable *and* all its required
+dependencies too.  All other modules will be loaded via the class
+loader mechanism (and hence not editable).
 
 #### Specifying required repositories to load
-You can limit the IDE from loading all classpath repositories dynamically found by the service loader by using the requiredRepositories configuration.
-This will load only the repositories specified and any required dependencies needed. 
+
+You can limit the IDE from loading all classpath repositories
+dynamically found by the service loader by using the
+requiredRepositories configuration.  This will load only the
+repositories specified and any required dependencies needed.
 
 ```
   "requiredRepositories" : ["core_external_language_java"]
 ```
 
-This will load the core_external_language_java in mutable state and all its dependencies. No other repositories will be loaded (e.g. repositories discovered by the service loader)
+This will load the core_external_language_java in mutable state and
+all its dependencies. No other repositories will be loaded
+(e.g. repositories discovered by the service loader)
 
 ### Runtime Pure properties
-The platform uses a number of properties to help with debugging of execution plan generation.
-In particular:
 
-1. PlanLocal - during query execution perform execution plan generation in the IDE rather than performing this on engine server
-2. DebugPlatformCodeGen - enable debug output for the platform code generation (currently Java code) 
-3. ShowLocalPlan - print out the execution plan into the console (needs PlanLocal to be enabled)
-4. ExecPlan - when executing a query use the generatePlan/executePlan endpoints on engine server rather than execute. If PlanLocal is true then the plan will be generated in the IDE and then sent to executePlan for execution, if not then the plan is generated via generatePlan before being sent to the executePlan endpoint.
+The platform uses a number of properties to help with debugging of
+execution plan generation.  In particular:
 
-These options can be set at startup via Java VM properties, for example setting the following when starting up the IDE:
+1. PlanLocal - perform execution plan generation in the IDE rather
+than performing this on engine server
+
+2. DebugPlatformCodeGen - enable debug output for the platform code
+generation (currently Java code)
+
+3. ShowLocalPlan - print out the execution plan into the console
+(needs PlanLocal to be enabled)
+
+4. ExecPlan - when executing a query use the generatePlan/executePlan
+endpoints on engine server rather than execute. If PlanLocal is true
+then the plan will be generated in the IDE and then sent to
+executePlan for execution, if not then the plan is generated via
+generatePlan before being sent to the executePlan endpoint.
+
+These options can be set at startup via Java VM properties, for
+example setting the following when starting up the IDE:
 
 ```
 -Dpure.option.PlanLocal
@@ -77,6 +108,7 @@ These options can be set at startup via Java VM properties, for example setting 
 
 These options can also be enabled/disabled using REST endpoints that are documented using Swagger: http://127.0.0.1:9200/swagger#/Pure%20Runtime%20Options/
 
-For example to enable the PlanLocal setting you can execute http://127.0.0.1:9200/pureRuntimeOptions/setPureRuntimeOption/PlanLocal/true
+For example to enable the PlanLocal setting you can execute
+http://127.0.0.1:9200/pureRuntimeOptions/setPureRuntimeOption/PlanLocal/true
 
 TODO: Add support in UI to set/view these options

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
@@ -16,13 +16,28 @@ package org.finos.legend.engine.ide;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.finos.legend.engine.pure.runtime.compiler.interpreted.natives.LegendCompileMixedProcessorSupport;
+import org.finos.legend.engine.ide.PureIDEServer;
+import org.finos.legend.engine.ide.SourceLocationConfiguration;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.fs.MutableFSCodeStorage;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 
+import javax.xml.transform.Source;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PureIDELight extends PureIDEServer
 {
@@ -33,96 +48,9 @@ public class PureIDELight extends PureIDEServer
     }
 
     @Override
-    protected MutableList<RepositoryCodeStorage> buildRepositories(SourceLocationConfiguration sourceLocationConfiguration)
-    {
-        return Lists.mutable.<RepositoryCodeStorage>empty()
-                .with(this.buildCore("legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-metadata-pure", "ide_metadata"))
-                .with(this.buildCore("legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core", ""))
-                .with(this.buildCore("legend-engine-xts-protocol-java-generation/legend-engine-protocol-generation-pure", "protocol_generation"))
-                .with(this.buildCore("legend-engine-xts-persistence/legend-engine-xt-persistence-pure", "persistence"))
-                .with(this.buildCore("legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-pure", "function_activator"))
-                .with(this.buildCore("legend-engine-xts-snowflakeApp/legend-engine-xt-snowflakeApp-pure", "snowflakeapp"))
-                .with(this.buildCore("legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-pure", "bigqueryfunction"))
-                .with(this.buildCore("legend-engine-xts-hostedService/legend-engine-xt-hostedService-pure", "hostedservice"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure", "relational"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-javaPlatformBinding-pure", "relational-java-platform-binding"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-pure", "relational_sqlserver"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure", "relational_duckdb"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure", "relational_memsql"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure", "relational_bigquery"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-pure", "relational_spanner"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure", "relational_athena"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure", "relational_snowflake"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-pure", "relational_redshift"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure", "relational_databricks"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-hive/legend-engine-xt-relationalStore-hive-pure", "relational_hive"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-pure", "relational_postgres"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-presto/legend-engine-xt-relationalStore-presto-pure", "relational_presto"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybase/legend-engine-xt-relationalStore-sybase-pure", "relational_sybase"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure", "relational_sybaseiq"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/legend-engine-xt-relationalStore-sparksql-pure", "relational_sparksql"))
-                .with(this.buildCore("legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-analytics/legend-engine-xt-relationalStore-store-entitlement-pure", "relational_store_entitlement"))
-                .with(this.buildCore("legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure", "servicestore"))
-                .with(this.buildCore("legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-javaPlatformBinding-pure", "servicestore-java-platform-binding"))
-                .with(this.buildCore("legend-engine-xts-text/legend-engine-xt-text-pure-metamodel", "text-metamodel"))
-                .with(this.buildCore("legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel", "data-space-metamodel"))
-                .with(this.buildCore("legend-engine-xts-data-space/legend-engine-xt-data-space-pure", "data-space"))
-                .with(this.buildCore("legend-engine-xts-diagram/legend-engine-xt-diagram-pure-metamodel", "diagram-metamodel"))
-                .with(this.buildCore("legend-engine-xts-diagram/legend-engine-xt-diagram-pure", "diagram"))
-                .with(this.buildCore("legend-engine-xts-flatdata/legend-engine-xt-flatdata-pure", "external-format-flatdata"))
-                .with(this.buildCore("legend-engine-xts-flatdata/legend-engine-xt-flatdata-javaPlatformBinding-pure", "external-format-flatdata-java-platform-binding"))
-                .with(this.buildCore("legend-engine-xts-json/legend-engine-xt-json-pure", "external-format-json"))
-                .with(this.buildCore("legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure", "external-format-json-java-platform-binding"))
-                .with(this.buildCore("legend-engine-xts-xml/legend-engine-xt-xml-pure", "external-format-xml"))
-                .with(this.buildCore("legend-engine-xts-xml/legend-engine-xt-xml-javaPlatformBinding-pure", "external-format-xml-java-platform-binding"))
-                .with(this.buildCore("legend-engine-xts-openapi/legend-engine-xt-openapi-pure", "external-format-openapi"))
-                .with(this.buildCore("legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure", "external-query-graphql"))
-                .with(this.buildCore("legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure-metamodel", "external-query-graphql-metamodel"))
-                .with(this.buildCore("legend-engine-xts-protobuf/legend-engine-xt-protobuf-pure", "external-format-protobuf"))
-                .with(this.buildCore("legend-engine-xts-avro/legend-engine-xt-avro-pure", "external-format-avro"))
-                .with(this.buildCore("legend-engine-xts-rosetta/legend-engine-xt-rosetta-pure", "external-format-rosetta"))
-                .with(this.buildCore("legend-engine-xts-morphir/legend-engine-xt-morphir-pure", "external-language-morphir"))
-                .with(this.buildCore("legend-engine-xts-haskell/legend-engine-xt-haskell-pure", "external-language-haskell"))
-                .with(this.buildCore("legend-engine-xts-daml/legend-engine-xt-daml-pure", "external-language-daml"))
-                .with(this.buildCore("legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure", "pure-changetoken"))
-                .with(this.buildCore("legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-pure", "analytics-mapping"))
-                .with(this.buildCore("legend-engine-xts-analytics/legend-engine-xts-analytics-class/legend-engine-xt-analytics-class-pure", "analytics-class"))
-                .with(this.buildCore("legend-engine-xts-analytics/legend-engine-xts-analytics-binding/legend-engine-xt-analytics-binding-pure", "analytics-binding"))
-                .with(this.buildCore("legend-engine-xts-analytics/legend-engine-xts-analytics-function/legend-engine-xt-analytics-function-pure", "analytics-function"))
-                .with(this.buildCore("legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure", "analytics-lineage"))
-                .with(this.buildCore("legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure", "analytics-search"))
-                .with(this.buildCore("legend-engine-xts-java/legend-engine-xt-javaGeneration-pure", "external-language-java"))
-                .with(this.buildCore("legend-engine-xts-java/legend-engine-xt-javaGeneration-featureBased-pure", "external-language-java-feature-based-generation"))
-                .with(this.buildCore("legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure", "java-platform-binding"))
-                .with(this.buildCore("legend-engine-xts-sql/legend-engine-xt-sql-pure-metamodel", "external-query-sql-metamodel"))
-                .with(this.buildCore("legend-engine-xts-sql/legend-engine-xt-sql-pure", "external-query-sql"))
-                .with(this.buildCore("legend-engine-xts-authentication/legend-engine-xt-authentication-pure", "authentication"))
-                .with(this.buildCore("legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-pure-specification-metamodel", "elasticsearch_specification_metamodel"))
-                .with(this.buildCore("legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test", "elasticsearch_execution_test"))
-                .with(this.buildCore("legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel", "elasticsearch_seven_metamodel"))
-                .with(this.buildCore("legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure", "nonrelational-mongodb"))
-                .with(this.buildCore("legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure", "nonrelational-mongodb-java-platform-binding"))
-                .with(this.buildCore("legend-engine-xts-service/legend-engine-language-pure-dsl-service-pure", "service"))
-                .with(this.buildCore("legend-engine-xts-iceberg/legend-engine-xt-iceberg-pure", "external-tableformat-iceberg"))
-                .with(this.buildCore("legend-engine-xts-arrow/legend-engine-xt-arrow-pure", "external-format-arrow"))
-                .with(this.buildCore("legend-engine-xts-relationalai/legend-engine-xt-relationalai-pure", "external-query-relationalai"))
-                ;
-    }
-
-    @Override
     protected void postInit()
     {
         FunctionExecutionInterpreted fe = (FunctionExecutionInterpreted) this.getPureSession().getFunctionExecution();
         fe.setProcessorSupport(new LegendCompileMixedProcessorSupport(fe.getRuntime().getContext(), fe.getRuntime().getModelRepository(), fe.getProcessorSupport()));
-    }
-
-    protected MutableFSCodeStorage buildCore(String path, String module)
-    {
-        String resourceDir = path + "/src/main/resources/";
-        String moduleName = "".equals(module) ? "core" : ("core_" + module.replace("-", "_"));
-        return new MutableFSCodeStorage(
-                GenericCodeRepository.build(Paths.get(resourceDir + moduleName + ".definition.json")),
-                Paths.get(resourceDir + moduleName)
-        );
     }
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDELight.java
@@ -14,30 +14,8 @@
 
 package org.finos.legend.engine.ide;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MutableMap;
 import org.finos.legend.engine.pure.runtime.compiler.interpreted.natives.LegendCompileMixedProcessorSupport;
-import org.finos.legend.engine.ide.PureIDEServer;
-import org.finos.legend.engine.ide.SourceLocationConfiguration;
-import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
-import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
-import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
-import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.fs.MutableFSCodeStorage;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-
-import javax.xml.transform.Source;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PureIDELight extends PureIDEServer
 {

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
@@ -191,7 +191,7 @@ public abstract class PureIDEServer extends Application<ServerConfiguration>
         return result;
     }
 
-    //TODO: This should probably in CodeRepositoryProviderHelper in legend-pure
+    //TODO: This should probably be moved to CodeRepositoryProviderHelper in legend-pure
     protected Map<CodeRepository, Path> findCodeRepositoriesAndMapToPath(String path)
     {
         Map<CodeRepository, Path> result = new HashMap<>();

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
@@ -164,9 +164,11 @@ public abstract class PureIDEServer extends Application<ServerConfiguration>
     protected MutableList<RepositoryCodeStorage> buildRepositories(SourceLocationConfiguration sourceLocationConfiguration)
     {
         Map<CodeRepository, Path> codeRepositoryPathMap = new HashMap<>();
-        List<String> directoriesToSearch = sourceLocationConfiguration.directories != null ? sourceLocationConfiguration.directories : Lists.mutable.of(".");
+        List<String> directoriesToSearch = sourceLocationConfiguration.directories != null && !sourceLocationConfiguration.directories.isEmpty()
+                                            ? sourceLocationConfiguration.directories
+                                            : Lists.mutable.of(".");
 
-        for (String path : sourceLocationConfiguration.directories)
+        for (String path : directoriesToSearch)
         {
             Map<CodeRepository, Path> p = findCodeRepositoriesAndMapToPath(path);
             codeRepositoryPathMap.putAll(p);

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
@@ -26,6 +26,5 @@ public class SourceLocationConfiguration
     public String welcomeFileDirectory;
     public String coreFilesLocation;
     public String ideFilesLocation;
-    //TODO better names for below
     public List<String> directories;
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
@@ -31,5 +31,5 @@ public class SourceLocationConfiguration
 
     public String welcomeFileDirectory;
     public List<String> directories;
-    public String pathPatternsToExclude;
+    public List<String> pathPatternsToExclude;
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
@@ -31,4 +31,5 @@ public class SourceLocationConfiguration
 
     public String welcomeFileDirectory;
     public List<String> directories;
+    public String pathPatternsToExclude;
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
@@ -16,6 +16,8 @@ package org.finos.legend.engine.ide;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.List;
+
 @JsonIgnoreProperties(
         ignoreUnknown = true
 )
@@ -24,4 +26,6 @@ public class SourceLocationConfiguration
     public String welcomeFileDirectory;
     public String coreFilesLocation;
     public String ideFilesLocation;
+    //TODO better names for below
+    public List<String> directories;
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/SourceLocationConfiguration.java
@@ -23,8 +23,12 @@ import java.util.List;
 )
 public class SourceLocationConfiguration
 {
-    public String welcomeFileDirectory;
-    public String coreFilesLocation;
+    //TODO: remove these are they are redundant
+    @Deprecated
     public String ideFilesLocation;
+    @Deprecated
+    public String coreFilesLocation;
+
+    public String welcomeFileDirectory;
     public List<String> directories;
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
@@ -29,6 +29,8 @@
     }
   },
   "sourceLocationConfiguration": {
-    "welcomeFileDirectory": "./"
-  }
+    "welcomeFileDirectory": "./",
+    "directories" : ["."]
+  },
+  "requiredRepositories" : []
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
@@ -31,7 +31,7 @@
   "sourceLocationConfiguration": {
     "welcomeFileDirectory": "./",
     "directories" : ["."],
-    "pathPatternsToExclude" : "*/**/{archetype-resources,target}"
+    "pathPatternsToExclude" : ["**/target", "**/archetype-resources"]
   },
   "requiredRepositories" : []
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
@@ -31,7 +31,7 @@
   "sourceLocationConfiguration": {
     "welcomeFileDirectory": "./",
     "directories" : ["."],
-    "pathPatternToExclude" : "**/{archetype,target}/"
+    "pathPatternsToExclude" : "*/**/{archetype-resources,target}"
   },
   "requiredRepositories" : []
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
@@ -30,7 +30,8 @@
   },
   "sourceLocationConfiguration": {
     "welcomeFileDirectory": "./",
-    "directories" : ["."]
+    "directories" : ["."],
+    "pathPatternToExclude" : "**/{archetype,target}/"
   },
   "requiredRepositories" : []
 }


### PR DESCRIPTION
Load code repositories via configuration and directory searching rather than hard coded in source. 
This change also allows configuration to support multiple directories to search for Pure code repositories