### PR TITLE
Improve handling of PlanVarPlaceHolders in platform executions

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/metaExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/metaExtension.pure
@@ -474,6 +474,25 @@ function meta::pure::functions::meta::findVariableExpressionsInValueSpecificatio
    findVariableExpressionsInValueSpecification($vs, true);
 }
 
+function meta::pure::functions::meta::findPlanVarPlaceHoldersInValueSpecification(vs: ValueSpecification[1]): meta::pure::executionPlan::PlanVarPlaceHolder[*]
+{
+   $vs->match([
+      f : FunctionExpression[1] | $f.parametersValues->evaluateAndDeactivate()->map(v | $v->findPlanVarPlaceHoldersInValueSpecification()),
+      i : InstanceValue[1] | $i.values->evaluateAndDeactivate()->map({x |
+         $x->match([
+            v : ValueSpecification[1] | $v->findPlanVarPlaceHoldersInValueSpecification(),
+            k : KeyExpression[1] | $k.expression->findPlanVarPlaceHoldersInValueSpecification(),
+            l : LambdaFunction<Any>[1] | $l.expressionSequence->map(e | $e->findPlanVarPlaceHoldersInValueSpecification()),
+            v : meta::pure::executionPlan::PlanVarPlaceHolder[1] | $v,
+            a : Any[1] | []
+         ])
+      }),
+      c : ClusteredValueSpecification[1] | $c.val->evaluateAndDeactivate()->findPlanVarPlaceHoldersInValueSpecification(),
+      r : RoutedValueSpecification[1] | $r.value->evaluateAndDeactivate()->findPlanVarPlaceHoldersInValueSpecification(),
+      a : Any[1] | []
+   ])
+}
+
 function meta::pure::functions::meta::findPropertyPathsInFunctionDefinition(func:FunctionDefinition<Any>[1]):Path<Nil,Any|*>[*]
 {
    $func.expressionSequence->evaluateAndDeactivate()->map(vs | $vs->collectPropertyPathsInValueSpecification([]));
@@ -652,17 +671,24 @@ function meta::pure::functions::meta::resolve(v:VariableExpression[1], vars:Map<
            if ($open->isEmpty(),
                  |[];,
                  |let res = $open.values;
-                  if($res->isEmpty(),
-                    |let multVal = ^MultiplicityValue(value=0);
-                     ^InstanceValue(multiplicity=PureZero, genericType=^GenericType(rawType=Nil), values=[])->evaluateAndDeactivate();,
-                    |let size = $res->size();
-                     let mult = if($size == 1,
-                                  |PureOne,
-                                  |let multVal = ^MultiplicityValue(value=$size);
-                                   ^Multiplicity(lowerBound=$multVal, upperBound=$multVal);
-                                );
-                     ^InstanceValue(multiplicity=$mult, genericType=$res->genericType(), values=$res)->evaluateAndDeactivate();
-                  );
+                  $res->match([
+                    {pv: meta::pure::executionPlan::PlanVarPlaceHolder[1] |
+                      ^InstanceValue(values=$pv, genericType=^GenericType(rawType=$pv.type), multiplicity=$pv.multiplicity->defaultIfEmpty(ZeroMany)->toOne())->evaluateAndDeactivate();
+                    },
+                    {a: Any[*] | 
+                      if($res->isEmpty(),
+                        |let multVal = ^MultiplicityValue(value=0);
+                         ^InstanceValue(multiplicity=PureZero, genericType=^GenericType(rawType=Nil), values=[])->evaluateAndDeactivate();,
+                        |let size = $res->size();
+                         let mult = if($size == 1,
+                                      |PureOne,
+                                      |let multVal = ^MultiplicityValue(value=$size);
+                                       ^Multiplicity(lowerBound=$multVal, upperBound=$multVal);
+                                    );
+                         ^InstanceValue(multiplicity=$mult, genericType=$res->genericType(), values=$res)->evaluateAndDeactivate();
+                      );
+                    }
+                  ]);
            );,
          | $val->toOne()
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/metaExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/metaExtension.pure
@@ -481,8 +481,8 @@ function meta::pure::functions::meta::findPlanVarPlaceHoldersInValueSpecificatio
       i : InstanceValue[1] | $i.values->evaluateAndDeactivate()->map({x |
          $x->match([
             v : ValueSpecification[1] | $v->findPlanVarPlaceHoldersInValueSpecification(),
-            k : KeyExpression[1] | $k.expression->findPlanVarPlaceHoldersInValueSpecification(),
-            l : LambdaFunction<Any>[1] | $l.expressionSequence->map(e | $e->findPlanVarPlaceHoldersInValueSpecification()),
+            k : KeyExpression[1] | $k.expression->evaluateAndDeactivate()->findPlanVarPlaceHoldersInValueSpecification(),
+            l : LambdaFunction<Any>[1] | $l.expressionSequence->evaluateAndDeactivate()->map(e | $e->findPlanVarPlaceHoldersInValueSpecification()),
             v : meta::pure::executionPlan::PlanVarPlaceHolder[1] | $v,
             a : Any[1] | []
          ])

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/platform/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/platform/executionPlan/executionPlan_generation.pure
@@ -46,14 +46,16 @@ function meta::pure::platform::executionPlan::generation::processValueSpecificat
 function <<access.private>> meta::pure::platform::executionPlan::generation::defaultFunctionProcessor(fe:FunctionExpression[1], state:PlatformPlanGenerationState[1], extensions : Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
    let children = $fe.parametersValues->evaluateAndDeactivate()->map(v|$v->recursivelyFetchClusteredValueSpecification(false))->map(v|$v->processValueSpecification($state, $extensions, $debug));
-   let funcParams = $fe->findVariableExpressionsInValueSpecification(false)->removeDuplicatesBy(v | $v.name);
-   let varInputs = $funcParams->map(v | ^VariableInput(name = $v.name->toOne(), type = $v.genericType->cast(@GenericType).rawType->toOne(), multiplicity = $v.multiplicity->toOne()));
+   let variableExpressions = $fe->findVariableExpressionsInValueSpecification(false)->removeDuplicatesBy(v | $v.name);
+   let variableExpressionInputs = $variableExpressions->map(v | ^VariableInput(name = $v.name->toOne(), type = $v.genericType->cast(@GenericType).rawType->toOne(), multiplicity = $v.multiplicity->toOne()));
+   let varPlaceHolders = $fe->findPlanVarPlaceHoldersInValueSpecification()->removeDuplicatesBy(v | $v.name);
+   let varPlaceHolderInputs = $varPlaceHolders->map(v | ^VariableInput(name = $v.name, type = $v.type, multiplicity = $v.multiplicity->toOne('Multiplicity not available for PlanVarPlaceHolder - \'' + $v.name + '\'')));
 
    ^PureExpressionPlatformExecutionNode
    (
       expression = $fe,
       resultType = ^ResultType(type=$fe.genericType.rawType->toOne()),
-      requiredVariableInputs = $varInputs,
+      requiredVariableInputs = $variableExpressionInputs->concatenate($varPlaceHolderInputs),
       resultSizeRange = $fe.multiplicity,
       executionNodes = $children,
       fromCluster = generatePlatformClusterForFunction($fe, $state.inScopeVars)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/printer/printer.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/printer/printer.pure
@@ -79,7 +79,6 @@ function meta::pure::router::printer::asString(f:ValueSpecification[1], pref:Pre
                                                                      a:meta::pure::graphFetch::GraphFetchTree[1]|meta::pure::graphFetch::routing::asString($a, false),
                                                                      b:KeyExpression[1]|'^KeyExpression(key = ' + $b.key->asString($pref) + ', value = '+ $b.expression->asString($pref) + ')',
                                                                      a:BasicColumnSpecification<Any>[1]| '^BasicColumnSpecification<' + $a->genericType().typeArguments.rawType.name->makeString() + '>(name = \'' + $a.name + '\', func = ' + $a.func->asString($pref) + ')';,
-                                                                     r:RoutedVariablePlaceHolder[1]|'$'+$r.name,
                                                                      p:meta::pure::executionPlan::PlanVarPlaceHolder[1]|'$'+$p.name,
                                                                      a:Class<Any>[1]|if (efq($pref),|$a->elementToPath(),|$a->genericType().rawType.name->toOne()+' '+$a->toString()),
                                                                      a:Any[1]|$a->genericType().rawType.name->toOne()+' '+$a->toString();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
@@ -26,10 +26,6 @@ import meta::pure::router::printer::*;
 import meta::pure::router::routing::*;
 import meta::pure::router::utils::*;
 import meta::core::runtime::*;
-Class meta::pure::router::RoutedVariablePlaceHolder
-{
-   name : String[1];
-}
 
 function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], extensions:Extension[*]):FunctionDefinition<Any>[1]
 {
@@ -53,16 +49,14 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
       assert($unavailableVars->isEmpty(), 'Unable to resolve var(s): ' + $unavailableVars->joinStrings(','));
 
       let unResolvedVars  = $reqVars->filter(v|let resolved = $a.second->get($v.name);
-                                               $resolved.values->isEmpty() || $resolved.values->at(0)->instanceOf(RoutedVariablePlaceHolder););
+                                               $resolved.values->isEmpty() || $resolved.values->at(0)->instanceOf(meta::pure::executionPlan::PlanVarPlaceHolder););
 
       if($unResolvedVars->isNotEmpty(),
         {|
           let unRoutedFunction = ^$l(expressionSequence = $vs, openVariables=$a.second->keys());
           let routedFunction   = routeFunction($unRoutedFunction, getPlatformRoutingStrategy(), $exeCtx, $a.second, $extensions, $debug);
           let deactivatedEs = $routedFunction.expressionSequence->evaluateAndDeactivate();
-          let vars             = $a.second->put($varName->toOne(), ^List<meta::pure::executionPlan::PlanVarPlaceHolder>(values=^meta::pure::executionPlan::PlanVarPlaceHolder(type = $deactivatedEs->last().genericType.rawType->toOne(), 
-                                                                                                                        name=$varName->toOne(), multiplicity = $deactivatedEs->last()->toOne().multiplicity, 
-                                                                                                                        supportsStream = $deactivatedEs->last()->toOne().multiplicity->isToMany())));
+          let vars             = $a.second->put($varName->toOne(), createPlanVarPlaceHolderInScopeVar($varName->toOne(), $deactivatedEs->last()->toOne()));
 
           ^$a
           (
@@ -81,7 +75,8 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
                 |let re   = $vs->reactivate($a.second);
                  let vars = $a.second->put($varName->toOne(), ^List<Any>(values=$re));
                  ^$a(first=$a.first, second = $vars);,
-                |let vars   = $a.second->put($varName->toOne(), ^List<RoutedVariablePlaceHolder>(values=^RoutedVariablePlaceHolder(name=$varName->toOne())));
+                |let deactivatedEs = $routed.expressionSequence->evaluateAndDeactivate();
+                 let vars   = $a.second->put($varName->toOne(), createPlanVarPlaceHolderInScopeVar($varName->toOne(), $deactivatedEs->last()->toOne()));
                  ^$a
                  (
                    first = ^$routed(expressionSequence = $a.first.expressionSequence->concatenate($routed.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>),
@@ -103,7 +98,7 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
   let vs      = $expressions->last()->toOne();
   let varName = $vs->extractLetVariableName();
   let vars    = if($varName->isNotEmpty(),
-                   | $initStatements.second->put($varName->toOne(), ^List<RoutedVariablePlaceHolder>(values=^RoutedVariablePlaceHolder(name=$varName->toOne()))),
+                   | $initStatements.second->put($varName->toOne(), createPlanVarPlaceHolderInScopeVar($varName->toOne(), $vs->cast(@FunctionExpression).parametersValues->evaluateAndDeactivate()->at(1))), // Since its a let function, use ->at(1) parameter
                    | $initStatements.second);
   let newF    = ^$l(expressionSequence    = $vs,
                     openVariables         = $vars->keys(),
@@ -111,6 +106,18 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
 
   let routed  = routeFunction($newF, getPlatformRoutingStrategy(), $exeCtx, $vars, $extensions, $debug);
   ^$routed(expressionSequence = $initStatements.first.expressionSequence->tail()->concatenate($routed.expressionSequence)->evaluateAndDeactivate()->toOneMany())->cast(@FunctionDefinition<Any>);
+}
+
+function <<access.private>> meta::pure::router::createPlanVarPlaceHolderInScopeVar(varName: String[1], vs: ValueSpecification[1]): List<meta::pure::executionPlan::PlanVarPlaceHolder>[1]
+{
+   ^List<meta::pure::executionPlan::PlanVarPlaceHolder>(
+      values = ^meta::pure::executionPlan::PlanVarPlaceHolder(
+         name = $varName,
+         type = $vs.genericType.rawType->toOne(), 
+         multiplicity = $vs.multiplicity,
+         supportsStream = $vs.multiplicity->isToMany()
+      )
+   )
 }
 
 function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], routingStrategy:RoutingStrategy[1], exeCtx: meta::pure::runtime::ExecutionContext[1], inScopeVars:Map<String, List<Any>>[0..1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):FunctionDefinition<Any>[1]

--- a/legend-engine-core/legend-engine-core-query-pure-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-query-pure-http-api/pom.xml
@@ -248,6 +248,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-core-extension</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-core.version}</version>

--- a/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestExecuteFunctionExecutionPlan.java
+++ b/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestExecuteFunctionExecutionPlan.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.query.pure.api.test.inMemory;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
@@ -27,10 +28,9 @@ import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransforme
 import org.finos.legend.engine.plan.platform.PlanPlatform;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
+import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.*;
-import org.finos.legend.pure.generated.core_java_platform_binding_legendJavaPlatformBinding_store_m2m_m2mLegendJavaPlatformBindingExtension;
 import org.finos.legend.pure.generated.Root_meta_pure_executionPlan_ExecutionPlan;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.generated.Root_meta_pure_mapping_Mapping_Impl;
@@ -42,6 +42,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 public class TestExecuteFunctionExecutionPlan
 {
@@ -50,12 +51,12 @@ public class TestExecuteFunctionExecutionPlan
         PureModelContextData pmcd = PureGrammarParser.newInstance().parseModel(functionGrammar);
         PureModel pureModelForFunction = Compiler.compile(pmcd, DeploymentMode.TEST_IGNORE_FUNCTION_MATCH, Identity.getAnonymousIdentity().getName());
         ConcreteFunctionDefinition<?> concreteFxn = pureModelForFunction.getConcreteFunctionDefinition_safe(funcName);
-        RichIterable<? extends Root_meta_pure_extension_Extension> extensions = core_java_platform_binding_legendJavaPlatformBinding_store_m2m_m2mLegendJavaPlatformBindingExtension.Root_meta_pure_mapping_modelToModel_executionPlan_platformBinding_legendJava_inMemoryExtensionsWithLegendJavaPlatformBinding__Extension_MANY_(pureModelForFunction.getExecutionSupport());
+        RichIterable<? extends Root_meta_pure_extension_Extension> extensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModelForFunction.getExecutionSupport()));
         Root_meta_pure_executionPlan_ExecutionPlan executionPlanInPure = core_pure_executionPlan_executionPlan_generation.Root_meta_pure_executionPlan_executionPlan_FunctionDefinition_1__Mapping_1__Runtime_1__Extension_MANY__ExecutionPlan_1_(concreteFxn, new Root_meta_pure_mapping_Mapping_Impl(""), new Root_meta_core_runtime_Runtime_Impl(""), extensions, pureModelForFunction.getExecutionSupport());
         PlanPlatform platform = PlanPlatform.JAVA;
         executionPlanInPure = platform.bindPlan(executionPlanInPure, null, pureModelForFunction, extensions);
         SingleExecutionPlan singleExecPlan = PlanGenerator.transformExecutionPlan(executionPlanInPure, pureModelForFunction, "vX_X_X", Identity.getAnonymousIdentity(), extensions, LegendPlanTransformers.transformers);
-        Result result = PlanExecutor.newPlanExecutor().execute(singleExecPlan, params);
+        Result result = PlanExecutor.newPlanExecutorBuilder().withAvailableStoreExecutors().build().execute(singleExecPlan, params);
         return result;
     }
 
@@ -115,5 +116,94 @@ public class TestExecuteFunctionExecutionPlan
         Assert.assertEquals(2, ((ArrayList)((ConstantResult) result).getValue()).size());
         Assert.assertEquals(12L, ((ArrayList)((ConstantResult) result).getValue()).get(0));
         Assert.assertEquals(22L, ((ArrayList)((ConstantResult) result).getValue()).get(1));
+    }
+
+    @Test
+    public void testExecutingFunctionWithAdvancedMultiLevelOperations()
+    {
+        String grammar = "###Pure\n" +
+                "Class test::Person\n" +
+                "{\n" +
+                "  name: String[1];\n" +
+                "}\n" +
+                "\n" +
+                "function test::testAdvancedMultiLevelOperations(p1: String[1], p2: String[0..1], p3: String[*]): String[1]\n" +
+                "{\n" +
+                "   let p1Upper  = $p1->toUpper();\n" +
+                "   let p2Lower  = if($p2->isEmpty(), | '', | $p2->toOne()->toLower());\n" +
+                "   let p3Joined = $p3->joinStrings('|');\n" +
+                "   let p3Parsed = $p3->map(x | $x->parseInteger());\n" +
+                "   let p3Sum    = $p3Parsed->sum();\n" +
+                "   let queryRes = test::Person.all()->filter(x | $p1 != '').name->count()->from(test::Map, test::Runtime);\n" +
+                "   let ifClause = if($p3Sum > 10, | $p1Upper + '~' + $queryRes->toString(), | $p2Lower + '~' + $queryRes->toString());\n" +
+                "\n" +
+                "   let res = [\n" +
+                "      ('P1Upper:' + $p1Upper),\n" +
+                "      ('P2Lower:' + $p2Lower),\n" +
+                "      ('P3Joined:' + $p3Joined),\n" +
+                "      ('P3Sum:' + $p3Sum->toString()),\n" +
+                "      ('QueryRes:' + $queryRes->toString()),\n" +
+                "      ('IfClause:' + $ifClause)\n" +
+                "   ]->joinStrings('[', ', ', ']');\n" +
+                "}\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping test::Map\n" +
+                "(\n" +
+                "  test::Person: Relational {\n" +
+                "    name: [test::DB]person.NAME\n" +
+                "  }\n" +
+                ")\n" +
+                "\n" +
+                "###Relational\n" +
+                "Database test::DB\n" +
+                "(\n" +
+                "  Table person(NAME VARCHAR(100) PRIMARY KEY)\n" +
+                ")\n" +
+                "\n" +
+                "###Runtime\n" +
+                "Runtime test::Runtime\n" +
+                "{\n" +
+                "  mappings:\n" +
+                "  [\n" +
+                "    test::Map\n" +
+                "  ];\n" +
+                "  connections:\n" +
+                "  [\n" +
+                "    test::DB:\n" +
+                "    [\n" +
+                "      c1: #{\n" +
+                "        RelationalDatabaseConnection\n" +
+                "        {\n" +
+                "          type: H2;\n" +
+                "          specification: LocalH2 {testDataSetupCSV: 'default\\nperson\\nNAME\\nPeter\\n----'; };\n" +
+                "          auth: DefaultH2;\n" +
+                "        }\n" +
+                "      }#\n" +
+                "    ]\n" +
+                "  ];\n" +
+                "}\n";
+
+        BiConsumer<Map<String, Object>, String> assertionFunc = (params, expected) ->
+        {
+            try (Result result = getResultFromFunctionGrammar(grammar, params, "test::testAdvancedMultiLevelOperations_String_1__String_$0_1$__String_MANY__String_1_"))
+            {
+                Assert.assertTrue(((ConstantResult) result).getValue() instanceof String);
+                Assert.assertEquals(expected, ((ConstantResult) result).getValue());
+            }
+        };
+
+        assertionFunc.accept(
+                Maps.mutable.of("p1", "Hello", "p2", "World", "p3", Lists.mutable.of("1", "4")),
+                "[P1Upper:HELLO, P2Lower:world, P3Joined:1|4, P3Sum:5, QueryRes:1, IfClause:world~1]"
+        );
+        assertionFunc.accept(
+                Maps.mutable.of("p1", "Hello", "p2", "World", "p3", Lists.mutable.of("6", "7")),
+                "[P1Upper:HELLO, P2Lower:world, P3Joined:6|7, P3Sum:13, QueryRes:1, IfClause:HELLO~1]"
+        );
+        assertionFunc.accept(
+                Maps.mutable.of("p1", "", "p3", Lists.mutable.empty()),
+                "[P1Upper:, P2Lower:, P3Joined:, P3Sum:0, QueryRes:0, IfClause:~0]"
+        );
     }
 }

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -172,6 +172,17 @@ function <<access.private>> meta::external::language::java::transform::processIn
          {v:ValueSpecification[1] |
             generateJava($v, $conventions, $debug);
          },
+         {v:meta::pure::executionPlan::PlanVarPlaceHolder[1] |
+            generateJava(
+               ^VariableExpression(
+                  name = $v.name,
+                  genericType = ^GenericType(rawType = $v.type),
+                  multiplicity = $v.multiplicity->toOne('Multiplicity not available for PlanVarPlaceHolder \'' + $v.name + '\'')
+               )->evaluateAndDeactivate(),
+               $conventions,
+               $debug
+            )
+         },
          {t:meta::pure::metamodel::type::Type[1] |
             j_null($conventions->pureTypeToJavaType($t, PureOne));
          },

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/store/m2m/m2mLegendJavaPlatformBindingExtension.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/store/m2m/m2mLegendJavaPlatformBindingExtension.pure
@@ -160,7 +160,7 @@ function meta::pure::mapping::modelToModel::executionPlan::platformBinding::lege
                   },
                   {
                      model: ModelConnection[1] |
-                        let varName = $model.instances->values()->at(0)->get(0)->match([p:PlanVarPlaceHolder[1]| $p.name, r:RoutedVariablePlaceHolder[1]| $r.name]);
+                        let varName = $model.instances->values()->at(0)->get(0)->match([p:PlanVarPlaceHolder[1]| $p.name]);
                         let typeArg = $storeStreamReadingContext->j_invoke('streamType', $conventions->className($pureClass)->j_field('class', javaClassType()), javaReflectType());
                         $conventions->meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::storeStreamReading::objectStream::streamReaderClass($path)
                            ->j_new($storeStreamReadingContext->j_invoke('getResult', [j_string($varName), $typeArg], javaStream($conventions->className($pureClass))))->j_return();


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Improve handling of PlanVarPlaceHolders in platform executions

Changes:

1. Remove RoutedVariablePlaceHolder concept in routing as this class does not have any type information (which is required when generating Java and other flows). Create PlanVarPlaceHolder instances instead

2. For a platform node, required variable inputs should include PlanVarPlaceHolders in addition to VariableExpressions (sometimes, VariableExpressions are resolved to PlanVarPlaceHolders during routing) 

3. During routing, when VariableExpression resolves to PlanVarPlaceHolder, create InstanceValue with the correct type and multiplicity (which is present in PlanVarPlaceHolder)

4. Support Java generation for PlanVarPlaceHolders just like VariableExpressions

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

