### PR TITLE
Add boolean literal processor for duckdb

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -35,7 +35,8 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::getLiteralProcessorsForDuckDB():Map<Type,LiteralProcessor>[1]
 {
    newMap([
-   ]->cast(@Pair<Type,LiteralProcessor>))
+      pair(Boolean,    ^LiteralProcessor(format = '%s', transform = toString_Any_1__String_1_->literalTransform()))
+   ])
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::getDynaFunctionToSqlForDuckDB(): DynaFunctionToSql[*]


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

Currently, there is a mismatch between the isBooleanLiteralSupported flag and how we process boolean literals in duckdb literalProcessors. 

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
