### PR TITLE
Identifiers that start with numbers should be quoted

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperMappingGrammarComposer.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperMappingGrammarComposer.java
@@ -166,7 +166,7 @@ public class HelperMappingGrammarComposer
 
     public static String renderMappingId(String id)
     {
-        return (id != null ? ("[" + PureGrammarComposerUtility.convertIdentifier(id) + "]") : "");
+        return (id != null ? ("[" + id + "]") : "");
     }
 
     public static String renderAggregateSetImplementationContainer(AggregateSetImplementationContainer agg, DEPRECATED_PureGrammarComposerCore transformer)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerUtility.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerUtility.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 public class PureGrammarComposerUtility
 {
     private static final String PACKAGE_SEPARATOR = "::";
-    private static final Pattern UNQUOTED_IDENTIFIER_PATTERN = Pattern.compile("[A-Za-z0-9_][A-Za-z0-9_$~]*"); // TODO
+    private static final Pattern UNQUOTED_IDENTIFIER_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_$~]*"); // TODO
 
     public static final String TAB = "  ";
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -307,6 +307,16 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     }
 
     @Test
+    public void testNumbersInEnumerationName()
+    {
+        test("Enum my::Enum\n" +
+                "{\n" +
+                "  '30_360',\n" +
+                "  '30_ACT'\n" +
+                "}\n");
+    }
+
+    @Test
     public void testAssociations()
     {
         test("Association myAsso\n" +

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestLambdaRoundtrip.java
@@ -257,6 +257,7 @@ public class TestLambdaRoundtrip
     public void testLambdaWithEnum()
     {
         testLambda("|MyEnum.ok");
+        testLambda("|MyEnum.'30_360'");
     }
 
     @Test

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestMappingGrammarRoundtrip.java
@@ -552,6 +552,11 @@ public class TestMappingGrammarRoundtrip extends TestGrammarRoundtrip.TestGramma
                 "    MT22: [200],\n" +
                 "    MT23: [300, 400]\n" +
                 "  }\n" +
+                "  meta::pure::mapping::modelToModel::test::enumerationMapping::enumToEnum::model::DayCount: EnumerationMapping\n" +
+                "  {\n" +
+                "    '30_ACT': [My::DayCount.'30_ACT'],\n" +
+                "    '30_360': [My::DayCount.'30_360']\n" +
+                "  }\n" +
                 ")\n");
     }
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
@@ -159,7 +159,7 @@ public class DataSpaceGrammarComposerExtension implements PureGrammarComposerExt
     private static String renderDataspaceTemplateExecutable(DataSpaceTemplateExecutable executable, PureGrammarComposerContext context)
     {
         return getTabString(2) + "{\n" +
-                (getTabString(3) + "id: " + convertIdentifier(executable.id) + ";\n") +
+                (getTabString(3) + "id: " + executable.id + ";\n") +
                 (getTabString(3) + "title: " + convertString(executable.title, true) + ";\n") +
                 (executable.description != null ? (getTabString(3) + "description: " + convertString(executable.description, true) + ";\n") : "") +
                 getTabString(3) + "query: " + executable.query.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(context).withIndentation(getTabSize(2)).build()) + ";\n" +


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

When identifiers are using in the form My::Enum.123_ABC, it fail as the `.` token seems to confuse ANTLR and cannot be parsed.  This forces any identifier that starts with numbers to be quoted to allow ANTLR to understand the limit of each token.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
