### PR TITLE
fixing calculation of report linage for queries with only groupBy

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/lineage/scanProject.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/lineage/scanProject.pure
@@ -59,6 +59,16 @@ function <<access.private>> meta::pure::lineage::scanProject::scanProjectRecursi
                                                                ]
                                                             );
 
+                                                      ),
+                                                      pair('meta::pure::tds::groupBy_K_MANY__Function_MANY__AggregateValue_MANY__String_MANY__TabularDataSet_1_',
+                                                        | let funcs = $fe.parametersValues->at(1)->match([s:InstanceValue[1]|$s.values, a:Any[*]|^Unknown()]);
+                                                          let aggregateFuncs = $fe.parametersValues->at(2)->scanAggregateValue();
+                                                          let allFuncs = $funcs->concatenate($aggregateFuncs);
+                                                          let names = $fe.parametersValues->at(3)->match([s:InstanceValue[1]|$s.values,a:Any[*]|^Unknown()]);
+                                                          ^Project(projectfuncEntryPoint = $fe,
+                                                                    columns = zip($names->match([s:String[*]|$s, a:Unknown[*]|range(1, $allFuncs->size(),1)->map(z|'unknown_'+$z->toString())]),
+                                                                                  $allFuncs->match([s:FunctionDefinition<Any>[*]|$s, a:Unknown[*]|[]]))
+                                                          );
                                                       )
                                                     ];
                                      let funcFullPath = $fe.func->toOne()->elementToPath();
@@ -86,4 +96,13 @@ function <<access.private>> meta::pure::lineage::scanProject::scanProjectRecursi
       a:Any[1]|$project
    ]
   );
+}
+
+function <<access.private>> meta::pure::lineage::scanProject::scanAggregateValue(val:Any[*]):FunctionDefinition<Any>[*]
+{
+  $val->match([
+    s:InstanceValue[*]|$s.values->scanAggregateValue(),
+    se: FunctionExpression[*]| $se->map(x| $x.parametersValues->at(0))->scanAggregateValue(),
+    f: FunctionDefinition<Any>[*]|$f,
+    a:Any[*]|[]]);
 }

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/src/main/resources/core_analytics_lineage/tests/scanProjectTests.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/src/main/resources/core_analytics_lineage/tests/scanProjectTests.pure
@@ -28,6 +28,17 @@ function <<access.private>> meta::pure::lineage::scanProject::test::executeWithP
                                 ]), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
 }
 
+function <<access.private>> meta::pure::lineage::scanProject::test::executeWithGroupBy():Any[1]
+{
+   execute(|Trade.all()->groupBy([x|$x.date->adjust(0, DurationUnit.DAYS)],
+               [
+                  agg(x | $x.quantity, y | $y->sum()),
+                  agg(x | $x.id, y | $y->count())
+               ],
+               ['tradeDate', 'quantity', 'count']
+               ), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+}
+
 function <<access.private>> meta::pure::lineage::scanProject::test::executeWithProjectUsingCol():Any[1]
 {
    execute(|Firm.all()->project([
@@ -93,4 +104,11 @@ function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanProject::t
    let x = meta::pure::lineage::scanProject::test::executeWithProjectUsingCol2__Any_1_->scanExecutes();
    let p = $x.funcEntryPoint->toOne()->evaluateAndDeactivate()->meta::pure::lineage::scanProject::scanProject();
    assertEquals(['a', 'b', 'c'], $p.columns.first);
+}
+
+function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanProject::test::testFindGroupBy():Boolean[1]
+{
+   let x = meta::pure::lineage::scanProject::test::executeWithGroupBy__Any_1_->scanExecutes();
+   let p = $x.funcEntryPoint->toOne()->evaluateAndDeactivate()->meta::pure::lineage::scanProject::scanProject();
+   assertEquals(['tradeDate', 'quantity', 'count'], $p.columns.first);
 }


### PR DESCRIPTION
#### What type of PR is this?
 Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
This change fixes the calculation for report lineage. Queries which only have groupBys in their lambda with no project used to fail report lineage generation, this change should fix this behaviour.
<!--
Describe change being introduced by this PR.
-->

#### Does this PR introduce a user-facing change?
<!--
-->
No