### PR TITLE
Change temp table processing in graphfetch

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
@@ -38,7 +38,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memsq
       identifierProcessor = processIdentifierWithBackTicks_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
@@ -38,7 +38,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memsq
       identifierProcessor = processIdentifierWithBackTicks_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_1__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/SnowflakeConnectionExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/SnowflakeConnectionExtension.java
@@ -210,7 +210,9 @@ public class SnowflakeConnectionExtension implements RelationalConnectionExtensi
                         snowflakeDatasourceSpecification.nonProxyHosts,
                         snowflakeDatasourceSpecification.accountType,
                         snowflakeDatasourceSpecification.organization,
-                        snowflakeDatasourceSpecification.role);
+                        snowflakeDatasourceSpecification.role,
+                        snowflakeDatasourceSpecification.tempTableDb,
+                        snowflakeDatasourceSpecification.tempTableSchema);
             }
             return null;
         };

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
@@ -42,6 +42,9 @@ public class SnowflakeDataSourceSpecification extends DataSourceSpecification
     public static final String SNOWFLAKE_ROLE = "role";
     public static final String SNOWFLAKE_ENABLE_QUERY_TAGS = "enableQueryTags";
 
+    public static final String SNOWFLAKE_TEMP_TABLE_DB = "tempTableDb";
+    public static final String SNOWFLAKE_TEMP_TABLE_SCHEMA = "tempTableSchema";
+
     public SnowflakeDataSourceSpecification(SnowflakeDataSourceSpecificationKey key, DatabaseManager databaseManager, AuthenticationStrategy authenticationStrategy, Properties extraUserProperties)
     {
         super(key, databaseManager, authenticationStrategy, extraUserProperties);
@@ -74,6 +77,10 @@ public class SnowflakeDataSourceSpecification extends DataSourceSpecification
         putIfNotEmpty(this.extraDatasourceProperties, SNOWFLAKE_PROXY_HOST, key.getProxyHost());
         putIfNotEmpty(this.extraDatasourceProperties, SNOWFLAKE_PROXY_PORT, key.getProxyPort());
         putIfNotEmpty(this.extraDatasourceProperties, SNOWFLAKE_NON_PROXY_HOSTS, key.getNonProxyHosts());
+
+        putIfNotEmpty(this.extraDatasourceProperties, SNOWFLAKE_TEMP_TABLE_DB, updateSnowflakeIdentifiers(key.getTempTableDb(), key.getQuoteIdentifiers()));
+        putIfNotEmpty(this.extraDatasourceProperties, SNOWFLAKE_TEMP_TABLE_SCHEMA, updateSnowflakeIdentifiers(key.getTempTableSchema(), key.getQuoteIdentifiers()));
+
         this.extraDatasourceProperties.put(SNOWFLAKE_USE_PROXY, this.extraDatasourceProperties.get(SNOWFLAKE_PROXY_HOST) != null);
     }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
@@ -42,8 +42,8 @@ public class SnowflakeDataSourceSpecification extends DataSourceSpecification
     public static final String SNOWFLAKE_ROLE = "role";
     public static final String SNOWFLAKE_ENABLE_QUERY_TAGS = "enableQueryTags";
 
-    public static final String SNOWFLAKE_TEMP_TABLE_DB = "tempTableDb";
-    public static final String SNOWFLAKE_TEMP_TABLE_SCHEMA = "tempTableSchema";
+    public static final String SNOWFLAKE_TEMP_TABLE_DB = "LEGEND_TEMP_DB";
+    public static final String SNOWFLAKE_TEMP_TABLE_SCHEMA = "LEGEND_TEMP_SCHEMA";
 
     public SnowflakeDataSourceSpecification(SnowflakeDataSourceSpecificationKey key, DatabaseManager databaseManager, AuthenticationStrategy authenticationStrategy, Properties extraUserProperties)
     {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/keys/SnowflakeDataSourceSpecificationKey.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/keys/SnowflakeDataSourceSpecificationKey.java
@@ -32,11 +32,20 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
     private String proxyPort;
     private String nonProxyHosts;
 
+    private String tempTableDb;
+    private String tempTableSchema;
+
     private SnowflakeAccountType accountType;
     private String organisation;
 
     private String role;
 
+    public SnowflakeDataSourceSpecificationKey(String accountName, String region, String warehouseName, String databaseName, String cloudType, Boolean quoteIdentifiers, Boolean enableQueryTags, String proxyHost, String proxyPort, String nonProxyHosts, String accountType, String organisation, String role, String tempTableDb, String tempTableSchema)
+    {
+        this(accountName, region, warehouseName, databaseName, cloudType, quoteIdentifiers, enableQueryTags, proxyHost, proxyPort, nonProxyHosts, accountType, organisation, role);
+        this.tempTableDb = tempTableDb;
+        this.tempTableSchema = tempTableSchema;
+    }
 
     public SnowflakeDataSourceSpecificationKey(String accountName, String region, String warehouseName, String databaseName, String cloudType, Boolean quoteIdentifiers, Boolean enableQueryTags, String proxyHost, String proxyPort, String nonProxyHosts, String accountType, String organisation, String role)
     {
@@ -139,6 +148,16 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
         return enableQueryTags;
     }
 
+    public String getTempTableDb()
+    {
+        return tempTableDb;
+    }
+
+    public String getTempTableSchema()
+    {
+        return tempTableSchema;
+    }
+
     @Override
     public String toString()
     {
@@ -152,6 +171,8 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
                 ", proxyHost='" + proxyHost + '\'' +
                 ", proxyPort='" + proxyPort + '\'' +
                 ", nonProxyHosts='" + nonProxyHosts + '\'' +
+                ", tempTableDb='" + tempTableDb + '\'' +
+                ", tempTableSchema='" + tempTableSchema + '\'' +
                 ", accountType='" + accountType + '\'' +
                 ", organisation='" + organisation + '\'' +
                 ", role='" + role + '\'' +
@@ -171,6 +192,8 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
                 "proxyHost:" + proxyHost + "_" +
                 "proxyPort:" + proxyPort + "_" +
                 "nonProxyHosts:" + nonProxyHosts + "_" +
+                "tempTableDb:" + tempTableDb + "_" +
+                "tempTableSchema:" + tempTableSchema + "_" +
                 "accountType:" + accountType + "_" +
                 "organisation:" + organisation + "_" +
                 "quoteIdentifiers:" + quoteIdentifiers +
@@ -198,6 +221,8 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
                 Objects.equals(proxyHost, that.proxyHost) &&
                 Objects.equals(proxyPort, that.proxyPort) &&
                 Objects.equals(nonProxyHosts, that.nonProxyHosts) &&
+                Objects.equals(tempTableDb, that.tempTableDb) &&
+                Objects.equals(tempTableSchema, that.tempTableSchema) &&
                 Objects.equals(accountType, that.accountType) &&
                 Objects.equals(organisation, that.organisation) &&
                 Objects.equals(quoteIdentifiers, that.quoteIdentifiers) &&
@@ -208,6 +233,6 @@ public class SnowflakeDataSourceSpecificationKey implements DataSourceSpecificat
     @Override
     public int hashCode()
     {
-        return Objects.hash(accountName, region, warehouseName, databaseName, cloudType, quoteIdentifiers, proxyHost, proxyPort, nonProxyHosts, accountType, organisation, role, enableQueryTags);
+        return Objects.hash(accountName, region, warehouseName, databaseName, cloudType, quoteIdentifiers, proxyHost, proxyPort, nonProxyHosts, tempTableDb, tempTableSchema, accountType, organisation, role, enableQueryTags);
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/pom.xml
@@ -95,6 +95,10 @@
         <!-- ENGINE -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/SnowflakeLexerGrammar.g4
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/SnowflakeLexerGrammar.g4
@@ -13,6 +13,8 @@ QUOTED_IDENTIFIERS_IGNORE_CASE:             'quotedIdentifiersIgnoreCase';
 PROXYHOST:                                  'proxyHost';
 PROXYPORT:                                  'proxyPort';
 NONPROXYHOSTS:                              'nonProxyHosts';
+TEMPTABLEDB:                                'tempTableDb';
+TEMPTABLESCHEMA:                            'tempTableSchema';
 ACCOUNTTYPE:                                'accountType';
 ORGANIZATION:                               'organization';
 ROLE:                                       'role';

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/SnowflakeParserGrammar.g4
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/SnowflakeParserGrammar.g4
@@ -24,6 +24,8 @@ snowflakeDatasourceSpecification:           SNOWFLAKE
                                                         | dbProxyHost
                                                         | dbProxyPort
                                                         | dbNonProxyHosts
+                                                        | dbTempTableDb
+                                                        | dbTempTableSchema
                                                         | dbAccountType
                                                         | dbOrganization
                                                         | dbRole
@@ -42,6 +44,10 @@ dbProxyHost:                                PROXYHOST COLON STRING SEMI_COLON
 dbProxyPort:                                PROXYPORT COLON STRING SEMI_COLON
 ;
 dbNonProxyHosts:                            NONPROXYHOSTS COLON STRING SEMI_COLON
+;
+dbTempTableDb:                              TEMPTABLEDB COLON STRING SEMI_COLON
+;
+dbTempTableSchema:                          TEMPTABLESCHEMA COLON STRING SEMI_COLON
 ;
 dbAccountType:                              ACCOUNTTYPE COLON identifier SEMI_COLON
 ;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SnowflakeCompilerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SnowflakeCompilerExtension.java
@@ -59,6 +59,10 @@ public class SnowflakeCompilerExtension implements IRelationalCompilerExtension
             if (datasourceSpecification instanceof SnowflakeDatasourceSpecification)
             {
                 SnowflakeDatasourceSpecification snowflakeDatasourceSpecification = (SnowflakeDatasourceSpecification) datasourceSpecification;
+                if (snowflakeDatasourceSpecification.tempTableDb != null ^ snowflakeDatasourceSpecification.tempTableSchema != null)
+                {
+                    throw new RuntimeException("One of Database name and schema name for temp tables is missing. Please specify both tempTableDb and tempTableSchema");
+                }
                 Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification _snowflake = new Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification_Impl("", null, context.pureModel.getClass("meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceSpecification"));
                 _snowflake._accountName(snowflakeDatasourceSpecification.accountName);
                 _snowflake._region(snowflakeDatasourceSpecification.region);
@@ -70,6 +74,8 @@ public class SnowflakeCompilerExtension implements IRelationalCompilerExtension
                 _snowflake._proxyHost(snowflakeDatasourceSpecification.proxyHost);
                 _snowflake._proxyPort(snowflakeDatasourceSpecification.proxyPort);
                 _snowflake._nonProxyHosts(snowflakeDatasourceSpecification.nonProxyHosts);
+                _snowflake._tempTableDb(snowflakeDatasourceSpecification.tempTableDb);
+                _snowflake._tempTableSchema(snowflakeDatasourceSpecification.tempTableSchema);
                 if (snowflakeDatasourceSpecification.accountType != null)
                 {
                     _snowflake._accountType(context.pureModel.getEnumValue("meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType", snowflakeDatasourceSpecification.accountType));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SnowflakeCompilerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/SnowflakeCompilerExtension.java
@@ -19,12 +19,15 @@ package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.SnowflakePublicAuthenticationStrategy;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.flows.DatabaseAuthenticationFlowKey;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.SnowflakeDatasourceSpecification;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_authentication_AuthenticationStrategy;
 import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_specification_DatasourceSpecification;
@@ -61,7 +64,7 @@ public class SnowflakeCompilerExtension implements IRelationalCompilerExtension
                 SnowflakeDatasourceSpecification snowflakeDatasourceSpecification = (SnowflakeDatasourceSpecification) datasourceSpecification;
                 if (snowflakeDatasourceSpecification.tempTableDb != null ^ snowflakeDatasourceSpecification.tempTableSchema != null)
                 {
-                    throw new RuntimeException("One of Database name and schema name for temp tables is missing. Please specify both tempTableDb and tempTableSchema");
+                    throw new EngineException("One of Database name and schema name for temp tables is missing. Please specify both tempTableDb and tempTableSchema", SourceInformation.getUnknownSourceInformation(), EngineErrorType.COMPILATION);
                 }
                 Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification _snowflake = new Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification_Impl("", null, context.pureModel.getClass("meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceSpecification"));
                 _snowflake._accountName(snowflakeDatasourceSpecification.accountName);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/SnowflakeGrammarParserExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/SnowflakeGrammarParserExtension.java
@@ -163,6 +163,12 @@ public class SnowflakeGrammarParserExtension implements IRelationalGrammarParser
         // nonProxyHosts
         SnowflakeParserGrammar.DbNonProxyHostsContext nonProxyHostsContext = PureGrammarParserUtility.validateAndExtractOptionalField(dbSpecCtx.dbNonProxyHosts(), "nonProxyHosts", dsSpec.sourceInformation);
         Optional.ofNullable(nonProxyHostsContext).ifPresent(nonProxyHostsCtx -> dsSpec.nonProxyHosts = PureGrammarParserUtility.fromGrammarString(nonProxyHostsCtx.STRING().getText(), true));
+        // tempTableDb
+        SnowflakeParserGrammar.DbTempTableDbContext tempTableDbContext = PureGrammarParserUtility.validateAndExtractOptionalField(dbSpecCtx.dbTempTableDb(), "tempTableDb", dsSpec.sourceInformation);
+        Optional.ofNullable(tempTableDbContext).ifPresent(tempTableDbCtx -> dsSpec.tempTableDb = PureGrammarParserUtility.fromGrammarString(tempTableDbCtx.STRING().getText(), true));
+        // tempTableSchema
+        SnowflakeParserGrammar.DbTempTableSchemaContext tempTableSchemaContext = PureGrammarParserUtility.validateAndExtractOptionalField(dbSpecCtx.dbTempTableSchema(), "tempTableSchema", dsSpec.sourceInformation);
+        Optional.ofNullable(tempTableSchemaContext).ifPresent(tempTableSchemaCtx -> dsSpec.tempTableSchema = PureGrammarParserUtility.fromGrammarString(tempTableSchemaCtx.STRING().getText(), true));
         // accountType
         SnowflakeParserGrammar.DbAccountTypeContext accountTypeContext = PureGrammarParserUtility.validateAndExtractOptionalField(dbSpecCtx.dbAccountType(), "accountType", dsSpec.sourceInformation);
         Optional.ofNullable(accountTypeContext).ifPresent(accountTypeCtx -> dsSpec.accountType = PureGrammarParserUtility.fromIdentifier(accountTypeCtx.identifier()));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/SnowflakeGrammarComposerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/SnowflakeGrammarComposerExtension.java
@@ -72,8 +72,8 @@ public class SnowflakeGrammarComposerExtension implements IRelationalGrammarComp
                         (spec.proxyHost != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "proxyHost: " + convertString(spec.proxyHost, true) + ";\n" : "") +
                         (spec.proxyPort != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "proxyPort: " + convertString(spec.proxyPort, true) + ";\n" : "") +
                         (spec.nonProxyHosts != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "nonProxyHosts: " + convertString(spec.nonProxyHosts, true) + ";\n" : "") +
-                        (spec.nonProxyHosts != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "nonProxyHosts: " + convertString(spec.nonProxyHosts, true) + ";\n" : "") +
-                        (spec.nonProxyHosts != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "nonProxyHosts: " + convertString(spec.nonProxyHosts, true) + ";\n" : "") +
+                        (spec.tempTableDb != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "tempTableDb: " + convertString(spec.tempTableDb, true) + ";\n" : "") +
+                        (spec.tempTableSchema != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "tempTableSchema: " + convertString(spec.tempTableSchema, true) + ";\n" : "") +
                         (spec.accountType != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "accountType: " + spec.accountType + ";\n" : "") +
                         (spec.organization != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "organization: " + convertString(spec.organization, true) + ";\n" : "") +
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/SnowflakeGrammarComposerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/SnowflakeGrammarComposerExtension.java
@@ -72,6 +72,8 @@ public class SnowflakeGrammarComposerExtension implements IRelationalGrammarComp
                         (spec.proxyHost != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "proxyHost: " + convertString(spec.proxyHost, true) + ";\n" : "") +
                         (spec.proxyPort != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "proxyPort: " + convertString(spec.proxyPort, true) + ";\n" : "") +
                         (spec.nonProxyHosts != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "nonProxyHosts: " + convertString(spec.nonProxyHosts, true) + ";\n" : "") +
+                        (spec.nonProxyHosts != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "nonProxyHosts: " + convertString(spec.nonProxyHosts, true) + ";\n" : "") +
+                        (spec.nonProxyHosts != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "nonProxyHosts: " + convertString(spec.nonProxyHosts, true) + ";\n" : "") +
                         (spec.accountType != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "accountType: " + spec.accountType + ";\n" : "") +
                         (spec.organization != null ? context.getIndentationString() + getTabString(baseIndentation + 1) + "organization: " + convertString(spec.organization, true) + ";\n" : "") +
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarCompiler.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarCompiler.java
@@ -49,6 +49,61 @@ public class TestSnowflakeConnectionGrammarCompiler
                 "    accountType: MultiTenant;\n" +
                 "    organization: 'sampleOrganization';\n" +
                 "    role: 'DB_ROLE_123';\n" +
+                "  };\n" +
+                "  auth: SnowflakePublic\n" +
+                "  {" +
+                "       publicUserName: 'name';\n" +
+                "       privateKeyVaultReference: 'privateKey';\n" +
+                "       passPhraseVaultReference: 'passPhrase';\n" +
+                "  };\n" +
+                "}\n");
+
+
+        Root_meta_external_store_relational_runtime_RelationalDatabaseConnection connection = (Root_meta_external_store_relational_runtime_RelationalDatabaseConnection) result.getTwo().getConnection("simple::StaticConnection", SourceInformation.getUnknownSourceInformation());
+
+        Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification specification = (Root_meta_pure_alloy_connections_alloy_specification_SnowflakeDatasourceSpecification) connection._datasourceSpecification();
+
+        Assert.assertEquals("test", specification._databaseName());
+        Assert.assertEquals("account", specification._accountName());
+        Assert.assertEquals("warehouseName", specification._warehouseName());
+        Assert.assertEquals("us-east2", specification._region());
+        Assert.assertEquals("sampleHost", specification._proxyHost());
+        Assert.assertEquals("samplePort", specification._proxyPort());
+        Assert.assertEquals("sample", specification._nonProxyHosts());
+        Assert.assertEquals(result.getTwo().getEnumValue("meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType", "MultiTenant"), specification._accountType());
+        Assert.assertEquals("sampleOrganization", specification._organization());
+        Assert.assertEquals("DB_ROLE_123", specification._role());
+
+
+        Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy authenticationStrategy = (Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy) connection._authenticationStrategy();
+
+        Assert.assertEquals("name", authenticationStrategy._publicUserName());
+        Assert.assertEquals("privateKey", authenticationStrategy._privateKeyVaultReference());
+        Assert.assertEquals("passPhrase", authenticationStrategy._passPhraseVaultReference());
+
+    }
+
+    @Test
+    public void testSnowflakeConnectionWithTempTableSpecPropagatedToCompiledGraph()
+    {
+        Pair<PureModelContextData, PureModel> result = test(TestRelationalCompilationFromGrammar.DB_INC +
+                "###Connection\n" +
+                "RelationalDatabaseConnection simple::StaticConnection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: Snowflake;\n" +
+                "  specification: Snowflake\n" +
+                "  {\n" +
+                "    name: 'test';\n" +
+                "    account: 'account';\n" +
+                "    warehouse: 'warehouseName';\n" +
+                "    region: 'us-east2';\n" +
+                "    proxyHost: 'sampleHost';\n" +
+                "    proxyPort: 'samplePort';\n" +
+                "    nonProxyHosts: 'sample';\n" +
+                "    accountType: MultiTenant;\n" +
+                "    organization: 'sampleOrganization';\n" +
+                "    role: 'DB_ROLE_123';\n" +
                 "    tempTableDb: 'temp_table_db';\n" +
                 "    tempTableSchema: 'temp_table_schema';\n" +
                 "  };\n" +

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarCompiler.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarCompiler.java
@@ -49,6 +49,8 @@ public class TestSnowflakeConnectionGrammarCompiler
                 "    accountType: MultiTenant;\n" +
                 "    organization: 'sampleOrganization';\n" +
                 "    role: 'DB_ROLE_123';\n" +
+                "    tempTableDb: 'temp_table_db';\n" +
+                "    tempTableSchema: 'temp_table_schema';\n" +
                 "  };\n" +
                 "  auth: SnowflakePublic\n" +
                 "  {" +
@@ -73,6 +75,9 @@ public class TestSnowflakeConnectionGrammarCompiler
         Assert.assertEquals(result.getTwo().getEnumValue("meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType", "MultiTenant"), specification._accountType());
         Assert.assertEquals("sampleOrganization", specification._organization());
         Assert.assertEquals("DB_ROLE_123", specification._role());
+        Assert.assertEquals("temp_table_db", specification._tempTableDb());
+        Assert.assertEquals("temp_table_schema", specification._tempTableSchema());
+
 
         Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy authenticationStrategy = (Root_meta_pure_alloy_connections_alloy_authentication_SnowflakePublicAuthenticationStrategy) connection._authenticationStrategy();
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarCompiler.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarCompiler.java
@@ -88,6 +88,70 @@ public class TestSnowflakeConnectionGrammarCompiler
     }
 
     @Test
+    public void testSnowflakeConnectionTempTableDbPresentAndSchemaAbsent()
+    {
+        test(TestRelationalCompilationFromGrammar.DB_INC +
+                "###Connection\n" +
+                "RelationalDatabaseConnection simple::SnowflakeConnection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: Snowflake;\n" +
+                "  specification: Snowflake\n" +
+                "  {\n" +
+                "    name: 'test';\n" +
+                "    account: 'account';\n" +
+                "    warehouse: 'warehouseName';\n" +
+                "    region: 'us-east2';\n" +
+                "    proxyHost: 'sampleHost';\n" +
+                "    proxyPort: 'samplePort';\n" +
+                "    nonProxyHosts: 'sample';\n" +
+                "    accountType: MultiTenant;\n" +
+                "    organization: 'sampleOrganization';\n" +
+                "    role: 'DB_ROLE_123';\n" +
+                "    tempTableDb: 'temp_table_db';\n" +
+                "  };\n" +
+                "  auth: SnowflakePublic\n" +
+                "  {" +
+                "       publicUserName: 'name';\n" +
+                "       privateKeyVaultReference: 'privateKey';\n" +
+                "       passPhraseVaultReference: 'passPhrase';\n" +
+                "  };\n" +
+                "}\n", "COMPILATION error at [65:1-88:1]: Error in 'simple::SnowflakeConnection': One of Database name and schema name for temp tables is missing. Please specify both tempTableDb and tempTableSchema");
+    }
+
+    @Test
+    public void testSnowflakeConnectionTempTableSchemaPresentAndDbAbsent()
+    {
+        test(TestRelationalCompilationFromGrammar.DB_INC +
+                "###Connection\n" +
+                "RelationalDatabaseConnection simple::SnowflakeConnection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: Snowflake;\n" +
+                "  specification: Snowflake\n" +
+                "  {\n" +
+                "    name: 'test';\n" +
+                "    account: 'account';\n" +
+                "    warehouse: 'warehouseName';\n" +
+                "    region: 'us-east2';\n" +
+                "    proxyHost: 'sampleHost';\n" +
+                "    proxyPort: 'samplePort';\n" +
+                "    nonProxyHosts: 'sample';\n" +
+                "    accountType: MultiTenant;\n" +
+                "    organization: 'sampleOrganization';\n" +
+                "    role: 'DB_ROLE_123';\n" +
+                "    tempTableSchema: 'temp_table_schema';\n" +
+                "  };\n" +
+                "  auth: SnowflakePublic\n" +
+                "  {" +
+                "       publicUserName: 'name';\n" +
+                "       privateKeyVaultReference: 'privateKey';\n" +
+                "       passPhraseVaultReference: 'passPhrase';\n" +
+                "  };\n" +
+                "}\n", "COMPILATION error at [65:1-88:1]: Error in 'simple::SnowflakeConnection': One of Database name and schema name for temp tables is missing. Please specify both tempTableDb and tempTableSchema");
+    }
+
+    @Test
     public void testSnowflakeConnectionPropertiesLocalMode()
     {
         Pair<PureModelContextData, PureModel> result = test(TestRelationalCompilationFromGrammar.DB_INC +

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarRoundtrip.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestSnowflakeConnectionGrammarRoundtrip.java
@@ -234,4 +234,33 @@ public class TestSnowflakeConnectionGrammarRoundtrip extends TestGrammarRoundtri
                 "}\n");
 
     }
+
+    @Test
+    public void testSnowflakeTempTableSpec()
+    {
+        test("###Connection\n" +
+                "RelationalDatabaseConnection meta::mySimpleConnection\n" +
+                "{\n" +
+                "  store: store::Store;\n" +
+                "  type: Snowflake;\n" +
+                "  specification: Snowflake\n" +
+                "  {\n" +
+                "    name: 'test';\n" +
+                "    account: 'account';\n" +
+                "    warehouse: 'warehousename';\n" +
+                "    region: 'us-east-1';\n" +
+                "    quotedIdentifiersIgnoreCase: false;\n" +
+                "    enableQueryTags: true;\n" +
+                "    tempTableDb: 'temp_table_db';\n" +
+                "    tempTableSchema: 'temp_table_schema';\n" +
+                "  };\n" +
+                "  auth: SnowflakePublic\n" +
+                "  {\n" +
+                "    publicUserName: 'myName';\n" +
+                "    privateKeyVaultReference: 'privateKeyRef';\n" +
+                "    passPhraseVaultReference: 'passRef';\n" +
+                "  };\n" +
+                "}\n");
+
+    }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/specification/SnowflakeDatasourceSpecification.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/specification/SnowflakeDatasourceSpecification.java
@@ -30,6 +30,9 @@ public class SnowflakeDatasourceSpecification extends DatasourceSpecification
     public String organization;
     public String accountType;
 
+    public String tempTableDb;
+    public String tempTableSchema;
+
     public String role;
 
     @Override

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/pom.xml
@@ -175,6 +175,10 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-graph-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-path-pure</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/pom.xml
@@ -74,6 +74,11 @@
                     </dependency>
                     <dependency>
                         <groupId>org.finos.legend.pure</groupId>
+                        <artifactId>legend-pure-m2-dsl-graph-pure</artifactId>
+                        <version>${legend.pure.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.pure</groupId>
                         <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
                         <version>${legend.pure.version}</version>
                     </dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/connection/metamodel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/connection/metamodel.pure
@@ -29,6 +29,9 @@ Class meta::pure::alloy::connections::alloy::specification::SnowflakeDatasourceS
     proxyPort:String[0..1];
     nonProxyHosts:String[0..1];
 
+    tempTableDb: String[0..1];
+    tempTableSchema: String[0..1];
+
     <<equality.Key>> accountType: meta::pure::alloy::connections::alloy::specification::SnowflakeAccountType[0..1];
     <<equality.Key>> organization:String[0..1];
     <<equality.Key>> cloudType:String[0..1];

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/executionPlan/tests/executionPlanTestSnowflake.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/executionPlan/tests/executionPlanTestSnowflake.pure
@@ -47,8 +47,8 @@ import meta::pure::runtime::*;
 import meta::core::runtime::*;
 import meta::pure::mapping::modelToModel::test::shared::src::*;
 import meta::pure::graphFetch::executionPlan::*;
-import meta::pure::graphFetch::routing::*;
 import meta::pure::functions::collection::*;
+import meta::relational::graphFetch::executionPlan::*;
 
 function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testFilterEqualsWithOptionalParameter_Snowflake():Boolean[1]
 {
@@ -149,3 +149,97 @@ function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testInExecut
   let varName = $allocationNode->at(0)->cast(@AllocationExecutionNode).varName;
   assertEquals('tempVarForIn_8', $varName);
 }
+
+function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFetchSnowflakeTempTableDbAndSchemaSpecified():Boolean[1]
+{
+  let tree = #{
+      Person {
+         firstName,
+         lastName,
+         firm {
+            legalName
+         }
+      }
+   }#;
+  let query = {|Person.all()->graphFetch($tree)->serialize($tree)};
+
+  let conn1 = ^RelationalDatabaseConnection(
+                  datasourceSpecification = ^SnowflakeDatasourceSpecification(region = 'us-region-1', warehouseName='warehouseName',databaseName='databaseName',accountName = 'accountName'),
+                  authenticationStrategy = ^SnowflakePublicAuthenticationStrategy(privateKeyVaultReference = 'privatekey', passPhraseVaultReference= 'passphrase', publicUserName = 'public'),
+                  type=DatabaseType.Snowflake
+              );
+  let generatedPlan1 = executionPlan($query, simpleRelationalMapping, ^Runtime(connectionStores=^ConnectionStore(element = 'database',connection=$conn1)), meta::relational::extension::relationalExtensions());
+  let rootNode1 = $generatedPlan1.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
+  let processedTempTableName1 = $rootNode1.processedTempTableName;
+  assertEquals('LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.temp_table_node_0', $processedTempTableName1);
+
+  let conn2 = ^RelationalDatabaseConnection(
+                  datasourceSpecification = ^SnowflakeDatasourceSpecification(region = 'us-region-1', warehouseName='warehouseName',databaseName='databaseName',accountName = 'accountName',tempTableDb = 'temp_db1',tempTableSchema = 'temp_schema1'),
+                  authenticationStrategy = ^SnowflakePublicAuthenticationStrategy(privateKeyVaultReference = 'privatekey', passPhraseVaultReference= 'passphrase', publicUserName = 'public'),
+                  type=DatabaseType.Snowflake
+              );
+  let generatedPlan2 = executionPlan($query, simpleRelationalMapping, ^Runtime(connectionStores=^ConnectionStore(element = 'database',connection=$conn2)), meta::relational::extension::relationalExtensions());
+  let rootNode2 = $generatedPlan2.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
+  let processedTempTableName2 = $rootNode2.processedTempTableName;
+  assertEquals('temp_db1.temp_schema1.temp_table_node_0', $processedTempTableName2);
+
+  
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFetchSnowflakeTempTableDbAndSchemaWithQuoteIdentifiers():Boolean[1]
+{
+  let tree = #{
+      Person {
+         firstName,
+         lastName,
+         firm {
+            legalName
+         }
+      }
+   }#;
+  let query = {|Person.all()->graphFetch($tree)->serialize($tree)};
+  let conn = ^RelationalDatabaseConnection(
+                  datasourceSpecification = ^SnowflakeDatasourceSpecification(region = 'us-region-1', warehouseName='warehouseName',databaseName='databaseName',accountName = 'accountName',tempTableDb = 'temp_db1',tempTableSchema = 'temp_schema1'),
+                  authenticationStrategy = ^SnowflakePublicAuthenticationStrategy(privateKeyVaultReference = 'privatekey', passPhraseVaultReference= 'passphrase', publicUserName = 'public'),
+                  type=DatabaseType.Snowflake, quoteIdentifiers = true
+              );
+  let generatedPlan = executionPlan($query, simpleRelationalMapping, ^Runtime(connectionStores=^ConnectionStore(element = 'database',connection=$conn)), meta::relational::extension::relationalExtensions());
+  let rootNode = $generatedPlan.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
+  let processedTempTableName = $rootNode.processedTempTableName;
+  assertEquals('"temp_db1"."temp_schema1".temp_table_node_0', $processedTempTableName);
+}
+function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testCrossStoreGraphFetchSnowflakeTempTableDbAndSchemaSpecified():Boolean[1]
+{
+   let tree = #{
+      meta::relational::graphFetch::tests::crossDatabase::Firm {
+         legalName,
+         ceo {
+            name
+         },
+         employees {
+            name
+         }
+      }
+   }#;
+
+   let query = {|meta::relational::graphFetch::tests::crossDatabase::Firm.all()->graphFetch($tree)->serialize($tree)};
+   let mapping = meta::relational::graphFetch::tests::crossDatabase::CrossMappingWithRelOpWithJoinKeys;
+   let conn1 = ^RelationalDatabaseConnection(
+                  datasourceSpecification = ^SnowflakeDatasourceSpecification(region = 'us-region-1', warehouseName='warehouseName',databaseName='databaseName',accountName = 'accountName', tempTableDb = 'temp_db1', tempTableSchema = 'temp_schema1'),
+                  authenticationStrategy = ^SnowflakePublicAuthenticationStrategy(privateKeyVaultReference = 'privatekey', passPhraseVaultReference= 'passphrase', publicUserName = 'public'),
+                  type=DatabaseType.Snowflake
+              );
+   let conn2 = ^RelationalDatabaseConnection(
+                  datasourceSpecification = ^SnowflakeDatasourceSpecification(region = 'us-region-1', warehouseName='warehouseName',databaseName='databaseName',accountName = 'accountName', tempTableDb = 'temp_db2', tempTableSchema = 'temp_schema2'),
+                  authenticationStrategy = ^SnowflakePublicAuthenticationStrategy(privateKeyVaultReference = 'privatekey', passPhraseVaultReference= 'passphrase', publicUserName = 'public'),
+                  type=DatabaseType.Snowflake
+              );              
+  let generatedPlan = executionPlan($query, $mapping, ^Runtime(connectionStores=[^ConnectionStore(element = meta::relational::graphFetch::tests::crossDatabase::FirmDB,connection=$conn1), ^ConnectionStore(element = meta::relational::graphFetch::tests::crossDatabase::EmployeeDB,connection=$conn2)]), meta::relational::extension::relationalExtensions());
+  let ceoChild = $generatedPlan.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).children->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalCrossRootQueryTempTableGraphFetchExecutionNode);
+  let employeeChild = $generatedPlan.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).children->at(1)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalCrossRootQueryTempTableGraphFetchExecutionNode);
+
+  assertEquals($ceoChild.processedParentTempTableName, $employeeChild.processedParentTempTableName);
+  assertEquals('temp_db2.temp_schema2.cross_temp_table_node_0', $employeeChild.processedParentTempTableName);
+  assertEquals('temp_db2.temp_schema2.temp_table_node_2', $ceoChild.processedTempTableName);
+  assertEquals('temp_db2.temp_schema2.temp_table_node_5', $employeeChild.processedTempTableName);
+}  

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/protocols/pure/vX_X_X/extension/extension_snowflake.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/protocols/pure/vX_X_X/extension/extension_snowflake.pure
@@ -39,6 +39,8 @@ meta::protocols::pure::vX_X_X::transformation::fromPureGraph::connection::snowfl
                      proxyHost = $s.proxyHost,
                      proxyPort = $s.proxyPort,
                      nonProxyHosts = $s.nonProxyHosts,
+                     tempTableDb = $s.tempTableDb,
+                     tempTableSchema = $s.tempTableSchema,
                      accountType = if($s.accountType->isEmpty(),|[],|$s.accountType->toOne()->toString()),
                      organization = $s.organization,
                      role = $s.role,

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/protocols/pure/vX_X_X/extension/metamodel_conection.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/protocols/pure/vX_X_X/extension/metamodel_conection.pure
@@ -29,6 +29,9 @@ Class meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::a
     proxyPort: String[0..1];
     nonProxyHosts: String[0..1];
 
+    tempTableDb: String[0..1];
+    tempTableSchema: String[0..1];
+
     role: String [0..1];
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -42,7 +42,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
       dynaFuncDispatch = $dynaFuncDispatch,
       preAndFinallyExecutionSQLQuery = preAndFinallyExecutionSQLQueryForSnowflake_DbConfig_1__DatabaseConnection_1__PreAndFinallyExecutionSQLQuery_MANY_,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameSnowflake_String_1__String_1_
+      processTempTableName = processTempTableNameSnowflake_String_1__DatabaseConnection_$0_1$__String_1_
    );
 }
 
@@ -68,9 +68,24 @@ function meta::relational::functions::sqlQueryToString::snowflake::getDDLCommand
               );
 }
 
-function meta::relational::functions::sqlQueryToString::snowflake::processTempTableNameSnowflake(tempTableName: String[1]): String[1]
+function meta::relational::functions::sqlQueryToString::snowflake::processTempTableNameSnowflake(tempTableName: String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]): String[1]
 {
-  'LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.' + $tempTableName;
+   if($dc->isNotEmpty() && 
+      $dc->toOne()->instanceOf(RelationalDatabaseConnection) && 
+      ($dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableDb->isNotEmpty() ||
+      $dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableSchema->isNotEmpty()),
+   |
+    let dbConfig = meta::relational::functions::sqlQueryToString::createDbConfig($dc->toOne().type, $dc->toOne().timeZone, $dc->toOne().quoteIdentifiers);
+    if($dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableDb->isNotEmpty() &&
+         $dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableSchema->isNotEmpty(),
+      | 
+        $dbConfig.identifierProcessor($dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableDb->toOne()) + '.' + 
+        $dbConfig.identifierProcessor($dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableSchema->toOne()) + '.' +
+        $tempTableName,
+      | fail('One of Database name and schema name for temp tables is missing. Please specify both.'); @String;
+      );,
+   | 'LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.' + $tempTableName;
+   )
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::translateCreateSchemaStatementForSnowflake(createSchemaSQL:CreateSchemaSQL[1], dbConfig:DbConfig[1]) : String[0..1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -42,7 +42,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
       dynaFuncDispatch = $dynaFuncDispatch,
       preAndFinallyExecutionSQLQuery = preAndFinallyExecutionSQLQueryForSnowflake_DbConfig_1__DatabaseConnection_1__PreAndFinallyExecutionSQLQuery_MANY_,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameSnowflake_String_1__DatabaseConnection_$0_1$__String_1_
+      processTempTableName = processTempTableNameSnowflake_String_1__DatabaseConnection_1__String_1_
    );
 }
 
@@ -68,10 +68,9 @@ function meta::relational::functions::sqlQueryToString::snowflake::getDDLCommand
               );
 }
 
-function meta::relational::functions::sqlQueryToString::snowflake::processTempTableNameSnowflake(tempTableName: String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]): String[1]
+function meta::relational::functions::sqlQueryToString::snowflake::processTempTableNameSnowflake(tempTableName: String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[1]): String[1]
 {
-   if($dc->isNotEmpty() && 
-      $dc->toOne()->instanceOf(RelationalDatabaseConnection) && 
+   if($dc->toOne()->instanceOf(RelationalDatabaseConnection) && 
       ($dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableDb->isNotEmpty() ||
       $dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification).tempTableSchema->isNotEmpty()),
    |

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/legend-engine-xt-relationalStore-sparksql-pure/src/main/resources/core_relational_sparksql/relational/sqlQueryToString/sparkSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/legend-engine-xt-relationalStore-sparksql-pure/src/main/resources/core_relational_sparksql/relational/sqlQueryToString/sparkSQLExtension.pure
@@ -34,7 +34,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::spark
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_1__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/legend-engine-xt-relationalStore-sparksql-pure/src/main/resources/core_relational_sparksql/relational/sqlQueryToString/sparkSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/legend-engine-xt-relationalStore-sparksql-pure/src/main/resources/core_relational_sparksql/relational/sqlQueryToString/sparkSQLExtension.pure
@@ -34,7 +34,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::spark
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
@@ -35,7 +35,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::sybas
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_1__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
@@ -35,7 +35,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::sybas
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -43,7 +43,6 @@ import meta::relational::milestoning::*;
 import meta::external::store::relational::runtime::*;
 import meta::relational::runtime::*;
 
-
 Class meta::relational::graphFetch::executionPlan::RelationalGraphFetchExecutionNode extends LocalGraphFetchExecutionNode
 {
    children : RelationalGraphFetchExecutionNode[*];
@@ -159,10 +158,10 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::dbsUsin
    dbsUsingLoadFromSubQueryTempTableStrategyForComplexProperty()->concatenate(dbsUsingLoadFromResultSetAsValueTuplesTempTableStrategyForNonPrimitiveChildNode());
 }
 
-function meta::relational::graphFetch::executionPlan::createTable(tempTableName: String[1], columns: SQLResultColumn[*], tempTableSchemaName: String[0..1], dbConfig: DbConfig[1]): Table[1]
+function meta::relational::graphFetch::executionPlan::createTable(tempTableName: String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[1], columns: SQLResultColumn[*], tempTableSchemaName: String[0..1], dbConfig: DbConfig[1]): Table[1]
 {
   let tempTableColumns = $columns->map(x|^Column(name = $x.label, type = $x.dataType->toOne()));
-  ^Table( name = $dbConfig.procesTempTableName($tempTableName),
+  ^Table( name = $dbConfig.procesTempTableName($tempTableName, $dc),
           schema = ^Schema(name = if($tempTableSchemaName->isNotEmpty(),|$tempTableSchemaName->toOne(),|'default') , database = ^Database(name='TempTableDb')),
           columns = $tempTableColumns,
           temporaryTable = true
@@ -360,8 +359,6 @@ function meta::relational::graphFetch::executionPlan::getTempTableStrategyForNon
   );
 }
 
-
-
 function meta::relational::graphFetch::executionPlan::planRootGraphFetchExecutionRelational(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], clusteredTree: StoreMappingClusteredGraphFetchTree[1], orderedPaths: String[*], mapping: Mapping[1], runtime: Runtime[1], exeCtx: ExecutionContext[1], enableConstraints: Boolean[1], checked: Boolean[1], extensions: Extension[*], debug: DebugContext[1]): LocalGraphFetchExecutionNode[1]
 {
    print(if($debug.debug,|$debug.space+'>Relational root graphFetch plan generation:\n',|''));
@@ -403,7 +400,7 @@ function meta::relational::graphFetch::executionPlan::planRootGraphFetchExecutio
    let dbConfig = $dbType->createDbConfig();
    let tempTableName = tempTableName(0);
    let tempTableStrategy = if(($hasChildren && useTempTableStrategy($dbType)),
-                            | let table = createTable($tempTableName,$columns,[],$dbConfig);
+                            | let table = createTable($tempTableName,$dbConnection,$columns,[],$dbConfig);
                               let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$table,$dbConnection,$extensions);
                               let loadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoot($dbType,$table,$dbConnection,$extensions);
                               let dropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$table,$dbConnection,$extensions);
@@ -417,7 +414,7 @@ function meta::relational::graphFetch::executionPlan::planRootGraphFetchExecutio
       graphFetchTree = $rootTree,
       batchSize      = $batchSize,
       tempTableName  = $tempTableName,
-      processedTempTableName = $dbConfig.procesTempTableName($tempTableName),
+      processedTempTableName = $dbConfig.procesTempTableName($tempTableName, $dbConnection),
       columns        = $columns,
       children       = $children,
       executionNodes = $wrappedNode,
@@ -530,7 +527,7 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::planGra
    let tempTableName = tempTableName($currentIdx);
 
    let tempTableStrategy = if(($hasChildren && useTempTableStrategy($dbType)),
-                            | let table = createTable($tempTableName,$columns,[],$dbConfig);
+                            | let table = createTable($tempTableName,$dbConnection,$columns,[],$dbConfig);
                               let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$table,$dbConnection,$extensions);
                               let loadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForNonPrimitiveChild($dbType,$table,$dbConnection,$extensions,$sqlNode.sqlQuery);
                               let dropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$table,$dbConnection,$extensions);
@@ -545,7 +542,7 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::planGra
       parentIndex    = $parentIdx,
       graphFetchTree = $currentTree,
       tempTableName  = $tempTableName,
-      processedTempTableName = $dbConfig.procesTempTableName($tempTableName),
+      processedTempTableName = $dbConfig.procesTempTableName($tempTableName, $dbConnection),
       columns        = $columns,
       children       = $children,
       executionNodes = $wrappedNode
@@ -635,7 +632,7 @@ function meta::relational::graphFetch::executionPlan::planCrossRootGraphFetchExe
    let parentTempTableName = crossTempTableName($parentIdx);
 
    let tempTableStrategy = if(($hasChildren && useTempTableStrategy($dbType)),
-                            | let table = createTable($tempTableName,$columns,[],$dbConfig);
+                            | let table = createTable($tempTableName,$dbConnection,$columns,[],$dbConfig);
                               let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$table,$dbConnection,$extensions);
                               let loadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoot($dbType,$table,$dbConnection,$extensions);
                               let dropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$table,$dbConnection,$extensions);
@@ -643,7 +640,7 @@ function meta::relational::graphFetch::executionPlan::planCrossRootGraphFetchExe
                             | []);
 
    let parentTempTableColumns = $srcProperties->map(x | ^SQLResultColumn(label = $x.name->toOne(), dataType = $x->crossKeyRelationalType()));
-   let parentTable = createTable($parentTempTableName,$parentTempTableColumns,[],$dbConfig);
+   let parentTable = createTable($parentTempTableName,$dbConnection,$parentTempTableColumns,[],$dbConfig);
    let parentCreateTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$parentTable,$dbConnection,$extensions);
    let parentLoadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoot($dbType,$parentTable,$dbConnection,$extensions);
    let parentDropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$parentTable,$dbConnection,$extensions);
@@ -657,10 +654,10 @@ function meta::relational::graphFetch::executionPlan::planCrossRootGraphFetchExe
       parentIndex             = $parentIdx,
       graphFetchTree          = $rootTree,
       tempTableName           = $tempTableName,
-      processedTempTableName  = $dbConfig.procesTempTableName($tempTableName),
+      processedTempTableName  = $dbConfig.procesTempTableName($tempTableName,$dbConnection),
       columns                 = $columns,
       parentTempTableName     = $parentTempTableName,
-      processedParentTempTableName = $dbConfig.procesTempTableName($parentTempTableName),
+      processedParentTempTableName = $dbConfig.procesTempTableName($parentTempTableName,$dbConnection),
       parentTempTableColumns  = $parentTempTableColumns,
       children                = $children,
       executionNodes          = $wrappedNode

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/processInOperation.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/processInOperation.pure
@@ -52,7 +52,7 @@ function <<access.private>> meta::relational::postProcessor::prefixForWrapperAll
    'inFilterClause_';
 }
 
-function <<access.private>> meta::relational::postProcessor::processedTempTableNameForIn(dbType: DatabaseType[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]):String[1]
+function <<access.private>> meta::relational::postProcessor::processedTempTableNameForIn(dbType: DatabaseType[1], dc: meta::external::store::relational::runtime::DatabaseConnection[1]):String[1]
 {
    $dbType->createDbConfig([]).procesTempTableName('tempTableForIn_', $dc);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/processInOperation.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/processInOperation.pure
@@ -52,9 +52,9 @@ function <<access.private>> meta::relational::postProcessor::prefixForWrapperAll
    'inFilterClause_';
 }
 
-function <<access.private>> meta::relational::postProcessor::processedTempTableNameForIn(dbType: DatabaseType[1]):String[1]
+function <<access.private>> meta::relational::postProcessor::processedTempTableNameForIn(dbType: DatabaseType[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]):String[1]
 {
-   $dbType->createDbConfig([]).procesTempTableName('tempTableForIn_');
+   $dbType->createDbConfig([]).procesTempTableName('tempTableForIn_', $dc);
 }
 
 function meta::relational::postProcessor::processInOperation(query:SQLQuery[1], runtime:Runtime[1], store:Database[0..1], exeCtx:ExecutionContext[1], extensions:Extension[*]):PostProcessorResult[1]
@@ -73,7 +73,7 @@ function meta::relational::postProcessor::processInOperation(query:SQLQuery[1], 
                                                          d  : DynaFunction[1] | if($d.name == 'in' &&  $d.parameters->at(1)->instanceOf(LiteralList) && ($d.parameters->at(1)->cast(@LiteralList).values->size() > $dbThreshold->toOne()),
                                                                                    |
                                                                                    let dbType               = $connection.type;
-                                                                                   let tempTableName        = $dbType->processedTempTableNameForIn() + $uniqueId->toString();
+                                                                                   let tempTableName        = $dbType->processedTempTableNameForIn($connection) + $uniqueId->toString();
                                                                                    let tempTableColumnName  = 'ColumnForStoringInCollection';
 
                                                                                    let firstLiteralValue    = $d.parameters->at(1)->cast(@LiteralList).values->map(l | $l.value)->at(0);
@@ -117,8 +117,8 @@ function meta::relational::postProcessor::generatePostProcessorResult(changedFun
 
                           let outerAllocationNodeName               = if($newInFunction.parameters->at(1)->instanceOf(VarPlaceHolder),
                                                                          |$newInFunction.parameters->at(1)->cast(@VarPlaceHolder).name,
-                                                                         |$newInFunction.parameters->at(1)->cast(@SelectSQLQuery).data.alias.name->toOne()->replace($dbType->processedTempTableNameForIn(), prefixForWrapperAllocationNodeName()));
-                          let tempTableName                         = $outerAllocationNodeName->replace(prefixForWrapperAllocationNodeName(), $dbType->processedTempTableNameForIn());
+                                                                         |$newInFunction.parameters->at(1)->cast(@SelectSQLQuery).data.alias.name->toOne()->replace($dbType->processedTempTableNameForIn($connection), prefixForWrapperAllocationNodeName()));
+                          let tempTableName                         = $outerAllocationNodeName->replace(prefixForWrapperAllocationNodeName(), $dbType->processedTempTableNameForIn($connection));
                           let tempTableColumnName                   = 'ColumnForStoringInCollection';
                           let allocationNodeName                    = $outerAllocationNodeName->replace(prefixForWrapperAllocationNodeName(), 'tempVarForIn_');
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -104,9 +104,9 @@ Class meta::relational::functions::sqlQueryToString::DbConfig
      if($this.dbExtension.tableNameToIdentifier->isEmpty(), |$s, |$this.dbExtension.tableNameToIdentifier->toOne()->eval($s, $this));
    }: String[1];
 
-   procesTempTableName(s:String[1])
+   procesTempTableName(s:String[1], dc:meta::external::store::relational::runtime::DatabaseConnection[0..1])
    {
-     if($this.dbExtension.processTempTableName->isEmpty(), |$s, |$this.dbExtension.processTempTableName->toOne()->eval($s));
+     if($this.dbExtension.processTempTableName->isEmpty(), |$s, |$this.dbExtension.processTempTableName->toOne()->eval($s, $dc));
    }: String[1];
 
    columnNameToIdentifier(s:String[1])
@@ -215,7 +215,7 @@ Class meta::relational::functions::sqlQueryToString::DbExtension
    dynaFuncDispatch: meta::pure::metamodel::function::Function<{DynaFunction[1], SqlGenerationContext[1] -> DynaFunctionToSql[1]}>[1];
    ddlCommandsTranslator : RelationalDDLCommandsTranslator[0..1];
    preAndFinallyExecutionSQLQuery: meta::pure::metamodel::function::Function<{DbConfig[1], meta::external::store::relational::runtime::DatabaseConnection[1] -> PreAndFinallyExecutionSQLQuery[*]}>[0..1];
-   processTempTableName: meta::pure::metamodel::function::Function<{String[1] -> String[1]}>[0..1];
+   processTempTableName: meta::pure::metamodel::function::Function<{String[1], meta::external::store::relational::runtime::DatabaseConnection[0..1] -> String[1]}>[0..1];
 }
 
 Class meta::relational::functions::sqlQueryToString::RelationalDDLCommandsTranslator

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -104,7 +104,7 @@ Class meta::relational::functions::sqlQueryToString::DbConfig
      if($this.dbExtension.tableNameToIdentifier->isEmpty(), |$s, |$this.dbExtension.tableNameToIdentifier->toOne()->eval($s, $this));
    }: String[1];
 
-   procesTempTableName(s:String[1], dc:meta::external::store::relational::runtime::DatabaseConnection[0..1])
+   procesTempTableName(s:String[1], dc:meta::external::store::relational::runtime::DatabaseConnection[1])
    {
      if($this.dbExtension.processTempTableName->isEmpty(), |$s, |$this.dbExtension.processTempTableName->toOne()->eval($s, $dc));
    }: String[1];
@@ -215,7 +215,7 @@ Class meta::relational::functions::sqlQueryToString::DbExtension
    dynaFuncDispatch: meta::pure::metamodel::function::Function<{DynaFunction[1], SqlGenerationContext[1] -> DynaFunctionToSql[1]}>[1];
    ddlCommandsTranslator : RelationalDDLCommandsTranslator[0..1];
    preAndFinallyExecutionSQLQuery: meta::pure::metamodel::function::Function<{DbConfig[1], meta::external::store::relational::runtime::DatabaseConnection[1] -> PreAndFinallyExecutionSQLQuery[*]}>[0..1];
-   processTempTableName: meta::pure::metamodel::function::Function<{String[1], meta::external::store::relational::runtime::DatabaseConnection[0..1] -> String[1]}>[0..1];
+   processTempTableName: meta::pure::metamodel::function::Function<{String[1], meta::external::store::relational::runtime::DatabaseConnection[1] -> String[1]}>[0..1];
 }
 
 Class meta::relational::functions::sqlQueryToString::RelationalDDLCommandsTranslator

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/db2/db2Extension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/db2/db2Extension.pure
@@ -35,7 +35,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::db2::
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDB2_String_1__DatabaseConnection_$0_1$__String_1_
+      processTempTableName = processTempTableNameDB2_String_1__DatabaseConnection_1__String_1_
    );
 }
 
@@ -48,7 +48,7 @@ function meta::relational::functions::sqlQueryToString::db2::getDDLCommandsTrans
               );
 }
 
-function meta::relational::functions::sqlQueryToString::db2::processTempTableNameDB2(tempTableName:String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]) : String[1]
+function meta::relational::functions::sqlQueryToString::db2::processTempTableNameDB2(tempTableName:String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[1]) : String[1]
 {
   'SESSION.' + $tempTableName;
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/db2/db2Extension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/db2/db2Extension.pure
@@ -35,7 +35,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::db2::
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDB2_String_1__String_1_
+      processTempTableName = processTempTableNameDB2_String_1__DatabaseConnection_$0_1$__String_1_
    );
 }
 
@@ -48,7 +48,7 @@ function meta::relational::functions::sqlQueryToString::db2::getDDLCommandsTrans
               );
 }
 
-function meta::relational::functions::sqlQueryToString::db2::processTempTableNameDB2(tempTableName:String[1]) : String[1]
+function meta::relational::functions::sqlQueryToString::db2::processTempTableNameDB2(tempTableName:String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]) : String[1]
 {
   'SESSION.' + $tempTableName;
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
@@ -31,7 +31,7 @@ function meta::relational::functions::sqlQueryToString::h2::v1_4_200::createDbEx
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_1__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
@@ -31,7 +31,7 @@ function meta::relational::functions::sqlQueryToString::h2::v1_4_200::createDbEx
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
@@ -35,7 +35,7 @@ function meta::relational::functions::sqlQueryToString::h2::v2_1_214::createDbEx
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
@@ -35,7 +35,7 @@ function meta::relational::functions::sqlQueryToString::h2::v2_1_214::createDbEx
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator(),
-      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_$0_1$__String_1_
+      processTempTableName = processTempTableNameDefault_String_1__DatabaseConnection_1__String_1_
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -500,7 +500,7 @@ function meta::relational::functions::sqlQueryToString::default::getDDLCommandsT
               );
 }
 
-function meta::relational::functions::sqlQueryToString::default::processTempTableNameDefault(tempTableName:String[1]) : String[1]
+function meta::relational::functions::sqlQueryToString::default::processTempTableNameDefault(tempTableName:String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]) : String[1]
 {
    $tempTableName;
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -500,7 +500,7 @@ function meta::relational::functions::sqlQueryToString::default::getDDLCommandsT
               );
 }
 
-function meta::relational::functions::sqlQueryToString::default::processTempTableNameDefault(tempTableName:String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[0..1]) : String[1]
+function meta::relational::functions::sqlQueryToString::default::processTempTableNameDefault(tempTableName:String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[1]) : String[1]
 {
    $tempTableName;
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/testTempTableSqlStatements.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/testTempTableSqlStatements.pure
@@ -30,7 +30,7 @@ function meta::relational::functions::sqlQueryToString::tests::createTable(tempT
     ^Column(name='date_Column', type=^meta::relational::metamodel::datatype::Date())
   ];
   let dbConfig  = $dbType->createDbConfig([]);
-  ^Table( name = $dbConfig.procesTempTableName('temp_table_test',[]),
+  ^Table( name = $dbConfig.procesTempTableName('temp_table_test', ^meta::external::store::relational::runtime::DatabaseConnection(type = $dbType)),
           schema = ^Schema(name = if($tempTableSchemaName->isNotEmpty(),|$tempTableSchemaName->toOne(),|'default') , database = ^Database(name='TempTableDb')),
           columns = $columns,
           temporaryTable = true
@@ -43,7 +43,7 @@ function meta::relational::functions::sqlQueryToString::tests::getProccessedTemp
   if($dbTypeEnum->isNotEmpty(),
   |let dbType = $dbTypeEnum->at(0)->toOne();
   let dbConfig  = $dbType->createDbConfig([]);
-  $dbConfig.procesTempTableName($tempTableName,[]);,
+  $dbConfig.procesTempTableName($tempTableName, ^meta::external::store::relational::runtime::DatabaseConnection(type = $dbType));,
   |[]);
 }
 function meta::relational::functions::sqlQueryToString::tests::getCreateTempTableSqlStatements(databaseType: String[1]): String[*]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/testTempTableSqlStatements.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/testTempTableSqlStatements.pure
@@ -30,7 +30,7 @@ function meta::relational::functions::sqlQueryToString::tests::createTable(tempT
     ^Column(name='date_Column', type=^meta::relational::metamodel::datatype::Date())
   ];
   let dbConfig  = $dbType->createDbConfig([]);
-  ^Table( name = $dbConfig.procesTempTableName('temp_table_test'),
+  ^Table( name = $dbConfig.procesTempTableName('temp_table_test',[]),
           schema = ^Schema(name = if($tempTableSchemaName->isNotEmpty(),|$tempTableSchemaName->toOne(),|'default') , database = ^Database(name='TempTableDb')),
           columns = $columns,
           temporaryTable = true
@@ -43,7 +43,7 @@ function meta::relational::functions::sqlQueryToString::tests::getProccessedTemp
   if($dbTypeEnum->isNotEmpty(),
   |let dbType = $dbTypeEnum->at(0)->toOne();
   let dbConfig  = $dbType->createDbConfig([]);
-  $dbConfig.procesTempTableName($tempTableName);,
+  $dbConfig.procesTempTableName($tempTableName,[]);,
   |[]);
 }
 function meta::relational::functions::sqlQueryToString::tests::getCreateTempTableSqlStatements(databaseType: String[1]): String[*]


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

Freemarker varaiables are processed recursively. In GraphFetch, we create INSERT SQL statements to insert into temp tables. Each SQL goes through free marker processing as a freemarker template. If data itself has freemarker templates, we try to process them too which leads to an exception. To avoid this, we skip freemarker processing for inserting into temp tables.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
