### PR TITLE
Set line separator to \n when using readFile to read expected results for tests

### DIFF
--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-http-api/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLFileGeneration.java
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-http-api/src/test/java/org/finos/legend/engine/query/graphQL/api/test/TestGraphQLFileGeneration.java
@@ -14,9 +14,7 @@
 
 package org.finos.legend.engine.query.graphQL.api.test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.eclipse.collections.impl.*;
-import org.eclipse.collections.impl.factory.*;
+import org.eclipse.collections.impl.factory.Iterables;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
@@ -24,13 +22,18 @@ import org.finos.legend.engine.query.graphQL.api.format.generation.GraphQLGenera
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.*;
 import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.InputStream;
-import java.util.*;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.finos.legend.pure.generated.core_external_query_graphql_deprecated_tests_generationTests.Root_meta_external_query_graphQL_generation_tests_constants_comparisonExpressions_String_MANY__String_1_;
 
@@ -39,81 +42,97 @@ public class TestGraphQLFileGeneration
     @Test
     public void testSimpleGraphQL()
     {
-        try
-        {
-            PureModelContextData pureModelContextData = getProtocol("simpleFileGeneration.json");
-            PureModel pureModel = new PureModel(pureModelContextData, Identity.getAnonymousIdentity().getName(), DeploymentMode.TEST);
-            FileGenerationSpecification fileGeneration = pureModelContextData.getElementsOfType(FileGenerationSpecification.class).get(0);
-            GraphQLGenerationExtension graphQLGenerationExtension = new GraphQLGenerationExtension();
-            List<? extends Root_meta_pure_generation_metamodel_GenerationOutput> outputs = graphQLGenerationExtension.generateFromElement(fileGeneration, pureModel.getContext());
+        PureModelContextData pureModelContextData = getProtocol("simpleFileGeneration.json");
+        PureModel pureModel = new PureModel(pureModelContextData, Identity.getAnonymousIdentity().getName(), DeploymentMode.TEST);
+        FileGenerationSpecification fileGeneration = pureModelContextData.getElementsOfType(FileGenerationSpecification.class).get(0);
+        GraphQLGenerationExtension graphQLGenerationExtension = new GraphQLGenerationExtension();
+        List<? extends Root_meta_pure_generation_metamodel_GenerationOutput> outputs = graphQLGenerationExtension.generateFromElement(fileGeneration, pureModel.getContext());
 
-            Assert.assertEquals(outputs.size(), 5);
-            outputs.forEach(o ->
-            {
-                if (o._fileName().endsWith("scalars.graphql"))
-                {
-                    Assert.assertEquals(getResourceAsString("scalars.graphql"), o._content());
-                }
-                else if (o._fileName().endsWith("primitive_comparisons.graphql"))
-                {
-                    Assert.assertEquals(Root_meta_external_query_graphQL_generation_tests_constants_comparisonExpressions_String_MANY__String_1_(Iterables.iList("Int", "String"), pureModel.getExecutionSupport()), o._content());
-                }
-                else
-                {
-                    Assert.assertEquals(getResourceAsString(o._fileName().substring(o._fileName().lastIndexOf('/') + 1)), o._content());
-                }
-            });
-        }
-        catch (Exception e)
+        Assert.assertEquals(outputs.size(), 5);
+        outputs.forEach(o ->
         {
-            throw new RuntimeException(e);
-        }
+            if (o._fileName().endsWith("scalars.graphql"))
+            {
+                Assert.assertEquals(getResourceAsString("scalars.graphql"), o._content());
+            }
+            else if (o._fileName().endsWith("primitive_comparisons.graphql"))
+            {
+                Assert.assertEquals(Root_meta_external_query_graphQL_generation_tests_constants_comparisonExpressions_String_MANY__String_1_(Iterables.iList("Int", "String"), pureModel.getExecutionSupport()), o._content());
+            }
+            else
+            {
+                Assert.assertEquals(getResourceAsString(o._fileName().substring(o._fileName().lastIndexOf('/') + 1)), o._content());
+            }
+        });
     }
 
     @Test
     public void testScalarGraphQL()
     {
-        try
-        {
-            PureModelContextData pureModelContextData = getProtocol("scalarFileGeneration.json");
-            PureModel pureModel = new PureModel(pureModelContextData, Identity.getAnonymousIdentity().getName(), DeploymentMode.TEST);
-            FileGenerationSpecification fileGeneration = pureModelContextData.getElementsOfType(FileGenerationSpecification.class).get(0);
-            GraphQLGenerationExtension graphQLGenerationExtension = new GraphQLGenerationExtension();
-            List<? extends Root_meta_pure_generation_metamodel_GenerationOutput> outputs = graphQLGenerationExtension.generateFromElement(fileGeneration, pureModel.getContext());
+        PureModelContextData pureModelContextData = getProtocol("scalarFileGeneration.json");
+        PureModel pureModel = new PureModel(pureModelContextData, Identity.getAnonymousIdentity().getName(), DeploymentMode.TEST);
+        FileGenerationSpecification fileGeneration = pureModelContextData.getElementsOfType(FileGenerationSpecification.class).get(0);
+        GraphQLGenerationExtension graphQLGenerationExtension = new GraphQLGenerationExtension();
+        List<? extends Root_meta_pure_generation_metamodel_GenerationOutput> outputs = graphQLGenerationExtension.generateFromElement(fileGeneration, pureModel.getContext());
 
-            Assert.assertEquals(outputs.size(), 3);
-            outputs.forEach(o ->
-            {
-                if (o._fileName().endsWith("scalars.graphql"))
-                {
-                    Assert.assertEquals(getResourceAsString("scalars.graphql"), o._content());
-                }
-                else if (o._fileName().endsWith("primitive_comparisons.graphql"))
-                {
-                    Assert.assertEquals(Root_meta_external_query_graphQL_generation_tests_constants_comparisonExpressions_String_MANY__String_1_(Iterables.iList("BigDecimal","Date", "DateTime"), pureModel.getExecutionSupport()), o._content());
-                }
-                else
-                {
-                    Assert.assertEquals(getResourceAsString(o._fileName().substring(o._fileName().lastIndexOf('/') + 1)), o._content());
-                }
-            });
-        }
-        catch (Exception e)
+        Assert.assertEquals(outputs.size(), 3);
+        outputs.forEach(o ->
         {
-            throw new RuntimeException(e);
-        }
+            if (o._fileName().endsWith("scalars.graphql"))
+            {
+                Assert.assertEquals(getResourceAsString("scalars.graphql"), o._content());
+            }
+            else if (o._fileName().endsWith("primitive_comparisons.graphql"))
+            {
+                Assert.assertEquals(Root_meta_external_query_graphQL_generation_tests_constants_comparisonExpressions_String_MANY__String_1_(Iterables.iList("BigDecimal","Date", "DateTime"), pureModel.getExecutionSupport()), o._content());
+            }
+            else
+            {
+                Assert.assertEquals(getResourceAsString(o._fileName().substring(o._fileName().lastIndexOf('/') + 1)), o._content());
+            }
+        });
     }
 
-    private PureModelContextData getProtocol(String fileName) throws JsonProcessingException
+    private PureModelContextData getProtocol(String fileName)
     {
-        String jsonString = this.getResourceAsString(fileName);
-        return ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(jsonString, PureModelContextData.class);
+        String jsonString = getResourceAsString(fileName, null);
+        try
+        {
+            return ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().readValue(jsonString, PureModelContextData.class);
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private String getResourceAsString(String fileName)
     {
-        InputStream inputStream = TestGraphQLFileGeneration.class.getResourceAsStream(fileName);
-        Scanner scanner = new Scanner(inputStream, "UTF-8").useDelimiter("\\A");
-        return scanner.hasNext() ? scanner.next() : "";
+        return getResourceAsString(fileName, "\n");
+    }
+
+    private String getResourceAsString(String fileName, String lineSeparator)
+    {
+        URL url = getClass().getResource(fileName);
+        if (url == null)
+        {
+            throw new RuntimeException("Cannot find: " + fileName);
+        }
+        StringBuilder builder = new StringBuilder();
+        try (Reader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))
+        {
+            char[] buffer = new char[8192];
+            int read;
+            while ((read = reader.read(buffer)) != -1)
+            {
+                builder.append(buffer, 0, read);
+            }
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+
+        return (lineSeparator == null) ? builder.toString() : Pattern.compile("\\R").matcher(builder).replaceAll(lineSeparator);
     }
 }

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/travel/testTravelX.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/travel/testTravelX.pure
@@ -5,7 +5,7 @@ import meta::pure::metamodel::serialization::grammar::*;
 function <<test.Test>> meta::external::query::graphQL::binding::toPure::introspection::tests::testTravelFromIntrospection():Boolean[1]
 {
     let str = readFile('/core_external_query_graphql/binding/toPure/introspection/tests/travel/travelx.json')->toOne();
-    let expected = readFile('/core_external_query_graphql/binding/toPure/introspection/tests/travel/travelResult.txt')->toOne();
+    let expected = readFile('/core_external_query_graphql/binding/toPure/introspection/tests/travel/travelResult.txt', '\n')->toOne();
     let res = $str->meta::json::fromJson(__Schema)->meta::external::query::graphQL::binding::toPure::introspection::buildPureTypesFromGraphQLSchema('');
     assertEquals($expected, $res->sortBy(r|$r->elementToPath())->map(r|$r->printType())->joinStrings('\n'));
 }


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Set line separator to \n when reading expected result from file in testTravelX.pure so that the test works regardless of the underlying OS. Previously, the test would fail when run on Windows because the default line separator is \r\n.

#### Does this PR introduce a user-facing change?

No