### PR TITLE
Deprecate backward compatibility methods in GrammarToJson and JsonToGrammar

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar-http-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar-http-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/grammarToJson/GrammarToJson.java
@@ -62,16 +62,17 @@ public class GrammarToJson extends GrammarAPI
                           @Context UriInfo uriInfo)
     {
         long start = System.currentTimeMillis();
-        Response response = model(text, sourceId, lineOffset, returnSourceInformation, pm);
+        PureGrammarParserExtensions.logExtensionList();
+        Response response = grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseModel(a, sourceId, lineOffset, 0, returnSourceInformation), pm, "Grammar to Json : Model");
         long end = System.currentTimeMillis();
         MetricsHandler.observeRequest(uriInfo != null ? uriInfo.getPath() : null, start, end);
         return response;
     }
 
+    @Deprecated
     public Response model(String text, String sourceId, int lineOffset, boolean returnSourceInformation, ProfileManager<CommonProfile> pm)
     {
-        PureGrammarParserExtensions.logExtensionList();
-        return grammarToJson(text, (a) -> PureGrammarParser.newInstance().parseModel(a, sourceId, lineOffset, 0, returnSourceInformation), pm, "Grammar to Json : Model");
+        return model(text, sourceId, lineOffset, returnSourceInformation, pm, null);
     }
 
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar-http-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/jsonToGrammar/JsonToGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar-http-api/src/main/java/org/finos/legend/engine/language/pure/grammar/api/jsonToGrammar/JsonToGrammar.java
@@ -64,16 +64,17 @@ public class JsonToGrammar extends GrammarAPI
                           @Context UriInfo uriInfo)
     {
         long start = System.currentTimeMillis();
-        Response response = model(pureModelContext, renderStyle, pm);
+        PureGrammarComposerExtensionLoader.logExtensionList();
+        Response response = jsonToGrammar(pureModelContext, renderStyle, (value, renderStyle1) -> PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(renderStyle1).build()).renderPureModelContextData(value), pm, "Json to Grammar : Model");
         long end = System.currentTimeMillis();
         MetricsHandler.observeRequest(uriInfo != null ? uriInfo.getPath() : null, start, end);
         return response;
     }
 
+    @Deprecated
     public Response model(PureModelContextData pureModelContext, RenderStyle renderStyle, ProfileManager<CommonProfile> pm)
     {
-        PureGrammarComposerExtensionLoader.logExtensionList();
-        return jsonToGrammar(pureModelContext, renderStyle, (value, renderStyle1) -> PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(renderStyle1).build()).renderPureModelContextData(value), pm, "Json to Grammar : Model");
+        return model(pureModelContext, renderStyle, pm, null);
     }
 
     @POST


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Deprecate some methods that are present only for backward compatibility.

#### Does this PR introduce a user-facing change?

No