### PR TITLE
fix failing to generate grammar if there is no execution context key in dataspace template query

### DIFF
--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
@@ -162,8 +162,8 @@ public class DataSpaceGrammarComposerExtension implements PureGrammarComposerExt
                 (getTabString(3) + "id: " + executable.id + ";\n") +
                 (getTabString(3) + "title: " + convertString(executable.title, true) + ";\n") +
                 (executable.description != null ? (getTabString(3) + "description: " + convertString(executable.description, true) + ";\n") : "") +
-                getTabString(3) + "query: " + executable.query.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(context).withIndentation(getTabSize(2)).build()) + ";\n" +
-                getTabString(3) + "executionContextKey: " +  convertString(executable.executionContextKey, true) + ";\n" +
+                getTabString(3) + "query: " + executable.query.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(context).withIndentation(getTabSize(3)).build()) + ";\n" +
+                (executable.executionContextKey != null ?  getTabString(3) + "executionContextKey: " +  convertString(executable.executionContextKey, true) + ";\n" : "") +
                 getTabString(2) + "}";
     }
 


### PR DESCRIPTION


fix failing to generate grammar if there is no execution context key in dataspace template query

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

Bug Fix

<!--
Describe change being introduced by this PR.
-->


fix failing to generate grammar if there is no execution context key in dataspace template query



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
