### PR TITLE
Fix connection eviction

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceStatistics.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/DataSourceStatistics.java
@@ -24,7 +24,7 @@ public class DataSourceStatistics
 {
     private final AtomicInteger builtConnections;
     private final AtomicInteger requestedConnections;
-    private final AtomicInteger connectionErrors = new AtomicInteger();
+    private final AtomicInteger connectionErrors;
     private final AtomicLong firstConnectionRequest;
     private AtomicLong lastConnectionRequest;
 
@@ -34,19 +34,22 @@ public class DataSourceStatistics
         this.builtConnections = new AtomicInteger(0);
         this.lastConnectionRequest = new AtomicLong(getCurrentTimeInInMillis());
         this.requestedConnections = new AtomicInteger(0);
+        this.connectionErrors = new AtomicInteger(0);
     }
 
-    private DataSourceStatistics(int builtConnections, long firstConnectionRequest, long lastConnectionRequest, int requestedConnections)
+    private DataSourceStatistics(int builtConnections, long firstConnectionRequest, long lastConnectionRequest, int requestedConnections, int connectionErrors)
     {
         this.builtConnections = new AtomicInteger(builtConnections);
         this.firstConnectionRequest = new AtomicLong(firstConnectionRequest);
         this.lastConnectionRequest = new AtomicLong(lastConnectionRequest);
         this.requestedConnections = new AtomicInteger(requestedConnections);
+        this.connectionErrors = new AtomicInteger(connectionErrors);
     }
 
     public static DataSourceStatistics clone(DataSourceStatistics statistics)
     {
-        return new DataSourceStatistics(statistics.builtConnections.get(), statistics.firstConnectionRequest.get(), statistics.lastConnectionRequest.get(), statistics.requestedConnections.get());
+        return new DataSourceStatistics(statistics.builtConnections.get(), statistics.firstConnectionRequest.get(),
+                statistics.lastConnectionRequest.get(), statistics.requestedConnections.get(), statistics.connectionErrors.get());
     }
 
     public int getRequestedConnections()

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/state/TestConnectionManagement.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/state/TestConnectionManagement.java
@@ -91,4 +91,11 @@ public abstract class TestConnectionManagement
             assertNotNull("State not found for pool=" + poolName, connectionStateManager.getConnectionStateManagerPOJO(poolName));
         }
     }
+
+    DataSourceWithStatistics getDataSourceWithStatistics(String user, ConnectionKey key)
+    {
+        Identity identity = new Identity(user);
+        String poolName = connectionStateManager.poolNameFor(identity, key);
+        return connectionStateManager.getDataSourceByPoolName(poolName);
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

When the connection pool is created for the first time, if the pool data-source cannot be built due to some exception, the incomplete pool(with null data source) should not be cached in the state manager and should get evicted immediately

The house keeping task should also be able to evict pools having non zero connection error statistics if no active connections are made from it during the specified duration

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
