### PR TITLE
Fix toJSON for constraints

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/modelSerialization.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/modelSerialization.pure
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import meta::json::*;
+import meta::pure::metamodel::constraint::*;
 import meta::pure::metamodel::serialization::json::*;
 import meta::pure::metamodel::serialization::grammar::*;
 import meta::pure::milestoning::*;
@@ -74,6 +75,14 @@ function meta::pure::metamodel::serialization::json::qualifiedPropertyToJSON(pro
                    newJSONKeyValue('stereotypes', ^JSONArray(values=$property.stereotypes->map(s | $s->stereotypeToJSON()))),
                    newJSONKeyValue('taggedValues', ^JSONArray(values=$property.taggedValues->map(t | $t->taggedValueToJSON())))
                    ])
+}
+
+function meta::pure::metamodel::serialization::json::constraintToJSON(constraint:Constraint[1]):JSONElement[1]
+{
+    newJSONObject(newJSONKeyValue('name', ^JSONString(value=$constraint.name->toOne()))
+                  ->concatenate(if($constraint.owner->isEmpty(), |[], |newJSONKeyValue('owner', ^JSONString(value=$constraint.owner->toOne()))))
+                  ->concatenate(if($constraint.externalId->isEmpty(), |[], |newJSONKeyValue('externalId', ^JSONString(value=$constraint.externalId->toOne()))))
+                  ->concatenate(if($constraint.enforcementLevel->isEmpty(), |[], |newJSONKeyValue('enforcementLevel', ^JSONString(value=$constraint.enforcementLevel->toOne())))))
 }
 
 function meta::pure::metamodel::serialization::json::parameterToJSON(p:VariableExpression[1]):JSONElement[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testToJson.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testToJson.pure
@@ -452,3 +452,21 @@ function <<test.Test>> meta::json::tests::testSerializeWithTreeAndConfig():Boole
    let expected = '{"@type":"meta::json::tests::TestLevel1","a":"A","l2":[{"@type":"meta::json::tests::TestLevel2_A","ba":"BA","b":"BA","l3a":[{"@type":"meta::json::tests::TestLevel3_A","ca":"CA"}]}]}';
    assertEq($expected, $plainJson);
 }
+
+Class meta::json::tests::TestClassWithConstraints
+[
+  $this.a != $this.b,
+  aA: $this.a->startsWith('A'),
+  bNotB( ~owner: Bee ~externalId: 'Bees b not B' ~function: !$this.b->startsWith('B') ~enforcementLevel: Warn ~message: 'Look out for the B!')
+]
+{
+  a: String[1];
+  b: String[1];
+}
+
+function <<test.Test>> meta::json::tests::testToJsonHandlesConstraints():Boolean[1]
+{
+  let actual = meta::json::tests::TestClassWithConstraints.constraints->toJSON();
+  let expected = '[{"name":"0"},{"name":"aA"},{"name":"bNotB","owner":"Bee","externalId":"Bees b not B","enforcementLevel":"Warn"}]';
+  assertEq($expected, $actual);
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/toJSON.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/toJSON.pure
@@ -15,6 +15,7 @@
 import meta::pure::functions::cipher::*;
 import meta::pure::graphFetch::routing::*;
 import meta::pure::graphFetch::*;
+import meta::pure::metamodel::constraint::*;
 import meta::pure::metamodel::treepath::*;
 import meta::pure::metamodel::serialization::json::*;
 import meta::pure::mapping::*;
@@ -341,6 +342,7 @@ function <<access.private>> meta::json::buildLambdas(extraSerializers:Function<{
          {g:GenericType[1], state:JSONState[1]  | $g->genericTypeToJSON()},
          {p:Property<Nil,Any|*>[1], state:JSONState[1]  | $p->propertyToJSON()},
          {q:QualifiedProperty<Any>[1], state:JSONState[1]  | $q->qualifiedPropertyToJSON()},
+         {c:Constraint[1], state:JSONState[1] | $c->constraintToJSON()},
          {s:Stereotype[1], state:JSONState[1]  | $s->stereotypeToJSON()},
          {t:TaggedValue[1], state:JSONState[1]  | $t->taggedValueToJSON()},
          {t:Tag[1], state:JSONState[1]  | $t->tagToJSON()},

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/constraints/constraintsModelDiagram.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/constraints/constraintsModelDiagram.pure
@@ -51,18 +51,6 @@ Diagram meta::pure::metamodel::constraint::ConstraintModelDiagram(width=875.2690
         width=80.00000,
         height=36.00000)
 
-    TypeView PackageableElement_$_3(
-        type=meta::pure::metamodel::PackageableElement,
-        stereotypesVisible=true,
-        attributesVisible=true,
-        attributeStereotypesVisible=true,
-        attributeTypesVisible=true,
-        color=#FFFFCC,
-        lineWidth=1.0,
-        position=(1115.00000, 190.00000),
-        width=139.39648,
-        height=36.00000)
-
     TypeView Type_$_4(
         type=meta::pure::metamodel::type::Type,
         stereotypesVisible=true,
@@ -74,18 +62,6 @@ Diagram meta::pure::metamodel::constraint::ConstraintModelDiagram(width=875.2690
         position=(1346.00000, 367.00000),
         width=47.11719,
         height=36.00000)
-
-    TypeView ModelElement_$_5(
-        type=meta::pure::metamodel::ModelElement,
-        stereotypesVisible=true,
-        attributesVisible=true,
-        attributeStereotypesVisible=true,
-        attributeTypesVisible=true,
-        color=#FFFFCC,
-        lineWidth=1.0,
-        position=(1127.00000, 88.00000),
-        width=112.93604,
-        height=48.00000)
 
     TypeView ValidationResult_$_6(
         type=meta::pure::metamodel::constraint::ValidationResult,
@@ -192,22 +168,4 @@ Diagram meta::pure::metamodel::constraint::ConstraintModelDiagram(width=875.2690
        label='',
        source=Class_$_0,
        target=Type_$_4)
-
-
-   GeneralizationView gview_16(color=#000000,
-       lineWidth=-1.0,
-       lineStyle=SIMPLE,
-       points=[(1184.69824,208.00000),(800.00000,388.00000)],
-       label='',
-       source=Constraint_$_2,
-       target=PackageableElement_$_3)
-
-   GeneralizationView gview_17(color=#000000,
-       lineWidth=-1.0,
-       lineStyle=SIMPLE,
-       points=[(1183.46802,112.00000),(1184.69824,208.00000)],
-       label='',
-       source=PackageableElement_$_3,
-       target=ModelElement_$_5)
-
 }


### PR DESCRIPTION
#### What type of PR is this?

Bug

#### What does this PR do / why is it needed ?

Fix toJSON for constraints. Previously, they were transformed to JSON as PackageableElements using their package path. But this is inappropriate since they do not have a package path. Now they have a substantive transformation.
