### PR TITLE
Remove persistence component overriding version for Duck DB

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>org.duckdb</groupId>
             <artifactId>duckdb_jdbc</artifactId>
-            <version>0.10.2</version>
             <scope>runtime</scope>
         </dependency>
         <!-- DRIVER -->

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/src/test/java/org/finos/legend/engine/persistence/components/e2e/BaseTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/src/test/java/org/finos/legend/engine/persistence/components/e2e/BaseTest.java
@@ -452,9 +452,10 @@ public class BaseTest
     {
         validateFileExists(path);
         String loadSql = "TRUNCATE TABLE \"TEST\".\"staging\";" +
-            "COPY \"TEST\".\"staging\"" +
+            "INSERT INTO \"TEST\".\"staging\"" +
             "(\"id\", \"name\", \"income\", \"start_time\", \"expiry_date\", \"digest\", \"delete_indicator\")" +
-            " FROM '" + path + "' CSV";
+            "SELECT \"id\", \"name\", \"income\", \"start_time\", \"expiry_date\", \"digest\", \"delete_indicator\" " +
+            " FROM READ_CSV('" + path + "', COLUMNS = {'id':'INTEGER', 'name':'VARCHAR', 'income':'BIGINT', 'start_time':'TIMESTAMP', 'expiry_date':'DATE', 'digest':'VARCHAR', 'delete_indicator':'VARCHAR'}, AUTO_DETECT = FALSE)";
         duckDBSink.executeStatement(loadSql);
     }
 


### PR DESCRIPTION
#### What type of PR is this?


- Improvement


#### What does this PR do / why is it needed ?

Remove overriding version for Duck DB from persistence component; tweaked test to not rely on CSV sniffer to ensure correct loading of test data.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
