### PR TITLE
Proper locks when accessing packages in parallel compiler 

### DIFF
--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/java/org/finos/legend/engine/server/Server.java
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/java/org/finos/legend/engine/server/Server.java
@@ -159,6 +159,7 @@ import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import javax.ws.rs.container.DynamicFeature;
 import java.io.FileInputStream;
+import java.util.concurrent.ForkJoinPool;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -269,7 +270,8 @@ public class Server<T extends ServerConfiguration> extends Application<T>
         DeploymentStateAndVersions.DEPLOYMENT_MODE = serverConfiguration.deployment.mode;
 
         SDLCLoader sdlcLoader = new SDLCLoader(serverConfiguration.metadataserver, null);
-        ModelManager modelManager = new ModelManager(serverConfiguration.deployment.mode, sdlcLoader);
+        ForkJoinPool compilerPool = new ForkJoinPool();
+        ModelManager modelManager = new ModelManager(serverConfiguration.deployment.mode, compilerPool, sdlcLoader);
 
         ChainFixingFilterHandler.apply(environment.getApplicationContext(), serverConfiguration.filterPriorities);
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/AutoCloseableLock.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/AutoCloseableLock.java
@@ -1,0 +1,23 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+public interface AutoCloseableLock extends AutoCloseable
+{
+    AutoCloseableLock lock();
+
+    void close();
+}

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
@@ -25,6 +25,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Proc
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.builder.FunctionExpressionBuilder;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.ImportAwareCodeSection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.Section;
@@ -212,6 +213,11 @@ public class CompileContext
 
 
     // ------------------------------------------ ELEMENT RESOLVER -----------------------------------------
+
+    public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement resolvePackageableElement(PackageableElementPointer pointer)
+    {
+        return this.resolvePackageableElement(pointer.path, pointer.sourceInformation);
+    }
 
     public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement resolvePackageableElement(String fullPath)
     {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperMeasureBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperMeasureBuilder.java
@@ -30,18 +30,8 @@ public class HelperMeasureBuilder
         final GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(targetUnit);
         context.pureModel.typesGenericTypeIndex.put(context.pureModel.buildPackageString(unit._package, unit.name), genericType);
         GenericType unitGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(context.pureModel.getType("meta::pure::metamodel::type::Unit"));
-
-        org.finos.legend.pure.m3.coreinstance.Package pack = context.pureModel.getOrCreatePackage(unit._package);
-
-        synchronized (pack)
-        {
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit res = targetUnit
-                    ._name(unit.name)
-                    ._classifierGenericType(unitGenericType)
-                    ._package(pack);
-            pack._childrenAdd(res);
-            return res;
-        }
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit res = targetUnit._classifierGenericType(unitGenericType);
+        return context.pureModel.setNameAndPackage(res, unit.name, unit._package, unit.sourceInformation);
     }
 
     public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit processUnitPackageableElementSecondPass(Unit unit, CompileContext context)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
@@ -175,7 +175,7 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
 
         ProcessingContext ctx = new ProcessingContext("Function '" + functionFullName + "' First Pass");
 
-        setNameAndPackage(targetFunc, functionSignature, function._package, function.sourceInformation)
+        this.context.pureModel.setNameAndPackage(targetFunc, functionSignature, function._package, function.sourceInformation)
                 ._functionName(functionName) // function name to be used in the handler map -> meta::pure::functions::date::isAfterDay
                 ._classifierGenericType(newGenericType(this.context.pureModel.getType("meta::pure::metamodel::function::ConcreteFunctionDefinition"), PureModel.buildFunctionType(ListIterate.collect(function.parameters, p -> (VariableExpression) p.accept(new ValueSpecificationBuilder(this.context, Lists.mutable.empty(), ctx))), this.context.resolveGenericType(function.returnType, function.sourceInformation), this.context.pureModel.getMultiplicity(function.returnMultiplicity), this.context.pureModel)))
                 ._stereotypes(ListIterate.collect(function.stereotypes, this::resolveStereotype))
@@ -314,35 +314,6 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
 
     private <T extends PackageableElement> T setNameAndPackage(T pureElement, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement sourceElement)
     {
-        return setNameAndPackage(pureElement, sourceElement.name, sourceElement._package, sourceElement.sourceInformation);
-    }
-
-    private <T extends PackageableElement> T setNameAndPackage(T pureElement, String name, String packagePath, SourceInformation sourceInformation)
-    {
-        // Validate and set name
-        if ((name == null) || name.isEmpty())
-        {
-            throw new EngineException("PackageableElement name may not be null or empty", sourceInformation, EngineErrorType.COMPILATION);
-        }
-        if (!name.equals(pureElement.getName()))
-        {
-            throw new EngineException("PackageableElement name '" + name + "' must match CoreInstance name '" + pureElement.getName() + "'", sourceInformation, EngineErrorType.COMPILATION);
-        }
-        pureElement._name(name);
-
-        // Validate and set package
-        Package pack = this.context.pureModel.getOrCreatePackage(packagePath);
-
-        synchronized (pack)
-        {
-            if (pack._children().anySatisfy(c -> name.equals(c._name())))
-            {
-                throw new EngineException("An element named '" + name + "' already exists in the package '" + packagePath + "'", sourceInformation, EngineErrorType.COMPILATION);
-            }
-            pureElement._package(pack);
-            pureElement.setSourceInformation(SourceInformationHelper.toM3SourceInformation(sourceInformation));
-            pack._childrenAdd(pureElement);
-        }
-        return pureElement;
+        return this.context.pureModel.setNameAndPackage(pureElement, sourceElement.name, sourceElement._package, sourceElement.sourceInformation);
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -1303,38 +1303,35 @@ public class PureModel implements IPureModel
 
     private org.finos.legend.pure.m3.coreinstance.Package getOrCreatePackage_int(org.finos.legend.pure.m3.coreinstance.Package parent, String pack, boolean insert, int start)
     {
-        try (AutoCloseableLock ignored = this.pureModelProcessParameter.readLock())
+        int end = pack.indexOf(':', start);
+        String name = (end == -1) ? pack.substring(start) : pack.substring(start, end);
+        org.finos.legend.pure.m3.coreinstance.Package child = findChildPackage(parent, name);
+        if (child == null)
         {
-            int end = pack.indexOf(':', start);
-            String name = (end == -1) ? pack.substring(start) : pack.substring(start, end);
-            org.finos.legend.pure.m3.coreinstance.Package child = findChildPackage(parent, name);
-            if (child == null)
+            if (!insert)
             {
-                if (!insert)
-                {
-                    StringBuilder builder = new StringBuilder("Can't find package '").append(pack, start, pack.length()).append("' in '");
-                    PackageableElement.writeUserPathForPackageableElement(builder, parent);
-                    builder.append("'");
-                    throw new EngineException(builder.toString());
-                }
-                if (RESERVED_PACKAGES.contains(name))
-                {
-                    throw new EngineException("Can't create package with reserved name '" + name + "'");
-                }
-
-                try (AutoCloseableLock ignored1 = this.pureModelProcessParameter.writeLock())
-                {
-                    child = findChildPackage(parent, name);
-                    if (child == null)
-                    {
-                        child = new Package_Impl(name, null, this.getClass("Package"))._name(name)._package(parent);
-                        parent._childrenAdd(child);
-                    }
-                }
+                StringBuilder builder = new StringBuilder("Can't find package '").append(pack, start, pack.length()).append("' in '");
+                PackageableElement.writeUserPathForPackageableElement(builder, parent);
+                builder.append("'");
+                throw new EngineException(builder.toString());
+            }
+            if (RESERVED_PACKAGES.contains(name))
+            {
+                throw new EngineException("Can't create package with reserved name '" + name + "'");
             }
 
-            return (end == -1) ? child : getOrCreatePackage_int(child, pack, insert, end + 2);
+            try (AutoCloseableLock ignored1 = this.pureModelProcessParameter.writeLock())
+            {
+                child = findChildPackage(parent, name);
+                if (child == null)
+                {
+                    child = new Package_Impl(name, null, this.getClass("Package"))._name(name)._package(parent);
+                    parent._childrenAdd(child);
+                }
+            }
         }
+
+        return (end == -1) ? child : getOrCreatePackage_int(child, pack, insert, end + 2);
     }
 
     private org.finos.legend.pure.m3.coreinstance.Package findChildPackage(org.finos.legend.pure.m3.coreinstance.Package parent, String childName)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -17,12 +17,6 @@ package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadInfo;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
@@ -300,16 +294,9 @@ public class PureModel implements IPureModel
             }, forkJoinPool);
             try
             {
-                pureModelCompilationFuture.get(10, TimeUnit.MINUTES);
+                pureModelCompilationFuture.join();
             }
-            catch (InterruptedException | TimeoutException e)
-            {
-                String threadDump = Stream.of(ManagementFactory.getThreadMXBean().dumpAllThreads(true, true))
-                        .map(ThreadInfo::toString)
-                        .collect(Collectors.joining("\n\t\t"));
-                throw new RuntimeException("Failure while waiting for compiler to finish.\n\nPool state: " + forkJoinPool.toString() + "\n\nThread Dump: " + threadDump, e);
-            }
-            catch (ExecutionException | CompletionException e)
+            catch (CompletionException e)
             {
                 Throwable cause = e.getCause();
                 if (cause instanceof Error)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -158,7 +158,6 @@ public class PureModel implements IPureModel
     final ConcurrentHashMap<String, Root_meta_pure_runtime_PackageableRuntime> packageableRuntimesIndex = new ConcurrentHashMap<>();
     final ConcurrentHashMap<String, Root_meta_core_runtime_Runtime> runtimesIndex = new ConcurrentHashMap<>();
     private final ConcurrentLinkedQueue<EngineException> engineExceptions = new ConcurrentLinkedQueue<>();
-    private final ForkJoinPool forkJoinPool;
 
     public PureModel(PureModelContextData pure, String user, DeploymentMode deploymentMode)
     {
@@ -188,15 +187,6 @@ public class PureModel implements IPureModel
         if (classLoader == null)
         {
             classLoader = Thread.currentThread().getContextClassLoader();
-        }
-
-        if (pureModelProcessParameter.getForkJoinPool() == null)
-        {
-            forkJoinPool = createForkJoinPool(classLoader);
-        }
-        else
-        {
-            forkJoinPool = pureModelProcessParameter.getForkJoinPool();
         }
 
         this.extensions = extensions;
@@ -269,10 +259,9 @@ public class PureModel implements IPureModel
                         return x.getClass();
                     });
 
-            CompletableFuture<Void> pureModelCompilationFuture = CompletableFuture.runAsync(() ->
+            Runnable runPasses = () ->
             {
-                Stream.concat(classToElements.removeAll(SectionIndex.class).stream(), classToElements.removeAll(Profile.class).stream())
-                        .parallel()
+                this.maybeParallel(Stream.concat(classToElements.removeAll(SectionIndex.class).stream(), classToElements.removeAll(Profile.class).stream()))
                         .forEach(handleEngineExceptions(this::processFirstPass));
 
                 MutableMap<java.lang.Class<? extends org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement>, Collection<java.lang.Class<? extends org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement>>> dependencyGraph = Maps.mutable.empty();
@@ -288,7 +277,7 @@ public class PureModel implements IPureModel
                 MutableMap<java.lang.Class<? extends org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement>, Collection<java.lang.Class<? extends org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement>>> dependentToDependencies = dependencyManagement.getDependentToDependencies();
                 dependencyManagement.detectCircularDependency();
                 MutableSet<MutableSet<java.lang.Class<? extends org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement>>> disjointDependencyGraphs = dependencyManagement.getDisjointDependencyGraphs();
-                disjointDependencyGraphs.parallelStream().forEach(disjointDependencyGraph ->
+                this.maybeParallel(disjointDependencyGraphs.stream()).forEach(disjointDependencyGraph ->
                 {
                     processPass("firstPass", classToElements, dependentToDependencies, handleEngineExceptions(this::processElementFirstPass), disjointDependencyGraph);
                     processPass("secondPass", classToElements, dependentToDependencies, handleEngineExceptions(this::processSecondPass), disjointDependencyGraph);
@@ -297,34 +286,45 @@ public class PureModel implements IPureModel
                     processPass("fifthPass", classToElements, dependentToDependencies, handleEngineExceptions(this::processFifthPass), disjointDependencyGraph);
                     processPass("sixthPass", classToElements, dependentToDependencies, handleEngineExceptions(this::processSixthPass), disjointDependencyGraph);
                 });
-            }, forkJoinPool);
-            try
+            };
+
+            ForkJoinPool forkJoinPool = pureModelProcessParameter.getForkJoinPool();
+            if (forkJoinPool != null)
             {
-                pureModelCompilationFuture.get(10, TimeUnit.MINUTES);
+                CompletableFuture<Void> pureModelCompilationFuture = CompletableFuture.runAsync(runPasses, forkJoinPool);
+                try
+                {
+                    pureModelCompilationFuture.get(10, TimeUnit.MINUTES);
+                }
+                catch (InterruptedException | TimeoutException e)
+                {
+                    String threadDump = Stream.of(ManagementFactory.getThreadMXBean().dumpAllThreads(true, true))
+                            .map(ThreadInfo::toString)
+                            .collect(Collectors.joining("\n\t\t"));
+                    throw new RuntimeException("Failure while waiting for compiler to finish.\n\nPool state: " + forkJoinPool.toString() + "\n\nThread Dump: " + threadDump, e);
+                }
+                catch (ExecutionException | CompletionException e)
+                {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof Error)
+                    {
+                        throw (Error) cause;
+                    }
+                    else if (cause instanceof RuntimeException)
+                    {
+                        throw (RuntimeException) cause;
+                    }
+                    else
+                    {
+                        throw new RuntimeException(cause);
+                    }
+                }
             }
-            catch (InterruptedException | TimeoutException e)
+            else
             {
-                String threadDump = Stream.of(ManagementFactory.getThreadMXBean().dumpAllThreads(true, true))
-                        .map(ThreadInfo::toString)
-                        .collect(Collectors.joining("\n\t\t"));
-                throw new RuntimeException("Failure while waiting for compiler to finish.\n\nPool state: " + forkJoinPool.toString() + "\n\nThread Dump: " + threadDump, e);
+                runPasses.run();
             }
-            catch (ExecutionException | CompletionException e)
-            {
-                Throwable cause = e.getCause();
-                if (cause instanceof Error)
-                {
-                    throw (Error) cause;
-                }
-                else if (cause instanceof RuntimeException)
-                {
-                    throw (RuntimeException) cause;
-                }
-                else
-                {
-                    throw new RuntimeException(cause);
-                }
-            }
+
 
             // Post Validation
             long postValidationStart = System.nanoTime();
@@ -362,23 +362,19 @@ public class PureModel implements IPureModel
         finally
         {
             span.finish();
-            if (this.pureModelProcessParameter.getForkJoinPool() == null)
-            {
-                forkJoinPool.shutdown();
-            }
         }
     }
 
-    private ForkJoinPool createForkJoinPool(ClassLoader classLoader)
+    private <T> Stream<T> maybeParallel(Stream<T> stream)
     {
-        return new ForkJoinPool(1, x ->
+        if (Thread.currentThread() instanceof ForkJoinWorkerThread)
         {
-            ForkJoinWorkerThread forkJoinWorkerThread = new ForkJoinWorkerThread(x)
-            {
-            };
-            forkJoinWorkerThread.setContextClassLoader(classLoader);
-            return forkJoinWorkerThread;
-        }, null, false);
+            return stream.parallel();
+        }
+        else
+        {
+            return stream.sequential();
+        }
     }
 
     private void processPostValidation(PureModelContextData pureModelContextData, CompilerExtensions extensions)
@@ -458,10 +454,10 @@ public class PureModel implements IPureModel
 
     private void registerElementForPathToElement(String pack, List<String> children)
     {
-        org.finos.legend.pure.m3.coreinstance.Package newPkg = getOrCreatePackage(root, pack);
-        org.finos.legend.pure.m3.coreinstance.Package oldPkg = getPackage((org.finos.legend.pure.m3.coreinstance.Package) METADATA_LAZY.getMetadata(M3Paths.Package, M3Paths.Root), pack);
-        synchronized (newPkg)
+        try (AutoCloseableLock ignored = this.pureModelProcessParameter.writeLock())
         {
+            org.finos.legend.pure.m3.coreinstance.Package newPkg = getOrCreatePackage(root, pack);
+            org.finos.legend.pure.m3.coreinstance.Package oldPkg = getPackage((org.finos.legend.pure.m3.coreinstance.Package) METADATA_LAZY.getMetadata(M3Paths.Package, M3Paths.Root), pack);
             for (String child : children)
             {
                 // allow duplicated registration, but only the first one will actually get registered
@@ -522,7 +518,7 @@ public class PureModel implements IPureModel
     {
         MutableMap<java.lang.Class<? extends org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement>, CompletableFuture<Void>> tracker = Maps.mutable.empty();
         disjointDependencyGraph.forEach(dependent -> tracker.put(dependent, new CompletableFuture<>()));
-        disjointDependencyGraph.parallelStream().forEach(dependent ->
+        this.maybeParallel(disjointDependencyGraph.stream()).forEach(dependent ->
         {
             MutableList<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement> elementsToCompile = classToElements.get(dependent);
 
@@ -534,7 +530,7 @@ public class PureModel implements IPureModel
                     {
                         try
                         {
-                            elementsToCompile.parallelStream().forEach(passConsumer);
+                            this.maybeParallel(elementsToCompile.stream()).forEach(passConsumer);
                             tracker.get(dependent).complete(null);
                             LOGGER.debug("{} - Completed {}", name, dependent);
                         }
@@ -644,6 +640,11 @@ public class PureModel implements IPureModel
 
     // ------------------------------------------ GETTER -----------------------------------------
 
+    public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement getPackageableElement(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement element)
+    {
+        return this.getPackageableElement(element.getPath(), element.sourceInformation);
+    }
+
     public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement getPackageableElement(String fullPath)
     {
         return getPackageableElement(fullPath, SourceInformation.getUnknownSourceInformation());
@@ -704,22 +705,25 @@ public class PureModel implements IPureModel
             return this.root;
         }
 
-        org.finos.legend.pure.m3.coreinstance.Package currentPackage = this.root;
-        int start = 0;
-        int end;
-        while ((end = fullPath.indexOf(':', start)) != -1)
+        try (AutoCloseableLock ignored = this.pureModelProcessParameter.readLock())
         {
-            String name = fullPath.substring(start, end);
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement child = currentPackage._children().detect(c -> name.equals(c._name()));
-            if (!(child instanceof org.finos.legend.pure.m3.coreinstance.Package))
+            org.finos.legend.pure.m3.coreinstance.Package currentPackage = this.root;
+            int start = 0;
+            int end;
+            while ((end = fullPath.indexOf(':', start)) != -1)
             {
-                return null;
+                String name = fullPath.substring(start, end);
+                org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement child = currentPackage._children().detect(c -> name.equals(c._name()));
+                if (!(child instanceof org.finos.legend.pure.m3.coreinstance.Package))
+                {
+                    return null;
+                }
+                currentPackage = (org.finos.legend.pure.m3.coreinstance.Package) child;
+                start = end + 2;
             }
-            currentPackage = (org.finos.legend.pure.m3.coreinstance.Package) child;
-            start = end + 2;
+            String name = fullPath.substring(start);
+            return currentPackage._children().detect(c -> name.equals(c._name()));
         }
-        String name = fullPath.substring(start);
-        return currentPackage._children().detect(c -> name.equals(c._name()));
     }
 
 
@@ -1299,48 +1303,54 @@ public class PureModel implements IPureModel
 
     private org.finos.legend.pure.m3.coreinstance.Package getOrCreatePackage_int(org.finos.legend.pure.m3.coreinstance.Package parent, String pack, boolean insert, int start)
     {
-        int end = pack.indexOf(':', start);
-        String name = (end == -1) ? pack.substring(start) : pack.substring(start, end);
-        org.finos.legend.pure.m3.coreinstance.Package child = findChildPackage(parent, name);
-        if (child == null)
+        try (AutoCloseableLock ignored = this.pureModelProcessParameter.readLock())
         {
-            if (!insert)
+            int end = pack.indexOf(':', start);
+            String name = (end == -1) ? pack.substring(start) : pack.substring(start, end);
+            org.finos.legend.pure.m3.coreinstance.Package child = findChildPackage(parent, name);
+            if (child == null)
             {
-                StringBuilder builder = new StringBuilder("Can't find package '").append(pack, start, pack.length()).append("' in '");
-                PackageableElement.writeUserPathForPackageableElement(builder, parent);
-                builder.append("'");
-                throw new EngineException(builder.toString());
-            }
-            if (RESERVED_PACKAGES.contains(name))
-            {
-                throw new EngineException("Can't create package with reserved name '" + name + "'");
-            }
-
-            synchronized (parent)
-            {
-                child = findChildPackage(parent, name);
-                if (child == null)
+                if (!insert)
                 {
-                    child = new Package_Impl(name, null, this.getClass("Package"))._name(name)._package(parent);
-                    parent._childrenAdd(child);
+                    StringBuilder builder = new StringBuilder("Can't find package '").append(pack, start, pack.length()).append("' in '");
+                    PackageableElement.writeUserPathForPackageableElement(builder, parent);
+                    builder.append("'");
+                    throw new EngineException(builder.toString());
+                }
+                if (RESERVED_PACKAGES.contains(name))
+                {
+                    throw new EngineException("Can't create package with reserved name '" + name + "'");
+                }
+
+                try (AutoCloseableLock ignored1 = this.pureModelProcessParameter.writeLock())
+                {
+                    child = findChildPackage(parent, name);
+                    if (child == null)
+                    {
+                        child = new Package_Impl(name, null, this.getClass("Package"))._name(name)._package(parent);
+                        parent._childrenAdd(child);
+                    }
                 }
             }
-        }
 
-        return (end == -1) ? child : getOrCreatePackage_int(child, pack, insert, end + 2);
+            return (end == -1) ? child : getOrCreatePackage_int(child, pack, insert, end + 2);
+        }
     }
 
     private org.finos.legend.pure.m3.coreinstance.Package findChildPackage(org.finos.legend.pure.m3.coreinstance.Package parent, String childName)
     {
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement child = parent._children().detect(c -> childName.equals(c.getName()));
-        if ((child != null) && !(child instanceof org.finos.legend.pure.m3.coreinstance.Package))
+        try (AutoCloseableLock ignored = this.pureModelProcessParameter.readLock())
         {
-            StringBuilder builder = new StringBuilder("Element ").append(childName).append(" in ");
-            PackageableElement.writeUserPathForPackageableElement(builder, parent);
-            builder.append(" is not a package");
-            throw new RuntimeException(builder.toString());
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement child = parent._children().detect(c -> childName.equals(c.getName()));
+            if ((child != null) && !(child instanceof org.finos.legend.pure.m3.coreinstance.Package))
+            {
+                StringBuilder builder = new StringBuilder("Element ").append(childName).append(" in ");
+                PackageableElement.writeUserPathForPackageableElement(builder, parent);
+                builder.append(" is not a package");
+                throw new RuntimeException(builder.toString());
+            }
+            return (org.finos.legend.pure.m3.coreinstance.Package) child;
         }
-        return (org.finos.legend.pure.m3.coreinstance.Package) child;
     }
 
     public CompiledExecutionSupport getExecutionSupport()
@@ -1388,20 +1398,12 @@ public class PureModel implements IPureModel
     {
         if (!(f instanceof UserDefinedFunctionHandler))
         {
-            String pkg = HelperModelBuilder.getElementFullPath(((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) f.getFunc())._package(), this.getExecutionSupport());
-            org.finos.legend.pure.m3.coreinstance.Package n = getOrCreatePackage(root, pkg);
-            org.finos.legend.pure.m3.coreinstance.Package o = getPackage((org.finos.legend.pure.m3.coreinstance.Package) METADATA_LAZY.getMetadata(M3Paths.Package, M3Paths.Root), pkg);
-
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pkgToAdd;
-
-            synchronized (o)
+            try (AutoCloseableLock ignored = this.pureModelProcessParameter.writeLock())
             {
-                pkgToAdd = Objects.requireNonNull(o._children().detect(c -> f.getFunctionSignature().equals(c._name())), "Can't find child element '" + f.getFunctionSignature() + "' in package '" + o._name() + "' for path registration");
-            }
-
-            synchronized (n)
-            {
-                n._childrenAdd(pkgToAdd);
+                String pkg = HelperModelBuilder.getElementFullPath(((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) f.getFunc())._package(), this.getExecutionSupport());
+                org.finos.legend.pure.m3.coreinstance.Package n = getOrCreatePackage(root, pkg);
+                org.finos.legend.pure.m3.coreinstance.Package o = getPackage((org.finos.legend.pure.m3.coreinstance.Package) METADATA_LAZY.getMetadata(M3Paths.Package, M3Paths.Root), pkg);
+                n._childrenAdd(o._children().detect(c -> f.getFunctionSignature().equals(c._name())));
             }
         }
     }
@@ -1533,5 +1535,33 @@ public class PureModel implements IPureModel
     private static double nanosDurationToMillis(long startNanos, long endNanos)
     {
         return (endNanos - startNanos) / 1_000_000.0d;
+    }
+
+    protected <T extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement> T setNameAndPackage(T pureElement, String name, String packagePath, SourceInformation sourceInformation)
+    {
+        // Validate and set name
+        if ((name == null) || name.isEmpty())
+        {
+            throw new EngineException("PackageableElement name may not be null or empty", sourceInformation, EngineErrorType.COMPILATION);
+        }
+        if (!name.equals(pureElement.getName()))
+        {
+            throw new EngineException("PackageableElement name '" + name + "' must match CoreInstance name '" + pureElement.getName() + "'", sourceInformation, EngineErrorType.COMPILATION);
+        }
+        pureElement._name(name);
+
+        try (AutoCloseableLock ignored = this.pureModelProcessParameter.writeLock())
+        {
+            // Validate and set package
+            Package pack = this.getOrCreatePackage(packagePath);
+            if (pack._children().anySatisfy(c -> name.equals(c._name())))
+            {
+                throw new EngineException("An element named '" + name + "' already exists in the package '" + packagePath + "'", sourceInformation, EngineErrorType.COMPILATION);
+            }
+            pureElement._package(pack);
+            pureElement.setSourceInformation(SourceInformationHelper.toM3SourceInformation(sourceInformation));
+            pack._childrenAdd(pureElement);
+        }
+        return pureElement;
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModelProcessParameter.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModelProcessParameter.java
@@ -152,7 +152,6 @@ public class PureModelProcessParameter
         public void close()
         {
             this.lock.unlock();
-            ;
         }
     }
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModelProcessParameter.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModelProcessParameter.java
@@ -15,12 +15,16 @@
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class PureModelProcessParameter
 {
     private final String packagePrefix;
     private final ForkJoinPool forkJoinPool;
     private final boolean enablePartialCompilation;
+    private final AutoCloseableLock parallelReadLock;
+    private final AutoCloseableLock parallelWriteLock;
 
     PureModelProcessParameter()
     {
@@ -37,6 +41,18 @@ public class PureModelProcessParameter
         this.packagePrefix = packagePrefix;
         this.forkJoinPool = forkJoinPool;
         this.enablePartialCompilation = enablePartialCompilation;
+        if (this.forkJoinPool != null)
+        {
+            ReentrantReadWriteLock parallelLock = new ReentrantReadWriteLock();
+            this.parallelReadLock = new AutoCloseableLockImpl(parallelLock.readLock());
+            this.parallelWriteLock = new AutoCloseableLockImpl(parallelLock.writeLock());
+        }
+        else
+        {
+            AutoCloseableLockNoOp noOpLock = new AutoCloseableLockNoOp();
+            this.parallelReadLock = noOpLock;
+            this.parallelWriteLock = noOpLock;
+        }
     }
 
     public String getPackagePrefix()
@@ -47,6 +63,16 @@ public class PureModelProcessParameter
     public ForkJoinPool getForkJoinPool()
     {
         return this.forkJoinPool;
+    }
+
+    AutoCloseableLock readLock()
+    {
+        return this.parallelReadLock.lock();
+    }
+
+    AutoCloseableLock writeLock()
+    {
+        return this.parallelWriteLock.lock();
     }
 
     public boolean getEnablePartialCompilation()
@@ -105,6 +131,43 @@ public class PureModelProcessParameter
         public PureModelProcessParameter build()
         {
             return new PureModelProcessParameter(this.packagePrefix, this.forkJoinPool, this.enablePartialCompilation);
+        }
+    }
+
+    private static class AutoCloseableLockImpl implements AutoCloseableLock
+    {
+        private final Lock lock;
+
+        public AutoCloseableLockImpl(Lock lock)
+        {
+            this.lock = lock;
+        }
+
+        public AutoCloseableLock lock()
+        {
+            this.lock.lock();
+            return this;
+        }
+
+        public void close()
+        {
+            this.lock.unlock();
+            ;
+        }
+    }
+
+    private static class AutoCloseableLockNoOp implements AutoCloseableLock
+    {
+        @Override
+        public AutoCloseableLock lock()
+        {
+            return this;
+        }
+
+        @Override
+        public void close()
+        {
+
         }
     }
 }

--- a/legend-engine-xts-authentication/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/authentication/compiler/toPureGraph/AuthenticationDemoCompilerExtension.java
+++ b/legend-engine-xts-authentication/legend-engine-xt-authentication-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/authentication/compiler/toPureGraph/AuthenticationDemoCompilerExtension.java
@@ -47,7 +47,7 @@ public class AuthenticationDemoCompilerExtension implements IAuthenticationDemoC
                         ._name(authenticationDemo.name),
                 (authenticationDemo, context) ->
                 {
-                    Root_meta_pure_runtime_connection_authentication_demo_AuthenticationDemo pureAuthenticationDemo = (Root_meta_pure_runtime_connection_authentication_demo_AuthenticationDemo) context.pureModel.getOrCreatePackage(authenticationDemo._package)._children().detect(c -> authenticationDemo.name.equals(c._name()));
+                    Root_meta_pure_runtime_connection_authentication_demo_AuthenticationDemo pureAuthenticationDemo = (Root_meta_pure_runtime_connection_authentication_demo_AuthenticationDemo) context.pureModel.getPackageableElement(authenticationDemo);
                     pureAuthenticationDemo._authentication(HelperAuthenticationBuilder.buildAuthenticationSpecification(authenticationDemo.authenticationSpecification, context));
                 }
         );

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/pom.xml
@@ -179,10 +179,6 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-dsl-service</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-executionPlan-generation</artifactId>
-        </dependency>
 
         <!-- ENGINE -->
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/HelperPersistenceBuilder.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/HelperPersistenceBuilder.java
@@ -26,6 +26,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.data.EmbeddedD
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.test.assertion.TestAssertionFirstPassBuilder;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.Persistence;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.dataset.DatasetTypeVisitor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.dataset.Delta;
@@ -248,17 +249,14 @@ public class HelperPersistenceBuilder
 
     public static Root_meta_legend_service_metamodel_Service buildService(Persistence persistence, CompileContext context)
     {
-        String service = persistence.service;
-        String servicePath = service.substring(0, service.lastIndexOf("::"));
-        String serviceName = service.substring(service.lastIndexOf("::") + 2);
-
-        PackageableElement packageableElement = context.pureModel.getOrCreatePackage(servicePath)._children().detect(c -> serviceName.equals(c._name()));
+        PackageableElementPointer service = persistence.service;
+        PackageableElement packageableElement = context.resolvePackageableElement(service);
         if (packageableElement instanceof Root_meta_legend_service_metamodel_Service)
         {
             return (Root_meta_legend_service_metamodel_Service) packageableElement;
         }
 
-        throw new EngineException(String.format("Service '%s' is not defined", service), persistence.sourceInformation, EngineErrorType.COMPILATION);
+        throw new EngineException(String.format("Service '%s' is not defined", service.path), persistence.sourceInformation, EngineErrorType.COMPILATION);
     }
 
     public static Root_meta_pure_persistence_metamodel_service_ServiceOutputTarget buildServiceOutputTarget(ServiceOutputTarget serviceOutputTarget, CompileContext context)
@@ -608,12 +606,9 @@ public class HelperPersistenceBuilder
         return purePersistenceTest;
     }
 
-    public static Database buildDatabase(String database, SourceInformation sourceInformation, CompileContext context)
+    public static Database buildDatabase(PackageableElementPointer database, SourceInformation sourceInformation, CompileContext context)
     {
-        String databasePath = database.substring(0, database.lastIndexOf("::"));
-        String databaseName = database.substring(database.lastIndexOf("::") + 2);
-
-        PackageableElement packageableElement = context.pureModel.getOrCreatePackage(databasePath)._children().detect(c -> databaseName.equals(c._name()));
+        PackageableElement packageableElement = context.resolvePackageableElement(database);
         if (packageableElement instanceof Database)
         {
             return (Database) packageableElement;
@@ -622,12 +617,9 @@ public class HelperPersistenceBuilder
         throw new EngineException(String.format("Database '%s' is not defined", database), sourceInformation, EngineErrorType.COMPILATION);
     }
 
-    public static Root_meta_external_format_shared_binding_Binding buildBinding(String binding, SourceInformation sourceInformation, CompileContext context)
+    public static Root_meta_external_format_shared_binding_Binding buildBinding(PackageableElementPointer binding, SourceInformation sourceInformation, CompileContext context)
     {
-        String bindingPath = binding.substring(0, binding.lastIndexOf("::"));
-        String bindingName = binding.substring(binding.lastIndexOf("::") + 2);
-
-        PackageableElement packageableElement = context.pureModel.getOrCreatePackage(bindingPath)._children().detect(c -> bindingName.equals(c._name()));
+        PackageableElement packageableElement = context.resolvePackageableElement(binding);
         if (packageableElement instanceof Root_meta_external_format_shared_binding_Binding)
         {
             return (Root_meta_external_format_shared_binding_Binding) packageableElement;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/HelperPersistenceContextBuilder.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/HelperPersistenceContextBuilder.java
@@ -21,6 +21,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.ConnectionFirs
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.ConnectionSecondPassBuilder;
 import org.finos.legend.engine.language.pure.dsl.persistence.grammar.to.PrimitiveValueSpecificationToObjectVisitor;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.PersistenceContext;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.context.PersistencePlatform;
@@ -39,11 +40,9 @@ public class HelperPersistenceContextBuilder
 
     public static Root_meta_pure_persistence_metamodel_Persistence buildPersistence(PersistenceContext persistenceContext, CompileContext context)
     {
-        String persistence = persistenceContext.persistence;
-        String persistencePath = persistence.substring(0, persistence.lastIndexOf("::"));
-        String persistenceName = persistence.substring(persistence.lastIndexOf("::") + 2);
+        PackageableElementPointer persistence = persistenceContext.persistence;
 
-        PackageableElement packageableElement = context.pureModel.getOrCreatePackage(persistencePath)._children().detect(c -> persistenceName.equals(c._name()));
+        PackageableElement packageableElement = context.resolvePackageableElement(persistence);
         if (packageableElement instanceof Root_meta_pure_persistence_metamodel_Persistence)
         {
             return (Root_meta_pure_persistence_metamodel_Persistence) packageableElement;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/toPureGraph/PersistenceCompilerExtension.java
@@ -28,7 +28,6 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Proc
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.test.assertion.TestAssertionFirstPassBuilder;
 import org.finos.legend.engine.language.pure.dsl.persistence.compiler.validation.ValidationResult;
 import org.finos.legend.engine.language.pure.dsl.persistence.compiler.validation.ValidationRuleSet;
-import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.PackageableConnection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.externalFormat.Binding;
@@ -93,7 +92,7 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                                 ._documentation(persistence.documentation),
                         (persistence, context) ->
                         {
-                            Root_meta_pure_persistence_metamodel_Persistence purePersistence = (Root_meta_pure_persistence_metamodel_Persistence) context.pureModel.getOrCreatePackage(persistence._package)._children().detect(c -> persistence.name.equals(c._name()));
+                            Root_meta_pure_persistence_metamodel_Persistence purePersistence = (Root_meta_pure_persistence_metamodel_Persistence) context.pureModel.getPackageableElement(persistence);
                             purePersistence._trigger(HelperPersistenceBuilder.buildTrigger(persistence.trigger, context));
                             purePersistence._service(HelperPersistenceBuilder.buildService(persistence, context));
                             if (persistence.serviceOutputTargets != null)
@@ -115,7 +114,7 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                         (persistenceContext, context) -> new Root_meta_pure_persistence_metamodel_PersistenceContext_Impl(persistenceContext.name, null, context.pureModel.getClass("meta::pure::persistence::metamodel::PersistenceContext"))._name(persistenceContext.name),
                         (persistenceContext, context) ->
                         {
-                            Root_meta_pure_persistence_metamodel_PersistenceContext purePersistenceContext = (Root_meta_pure_persistence_metamodel_PersistenceContext) context.pureModel.getOrCreatePackage(persistenceContext._package)._children().detect(c -> persistenceContext.name.equals(c._name()));
+                            Root_meta_pure_persistence_metamodel_PersistenceContext purePersistenceContext = (Root_meta_pure_persistence_metamodel_PersistenceContext) context.pureModel.getPackageableElement(persistenceContext);
                             purePersistenceContext._persistence(HelperPersistenceContextBuilder.buildPersistence(persistenceContext, context));
                             purePersistenceContext._platform(HelperPersistenceContextBuilder.buildPersistencePlatform(persistenceContext.platform, context));
                             purePersistenceContext._serviceParameters(ListIterate.collect(persistenceContext.serviceParameters, sp -> HelperPersistenceContextBuilder.buildServiceParameter(sp, context)));
@@ -130,9 +129,7 @@ public class PersistenceCompilerExtension implements IPersistenceCompilerExtensi
                         // use the final compiler pass to invoke validation extensions
                         (persistenceContext, context) ->
                         {
-                            Root_meta_pure_persistence_metamodel_PersistenceContext purePersistenceContext = (Root_meta_pure_persistence_metamodel_PersistenceContext) context.pureModel.getOrCreatePackage(persistenceContext._package)._children().detect(c -> persistenceContext.name.equals(c._name()));
-
-                            ListIterable<PlanGeneratorExtension> generatorExtensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
+                            Root_meta_pure_persistence_metamodel_PersistenceContext purePersistenceContext = (Root_meta_pure_persistence_metamodel_PersistenceContext) context.pureModel.getPackageableElement(persistenceContext);
                             ListIterable<? extends Root_meta_pure_extension_Extension> pureExtensions = PureCoreExtensionLoader.extensions().flatCollect(x -> x.extraPureCoreExtensions(context.pureModel.getExecutionSupport())).toList();
 
                             // execute common validations

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/from/PersistenceParseTreeWalker.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/from/PersistenceParseTreeWalker.java
@@ -27,6 +27,8 @@ import org.finos.legend.engine.language.pure.grammar.from.domain.DomainParser;
 import org.finos.legend.engine.language.pure.grammar.from.test.assertion.HelperTestAssertionGrammarParser;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.Persistence;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.dataset.DatasetType;
@@ -190,7 +192,11 @@ public class PersistenceParseTreeWalker
 
         // service
         PersistenceParserGrammar.ServiceContext serviceContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.service(), "service", persistence.sourceInformation);
-        persistence.service = PureGrammarParserUtility.fromQualifiedName(serviceContext.qualifiedName().packagePath() == null ? Collections.emptyList() : serviceContext.qualifiedName().packagePath().identifier(), serviceContext.qualifiedName().identifier());
+        persistence.service = new PackageableElementPointer(
+                PackageableElementType.SERVICE,
+                PureGrammarParserUtility.fromQualifiedName(serviceContext.qualifiedName().packagePath() == null ? Collections.emptyList() : serviceContext.qualifiedName().packagePath().identifier(), serviceContext.qualifiedName().identifier())
+        );
+        persistence.service.sourceInformation = walkerSourceInformation.getSourceInformation(serviceContext);
 
         // service output targets (optional)
         PersistenceParserGrammar.ServiceOutputTargetsContext serviceOutputTargetsContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.serviceOutputTargets(), "serviceOutputTargets", persistence.sourceInformation);
@@ -943,7 +949,11 @@ public class PersistenceParseTreeWalker
 
         // database
         PersistenceParserGrammar.SinkDatabaseContext sinkDatabaseContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.sinkDatabase(), "database", sink.sourceInformation);
-        sink.database = visitDatabasePointer(sinkDatabaseContext, sink.sourceInformation);
+        sink.database = new PackageableElementPointer(
+                PackageableElementType.STORE,
+                visitDatabasePointer(sinkDatabaseContext, sink.sourceInformation)
+        );
+        sink.database.sourceInformation = walkerSourceInformation.getSourceInformation(sinkDatabaseContext);
 
         return sink;
     }
@@ -955,7 +965,8 @@ public class PersistenceParseTreeWalker
 
         // binding
         PersistenceParserGrammar.SinkBindingContext sinkBindingContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.sinkBinding(), "binding", sink.sourceInformation);
-        sink.binding = visitBindingPointer(sinkBindingContext, sink.sourceInformation);
+        sink.binding = new PackageableElementPointer(visitBindingPointer(sinkBindingContext, sink.sourceInformation));
+        sink.binding.sourceInformation = walkerSourceInformation.getSourceInformation(sinkBindingContext);
 
         return sink;
     }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/from/context/PersistenceContextParseTreeWalker.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/from/context/PersistenceContextParseTreeWalker.java
@@ -23,6 +23,8 @@ import org.finos.legend.engine.language.pure.grammar.from.connection.ConnectionP
 import org.finos.legend.engine.language.pure.grammar.from.domain.DomainParser;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.ConnectionPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.PersistenceContext;
@@ -64,7 +66,11 @@ public class PersistenceContextParseTreeWalker
 
         // persistence
         PersistenceParserGrammar.ContextPersistenceContext persistenceContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.contextPersistence(), "persistence", context.sourceInformation);
-        context.persistence = PureGrammarParserUtility.fromQualifiedName(ctx.qualifiedName().packagePath() == null ? Collections.emptyList() : persistenceContext.qualifiedName().packagePath().identifier(), persistenceContext.qualifiedName().identifier());
+        context.persistence = new PackageableElementPointer(
+                PackageableElementType.PERSISTENCE,
+                PureGrammarParserUtility.fromQualifiedName(persistenceContext.qualifiedName().packagePath() == null ? Collections.emptyList() : persistenceContext.qualifiedName().packagePath().identifier(), persistenceContext.qualifiedName().identifier())
+        );
+        context.persistence.sourceInformation = walkerSourceInformation.getSourceInformation(persistenceContext);
 
         // persistence platform
         PersistenceParserGrammar.ContextPlatformContext platformContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.contextPlatform(), "platform", context.sourceInformation);

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceComposer.java
@@ -141,7 +141,7 @@ public class HelperPersistenceComposer
                 "{\n" +
                 renderDocumentation(persistence.documentation, indentLevel) +
                 renderTrigger(persistence.trigger, indentLevel, context) +
-                renderService(persistence.service, indentLevel) +
+                renderService(persistence.service.path, indentLevel) +
                 renderServiceOutputTargets(persistence.serviceOutputTargets, indentLevel, context) +
                 //TODO: ledav -- remove once v2 is rolled out | START
                 renderPersister(persistence.persister, indentLevel, context) +
@@ -729,7 +729,7 @@ public class HelperPersistenceComposer
         {
             return getTabString(indentLevel) + "sink: Relational\n" +
                     getTabString(indentLevel) + "{\n" +
-                    renderDatabasePointer(val.database, indentLevel + 1) +
+                    renderDatabasePointer(val.database.path, indentLevel + 1) +
                     getTabString(indentLevel) + "}\n";
         }
 
@@ -738,7 +738,7 @@ public class HelperPersistenceComposer
         {
             return getTabString(indentLevel) + "sink: ObjectStorage\n" +
                     getTabString(indentLevel) + "{\n" +
-                    renderBindingPointer(val.binding, indentLevel + 1) +
+                    renderBindingPointer(val.binding.path, indentLevel + 1) +
                     getTabString(indentLevel) + "}\n";
         }
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceContextComposer.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/grammar/to/HelperPersistenceContextComposer.java
@@ -44,7 +44,7 @@ public class HelperPersistenceContextComposer
     {
         return "PersistenceContext " + convertPath(persistenceContext.getPath()) + "\n" +
                 "{\n" +
-                renderPersistencePointer(persistenceContext.persistence, indentLevel) +
+                renderPersistencePointer(persistenceContext.persistence.path, indentLevel) +
                 renderPersistencePlatform(persistenceContext.platform, indentLevel, context) +
                 renderServiceParameters(persistenceContext.serviceParameters, indentLevel, context) +
                 (persistenceContext.sinkConnection == null ? "" : renderConnection(persistenceContext.sinkConnection, "sinkConnection", indentLevel, context)) +

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceCompilationFromGrammar.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceCompilationFromGrammar.java
@@ -142,7 +142,7 @@ public class TestPersistenceCompilationFromGrammar extends TestCompilationFromGr
                 "      filterDuplicates: false;\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n", "COMPILATION error at [5:1-27:1]: Service 'test::Service' is not defined");
+                "}\n", "COMPILATION error at [9:3-25]: Can't find the packageable element 'test::Service'");
     }
 
     @Test
@@ -203,7 +203,7 @@ public class TestPersistenceCompilationFromGrammar extends TestCompilationFromGr
                 "      filterDuplicates: false;\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n", "COMPILATION error at [41:11-44:5]: Binding 'test::Binding' is not defined");
+                "}\n", "COMPILATION error at [43:7-29]: Can't find the packageable element 'test::Binding'");
     }
 
     @Test
@@ -264,7 +264,7 @@ public class TestPersistenceCompilationFromGrammar extends TestCompilationFromGr
                 "      filterDuplicates: false;\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n", "COMPILATION error at [41:11-43:36]: Database 'test::Database' is not defined");
+                "}\n", "COMPILATION error at [43:7-31]: Can't find the packageable element 'test::Database'");
     }
 
     @Test

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceContextCompilationFromGrammar.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceContextCompilationFromGrammar.java
@@ -58,7 +58,7 @@ public class TestPersistenceContextCompilationFromGrammar extends TestCompilatio
                 "PersistenceContext test::TestPersistenceContext\n" +
                 "{\n" +
                 "  persistence: test::TestPersistence;\n" +
-                "}\n", "COMPILATION error at [3:1-6:1]: Persistence 'test::TestPersistence' is not defined");
+                "}\n", "COMPILATION error at [5:3-37]: Can't find the packageable element 'test::TestPersistence'");
     }
 
     @Test

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceV2CompilationFromGrammar.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/compiler/test/TestPersistenceV2CompilationFromGrammar.java
@@ -146,7 +146,7 @@ public class TestPersistenceV2CompilationFromGrammar extends TestCompilationFrom
             "    {\n" +
             "    }\n" +
             "  ];" +
-            "}\n", "COMPILATION error at [2:1-33:5]: Service 'test::Service' is not defined");
+            "}\n", "COMPILATION error at [6:3-25]: Can't find the packageable element 'test::Service'");
     }
 
     @Test

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/pom.xml
@@ -43,6 +43,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
         <!-- JACKSON -->
 
         <!-- ECLIPSE COLLECTIONS -->

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/Persistence.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/Persistence.java
@@ -14,7 +14,9 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElementVisitor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.notifier.Notifier;
@@ -27,7 +29,8 @@ public class Persistence extends PackageableElement
 {
     public String documentation;
     public Trigger trigger;
-    public String service;
+    @JsonSerialize(converter = PackageableElementPointer.ToPathSerializerConverter.class)
+    public PackageableElementPointer service;
     public List<ServiceOutputTarget> serviceOutputTargets;
     public Persister persister;
     public Notifier notifier;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/PersistenceContext.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/PersistenceContext.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElementVisitor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
@@ -24,7 +26,8 @@ import java.util.List;
 
 public class PersistenceContext extends PackageableElement
 {
-    public String persistence;
+    @JsonSerialize(converter = PackageableElementPointer.ToPathSerializerConverter.class)
+    public PackageableElementPointer persistence;
     public PersistencePlatform platform;
     public List<ServiceParameter> serviceParameters;
     public Connection sinkConnection;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/persister/sink/ObjectStorageSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/persister/sink/ObjectStorageSink.java
@@ -14,9 +14,13 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.persister.sink;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
+
 public class ObjectStorageSink extends Sink
 {
-    public String binding;
+    @JsonSerialize(converter = PackageableElementPointer.ToPathSerializerConverter.class)
+    public PackageableElementPointer binding;
 
     @Override
     public <T> T accept(SinkVisitor<T> visitor)

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/persister/sink/RelationalSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/persister/sink/RelationalSink.java
@@ -14,9 +14,13 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.persister.sink;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
+
 public class RelationalSink extends Sink
 {
-    public String database;
+    @JsonSerialize(converter = PackageableElementPointer.ToPathSerializerConverter.class)
+    public PackageableElementPointer database;
 
     @Override
     public <T> T accept(SinkVisitor<T> visitor)

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/compiler/toPureGraph/HelperPersistenceRelationalBuilder.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/compiler/toPureGraph/HelperPersistenceRelationalBuilder.java
@@ -22,6 +22,7 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.sink.RelationalPersistenceTarget;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.temporality.Bitemporal;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.temporality.Nontemporal;
@@ -98,12 +99,9 @@ public class HelperPersistenceRelationalBuilder
             ._milestoning(buildMilestoning(persistenceTarget.temporality, context, table));
     }
 
-    public static Database buildDatabase(String database, SourceInformation sourceInformation, CompileContext context)
+    public static Database buildDatabase(PackageableElementPointer database, SourceInformation sourceInformation, CompileContext context)
     {
-        String databasePath = database.substring(0, database.lastIndexOf("::"));
-        String databaseName = database.substring(database.lastIndexOf("::") + 2);
-
-        PackageableElement packageableElement = context.pureModel.getOrCreatePackage(databasePath)._children().detect(c -> databaseName.equals(c._name()));
+        PackageableElement packageableElement = context.resolvePackageableElement(database);
         if (packageableElement instanceof Database)
         {
             return (Database) packageableElement;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/from/PersistenceRelationalParseTreeWalker.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/from/PersistenceRelationalParseTreeWalker.java
@@ -18,6 +18,8 @@ import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceI
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserUtility;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.sink.RelationalPersistenceTarget;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.temporality.Bitemporal;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.temporality.Nontemporal;
@@ -72,7 +74,11 @@ public class PersistenceRelationalParseTreeWalker
 
         // database
         PersistenceRelationalParserGrammar.DatabaseContext databaseContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.database(), "database", persistenceTarget.sourceInformation);
-        persistenceTarget.database = visitDatabasePointer(databaseContext, persistenceTarget.sourceInformation);
+        persistenceTarget.database = new PackageableElementPointer(
+                PackageableElementType.STORE,
+                visitDatabasePointer(databaseContext, persistenceTarget.sourceInformation)
+        );
+        persistenceTarget.database.sourceInformation = walkerSourceInformation.getSourceInformation(databaseContext);
 
         // temporality (optional)
         PersistenceRelationalParserGrammar.TemporalityContext temporalityContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.temporality(), "temporality", persistenceTarget.sourceInformation);

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/to/HelperPersistenceRelationalComposer.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/main/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/grammar/to/HelperPersistenceRelationalComposer.java
@@ -60,7 +60,7 @@ public class HelperPersistenceRelationalComposer
         return getTabString(indentLevel) + "Relational\n" +
             getTabString(indentLevel) + "#{\n" +
             renderTable(persistenceTarget.table, indentLevel + 1) +
-            renderDatabasePointer(persistenceTarget.database, indentLevel + 1) +
+            renderDatabasePointer(persistenceTarget.database.path, indentLevel + 1) +
             renderTemporality(persistenceTarget.temporality, indentLevel + 1) +
             getTabString(indentLevel) + "}#";
     }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/compiler/test/TestPersistenceRelationalCompilationFromGrammar.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/src/test/java/org/finos/legend/engine/language/pure/dsl/persistence/relational/compiler/test/TestPersistenceRelationalCompilationFromGrammar.java
@@ -235,7 +235,7 @@ public class TestPersistenceRelationalCompilationFromGrammar extends TestCompila
             "      isTestDataFromServiceOutput: false;\n" +
             "    }\n" +
             "  ]\n" +
-            "}\n", "COMPILATION error at [63:7-69:7]: Database 'test::Database' is not defined");
+            "}\n", "COMPILATION error at [64:7-31]: Can't find the packageable element 'test::Database'");
     }
 
     @Test

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-protocol/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-protocol/pom.xml
@@ -47,6 +47,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
         <!-- JACKSON -->
 
         <!-- ECLIPSE COLLECTIONS -->

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/relational/sink/RelationalPersistenceTarget.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/persistence/relational/sink/RelationalPersistenceTarget.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.sink;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.relational.temporality.Temporality;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.sink.PersistenceTarget;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persistence.sink.PersistenceTargetVisitor;
@@ -21,7 +23,8 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.persist
 public class RelationalPersistenceTarget extends PersistenceTarget
 {
     public String table;
-    public String database;
+    @JsonSerialize(converter = PackageableElementPointer.ToPathSerializerConverter.class)
+    public PackageableElementPointer database;
     public Temporality temporality;
 
     @Override

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service/src/main/java/org/finos/legend/engine/language/pure/dsl/service/compiler/toPureGraph/ServiceCompilerExtensionImpl.java
@@ -97,7 +97,7 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
                         },
                         (service, context) ->
                         {
-                            Root_meta_legend_service_metamodel_Service pureService = (Root_meta_legend_service_metamodel_Service) context.pureModel.getOrCreatePackage(service._package)._children().detect(c -> service.name.equals(c._name()));
+                            Root_meta_legend_service_metamodel_Service pureService = (Root_meta_legend_service_metamodel_Service) context.pureModel.getPackageableElement(service);
 
                             pureService._execution(HelperServiceBuilder.processServiceExecution(service.execution, context));
 
@@ -213,7 +213,7 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
                                 ._name(execEnv.name),
                         (execEnv, context) ->
                         {
-                            Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance pureExecEnv = (Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance) context.pureModel.getOrCreatePackage(execEnv._package)._children().detect(c -> execEnv.name.equals(c._name()));
+                            Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance pureExecEnv = (Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance) context.pureModel.getPackageableElement(execEnv);
                             pureExecEnv._executionParameters(ListIterate.collect(execEnv.executionParameters, params -> HelperServiceBuilder.processExecutionParameters(params, context)));
                         })
         );
@@ -332,7 +332,7 @@ public class ServiceCompilerExtensionImpl implements ServiceCompilerExtension
         return Maps.mutable.with("executionEnvironmentInstance", (obj, context, processingContext) ->
                 {
                     ExecutionEnvironmentInstance execEnv = (ExecutionEnvironmentInstance) obj;
-                    Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance pureExecEnv = (Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance) context.pureModel.getOrCreatePackage(execEnv._package)._children().detect(c -> execEnv.name.equals(c._name()));
+                    Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance pureExecEnv = (Root_meta_legend_service_metamodel_ExecutionEnvironmentInstance) context.pureModel.getPackageableElement(execEnv);
                     pureExecEnv._executionParameters(ListIterate.collect(execEnv.executionParameters, params -> HelperServiceBuilder.processExecutionParameters(params, context)));
                     GenericType execEnvGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(context.pureModel.getType("meta::legend::service::metamodel::ExecutionEnvironmentInstance"));
                     return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))


### PR DESCRIPTION
This aims to improve the parallel compiler, moving from synchronize blocks to RW locks to protect access to the Pure graph..

By having read locks, concurrent threads can access the graph, and the lock can be escalated to write when needed.  In contracts, sync blocks will always create contention even during heavy reads, which is what we do mostly on the graph.

The PR refactors access to packages, and its children, so all the access is done thru common APIs that respect the locking, while also removing duplicated code by using these utility methods.

The performance of this approach yields better than previous sync block implementation, and scale better than the previous implementation.

Below results of benchmarking (using this https://github.com/finos/legend-engine/pull/2949) 

* -1 is old code
* The rest is log base 2 (0 is 1 thread, 1 is 2 threads, etc)  
* PMCD size also is log base 2
* PMCD contains 36 elements:
  * Association - 11
  * Diagram - 1
  * Service - 6
  * DataSpace - 1
  * Class - 13
  * Enumeration - 1
  * Mapping - 1
  * Runtime - 1
  * Database - 1

The first image is % compared to the worst run on the row (constant PMCD size).  

<img width="763" alt="image" src="https://github.com/user-attachments/assets/7f82d666-f52e-4506-b23f-43ee9f059434">
 
* The old code is slower for smaller PMCDs,
* As the PMCD size grows, old code it outperforms the new code in single threaded mode.  (-1 vs 0 on the pivot table) 
* This is visible as the 100% (worst run on the row) moves from 1st column to 2nd column when PMCD scale goes from 4 to 5.
* On this particular scenario and on my machine, the peak performance is reached at parallelism 3 (8 threads), where it runs in ~30% of the time when compared to single threaded runs.

Below a graph for better visualizing these values, and the tipping point when old code outperforms single threaded and 2 threads on new code.

<img width="877" alt="image" src="https://github.com/user-attachments/assets/b0f6c223-c09c-40da-a58c-072196b64817">


Raw Table:

Benchmark | (parallelism) | log(parallelism, 2) | (pmcdCount) | log(pmcdCount, 2) | Mode | Cnt | Score |   | Error | Units
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
PureModelBenchmark.compile | -1 | -1 | 1 | 0 | avgt | 25 | 0.202 | ± | 0.066 | s/op
PureModelBenchmark.compile | -1 | -1 | 2 | 1 | avgt | 25 | 0.2 | ± | 0.016 | s/op
PureModelBenchmark.compile | -1 | -1 | 4 | 2 | avgt | 25 | 0.214 | ± | 0.002 | s/op
PureModelBenchmark.compile | -1 | -1 | 8 | 3 | avgt | 25 | 0.251 | ± | 0.002 | s/op
PureModelBenchmark.compile | -1 | -1 | 16 | 4 | avgt | 25 | 0.385 | ± | 0.098 | s/op
PureModelBenchmark.compile | -1 | -1 | 32 | 5 | avgt | 25 | 0.466 | ± | 0.022 | s/op
PureModelBenchmark.compile | -1 | -1 | 64 | 6 | avgt | 25 | 0.773 | ± | 0.017 | s/op
PureModelBenchmark.compile | -1 | -1 | 128 | 7 | avgt | 25 | 1.356 | ± | 0.011 | s/op
PureModelBenchmark.compile | 1 | 0 | 1 | 0 | avgt | 15 | 0.057 | ± | 0.001 | s/op
PureModelBenchmark.compile | 1 | 0 | 2 | 1 | avgt | 15 | 0.08 | ± | 0.001 | s/op
PureModelBenchmark.compile | 1 | 0 | 4 | 2 | avgt | 15 | 0.123 | ± | 0.003 | s/op
PureModelBenchmark.compile | 1 | 0 | 8 | 3 | avgt | 15 | 0.209 | ± | 0.003 | s/op
PureModelBenchmark.compile | 1 | 0 | 16 | 4 | avgt | 15 | 0.372 | ± | 0.007 | s/op
PureModelBenchmark.compile | 2 | 1 | 1 | 0 | avgt | 15 | 0.056 | ± | 0.001 | s/op
PureModelBenchmark.compile | 2 | 1 | 2 | 1 | avgt | 15 | 0.061 | ± | 0.001 | s/op
PureModelBenchmark.compile | 2 | 1 | 4 | 2 | avgt | 15 | 0.085 | ± | 0.002 | s/op
PureModelBenchmark.compile | 2 | 1 | 8 | 3 | avgt | 15 | 0.132 | ± | 0.003 | s/op
PureModelBenchmark.compile | 2 | 1 | 16 | 4 | avgt | 15 | 0.22 | ± | 0.002 | s/op
PureModelBenchmark.compile | 4 | 2 | 1 | 0 | avgt | 15 | 0.056 | ± | 0.001 | s/op
PureModelBenchmark.compile | 4 | 2 | 2 | 1 | avgt | 15 | 0.06 | ± | 0.002 | s/op
PureModelBenchmark.compile | 4 | 2 | 4 | 2 | avgt | 15 | 0.07 | ± | 0.005 | s/op
PureModelBenchmark.compile | 4 | 2 | 8 | 3 | avgt | 15 | 0.098 | ± | 0.003 | s/op
PureModelBenchmark.compile | 4 | 2 | 16 | 4 | avgt | 15 | 0.164 | ± | 0.012 | s/op
PureModelBenchmark.compile | 8 | 3 | 1 | 0 | avgt | 15 | 0.056 | ± | 0.001 | s/op
PureModelBenchmark.compile | 8 | 3 | 2 | 1 | avgt | 15 | 0.061 | ± | 0.002 | s/op
PureModelBenchmark.compile | 8 | 3 | 4 | 2 | avgt | 15 | 0.065 | ± | 0.001 | s/op
PureModelBenchmark.compile | 8 | 3 | 8 | 3 | avgt | 15 | 0.092 | ± | 0.004 | s/op
PureModelBenchmark.compile | 8 | 3 | 16 | 4 | avgt | 15 | 0.134 | ± | 0.003 | s/op
PureModelBenchmark.compile | 16 | 4 | 1 | 0 | avgt | 15 | 0.056 | ± | 0.001 | s/op
PureModelBenchmark.compile | 16 | 4 | 2 | 1 | avgt | 15 | 0.06 | ± | 0.002 | s/op
PureModelBenchmark.compile | 16 | 4 | 4 | 2 | avgt | 15 | 0.066 | ± | 0.001 | s/op
PureModelBenchmark.compile | 16 | 4 | 8 | 3 | avgt | 15 | 0.088 | ± | 0.008 | s/op
PureModelBenchmark.compile | 16 | 4 | 16 | 4 | avgt | 15 | 0.129 | ± | 0.004 | s/op
PureModelBenchmark.compile | 1 | 0 | 32 | 5 | avgt | 15 | 0.729 | ± | 0.011 | s/op
PureModelBenchmark.compile | 1 | 0 | 64 | 6 | avgt | 15 | 1.43 | ± | 0.038 | s/op
PureModelBenchmark.compile | 1 | 0 | 128 | 7 | avgt | 15 | 2.804 | ± | 0.034 | s/op
PureModelBenchmark.compile | 2 | 1 | 32 | 5 | avgt | 15 | 0.409 | ± | 0.005 | s/op
PureModelBenchmark.compile | 2 | 1 | 64 | 6 | avgt | 15 | 0.785 | ± | 0.009 | s/op
PureModelBenchmark.compile | 2 | 1 | 128 | 7 | avgt | 15 | 1.556 | ± | 0.024 | s/op
PureModelBenchmark.compile | 4 | 2 | 32 | 5 | avgt | 15 | 0.294 | ± | 0.024 | s/op
PureModelBenchmark.compile | 4 | 2 | 64 | 6 | avgt | 15 | 0.551 | ± | 0.058 | s/op
PureModelBenchmark.compile | 4 | 2 | 128 | 7 | avgt | 15 | 0.987 | ± | 0.063 | s/op
PureModelBenchmark.compile | 8 | 3 | 32 | 5 | avgt | 15 | 0.225 | ± | 0.008 | s/op
PureModelBenchmark.compile | 8 | 3 | 64 | 6 | avgt | 15 | 0.404 | ± | 0.012 | s/op
PureModelBenchmark.compile | 8 | 3 | 128 | 7 | avgt | 15 | 0.78 | ± | 0.036 | s/op
PureModelBenchmark.compile | 16 | 4 | 32 | 5 | avgt | 15 | 0.213 | ± | 0.01 | s/op
PureModelBenchmark.compile | 16 | 4 | 64 | 6 | avgt | 15 | 0.376 | ± | 0.012 | s/op
PureModelBenchmark.compile | 16 | 4 | 128 | 7 | avgt | 15 | 0.738 | ± | 0.032 | s/op
PureModelBenchmark.compile | 32 | 5 | 32 | 5 | avgt | 15 | 0.208 | ± | 0.006 | s/op
PureModelBenchmark.compile | 32 | 5 | 64 | 6 | avgt | 15 | 0.378 | ± | 0.014 | s/op
PureModelBenchmark.compile | 32 | 5 | 128 | 7 | avgt | 15 | 0.719 | ± | 0.026 | s/op
PureModelBenchmark.compile | 64 | 6 | 32 | 5 | avgt | 15 | 0.205 | ± | 0.005 | s/op
PureModelBenchmark.compile | 64 | 6 | 64 | 6 | avgt | 15 | 0.386 | ± | 0.01 | s/op
PureModelBenchmark.compile | 64 | 6 | 128 | 7 | avgt | 15 | 0.736 | ± | 0.034 | s/op
PureModelBenchmark.compile | 128 | 7 | 32 | 5 | avgt | 15 | 0.212 | ± | 0.007 | s/op
PureModelBenchmark.compile | 128 | 7 | 64 | 6 | avgt | 15 | 0.388 | ± | 0.013 | s/op
PureModelBenchmark.compile | 128 | 7 | 128 | 7 | avgt | 15 | 0.741 | ± | 0.029 | s/op
PureModelBenchmark.compile | 32 | 5 | 1 | 0 | avgt | 15 | 0.057 | ± | 0.001 | s/op
PureModelBenchmark.compile | 32 | 5 | 2 | 1 | avgt | 15 | 0.061 | ± | 0.001 | s/op
PureModelBenchmark.compile | 32 | 5 | 4 | 2 | avgt | 15 | 0.067 | ± | 0.001 | s/op
PureModelBenchmark.compile | 32 | 5 | 8 | 3 | avgt | 15 | 0.084 | ± | 0.001 | s/op
PureModelBenchmark.compile | 32 | 5 | 16 | 4 | avgt | 15 | 0.121 | ± | 0.004 | s/op
PureModelBenchmark.compile | 64 | 6 | 1 | 0 | avgt | 15 | 0.057 | ± | 0.001 | s/op
PureModelBenchmark.compile | 64 | 6 | 2 | 1 | avgt | 15 | 0.062 | ± | 0.001 | s/op
PureModelBenchmark.compile | 64 | 6 | 4 | 2 | avgt | 15 | 0.068 | ± | 0.002 | s/op
PureModelBenchmark.compile | 64 | 6 | 8 | 3 | avgt | 15 | 0.085 | ± | 0.001 | s/op
PureModelBenchmark.compile | 64 | 6 | 16 | 4 | avgt | 15 | 0.124 | ± | 0.004 | s/op
PureModelBenchmark.compile | 128 | 7 | 1 | 0 | avgt | 15 | 0.058 | ± | 0.001 | s/op
PureModelBenchmark.compile | 128 | 7 | 2 | 1 | avgt | 15 | 0.061 | ± | 0.001 | s/op
PureModelBenchmark.compile | 128 | 7 | 4 | 2 | avgt | 15 | 0.069 | ± | 0.003 | s/op
PureModelBenchmark.compile | 128 | 7 | 8 | 3 | avgt | 15 | 0.087 | ± | 0.003 | s/op
PureModelBenchmark.compile | 128 | 7 | 16 | 4 | avgt | 15 | 0.127 | ± | 0.004 | s/op