### PR TITLE
External format JSON: add functions with config params to compiler

### DIFF
--- a/legend-engine-xts-json/legend-engine-xt-json-model/src/main/java/org/finos/legend/engine/external/format/json/compile/JsonSchemaCompiler.java
+++ b/legend-engine-xts-json/legend-engine-xt-json-model/src/main/java/org/finos/legend/engine/external/format/json/compile/JsonSchemaCompiler.java
@@ -67,12 +67,17 @@ public class JsonSchemaCompiler implements CompilerExtension
                                 handlers.m(handlers.h("meta::json::schema::discriminateOneOf_Any_1__Any_1__Type_MANY__DiscriminatorMapping_MANY__Boolean_1_", false, ps -> handlers.res("Boolean", "one"), ps -> ps.size() == 4))
                         ),
                         new FunctionExpressionBuilderRegistrationInfo(null,
-                                handlers.m(handlers.h("meta::external::format::json::functions::toJson_T_MANY__RootGraphFetchTree_1__String_1_", false, ps -> handlers.res("String", "one"), ps -> ps.size() == 2))
+                                handlers.m(
+                                        handlers.m(handlers.h("meta::external::format::json::functions::toJson_T_MANY__RootGraphFetchTree_1__String_1_", false, ps -> handlers.res("String", "one"), ps -> ps.size() == 2)),
+                                        handlers.m(handlers.h("meta::external::format::json::functions::toJson_T_MANY__RootGraphFetchTree_1__JsonSchemaExternalizeConfig_1__String_1_", false, ps -> handlers.res("String", "one"), ps -> ps.size() == 3))
+                                )
                         ),
                         new FunctionExpressionBuilderRegistrationInfo(null,
                                 handlers.m(
                                         handlers.m(handlers.h("meta::external::format::json::functions::fromJson_Class_1__String_1__T_MANY_", false, ps -> handlers.res(ps.get(0)._genericType()._typeArguments().getFirst(), "zeroMany"), ps -> Lists.mutable.with(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> ps.size() == 2 && "String".equals(ps.get(1)._genericType()._rawType()._name()))),
-                                        handlers.m(handlers.h("meta::external::format::json::functions::fromJson_Class_1__Byte_MANY__T_MANY_", false, ps -> handlers.res(ps.get(0)._genericType()._typeArguments().getFirst(), "zeroMany"), ps -> Lists.mutable.with(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> ps.size() == 2 && "Byte".equals(ps.get(1)._genericType()._rawType()._name())))
+                                        handlers.m(handlers.h("meta::external::format::json::functions::fromJson_Class_1__String_1__JsonSchemaInternalizeConfig_1__T_MANY_", false, ps -> handlers.res(ps.get(0)._genericType()._typeArguments().getFirst(), "zeroMany"), ps -> Lists.mutable.with(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> ps.size() == 3 && "String".equals(ps.get(1)._genericType()._rawType()._name()))),
+                                        handlers.m(handlers.h("meta::external::format::json::functions::fromJson_Class_1__Byte_MANY__T_MANY_", false, ps -> handlers.res(ps.get(0)._genericType()._typeArguments().getFirst(), "zeroMany"), ps -> Lists.mutable.with(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> ps.size() == 2 && "Byte".equals(ps.get(1)._genericType()._rawType()._name()))),
+                                        handlers.m(handlers.h("meta::external::format::json::functions::fromJson_Class_1__Byte_MANY__JsonSchemaInternalizeConfig_1__T_MANY_", false, ps -> handlers.res(ps.get(0)._genericType()._typeArguments().getFirst(), "zeroMany"), ps -> Lists.mutable.with(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> ps.size() == 3 && "Byte".equals(ps.get(1)._genericType()._rawType()._name())))
                                 )
                         )
                 ));

--- a/legend-engine-xts-json/legend-engine-xt-json-model/src/test/java/org/finos/legend/engine/external/format/json/TestJsonFunctionCompilation.java
+++ b/legend-engine-xts-json/legend-engine-xt-json-model/src/test/java/org/finos/legend/engine/external/format/json/TestJsonFunctionCompilation.java
@@ -22,15 +22,45 @@ public class TestJsonFunctionCompilation
     @Test
     public void testToJson()
     {
-        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:String[1] | demo::Person->fromJson($data)"));
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:String[1] | demo::Person->toJson($data)"));
 
-        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:Byte[*] | demo::Person->fromJson($data)"));
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:Byte[*] | demo::Person->toJson($data)"));
+    }
+
+    @Test
+    public void testToJsonWithConfig()
+    {
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:String[1] | let config = ^meta::external::format::json::metamodel::externalize::JsonSchemaExternalizeConfig(typeKeyName='_type', \n" +
+                "                                                                                                             includeType=true,\n" +
+                "                                                                                                             includeEnumType=false,\n" +
+                "                                                                                                             removePropertiesWithNullValues=false,\n" +
+                "                                                                                                             removePropertiesWithEmptySets=false,\n" +
+                "                                                                                                             fullyQualifiedTypePath=true\n" +
+                "                                                                                                             );\n" +
+                "                                                                                                             demo::Person->toJson($data, $config);"));
+
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:Byte[*] | demo::Person->toJson($data, ^meta::external::format::json::metamodel::externalize::JsonSchemaExternalizeConfig(typeKeyName='_type', \n" +
+                "                                                                                                             includeType=true,\n" +
+                "                                                                                                             includeEnumType=false,\n" +
+                "                                                                                                             removePropertiesWithNullValues=false,\n" +
+                "                                                                                                             removePropertiesWithEmptySets=false,\n" +
+                "                                                                                                             fullyQualifiedTypePath=true\n" +
+                "                                                                                                             ))"));
     }
 
     @Test
     public void testFromJson()
     {
         TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:String[1] | demo::Person->fromJson($data)->toJson(#{demo::Person{prop}}#)"));
+    }
+
+    @Test
+    public void testFromJsonWithConfig()
+    {
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:String[1] | let config = ^meta::external::format::json::metamodel::internalize::JsonSchemaInternalizeConfig(typeKeyName='_type'); \n" +
+                                                                                            "demo::Person->fromJson($data, $config)->toJson(#{demo::Person{prop}}#);"));
+
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(completeGrammar("data:String[1] | demo::Person->fromJson($data, ^meta::external::format::json::metamodel::internalize::JsonSchemaInternalizeConfig(typeKeyName='_type'))->toJson(#{demo::Person{prop}}#)"));
     }
 
     private String completeGrammar(String funcExp)


### PR DESCRIPTION
External format JSON: add functions with config params to compiler

Exposes functionality enabled by https://github.com/finos/legend-engine/pull/2875