### PR TITLE
Handle edge cases in dataquality fetch trees

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
@@ -116,6 +116,7 @@ public class DataQualityCompilerExtension implements CompilerExtension
                             metamodel._context(buildDataQualityExecutionContext(dataquality, compileContext))
                                     ._filter(getFilterLambda(dataquality, compileContext))
                                     ._validationTree(buildRootGraphFetchTree(dataquality.dataQualityRootGraphFetchTree, compileContext, compileContext.pureModel.getClass(dataquality.dataQualityRootGraphFetchTree._class), null, new ProcessingContext("DataQuality")));
+                            metamodel._validate(true, SourceInformationHelper.toM3SourceInformation(dataquality.sourceInformation), compileContext.getExecutionSupport());
                         }
                 )
         );

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -60,7 +60,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
     }
 
     @Test
-    public void testOnlyModelConstraints()
+    public void testRootClassNoModelConstraints()
     {
         TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(COMPILATION_PREREQUISITE_CODE +
                 "###DataQualityValidation\n" +

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -76,6 +76,37 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "}");
     }
 
+    @Test
+    public void testRootClassNoStructuralConstraints()
+    {
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(COMPILATION_PREREQUISITE_CODE +
+                "###DataQualityValidation\n" +
+                "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
+                "    validationTree: $[\n" +
+                "      meta::dataquality::Person<mustBeOfLegalAge>{\n" +
+                "      }\n" +
+                "    ]$;\n" +
+                "}");
+    }
+
+    @Test
+    public void testRootClassEmptyTree()
+    {
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(COMPILATION_PREREQUISITE_CODE +
+                "###DataQualityValidation\n" +
+                "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
+                "    validationTree: $[\n" +
+                "      meta::dataquality::Person{\n" +
+                "      }\n" +
+                "    ]$;\n" +
+                "}");
+    }
 
 
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -60,7 +60,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
     }
 
     @Test
-    public void testRootClassNoModelConstraints()
+    public void testOnlyModelConstraints()
     {
         TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(COMPILATION_PREREQUISITE_CODE +
                 "###DataQualityValidation\n" +

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -105,7 +105,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "      meta::dataquality::Person{\n" +
                 "      }\n" +
                 "    ]$;\n" +
-                "}");
+                "}", " at [92:1-100:1]: Error in 'meta::dataquality::PersonDataQualityValidation': Execution error at (resource: lines:92c1-100c1), \"Constraint :[mustHaveAtLeastOnePropertyOrConstraint] violated in the Class DataQualityRootGraphFetchTree\"");
     }
 
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityParserGrammar.g4
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityParserGrammar.g4
@@ -59,7 +59,7 @@ filter:                               FILTER COLON combinedExpression SEMI_COLON
 dqGraphDefinition:                  GRAPH_START qualifiedName(constraintList)? graphDefinition GRAPH_END
 ;
 graphDefinition:                    BRACE_OPEN
-                                        graphPaths
+                                        (graphPaths)?
                                     BRACE_CLOSE
 ;
 graphPaths:                         (graphPath | subTypeGraphPath) (COMMA (graphPath | subTypeGraphPath))*

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/DataQualityTreeWalker.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/DataQualityTreeWalker.java
@@ -105,10 +105,14 @@ public class DataQualityTreeWalker
     {
         List<GraphFetchTree> subTrees = new ArrayList<>();
         List<SubTypeGraphFetchTree> subTypeTrees = new ArrayList<>();
-        for (DataQualityParserGrammar.GraphPathContext graphPathContext : graphDefinitionContext.graphPaths().graphPath())
+        if (Objects.nonNull(graphDefinitionContext.graphPaths()))
         {
-            subTrees.add(this.visitGraphPathContext(graphPathContext));
+            for (DataQualityParserGrammar.GraphPathContext graphPathContext : graphDefinitionContext.graphPaths().graphPath())
+            {
+                subTrees.add(this.visitGraphPathContext(graphPathContext));
+            }
         }
+
 //        for (GraphFetchTreeParserGrammar.SubTypeGraphPathContext subTypeGraphPathContext : graphDefinitionContext.graphPaths().subTypeGraphPath())
 //        {
 //            subTypeTrees.add(this.visitSubTypeGraphPathContext(subTypeGraphPathContext));
@@ -138,7 +142,7 @@ public class DataQualityTreeWalker
     private PropertyGraphFetchTree visitGraphPathContext(DataQualityParserGrammar.GraphPathContext graphPathContext)
     {
         List<GraphFetchTree> subTrees = new ArrayList<>();
-        if (graphPathContext.graphDefinition() != null)
+        if (graphPathContext.graphDefinition() != null && graphPathContext.graphDefinition().graphPaths() != null)
         {
             // validationForSubTypeTrees(graphPathContext.graphDefinition());
             for (DataQualityParserGrammar.GraphPathContext subGraphPathContext : graphPathContext.graphDefinition().graphPaths().graphPath())

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/from/TestDataQualityParsing.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/from/TestDataQualityParsing.java
@@ -185,6 +185,7 @@ public class TestDataQualityParsing extends TestGrammarParser.TestGrammarParserT
                 "    ]$;\n" +
                 "}");
         // both model and structural constraints are absent
+        // note: parser is lenient to allow empty trees but fails in compilation as constraints are added in tree pure model
         test("###DataQualityValidation\n" +
                 "DataQualityValidation meta::external::dataquality::PersonDataQualityValidation\n" +
                 "{\n" +

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/from/TestDataQualityParsing.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/from/TestDataQualityParsing.java
@@ -137,6 +137,66 @@ public class TestDataQualityParsing extends TestGrammarParser.TestGrammarParserT
 
     }
 
+    @Test
+    public void testEdgeScenarios()
+    {
+        // only model constraints
+        test("###DataQualityValidation\n" +
+                "DataQualityValidation meta::external::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromDataSpace(meta::external::dataquality::PersonDataSpace, 'Local_Context');\n" +
+                "    validationTree: $[\n" +
+                "     Person<ageMustBePositive>{\n" +
+                "     }\n" +
+                "    ]$;\n" +
+                "}");
+        test("###DataQualityValidation\n" +
+                "DataQualityValidation meta::external::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromDataSpace(meta::external::dataquality::PersonDataSpace, 'Local_Context');\n" +
+                "    validationTree: $[\n" +
+                "     Person{\n" +
+                "       addresses<idMustBeValid>{\n" +
+                "       }\n" +
+                "     }\n" +
+                "    ]$;\n" +
+                "}");
+        // only structural constraints
+        test("###DataQualityValidation\n" +
+                "DataQualityValidation meta::external::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromDataSpace(meta::external::dataquality::PersonDataSpace, 'Local_Context');\n" +
+                "    validationTree: $[\n" +
+                "     Person{\n" +
+                "        age\n" +
+                "     }\n" +
+                "    ]$;\n" +
+                "}");
+        test("###DataQualityValidation\n" +
+                "DataQualityValidation meta::external::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromDataSpace(meta::external::dataquality::PersonDataSpace, 'Local_Context');\n" +
+                "    validationTree: $[\n" +
+                "     Person{\n" +
+                "       addresses{\n" +
+                "         id\n" +
+                "       }\n" +
+                "     }\n" +
+                "    ]$;\n" +
+                "}");
+        // both model and structural constraints are absent
+        test("###DataQualityValidation\n" +
+                "DataQualityValidation meta::external::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromDataSpace(meta::external::dataquality::PersonDataSpace, 'Local_Context');\n" +
+                "    validationTree: $[\n" +
+                "     Person{\n" +
+                "     }\n" +
+                "    ]$;\n" +
+                "}");
+
+    }
+
 
 
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -31,7 +31,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration(
   assert($dqLambda->isNotEmpty());
 }
 
-function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_NO_RootConstraints():Boolean[1]
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_OnlyStructuralConstraints():Boolean[1]
 { let dqRootConstraints = meta::external::dataquality::tests::Person->getAllTypeGeneralisations()->filter(x| $x->instanceOf(ElementWithConstraints))->cast(@ElementWithConstraints).constraints->filter(x| $x.name == 'addressIDGreaterThan2');
 
   let validationTree = ^DataQualityRootGraphFetchTree<Person>(

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -48,21 +48,6 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
   assert($dqLambda->isNotEmpty());
 }
 
-function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_EmptyTree():Boolean[1]
-{ let dqRootConstraints = meta::external::dataquality::tests::Person->getAllTypeGeneralisations()->filter(x| $x->instanceOf(ElementWithConstraints))->cast(@ElementWithConstraints).constraints->filter(x| $x.name == 'addressIDGreaterThan2');
-
-  let validationTree = ^DataQualityRootGraphFetchTree<Person>(
-    class=meta::external::dataquality::tests::Person,
-    constraints=[],
-    subTrees=[]
-  );
-
-  let dataquality = ^DataQuality<Person>(validationTree=$validationTree,
-                                         context=^meta::external::dataquality::MappingAndRuntimeDataQualityExecutionContext(runtime=^meta::core::runtime::EngineRuntime(connectionStores = testDatabaseConnection(meta::relational::tests::db, [])), mapping=meta::external::dataquality::tests::dqValidationPersonMapping));
-  
-  let dqLambda = meta::external::dataquality::executeDataQualityValidation($dataquality, []);
-  assert($dqLambda->isNotEmpty());
-}
 
 
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -13,7 +13,7 @@ import meta::pure::profiles::*;
 import meta::pure::metamodel::serialization::grammar::*;
 
 
-function <<test.Test>> meta::external::dataquality::tests::testPlanGeneration():Boolean[1]
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration():Boolean[1]
 { let dqRootConstraints = meta::external::dataquality::tests::Person->getAllTypeGeneralisations()->filter(x| $x->instanceOf(ElementWithConstraints))->cast(@ElementWithConstraints).constraints->filter(x| $x.name == 'addressIDGreaterThan2');
 
   let validationTree = ^DataQualityRootGraphFetchTree<Person>(
@@ -30,6 +30,40 @@ function <<test.Test>> meta::external::dataquality::tests::testPlanGeneration():
   let dqLambda = meta::external::dataquality::executeDataQualityValidation($dataquality, []);
   assert($dqLambda->isNotEmpty());
 }
+
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_NO_RootConstraints():Boolean[1]
+{ let dqRootConstraints = meta::external::dataquality::tests::Person->getAllTypeGeneralisations()->filter(x| $x->instanceOf(ElementWithConstraints))->cast(@ElementWithConstraints).constraints->filter(x| $x.name == 'addressIDGreaterThan2');
+
+  let validationTree = ^DataQualityRootGraphFetchTree<Person>(
+    class=meta::external::dataquality::tests::Person,
+    constraints=[],
+    subTrees=meta::external::dataquality::tests::Person->hierarchicalProperties()->filter(p | $p->isPrimitiveValueProperty())->filter(p| $p.name=='age')->map(p | ^DataQualityPropertyGraphFetchTree(property=$p))
+  );
+  let filter = p:Person[1]| $p.name=='John';
+  let dataquality = ^DataQuality<Person>(validationTree=$validationTree,
+                                         context=^meta::external::dataquality::MappingAndRuntimeDataQualityExecutionContext(runtime=^meta::core::runtime::EngineRuntime(connectionStores = testDatabaseConnection(meta::relational::tests::db, [])), mapping=meta::external::dataquality::tests::dqValidationPersonMapping),
+                                         filter=$filter);
+  
+  let dqLambda = meta::external::dataquality::executeDataQualityValidation($dataquality, []);
+  assert($dqLambda->isNotEmpty());
+}
+
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_EmptyTree():Boolean[1]
+{ let dqRootConstraints = meta::external::dataquality::tests::Person->getAllTypeGeneralisations()->filter(x| $x->instanceOf(ElementWithConstraints))->cast(@ElementWithConstraints).constraints->filter(x| $x.name == 'addressIDGreaterThan2');
+
+  let validationTree = ^DataQualityRootGraphFetchTree<Person>(
+    class=meta::external::dataquality::tests::Person,
+    constraints=[],
+    subTrees=[]
+  );
+
+  let dataquality = ^DataQuality<Person>(validationTree=$validationTree,
+                                         context=^meta::external::dataquality::MappingAndRuntimeDataQualityExecutionContext(runtime=^meta::core::runtime::EngineRuntime(connectionStores = testDatabaseConnection(meta::relational::tests::db, [])), mapping=meta::external::dataquality::tests::dqValidationPersonMapping));
+  
+  let dqLambda = meta::external::dataquality::executeDataQualityValidation($dataquality, []);
+  assert($dqLambda->isNotEmpty());
+}
+
 
 
 // -------------------------------------- Test Setup -------------------------------------------------------------------------//

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -267,10 +267,13 @@ function meta::external::dataquality::generateFilterQuery<T>(c:Class<T>[1], f: F
 
 
 function meta::external::dataquality::generateConstraintsNegatedORQuery<T>(c:Class<T>[1], f: FunctionExpression[1], constraints: List<Constraint>[1]):FunctionExpression[1] {
-   if ($constraints.values->size() == 1,
-    | $c->generateConstraintNegatedQuery($f, $constraints.values->at(0)) ,
-    | $c->generateORNegatedQuery($f, $constraints)
-   );
+  if ($constraints.values->isEmpty(),
+       | $f ,
+       | if ($constraints.values->size() == 1,
+             | $c->generateConstraintNegatedQuery($f, $constraints.values->at(0)) ,
+             | $c->generateORNegatedQuery($f, $constraints)
+            );
+     );
 }
 
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
@@ -6,6 +6,9 @@ import meta::core::runtime::*;
 
 
 Class meta::external::dataquality::DataQualityRootGraphFetchTree<T> extends RootGraphFetchTree<T>
+[
+  mustHaveAtLeastOnePropertyOrConstraint: $this.constraints->isNotEmpty() || $this.subTrees->isNotEmpty()
+]
 {
    constraints: Constraint[*]; 
    


### PR DESCRIPTION
#### What type of PR is this?
- Improvement/Bug fix

#### What does this PR do / why is it needed ?
1. Handles only structural constraints selection, this was supported in spec but was failing in lambda generation.
```
Person{
age
}
```
2. Handles only model constraint selection. this was failing in parsing which is now handled.
```
Person<isOfLegalAge>{
}
```
3. Throws exception when an empty tree is found. This is added as a constraint on the dataquality tree metamodel class.
```
Person{
}
```

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
