### PR TITLE
Fix filter-limit composition sql generation issue in new relation API

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testSliceTakeLimitDrop.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/functions/tests/testSliceTakeLimitDrop.pure
@@ -16,6 +16,7 @@ import meta::relational::mapping::*;
 import meta::relational::tests::model::simple::*;
 import meta::relational::tests::*;
 import meta::external::store::relational::tests::*;
+import meta::pure::executionPlan::*;
 import meta::pure::profiles::*;
 import meta::relational::functions::sqlstring::*;
 
@@ -89,4 +90,34 @@ function <<test.Test>> meta::relational::tests::query::drop::testSimpleDrop():Bo
    let result2 = execute(|Person.all()->drop(1), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    assertEquals('select "root".ID as "pk_0", "root".FIRSTNAME as "firstName", "root".AGE as "age", "root".LASTNAME as "lastName" from personTable as "root" offset 1 rows', $result2->sqlRemoveFormatting());
    assertSize($result2.values, 11 );
+}
+
+function <<test.Test>> meta::relational::tests::query::take::testLimitFilterInSequence():Boolean[1]
+{
+   let result = execute(|Person.all()->project([x|$x.firstName,x|$x.lastName,x|$x.age],['firstName','lastName','age'])->limit(1)->filter(x | $x.getInteger('age') > 25);, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   assertEquals('select "firstName" as "firstName", "lastName" as "lastName", "age" as "age" from (select top 1 "root".FIRSTNAME as "firstName", "root".LASTNAME as "lastName", "root".AGE as "age" from personTable as "root") as "subselect" where "age" > 25', $result->sqlRemoveFormatting());
+   assertSize($result.values.rows, 1 ); 
+}
+
+function <<test.Test>> meta::relational::tests::query::take::testFilterLimitInSequence():Boolean[1]
+{
+   let result = execute(|Person.all()->project([x|$x.firstName,x|$x.lastName,x|$x.age],['firstName','lastName','age'])-> filter(x | $x.getInteger('age') > 30)->limit(2);, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   assertEquals('select top 2 "root".FIRSTNAME as "firstName", "root".LASTNAME as "lastName", "root".AGE as "age" from personTable as "root" where "root".AGE > 30',  $result->sqlRemoveFormatting());
+   assertSize($result.values.rows, 2 );
+}
+
+function <<test.Test>> meta::relational::tests::query::take::testLimitFilterInSequenceForTableAccessor():Boolean[1]
+{
+   let fun = {|#>{meta::relational::tests::dbInc.personTable}#->limit(1)->filter(x | $x.AGE > 25)-> select(~[FIRSTNAME,LASTNAME])};
+   let actualPlan =  meta::pure::executionPlan::executionPlan($fun,meta::relational::tests::simpleRelationalMapping,meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions())
+    ->  meta::pure::executionPlan::toString::planToStringWithoutFormatting(meta::relational::extension::relationalExtensions());
+   assertEquals('Relational(type=TDS[(FIRSTNAME,String,"",""),(LASTNAME,String,"","")]resultColumns=[("FIRSTNAME",""),("LASTNAME","")]sql=select"FIRSTNAME"as"FIRSTNAME","LASTNAME"as"LASTNAME"from(selecttop1"persontable_1".IDas"ID","persontable_1".FIRSTNAMEas"FIRSTNAME","persontable_1".LASTNAMEas"LASTNAME","persontable_1".AGEas"AGE","persontable_1".ADDRESSIDas"ADDRESSID","persontable_1".FIRMIDas"FIRMID","persontable_1".MANAGERIDas"MANAGERID"frompersonTableas"persontable_1")as"subselect"where("subselect"."AGE"isnotnulland"subselect"."AGE">25)connection=TestDatabaseConnection(type="H2"))', $actualPlan);
+}
+
+function <<test.Test>> meta::relational::tests::query::take::testFilterLimitInSequenceForTableAccessor():Boolean[1]
+{
+    let fun = {|#>{meta::relational::tests::dbInc.personTable}#->filter(x | $x.AGE > 25)->limit(1)-> select(~[FIRSTNAME,LASTNAME])};
+    let actualPlan =  meta::pure::executionPlan::executionPlan($fun,meta::relational::tests::simpleRelationalMapping,meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions())
+    ->  meta::pure::executionPlan::toString::planToStringWithoutFormatting(meta::relational::extension::relationalExtensions());
+   assertEquals('Relational(type=TDS[(FIRSTNAME,String,"",""),(LASTNAME,String,"","")]resultColumns=[("FIRSTNAME",""),("LASTNAME","")]sql=select"FIRSTNAME"as"FIRSTNAME","LASTNAME"as"LASTNAME"from(selecttop1"persontable_1".IDas"ID","persontable_1".FIRSTNAMEas"FIRSTNAME","persontable_1".LASTNAMEas"LASTNAME","persontable_1".AGEas"AGE","persontable_1".ADDRESSIDas"ADDRESSID","persontable_1".FIRMIDas"FIRMID","persontable_1".MANAGERIDas"MANAGERID"frompersonTableas"persontable_1"where("persontable_1".AGEisnotnulland"persontable_1".AGE>25))as"subselect"connection=TestDatabaseConnection(type="H2"))', $actualPlan);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -551,6 +551,7 @@ function meta::relational::functions::pureToSqlQuery::processValue(vals:Any[*], 
 function meta::relational::functions::pureToSqlQuery::processFunctionExpression(functionExpression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):OperationWithParentPropertyMapping[*]
 {
   print(if(!$context.debug, |'', | $context.space+'>Process Function Expression: '+ $functionExpression.func.name->toOne() + '\n'));
+
   let res  = $functionExpression.func->match ([
                                     p:Property<Nil,Any|*>[1] | processPropertyFunctionExpression($functionExpression, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context->shift(), $extensions);,
                                     q:QualifiedProperty<Any>[1] | processQualifiedPropertyFunctionExpression($functionExpression, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context->shift(), $extensions);,
@@ -583,7 +584,9 @@ function meta::relational::functions::pureToSqlQuery::processColumnFunctionExpre
       let colAlias = ^TableAliasColumnName(columnName = $fColumn->cast(@Alias).name->toOne(), alias=$tAlias);
       let newSelect = $state.inFilter->if(|^$nestedSelect(filteringOperation=$colAlias),|^$nestedSelect(columns=$colAlias));
       ^$leftSide(element = ^$nestedQuery(select=$newSelect));,
-    | let colAlias = ^TableAliasColumn(alias = $tableAlias, column = $foundColumn->toOne()->cast(@Column));
+    | let colAlias = $foundColumn->toOne() -> match([
+      c:Column[1]|^TableAliasColumn(alias = $tableAlias, column = $c),
+    a:Alias[1]|^TableAliasColumnName(columnName = $a.name->toOne(), alias=$tableAlias)]);
       let newSelect = $state.inFilter->if(|^$leftSelect(filteringOperation=$colAlias),|^$leftSelect(columns=$colAlias));
       ^$leftSide(element = ^$operation(select=$newSelect));
   );
@@ -2727,7 +2730,8 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::isolate
    if ($p->size() > 1,
     | let fe = $p->at($p->size()-2);
       let ft = $fe.func->functionType();
-      if([$ft.parameters->at(0).genericType->toOne(), $ft.returnType]->forAll(x|$x.rawType->toOne()->_subTypeOf(TabularDataSet)),
+      if([$ft.parameters->at(0).genericType->toOne(), $ft.returnType]->forAll(x|$x.rawType->toOne()->_subTypeOf(TabularDataSet) ||
+      $x.rawType->toOne()->_subTypeOf(meta::pure::metamodel::relation::Relation)),
                   | isolateTdsSelect($select->cast(@TdsSelectSqlQuery), $query, $extensions);,
                   | ^$query(select=$select)
       );,


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?

This PR fixes the incorrect SQL composition issue while user uses table expression with limit clause and filter condition sequentially.  This will now create subquery for limit clause and then it will apply where clause.

#### Does this PR introduce a user-facing change?
No
