### PR TITLE
Persistence: keep duckdb versions consistent

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>org.duckdb</groupId>
             <artifactId>duckdb_jdbc</artifactId>
-            <version>0.10.2</version>
             <scope>runtime</scope>
         </dependency>
         <!-- DRIVER -->


### PR DESCRIPTION
Persistence: keep duckdb versions consistent to avoid flakey test failures in the persistence duckdb module. 
(Error message is the same as documented here https://duckdb.org/docs/internals/storage.html#error-message-when-opening-an-incompatible-database-file)

Looks like https://github.com/finos/legend-engine/pull/2956 inadvertently added back the old version of duckdb that was updated in https://github.com/finos/legend-engine/pull/2968