### PR TITLE
Add equality keys to ExecutionOptionContext

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlanFeature.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlanFeature.pure
@@ -30,7 +30,7 @@ function  meta::pure::executionPlan::featureFlag::withFeatureFlags<T>(object:T[*
 
 Class meta::pure::executionPlan::featureFlag::FeatureFlagOption  extends meta::pure::executionPlan::ExecutionOption
 {
-  flags:Enum[*];
+  <<equality.Key>> flags:Enum[*];
 }
 
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
@@ -111,7 +111,7 @@ function <<access.private>> meta::pure::executionPlan::collectionMultiExecutionC
 
 Class meta::pure::executionPlan::ExecutionOptionContext extends MultiExecutionContext
 {
-   executionOptions : ExecutionOption[*];
+   <<equality.Key>> executionOptions : ExecutionOption[*];
 }
 
 // Move to platform

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/test/testExecutionPlanFeatureFlag.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/test/testExecutionPlanFeatureFlag.pure
@@ -50,3 +50,13 @@ function <<test.Test>> meta::pure::executionPlan::tests::featureFlag::testContex
   assert( $context1 ->contextHasFlag(meta::pure::executionPlan::tests::ExampleFlag.myFlag));
 
 }
+
+function <<test.Test>> meta::pure::executionPlan::tests::featureFlagOptionEquality(): Boolean[1]
+{
+  let context1 = ^ExecutionOptionContext(executionOptions=^FeatureFlagOption(flags=meta::pure::executionPlan::tests::ExampleFlag.myFlag));
+  let context2 = ^ExecutionOptionContext(executionOptions=^FeatureFlagOption(flags=meta::pure::executionPlan::tests::ExampleFlag.myFlag));
+  let context3 = ^ExecutionOptionContext(executionOptions=^FeatureFlagOption());
+  
+  assertEquals($context1, $context2);
+  assertNotEquals($context1, $context3);
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Bug Fix
-->

#### What does this PR do / why is it needed ?

Add equality keys to ExecutionOptionContext to ensure routing identities cross store routing correctly based on this exec ctx

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
