### PR TITLE
relation: fix distinct()

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/distinct.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/distinct.pure
@@ -15,18 +15,76 @@
 import meta::pure::metamodel::relation::*;
 import meta::pure::test::pct::*;
 
-native function meta::pure::functions::relation::distinct<X,T>(rel:Relation<T>[1], columns:ColSpecArray<X⊆T>[1]):Relation<T>[1];
+native function <<PCT.function>> meta::pure::functions::relation::distinct<X,T>(rel:Relation<T>[1], columns:ColSpecArray<X⊆T>[1]):Relation<X>[1];
+native function <<PCT.function>> meta::pure::functions::relation::distinct<T>(rel:Relation<T>[1]):Relation<T>[1];
 
-function <<test.Test>> meta::pure::functions::relation::tests::distinct::testSimpleDistinct():Boolean[1]
+function <<PCT.test>> meta::pure::functions::relation::tests::distinct::testDistinctSingle<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
-    let res = #TDS
-                val, str
-                1, a
-                3, ewe
-                1, qw
-                5, wwe
-                5, weq
-              #->distinct(~[val]);
-    assertEquals(3, $res->size());
-    assertEquals('135', $res->map(c|$c.val->toOne()->toString())->joinStrings(''));
+    let expr = {
+                |#TDS
+                  val, str
+                  1, a
+                  3, ewe
+                  1, qw
+                  5, weq
+                  5, weq
+                #->distinct(~[val])
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   val\n'+
+                  '   1\n'+
+                  '   3\n'+
+                  '   5\n'+
+                  '#', $res->sort(~val->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::distinct::testDistinctMultiple<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                |#TDS
+                  val, str
+                  1, a
+                  3, ewe
+                  1, qw
+                  5, weq
+                  5, weq
+                #->distinct(~[val, str])
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   val,str\n'+
+                  '   1,a\n'+
+                  '   1,qw\n'+
+                  '   3,ewe\n'+
+                  '   5,weq\n'+
+                  '#', $res->sort(~val->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::distinct::testDistinctAll<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                |#TDS
+                  val, str
+                  1, a
+                  3, ewe
+                  1, qw
+                  5, weq
+                  5, weq
+                #->distinct()
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   val,str\n'+
+                  '   1,a\n'+
+                  '   1,qw\n'+
+                  '   3,ewe\n'+
+                  '   5,weq\n'+
+                  '#', $res->sort([ascending(~val), ascending(~str)])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationExtensionCompiled.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationExtensionCompiled.java
@@ -67,6 +67,7 @@ public class RelationExtensionCompiled implements CompiledExtension
                 new GroupByArray(),
                 new Slice(),
                 new Distinct(),
+                new DistinctAll(),
                 new Select(),
                 new SelectArray(),
                 new SelectAll(),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationNativeImplementation.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationNativeImplementation.java
@@ -79,6 +79,12 @@ public class RelationNativeImplementation
         return list;
     }
 
+    public static <T> Relation<? extends T> distinct(Relation<? extends T> rel, ExecutionSupport es)
+    {
+        ProcessorSupport ps = ((CompiledExecutionSupport) es).getProcessorSupport();
+        return new TDSContainer((TestTDSCompiled) RelationNativeImplementation.getTDS(rel).distinct(RelationNativeImplementation.getTDS(rel).getColumnNames()), ps);
+    }
+
     public static <T> Relation<? extends T> distinct(Relation<? extends T> rel, ColSpecArray<?> columns, ExecutionSupport es)
     {
         ProcessorSupport ps = ((CompiledExecutionSupport) es).getProcessorSupport();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/DistinctAll.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/DistinctAll.java
@@ -1,0 +1,28 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.extension.external.relation.compiled.natives;
+
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.ColSpecArray;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.Relation;
+import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.AbstractNativeFunctionGeneric;
+
+public class DistinctAll extends AbstractNativeFunctionGeneric
+{
+    public DistinctAll()
+    {
+        super("org.finos.legend.pure.runtime.java.extension.external.relation.compiled.RelationNativeImplementation.distinct", new Class[]{Relation.class, ExecutionSupport.class}, false, true, false, "distinct_Relation_1__Relation_1_");
+    }
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/RelationExtensionInterpreted.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/RelationExtensionInterpreted.java
@@ -86,6 +86,7 @@ public class RelationExtensionInterpreted extends BaseInterpretedExtension
                 Tuples.pair("sort_Relation_1__SortInfo_MANY__Relation_1_", Sort::new),
                 Tuples.pair("join_Relation_1__Relation_1__JoinKind_1__Function_1__Relation_1_", Join::new),
                 Tuples.pair("distinct_Relation_1__ColSpecArray_1__Relation_1_", Distinct::new),
+                Tuples.pair("distinct_Relation_1__Relation_1_", Distinct::new),
                 Tuples.pair("groupBy_Relation_1__ColSpecArray_1__AggColSpec_1__Relation_1_", GroupBy::new),
                 Tuples.pair("groupBy_Relation_1__ColSpec_1__AggColSpec_1__Relation_1_", GroupBy::new),
                 Tuples.pair("groupBy_Relation_1__ColSpec_1__AggColSpecArray_1__Relation_1_", GroupBy::new),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/natives/Distinct.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/natives/Distinct.java
@@ -48,7 +48,7 @@ public class Distinct extends Shared
     {
         CoreInstance returnGenericType = getReturnGenericType(resolvedTypeParameters, resolvedMultiplicityParameters, functionExpressionToUseInStack, processorSupport);
         TestTDS tds = getTDS(params, 0, processorSupport);
-        MutableList<String> columns = Instance.getValueForMetaPropertyToManyResolved(params.get(1), M3Properties.values, processorSupport).flatCollect(c -> c.getValueForMetaPropertyToMany("names")).collect(CoreInstance::getName).toList();
+        MutableList<String> columns = params.size() == 1 ? tds.getColumnNames() : Instance.getValueForMetaPropertyToManyResolved(params.get(1), M3Properties.values, processorSupport).flatCollect(c -> c.getValueForMetaPropertyToMany("names")).collect(CoreInstance::getName).toList();
         return ValueSpecificationBootstrap.wrapValueSpecification(new TDSCoreInstance(tds.distinct(columns), returnGenericType, repository, processorSupport), false, processorSupport);
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/TestTDS.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/TestTDS.java
@@ -671,7 +671,8 @@ public abstract class TestTDS
     public TestTDS distinct(MutableList<String> columns)
     {
         Pair<TestTDS, MutableList<Pair<Integer, Integer>>> res = this.sort(columns.collect(c -> new SortInfo(c, SortDirection.ASC)));
-        return res.getOne()._distinct(res.getTwo());
+        TestTDS result = res.getOne()._distinct(res.getTwo());
+        return result.select(columns.toSet());
     }
 
     public TestTDS _distinct(MutableList<Pair<Integer, Integer>> ranges)
@@ -1149,7 +1150,7 @@ public abstract class TestTDS
     public long ntile(int row, long tiles)
     {
         int size = (int) this.getRowCount();
-        return (long)((double)row * tiles / size) + 1;
+        return (long) ((double) row * tiles / size) + 1;
     }
 
     public double cumulativeDistribution(MutableList<SortInfo> sorts, int row)
@@ -1158,7 +1159,7 @@ public abstract class TestTDS
         int size = (int) this.getRowCount();
         MutableList<?> baseRow = fetch(this, columns, row);
         int rank = findFirstPrecedentDifferentRow(row, this, columns, baseRow);
-        return (double)(rank + 1) / size;
+        return (double) (rank + 1) / size;
     }
 
     public int nth(int row, Window w, long l)
@@ -1168,7 +1169,7 @@ public abstract class TestTDS
 
         if (offset <= high)
         {
-            return (int)offset;
+            return (int) offset;
         }
         else
         {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/test/java/org/finos/legend/pure/runtime/java/extension/relation/TestTestTDS.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/test/java/org/finos/legend/pure/runtime/java/extension/relation/TestTestTDS.java
@@ -104,20 +104,20 @@ public class TestTestTDS
                 "1, Pierre, F";
         TestTDS tds = new TestTDSImpl(initialTDS);
 
-        Assert.assertEquals("id, name, otherOne\n" +
-                "1, Pierre, F\n" +
-                "2, Bla, B\n" +
-                "3, Ephrim, C\n" +
-                "4, Simple, D", tds.distinct(Lists.mutable.with("id")).toString());
+        Assert.assertEquals("id\n" +
+                "1\n" +
+                "2\n" +
+                "3\n" +
+                "4", tds.distinct(Lists.mutable.with("id")).toString());
 
-        Assert.assertEquals("id, name, otherOne\n" +
-                "1, Pierre, F\n" +
-                "2, Bla, B\n" +
-                "2, Neema, F\n" +
-                "3, Ephrim, C\n" +
-                "3, Nop, E\n" +
-                "3, Ok, D\n" +
-                "4, Simple, D", tds.distinct(Lists.mutable.with("id", "name")).toString());
+        Assert.assertEquals("id, name\n" +
+                "1, Pierre\n" +
+                "2, Bla\n" +
+                "2, Neema\n" +
+                "3, Ephrim\n" +
+                "3, Nop\n" +
+                "3, Ok\n" +
+                "4, Simple", tds.distinct(Lists.mutable.with("id", "name")).toString());
 
         Assert.assertEquals("id, name, otherOne\n" +
                 "4, Simple, D\n" +

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_RelationFunction_PCT.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_RelationFunction_PCT.java
@@ -71,6 +71,11 @@ public class Test_JAVA_RelationFunction_PCT extends PCTReportConfiguration
             one("meta::pure::functions::relation::tests::rank::testOLAPWithPartitionAndOrderRank_Function_1__Boolean_1_", "\"meta::pure::functions::relation::extend_Relation_1___Window_1__FuncColSpec_1__Relation_1_ is not supported yet!\""),
             one("meta::pure::functions::relation::tests::rowNumber::testOLAPWithPartitionAndRowNumber_Function_1__Boolean_1_", "\"meta::pure::functions::relation::extend_Relation_1___Window_1__FuncColSpec_1__Relation_1_ is not supported yet!\""),
 
+            // Distinct
+            one("meta::pure::functions::relation::tests::distinct::testDistinctAll_Function_1__Boolean_1_", "\"meta::pure::functions::relation::distinct_Relation_1__Relation_1_ is not supported yet!\""),
+            one("meta::pure::functions::relation::tests::distinct::testDistinctMultiple_Function_1__Boolean_1_", "\"meta::pure::functions::relation::distinct_Relation_1__ColSpecArray_1__Relation_1_ is not supported yet!\""),
+            one("meta::pure::functions::relation::tests::distinct::testDistinctSingle_Function_1__Boolean_1_", "\"meta::pure::functions::relation::distinct_Relation_1__ColSpecArray_1__Relation_1_ is not supported yet!\""),
+
             // Filter
             pack("meta::pure::functions::relation::tests::filter", "\"meta::pure::functions::relation::filter_Relation_1__Function_1__Relation_1_ is not supported yet!\""),
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -6934,6 +6934,15 @@ function meta::relational::functions::pureToSqlQuery::processDistinct(expression
                      );
 }
 
+function meta::relational::functions::pureToSqlQuery::processDistinctByColumns(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+  let selectWithCursor = meta::relational::functions::pureToSqlQuery::processTdsRestrict($expression, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->cast(@SelectWithCursor);
+  let select = $selectWithCursor.select;
+  ^$selectWithCursor(select = ^$select(
+    distinct = true
+  ));
+}
+
 function meta::relational::functions::pureToSqlQuery::processRowCount(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
    let nested = processValueSpecification($expression.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne();
@@ -8449,7 +8458,8 @@ function meta::relational::functions::pureToSqlQuery::getSupportedFunctions():Ma
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::string::levenshteinDistance_String_1__String_1__Integer_1_, second=meta::relational::functions::pureToSqlQuery::processDynaFunction_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
 
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::filter_Relation_1__Function_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processTdsFilter_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
-        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::distinct_Relation_1__ColSpecArray_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processDistinct_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::distinct_Relation_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processDistinct_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::distinct_Relation_1__ColSpecArray_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processDistinctByColumns_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::concatenate_Relation_1__Relation_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processConcatenate_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::drop_Relation_1__Integer_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processDrop_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::extend_Relation_1__FuncColSpec_1__Relation_1_,second=meta::relational::functions::pureToSqlQuery::processTdsExtend_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),


### PR DESCRIPTION
make sure `relation:distinct` works like SQL DISTINCT where the specified columns will be the only columns remain after execution