### PR TITLE
Package all flavors of REPL the same way for easy access and debugging

### DIFF
--- a/legend-engine-config/legend-engine-repl/README.md
+++ b/legend-engine-config/legend-engine-repl/README.md
@@ -2,7 +2,12 @@
 
 ## Quick Start
 
-Run the REPL either in IDE (IntelliJ) or assembling a JAR and run the JAR. Within the REPL, to start
+Run the REPL either in IDE (IntelliJ) or run the script in legend-engine-repl-app-assembly module.
+
+The legend-engine-repl-app-assembly allow you to pick which REPL to run: default, relational, or datacube.
+
+The script also allow developers to enable debug on a given port.  This allows to run the REPL on an OS native terminal, 
+and still be able to debug it through an IDE.
 
 > For autocomplete to work properly, it is recommended to run the REPL in a terminal; integrated terminal
 > in IDE often override hotkeys / keybindings that are used by the REPL. _Developers are also recommended

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/assembly.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/assembly.xml
@@ -1,0 +1,57 @@
+<!--
+  ~ Copyright 2024 Goldman Sachs
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>repl-app</id>
+    <formats>
+<!--        <format>zip</format>-->
+        <format>dir</format>
+    </formats>
+    <baseDirectory>repl-app</baseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/assemble/</directory>
+            <outputDirectory/>
+            <includes>
+                <include>pom.xml</include>
+            </includes>
+            <filtered>true</filtered>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/assemble/</directory>
+            <outputDirectory/>
+            <includes>
+                <include>repl*.bat</include>
+            </includes>
+            <lineEnding>windows</lineEnding>
+            <fileMode>0777</fileMode>
+            <filtered>true</filtered>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/assemble/</directory>
+            <outputDirectory/>
+            <includes>
+                <include>repl*.sh</include>
+            </includes>
+            <lineEnding>unix</lineEnding>
+            <fileMode>0777</fileMode>
+            <filtered>true</filtered>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/pom.xml
@@ -26,6 +26,15 @@
     <version>local-pom</version>
     <packaging>pom</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <scope>runtime</scope>
+            <version>${slf4j.version}</version>
+        </dependency>
+    </dependencies>
+
     <profiles>
         <profile>
             <id>relational</id>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024 Goldman Sachs
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.finos.legend.engine</groupId>
+    <artifactId>legend-engine-repl-app-assembly</artifactId>
+    <version>local-pom</version>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <profile>
+            <id>relational</id>
+            <properties>
+                <replMainClass>org.finos.legend.engine.repl.relational.client.RClient</replMainClass>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.finos.legend.engine</groupId>
+                    <artifactId>legend-engine-repl-relational</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>datacube</id>
+            <properties>
+                <replMainClass>org.finos.legend.engine.repl.dataCube.client.DataCubeClient</replMainClass>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.finos.legend.engine</groupId>
+                    <artifactId>legend-engine-repl-data-cube</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <replMainClass>org.finos.legend.engine.repl.client.Client</replMainClass>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.finos.legend.engine</groupId>
+                    <artifactId>legend-engine-repl-client</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/repl.bat
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/repl.bat
@@ -1,0 +1,68 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+:: Initialize variables
+set "debug="
+set "profile=default"
+
+:parse_options
+if "%~1"=="-d" (
+    shift
+    if "%~2"=="" (
+        echo Error: Missing port number after -d option.
+        goto show_usage
+    )
+    SET "var="&for /f "delims=0123456789" %%i in ("%~2") do set var=%%i
+    if defined var (
+        echo Error: Invalid port number "%~2". It must be an integer.
+        goto show_usage
+    )
+    set "debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:%~2"
+    shift
+    goto parse_options
+)
+
+if "%~1"=="-p" (
+    shift
+    if "%~2"=="" (
+        echo Error: Missing profile value after -p option.
+        goto show_usage
+    )
+    if /i "%~2"=="default" set "profile=default" & shift & goto parse_options
+    if /i "%~2"=="relational" set "profile=relational" & shift & goto parse_options
+    if /i "%~2"=="datacube" set "profile=datacube" & shift & goto parse_options
+    echo Error: Invalid profile "%~2". Valid options are: default, relational, datacube.
+    goto show_usage
+)
+
+if "%~1"=="-h" goto show_usage
+
+if "%~1"=="" goto endparse
+
+echo Error: Invalid option "%~1".
+goto show_usage
+
+:endparse
+
+set "classpathFile=%~dp0%profile%-win-classpath.txt"
+set "replMainClassFile=%~dp0%profile%-win-replMainClass.txt"
+
+if not exist "%classpathFile%" (
+    echo Computing %profile% classpath...
+    call mvn -q -DforceStdout -P %profile% dependency:build-classpath -Dmdep.outputFile="%classpathFile%"
+)
+
+if not exist "%replMainClassFile%" (
+    echo Computing %profile% REPL main class...
+    call mvn -q -DforceStdout help:evaluate -P %profile% -Dexpression=replMainClass -q -DforceStdout --log-file %replMainClassFile%
+)
+
+java -cp @%classpathFile% %debug% @%replMainClassFile%
+exit /b 0
+
+:show_usage
+echo Usage: %~nx0 [-d port_number] [-p {default^|relational^|datacube}] [-h]
+echo   -d port_number     Enable debug mode with a specified port number.
+echo   -p {default^|relational^|datacube}  Specify the profile to use.
+echo   -h                 Show this help message and exit.
+exit /b 1

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/repl.sh
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/assemble/repl.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Initialize variables
+debug=""
+profile="default"
+
+# Function to show usage
+show_usage() {
+    echo "Usage: $0 [-d port_number] [-p {default|relational|datacube}] [-h]"
+    echo "  -d port_number     Enable debug mode with a specified port number."
+    echo "  -p {default|relational|datacube}  Specify the profile to use."
+    echo "  -h                 Show this help message and exit."
+    exit 0
+}
+
+# Parse options
+while getopts "d:p:h" opt; do
+    case $opt in
+        d)
+            if ! [[ "$OPTARG" =~ ^[0-9]+$ ]]; then
+                echo "Invalid port number for -d. Port number must be an integer."
+                show_usage
+            fi
+            debug="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$OPTARG"
+            ;;
+        p)
+            if [[ "$OPTARG" != "default" && "$OPTARG" != "relational" && "$OPTARG" != "datacube" ]]; then
+                echo "Invalid value for -p. Valid options are: default, relational, datacube"
+                show_usage
+            fi
+            profile="$OPTARG"
+            ;;
+        h)
+            show_usage
+            ;;
+        *)
+            show_usage
+            ;;
+    esac
+done
+
+classpathFile=$(dirname "$0")/$profile-classpath.txt
+replMainClassFile=$(dirname "$0")/$profile-replMainClass.txt
+
+if [ ! -f "$classpathFile" ]; then
+    echo "Computing $profile repl classpath"
+    mvn -q -DforceStdout -P "$profile" dependency:build-classpath -Dmdep.outputFile="$classpathFile"
+fi
+
+if [ ! -f "$replMainClassFile" ]; then
+  echo "Computing $profile repl main class"
+  mvn -q -DforceStdout help:evaluate -P "$profile" -Dexpression=replMainClass -q -DforceStdout --log-file "$replMainClassFile"
+fi
+
+java -cp @$classpathFile $debug @$replMainClassFile

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024 Goldman Sachs
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-repl</artifactId>
+        <version>4.54.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-engine-repl-app-assembly</artifactId>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>repl-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>repl-app</finalName>
+                            <descriptors>
+                                <descriptors>${project.basedir}/assemble/assembly.xml</descriptors>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-client/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-client/pom.xml
@@ -26,44 +26,6 @@
     <artifactId>legend-engine-repl-client</artifactId>
     <name>Legend Engine - REPL - Client</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>module-info.class</exclude>
-                                        <exclude>META-INF/**/module-info.class</exclude>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.finos.legend.engine.repl.client.Client</mainClass>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
@@ -178,11 +140,6 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jansi</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.fusesource.jansi</groupId>
-            <artifactId>jansi</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
@@ -257,40 +257,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>shade</goal>
-                                </goals>
-                                <configuration>
-                                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                                    <finalName>legend-engine-repl-data-cube-${project.version}-DEV</finalName>
-                                    <filters>
-                                        <filter>
-                                            <artifact>*:*</artifact>
-                                            <excludes>
-                                                <exclude>module-info.class</exclude>
-                                                <exclude>META-INF/**/module-info.class</exclude>
-                                                <exclude>META-INF/*.SF</exclude>
-                                                <exclude>META-INF/*.DSA</exclude>
-                                                <exclude>META-INF/*.RSA</exclude>
-                                            </excludes>
-                                        </filter>
-                                    </filters>
-                                    <transformers>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                            <mainClass>org.finos.legend.engine.repl.dataCube.client.DataCubeClient</mainClass>
-                                        </transformer>
-                                    </transformers>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
@@ -257,6 +257,40 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                                    <finalName>legend-engine-repl-data-cube-${project.version}-DEV</finalName>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>module-info.class</exclude>
+                                                <exclude>META-INF/**/module-info.class</exclude>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>org.finos.legend.engine.repl.dataCube.client.DataCubeClient</mainClass>
+                                        </transformer>
+                                    </transformers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
@@ -74,86 +74,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>module-info.class</exclude>
-                                        <exclude>META-INF/**/module-info.class</exclude>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.finos.legend.engine.repl.dataCube.client.DataCubeClient</mainClass>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>${maven.enforcer.requireJavaVersion}</version>
-                                </requireJavaVersion>
-                                <requireMavenVersion>
-                                    <version>${maven.enforcer.requireMavenVersion}</version>
-                                </requireMavenVersion>
-                                <dependencyConvergence />
-                                <bannedDependencies>
-                                    <excludes>
-                                        <!-- Default -->
-                                        <exclude>log4j:*:*:*:compile</exclude>
-                                        <exclude>log4j:*:*:*:runtime</exclude>
-                                        <exclude>org.slf4j:*:*:*:compile</exclude>
-                                        <exclude>org.slf4j:*:*:*:runtime</exclude>
-                                        <exclude>commons-logging</exclude>
-                                        <exclude>javax.mail</exclude>
-                                        <!-- Default -->
-                                    </excludes>
-                                    <includes>
-                                        <!--only the specific included logging jars are allowed -->
-                                        <include>org.slf4j:slf4j-nop:${slf4j.version}</include> <!-- include this since there is no need for logging in REPL -->
-                                        <include>org.slf4j:jul-to-slf4j:${slf4j.version}</include>
-                                        <include>org.slf4j:slf4j-api:${slf4j.version}</include>
-                                        <include>org.slf4j:jcl-over-slf4j:${slf4j.version}</include>
-                                        <include>org.slf4j:slf4j-jdk14:${slf4j.version}</include>
-                                        <include>org.slf4j:slf4j-log4j12:${slf4j.version}</include>
-                                        <include>org.slf4j:slf4j-ext:${slf4j.version}</include>
-                                        <include>log4j:log4j:${log4j.version}</include>
-                                        <include>log4j:apache-log4j-extras:${log4j.version}</include>
-                                    </includes>
-                                </bannedDependencies>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -299,13 +219,6 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
-            <scope>runtime</scope>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>

--- a/legend-engine-config/legend-engine-repl/pom.xml
+++ b/legend-engine-config/legend-engine-repl/pom.xml
@@ -30,5 +30,6 @@
         <module>legend-engine-repl-client</module>
         <module>legend-engine-repl-relational</module>
         <module>legend-engine-repl-data-cube</module>
+        <module>legend-engine-repl-app-assembly</module>
     </modules>
 </project>

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
@@ -93,39 +93,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>module-info.class</exclude>
-                                        <exclude>META-INF/**/module-info.class</exclude>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.finos.legend.engine.ide.PureIDELight_NoExtension</mainClass>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,7 @@
         <testcontainers.version>1.18.3</testcontainers.version>
         <wiremock.version>2.27.2</wiremock.version>
         <zipkin.reporter.version>2.15.0</zipkin.reporter.version>
+        <jline.version>3.26.3</jline.version>
 
         <!-- Plugin versions -->
         <build-helper.maven.plugin.version>3.2.0</build-helper.maven.plugin.version>
@@ -3894,22 +3895,22 @@
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
-                <version>3.25.0</version>
+                <version>${jline.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline-terminal</artifactId>
-                <version>3.25.0</version>
+                <version>${jline.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline-terminal-jansi</artifactId>
-                <version>3.25.0</version>
+                <version>${jline.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.fusesource.jansi</groupId>
-                <artifactId>jansi</artifactId>
-                <version>2.4.1</version>
+                <groupId>org.jline</groupId>
+                <artifactId>jline-terminal-jna</artifactId>
+                <version>${jline.version}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

This introduce a new assembly module for REPL that create scripts to run all the flavors of REPL: default, relational, datacube.

This is the first step to unify how to access and run the REPLs, and the next step is to have a single main, and allow users to select the features they want, reducing duplication and confusion on what REPL to use.     