### PR TITLE
fix null executables diagrams in dataspace metamodel

### DIFF
--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
@@ -255,7 +255,7 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
                         {
                             throw new EngineException("Data space executables could only be template or executable", dataSpace.sourceInformation, EngineErrorType.COMPILATION);
                         }
-                    }) : null);
+                    }) : Lists.immutable.empty());
 
                     // diagrams
                     if (dataSpace.featuredDiagrams != null)
@@ -281,7 +281,7 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
                             new Root_meta_pure_metamodel_dataSpace_DataSpaceDiagram_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::dataSpace::DataSpaceDiagram"))
                                     ._title(diagram.title)
                                     ._description(diagram.description)
-                                    ._diagram(HelperDiagramBuilder.resolveDiagram(diagram.diagram.path, diagram.diagram.sourceInformation, context))) : null);
+                                    ._diagram(HelperDiagramBuilder.resolveDiagram(diagram.diagram.path, diagram.diagram.sourceInformation, context))) : Lists.immutable.empty());
 
                     // support info
                     if (dataSpace.supportInfo != null)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/pom.xml
@@ -113,6 +113,15 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-data-space-compiler</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-data-space-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-data-space-grammar</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
@@ -27,6 +27,7 @@ import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityRootGra
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataSpaceDataQualityExecutionContext;
 import org.finos.legend.engine.protocol.dataquality.metamodel.MappingAndRuntimeDataQualityExecutionContext;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpace;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.PackageableRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
@@ -87,7 +88,7 @@ public class DataQualityCompilerExtension implements CompilerExtension
         return Lists.fixedSize.of(
                 Processor.newProcessor(
                         DataQuality.class,
-                        org.eclipse.collections.impl.factory.Lists.fixedSize.with(PackageableRuntime.class, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping.class, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Class.class),
+                        org.eclipse.collections.impl.factory.Lists.fixedSize.with(PackageableRuntime.class, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping.class, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Class.class, DataSpace.class),
                         (dataquality, compileContext) ->
                         {
                             Root_meta_external_dataquality_DataQuality_Impl<Object> metamodel = new Root_meta_external_dataquality_DataQuality_Impl<>(

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -39,7 +39,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
     @Override
     public String getDuplicatedElementTestExpectedErrorMessage()
     {
-        return "COMPILATION error at [92:1-101:1]: Duplicated element 'meta::dataquality::Person'";
+        return "COMPILATION error at [104:1-113:1]: Duplicated element 'meta::dataquality::Person'";
     }
 
     @Test
@@ -50,6 +50,23 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
                 "{\n" +
                 "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
+                "    validationTree: $[\n" +
+                "      meta::dataquality::Person<mustBeOfLegalAge>{\n" +
+                "        name\n" +
+                "      }\n" +
+                "    ]$;\n" +
+                "}");
+    }
+
+    @Test
+    public void testHappyPath_withDataspace()
+    {
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(COMPILATION_PREREQUISITE_CODE +
+                "###DataQualityValidation\n" +
+                "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
+                "{\n" +
+                "    context: fromDataSpace(meta::dataquality::PersonDataspace, 'default');\n" +
                 "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
                 "    validationTree: $[\n" +
                 "      meta::dataquality::Person<mustBeOfLegalAge>{\n" +
@@ -105,7 +122,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "      meta::dataquality::Person{\n" +
                 "      }\n" +
                 "    ]$;\n" +
-                "}", " at [92:1-100:1]: Error in 'meta::dataquality::PersonDataQualityValidation': Execution error at (resource: lines:92c1-100c1), \"Constraint :[mustHaveAtLeastOnePropertyOrConstraint] violated in the Class DataQualityRootGraphFetchTree\"");
+                "}", " at [104:1-112:1]: Error in 'meta::dataquality::PersonDataQualityValidation': Execution error at (resource: lines:104c1-112c1), \"Constraint :[mustHaveAtLeastOnePropertyOrConstraint] violated in the Class DataQualityRootGraphFetchTree\"");
     }
 
 
@@ -200,6 +217,18 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
             "   street: String[1];\n" +
             "   locality: String[1];\n" +
             "}\n" +
-            "\n";
+            "###DataSpace\n" +
+            "DataSpace meta::dataquality::PersonDataspace\n" +
+            "{\n" +
+            "  executionContexts:\n" +
+            "  [\n" +
+            "    {\n" +
+            "      name: 'default';\n" +
+            "      mapping: meta::dataquality::dataqualitymappings;\n" +
+            "      defaultRuntime: meta::dataquality::DataQualityRuntime;\n" +
+            "    }\n" +
+            "  ];\n" +
+            "  defaultExecutionContext: 'default';\n" +
+            "}\n";
 
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 public class DataQualityLambdaGenerator
 {
-    public static final int DEFAULT_QUERY_LIMIT = Integer.MAX_VALUE;
+    public static final int DEFAULT_QUERY_LIMIT = 100;
 
     public static LambdaFunction generateLambda(PureModel pureModel, String qualifiedPath)
     {

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 public class DataQualityLambdaGenerator
 {
-    public static final int DEFAULT_QUERY_LIMIT = 100;
+    public static final int DEFAULT_QUERY_LIMIT = Integer.MAX_VALUE;
 
     public static LambdaFunction generateLambda(PureModel pureModel, String qualifiedPath)
     {


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
The data space compiler extension sets the executables and diagrams as null in the dataspace metamodel when they are null in the protocol. Since they have [*] multiplicity, the validate method of the metamodel expects them to be non-null or empty. This bug leads to NPEs when validate method is called on the dataspace element.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No