### PR TITLE
[Legend SQL] Support fetch size

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
@@ -36,6 +36,12 @@ public class ExecutionDispatcher extends SqlBaseParserBaseVisitor<SessionHandler
     }
 
     @Override
+    public SessionHandler visitBegin(SqlBaseParser.BeginContext ctx)
+    {
+        return EMPTY_SESSION_HANDLER;
+    }
+
+    @Override
     public SessionHandler visitSet(SqlBaseParser.SetContext ctx)
     {
         // TODO: Handle set queries instead of returning empty result set

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Messages.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Messages.java
@@ -582,8 +582,10 @@ public class Messages
 
     /**
      * Send a message that just contains the msgType and the msg length
+     *
+     * @return
      */
-    private void sendShortMsg(Channel channel, char msgType, final String traceLogMsg)
+    private ChannelFuture sendShortMsg(Channel channel, char msgType, final String traceLogMsg)
     {
         ByteBuf buffer = channel.alloc().buffer(5);
         buffer.writeByte(msgType);
@@ -594,11 +596,12 @@ public class Messages
         {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace(traceLogMsg));
         }
+        return channelFuture;
     }
 
-    void sendPortalSuspended(Channel channel)
+    ChannelFuture sendPortalSuspended(Channel channel)
     {
-        sendShortMsg(channel, 's', "sentPortalSuspended");
+        return sendShortMsg(channel, 's', "sentPortalSuspended");
     }
 
     /**

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Messages.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Messages.java
@@ -124,7 +124,7 @@ public class Messages
         buffer.writeByte('C');
         buffer.writeInt(length);
         writeCString(buffer, commandTagBytes);
-        ChannelFuture channelFuture = channel.write(buffer);
+        ChannelFuture channelFuture = channel.writeAndFlush(buffer);
         if (LOGGER.isTraceEnabled())
         {
             channelFuture.addListener(
@@ -183,7 +183,7 @@ public class Messages
         buffer.writeInt(length);
         writeCString(buffer, nameBytes);
         writeCString(buffer, valueBytes);
-        ChannelFuture channelFuture = channel.write(buffer);
+        ChannelFuture channelFuture = channel.writeAndFlush(buffer);
         if (LOGGER.isTraceEnabled())
         {
             channelFuture.addListener(
@@ -457,7 +457,7 @@ public class Messages
             int pgTypeId = PGTypes.get(parameters.getParameterType(i), parameters.getScale(i)).oid();
             buffer.writeInt(pgTypeId);
         }
-        channel.write(buffer);
+        channel.writeAndFlush(buffer);
     }
 
  /*   private static boolean isRefWithPosition(Symbol symbol) {
@@ -523,7 +523,7 @@ public class Messages
         }
 
         buffer.setInt(1, length);
-        ChannelFuture channelFuture = channel.write(buffer);
+        ChannelFuture channelFuture = channel.writeAndFlush(buffer);
         if (LOGGER.isTraceEnabled())
         {
             channelFuture.addListener(
@@ -589,7 +589,7 @@ public class Messages
         buffer.writeByte(msgType);
         buffer.writeInt(4);
 
-        ChannelFuture channelFuture = channel.write(buffer);
+        ChannelFuture channelFuture = channel.writeAndFlush(buffer);
         if (LOGGER.isTraceEnabled())
         {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace(traceLogMsg));

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Messages.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Messages.java
@@ -55,7 +55,7 @@ import org.slf4j.Logger;
  * tag, but including the length itself)
  * <p>
  * <p>
- * See https://www.postgresql.org/docs/9.2/static/protocol-message-formats.html
+ * See <a href="https://www.postgresql.org/docs/9.2/static/protocol-message-formats.html">postgresql docs</a>
  */
 public class Messages
 {

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresServerException.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresServerException.java
@@ -27,9 +27,9 @@ import org.finos.legend.engine.postgres.utils.OpenTelemetryUtil;
 
 public class PostgresServerException extends RuntimeException
 {
-    private static final TextMapSetter<Map> TEXT_MAP_SETTER = (map, key, value) -> Objects.requireNonNull(map).put(key, value);
+    private static final TextMapSetter<Map<String, String>> TEXT_MAP_SETTER = (map, key, value) -> Objects.requireNonNull(map).put(key, value);
 
-    private Map<String, String> tracingDetails = new HashMap<>();
+    private final Map<String, String> tracingDetails = new HashMap<>();
 
     public PostgresServerException(Throwable cause)
     {

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresServerException.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresServerException.java
@@ -16,10 +16,13 @@ package org.finos.legend.engine.postgres;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
 import org.finos.legend.engine.postgres.utils.OpenTelemetryUtil;
 
 public class PostgresServerException extends RuntimeException
@@ -48,11 +51,20 @@ public class PostgresServerException extends RuntimeException
 
     public static PostgresServerException wrapException(Throwable e)
     {
-        if (!(e instanceof PostgresServerException))
+        Throwable toThrow;
+        if (e instanceof ExecutionException)
         {
-            return new PostgresServerException(e);
+            toThrow = e.getCause();
         }
-        return (PostgresServerException) e;
+        else
+        {
+            toThrow = e;
+        }
+        if (!(toThrow instanceof PostgresServerException))
+        {
+            return new PostgresServerException(toThrow);
+        }
+        return (PostgresServerException) toThrow;
 
     }
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
@@ -821,7 +821,7 @@ public class PostgresWireProtocol
 
         Tracer tracer = OpenTelemetryUtil.getTracer();
         Span span = tracer.spanBuilder("WireProtocol Handle Describe Message").startSpan();
-        try (Scope scope = span.makeCurrent())
+        try (Scope ignored = span.makeCurrent())
         {
             byte type = buffer.readByte();
             String portalOrStatement = readCString(buffer);

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/PostgresWireProtocol.java
@@ -52,6 +52,7 @@ import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import javax.net.ssl.SSLSession;
@@ -72,7 +73,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-
 import static org.finos.legend.engine.postgres.FormatCodes.getFormatCode;
 
 
@@ -181,15 +181,14 @@ import static org.finos.legend.engine.postgres.FormatCodes.getFormatCode;
  * <p>
  * Take a look at {@link Messages} to see how the messages are structured.
  * <p>
- * See https://www.postgresql.org/docs/current/static/protocol-flow.html for a more detailed
+ * See <a href="https://www.postgresql.org/docs/current/static/protocol-flow.html">postgresql docs</a> for a more detailed
  * description of the message flow
  */
 
 public class PostgresWireProtocol
 {
 
-    //private static final Logger LOGGER = LogManager.getLogger(PostgresWireProtocol.class);
-    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(
+    private static final Logger LOGGER = LoggerFactory.getLogger(
             PostgresWireProtocol.class);
 
     public static int SERVER_VERSION_NUM = 100500;
@@ -930,7 +929,7 @@ public class PostgresWireProtocol
 
 
             DelayableWriteChannel.DelayedWrites delayedWrites = channel.delayWrites();
-            ResultSetReceiver resultReceiver = new ResultSetReceiver(query, channel, delayedWrites, false, null,messages);
+            ResultSetReceiver resultReceiver = new ResultSetReceiver(query, channel, delayedWrites, false, null, messages);
             session.execute(portalName, maxRows, resultReceiver);
         }
         catch (Exception e)
@@ -1120,7 +1119,7 @@ public class PostgresWireProtocol
         {
             final GSSName gssName = manager.createName(this.accountPrincipal, GSSName.NT_USER_NAME);
             return manager
-                    .createCredential(gssName, GSSCredential.DEFAULT_LIFETIME, new Oid[] {
+                    .createCredential(gssName, GSSCredential.DEFAULT_LIFETIME, new Oid[]{
                             new Oid("1.2.840.113554.1.2.2"),    // Kerberos v5
                             new Oid("1.3.6.1.5.5.2")            // SPNEGO
                     }, GSSCredential.ACCEPT_ONLY);

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ResultSetReceiver.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ResultSetReceiver.java
@@ -54,13 +54,14 @@ class ResultSetReceiver
     private final Messages messages;
     private long rowCount = 0;
 
-    ResultSetReceiver(String query, DelayableWriteChannel channel, DelayedWrites delayedWrites,
+    ResultSetReceiver(String query, DelayableWriteChannel channel,
                       boolean isSimpleQuery, FormatCodes.FormatCode[] formatCodes, Messages messages)
     {
         this.query = query;
         this.channel = channel;
         this.isSimpleQuery = isSimpleQuery;
-        this.delayedWrites = delayedWrites;
+        // ResultSetReceiver is only created when actual execution is in progress, so it is safe to delay writes here
+        this.delayedWrites = channel.delayWrites();
         this.formatCodes = formatCodes;
         this.directChannel = this.channel.bypassDelay();
         this.messages = messages;

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ResultSetReceiver.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ResultSetReceiver.java
@@ -44,20 +44,14 @@ import org.slf4j.Logger;
 class ResultSetReceiver
 {
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ResultSetReceiver.class);
-
-
     private final String query;
     private final DelayableWriteChannel channel;
-    private boolean isSimpleQuery;
-    private Channel directChannel;
-    private DelayedWrites delayedWrites;
+    private final boolean isSimpleQuery;
+    private final Channel directChannel;
+    private final DelayedWrites delayedWrites;
     private final FormatCodes.FormatCode[] formatCodes;
-
-    private CompletableFuture<Void> completionFuture = new CompletableFuture<>();
-
+    private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
     private final Messages messages;
-
-
     private long rowCount = 0;
 
     ResultSetReceiver(String query, DelayableWriteChannel channel, DelayedWrites delayedWrites,
@@ -77,7 +71,7 @@ class ResultSetReceiver
     {
         Tracer tracer = OpenTelemetryUtil.getTracer();
         Span span = tracer.spanBuilder("ResultSet Receiver Send ResultSet").startSpan();
-        try (Scope scope = span.makeCurrent())
+        try (Scope ignored = span.makeCurrent())
         {
             if (rs != null)
             {
@@ -120,7 +114,7 @@ class ResultSetReceiver
     {
         Tracer tracer = OpenTelemetryUtil.getTracer();
         Span span = tracer.spanBuilder("ResultSet Receiver Finish Handling").startSpan();
-        try (Scope scope = span.makeCurrent())
+        try (Scope ignored = span.makeCurrent())
         {
             ChannelFuture sendCommandComplete = messages.sendCommandComplete(directChannel, query, rowCount);
             channel.writePendingMessages(delayedWrites);
@@ -137,7 +131,7 @@ class ResultSetReceiver
     {
         Tracer tracer = OpenTelemetryUtil.getTracer();
         Span span = tracer.spanBuilder("ResultSet Receiver Finish Handling").startSpan();
-        try (Scope scope = span.makeCurrent())
+        try (Scope ignored = span.makeCurrent())
         {
             ChannelFuture sendCommandComplete = messages.sendPortalSuspended(directChannel);
             channel.writePendingMessages(delayedWrites);
@@ -155,7 +149,7 @@ class ResultSetReceiver
     {
         Tracer tracer = OpenTelemetryUtil.getTracer();
         Span span = tracer.spanBuilder("ResultSet Receiver Failure").startSpan();
-        try (Scope scope = span.makeCurrent())
+        try (Scope ignored = span.makeCurrent())
         {
             ChannelFuture sendErrorResponse = messages.sendErrorResponse(directChannel, throwable);
             channel.writePendingMessages(delayedWrites);

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
@@ -28,11 +28,11 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
 import org.finos.legend.engine.language.sql.grammar.from.SQLGrammarParser;
@@ -51,10 +51,10 @@ public class Session implements AutoCloseable
 {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Session.class);
-    private final Map<String, Prepared> parsed = new HashMap<>();
-    private final Map<String, Portal> portals = new HashMap<>();
+    private final Map<String, Prepared> parsed = new ConcurrentHashMap<>();
+    private final Map<String, Portal> portals = new ConcurrentHashMap<>();
     private final ExecutionDispatcher dispatcher;
-    private ExecutorService executorService;
+    private final ExecutorService executorService;
     private CompletableFuture<?> activeExecution;
 
     private Identity identity;

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/PostgresPreparedStatement.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/PostgresPreparedStatement.java
@@ -29,6 +29,10 @@ public interface PostgresPreparedStatement
 
     void setMaxRows(int maxRows) throws Exception;
 
+    int getMaxRows() throws Exception;
+
+    boolean isExecuted();
+
     boolean execute() throws Exception;
 
     PostgresResultSet getResultSet() throws Exception;

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/empty/EmptyPreparedStatement.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/empty/EmptyPreparedStatement.java
@@ -25,7 +25,7 @@ public class EmptyPreparedStatement implements PostgresPreparedStatement
     @Override
     public void setObject(int i, Object o)
     {
-
+        // empty statement doesn't require objects to be set
     }
 
     @Override
@@ -43,13 +43,25 @@ public class EmptyPreparedStatement implements PostgresPreparedStatement
     @Override
     public void close() throws Exception
     {
-
+        // empty statement doesn't require closure
     }
 
     @Override
     public void setMaxRows(int maxRows)
     {
+        // empty statement doesn't require max rows
+    }
 
+    @Override
+    public int getMaxRows()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isExecuted()
+    {
+        return true;
     }
 
     @Override

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/jdbc/JDBCSessionFactory.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/jdbc/JDBCSessionFactory.java
@@ -57,7 +57,7 @@ public class JDBCSessionFactory implements SessionsFactory
     private static class JDBCPostgresStatement implements PostgresStatement
     {
 
-        private Statement postgresStatement;
+        private final Statement postgresStatement;
 
         public JDBCPostgresStatement(Statement postgresStatement)
         {
@@ -82,7 +82,6 @@ public class JDBCSessionFactory implements SessionsFactory
             if (postgresStatement != null)
             {
                 postgresStatement.close();
-                ;
             }
         }
 
@@ -91,7 +90,8 @@ public class JDBCSessionFactory implements SessionsFactory
     private static class JDBCPostgresPreparedStatement implements PostgresPreparedStatement
     {
 
-        private PreparedStatement preparedStatement;
+        private final PreparedStatement preparedStatement;
+        private boolean isExecuted = false;
 
         public JDBCPostgresPreparedStatement(PreparedStatement preparedStatement)
         {
@@ -129,8 +129,21 @@ public class JDBCSessionFactory implements SessionsFactory
         }
 
         @Override
+        public int getMaxRows() throws Exception
+        {
+            return preparedStatement.getMaxRows();
+        }
+
+        @Override
+        public boolean isExecuted()
+        {
+            return isExecuted;
+        }
+
+        @Override
         public boolean execute() throws Exception
         {
+            isExecuted = true;
             return preparedStatement.execute();
         }
 
@@ -144,7 +157,7 @@ public class JDBCSessionFactory implements SessionsFactory
     private static class JDBCPostgresResultSet implements PostgresResultSet
     {
 
-        private ResultSet resultSet;
+        private final ResultSet resultSet;
 
         public JDBCPostgresResultSet(ResultSet resultSet)
         {
@@ -192,7 +205,7 @@ public class JDBCSessionFactory implements SessionsFactory
     private static class JDBCPostgresResultSetMetaData implements PostgresResultSetMetaData
     {
 
-        private ResultSetMetaData resultSetMetaData;
+        private final ResultSetMetaData resultSetMetaData;
 
 
         public JDBCPostgresResultSetMetaData(ResultSetMetaData resultSetMetaData)

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendPreparedStatement.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/legend/LegendPreparedStatement.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.postgres.handler.legend;
 import java.security.PrivilegedAction;
 import java.sql.ParameterMetaData;
 import javax.security.auth.Subject;
+
 import org.finos.legend.engine.postgres.handler.PostgresPreparedStatement;
 import org.finos.legend.engine.postgres.handler.PostgresResultSet;
 import org.finos.legend.engine.postgres.handler.PostgresResultSetMetaData;
@@ -27,9 +28,9 @@ public class LegendPreparedStatement implements PostgresPreparedStatement
 {
     private final String query;
     private final LegendExecutionService client;
-
     private final Identity identity;
-
+    private boolean isExecuted;
+    private int maxRows;
     private LegendResultSet legendResultSet;
 
     public LegendPreparedStatement(String query, LegendExecutionService client, Identity identity)
@@ -79,12 +80,25 @@ public class LegendPreparedStatement implements PostgresPreparedStatement
     @Override
     public void setMaxRows(int maxRows)
     {
+        this.maxRows = maxRows;
+    }
 
+    @Override
+    public int getMaxRows()
+    {
+        return maxRows;
+    }
+
+    @Override
+    public boolean isExecuted()
+    {
+        return isExecuted;
     }
 
     @Override
     public boolean execute()
     {
+        isExecuted = true;
         if (identity.getFirstCredential() instanceof LegendKerberosCredential)
 
         {

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -174,7 +174,8 @@ public class PostgresServerTest
             while (resultSet.next())
             {
                 rows++;
-            }            Assert.assertEquals(4, rows);
+            }
+            Assert.assertEquals(4, rows);
         }
     }
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -109,6 +109,7 @@ public class PostgresServerTest
 
     /**
      * Verify that schema created as part of the metadata H2 DB creation exits
+     *
      * @throws SQLException on errors
      */
     @Test
@@ -167,6 +168,20 @@ public class PostgresServerTest
                 rows++;
             }
             Assert.assertEquals(4, rows);
+        }
+    }
+
+    @Test
+    public void testAutoCommitOff() throws SQLException
+    {
+        try (
+                Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                        "dummy", "dummy");
+
+        )
+        {
+            connection.setAutoCommit(false);
+            Assert.assertFalse(connection.getAutoCommit());
         }
     }
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -80,7 +80,7 @@ public class PostgresServerTest
         try (
                 Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
                         "dummy", "dummy");
-                PreparedStatement statement = connection.prepareStatement("SELECT * FROM service.\"/personService\"");
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM service.\"/personService\"")
         )
         {
             ResultSetMetaData resultSetMetaData = statement.getMetaData();
@@ -231,8 +231,7 @@ public class PostgresServerTest
     {
         try (
                 Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
-                        "dummy", "dummy");
-
+                        "dummy", "dummy")
         )
         {
             connection.setAutoCommit(false);
@@ -412,7 +411,7 @@ public class PostgresServerTest
         try (
                 Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
                         "dummy", "dummy");
-                PreparedStatement statement = connection.prepareStatement("SELECT blah FROM service('/blah')");
+                PreparedStatement statement = connection.prepareStatement("SELECT blah FROM service('/blah')")
         )
         {
             PSQLException exception = Assert.assertThrows(PSQLException.class, statement::executeQuery);
@@ -428,7 +427,7 @@ public class PostgresServerTest
         try (
                 Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
                         "dummy", "dummy");
-                PreparedStatement statement = connection.prepareStatement("SELECT \"some_random_column_name\" FROM service('/personService')");
+                PreparedStatement statement = connection.prepareStatement("SELECT \"some_random_column_name\" FROM service('/personService')")
         )
         {
             PSQLException exception = Assert.assertThrows(PSQLException.class, statement::executeQuery);
@@ -445,7 +444,7 @@ public class PostgresServerTest
         try (
                 Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
                         "dummy", "dummy");
-                PreparedStatement statement = connection.prepareStatement("SELECT blah FROM service('/blah')");
+                PreparedStatement statement = connection.prepareStatement("SELECT blah FROM service('/blah')")
         )
         {
             PSQLException exception = Assert.assertThrows(PSQLException.class, statement::getMetaData);
@@ -461,7 +460,7 @@ public class PostgresServerTest
         try (
                 Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
                         "dummy", "dummy");
-                PreparedStatement statement = connection.prepareStatement("SELECT \"some_random_column_name\" FROM service('/personService')");
+                PreparedStatement statement = connection.prepareStatement("SELECT \"some_random_column_name\" FROM service('/personService')")
         )
         {
             PSQLException exception = Assert.assertThrows(PSQLException.class, statement::getMetaData);


### PR DESCRIPTION
#### What type of PR is this?
Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
This PR allows users to set fetch size so that entire result set is not loaded to memory
<!--
Describe change being introduced by this PR.
-->
#### Other notes for reviewers:
- The `BEGIN` command is silently ignored since it is not applicable for the read only use case of Legend SQL
- No impact for clients which do not invoke `setFetchSize`

