### PR TITLE
Update legend-engine for unit changes

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/Compiler.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/Compiler.java
@@ -23,7 +23,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModelProce
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.runtime.java.compiled.metadata.Metadata;
 
 public class Compiler
@@ -51,7 +51,7 @@ public class Compiler
 
     public static String getLambdaReturnType(Lambda lambda, PureModel pureModel)
     {
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification valueSpecification = HelperValueSpecificationBuilder.buildLambdaWithContext(lambda.body, lambda.parameters, new CompileContext.Builder(pureModel).build(), new ProcessingContext("Processing return type for lambda"))._expressionSequence().getLast();
-        return HelperModelBuilder.getElementFullPath((PackageableElement) valueSpecification._genericType()._rawType(), pureModel.getExecutionSupport());
+        ValueSpecification valueSpecification = HelperValueSpecificationBuilder.buildLambdaWithContext(lambda.body, lambda.parameters, new CompileContext.Builder(pureModel).build(), new ProcessingContext("Processing return type for lambda"))._expressionSequence().getLast();
+        return HelperModelBuilder.getTypeFullPath(valueSpecification._genericType()._rawType(), pureModel.getExecutionSupport());
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingSecondPassBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingSecondPassBuilder.java
@@ -48,15 +48,15 @@ public class ClassMappingSecondPassBuilder implements ClassMappingVisitor<SetImp
         if (classMapping.extendsClassMappingId != null)
         {
             String superSetId = classMapping.extendsClassMappingId;
-            ImmutableSet<SetImplementation> superSets = HelperMappingBuilder.getAllClassMappings(parentMapping).select(c -> c._id().equals(superSetId));
-            if (superSets.size() == 0)
+            ImmutableSet<SetImplementation> superSets = HelperMappingBuilder.getAllClassMappings(this.parentMapping).select(c -> c._id().equals(superSetId));
+            if (superSets.isEmpty())
             {
-                throw new EngineException("Can't find extends class mapping '" + superSetId + "' in mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "'", classMapping.sourceInformation, EngineErrorType.COMPILATION);
+                throw new EngineException("Can't find extends class mapping '" + superSetId + "' in mapping '" + HelperModelBuilder.getElementFullPath(this.parentMapping, this.context.pureModel.getExecutionSupport()) + "'", classMapping.sourceInformation, EngineErrorType.COMPILATION);
             }
             if (superSets.size() > 1)
             {
                 String parents = superSets.stream().map(superSet -> "'" + HelperModelBuilder.getElementFullPath(superSet._parent(), this.context.pureModel.getExecutionSupport()) + "'").sorted().collect(Collectors.joining(", "));
-                throw new EngineException("Duplicated class mappings found with ID '" + superSetId + "' in mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "'" + "; parent mapping for duplicated: " + parents, classMapping.sourceInformation, EngineErrorType.COMPILATION);
+                throw new EngineException("Duplicated class mappings found with ID '" + superSetId + "' in mapping '" + HelperModelBuilder.getElementFullPath(this.parentMapping, this.context.pureModel.getExecutionSupport()) + "'; parent mapping for duplicated: " + parents, classMapping.sourceInformation, EngineErrorType.COMPILATION);
             }
         }
         this.context.getCompilerExtensions().getExtraClassMappingSecondPassProcessors().forEach(processor -> processor.value(classMapping, this.parentMapping, this.context));
@@ -66,13 +66,13 @@ public class ClassMappingSecondPassBuilder implements ClassMappingVisitor<SetImp
     @Override
     public SetImplementation visit(OperationClassMapping classMapping)
     {
-        OperationSetImplementation operationSetImplementation = (OperationSetImplementation) parentMapping._classMappings().detect(c -> c._id().equals(HelperMappingBuilder.getClassMappingId(classMapping, this.context)));
+        OperationSetImplementation operationSetImplementation = (OperationSetImplementation) this.parentMapping._classMappings().detect(c -> c._id().equals(HelperMappingBuilder.getClassMappingId(classMapping, this.context)));
         return operationSetImplementation._parameters(ListIterate.collect(classMapping.parameters, classMappingId ->
         {
-            SetImplementation match = HelperMappingBuilder.getAllClassMappings(parentMapping).detect(c -> c._id().equals(classMappingId));
+            SetImplementation match = HelperMappingBuilder.getAllClassMappings(this.parentMapping).detect(c -> c._id().equals(classMappingId));
             if (match == null)
             {
-                throw new EngineException("Can't find class mapping '" + classMappingId + "' in mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "'", classMapping.sourceInformation, EngineErrorType.COMPILATION);
+                throw new EngineException("Can't find class mapping '" + classMappingId + "' in mapping '" + HelperModelBuilder.getElementFullPath(this.parentMapping, this.context.pureModel.getExecutionSupport()) + "'", classMapping.sourceInformation, EngineErrorType.COMPILATION);
             }
             return new Root_meta_pure_mapping_SetImplementationContainer_Impl("", null, context.pureModel.getClass("meta::pure::mapping::SetImplementationContainer"))._id(classMappingId)._setImplementation(match);
         }));

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingThirdPassBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingThirdPassBuilder.java
@@ -16,7 +16,7 @@ package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
@@ -30,12 +30,12 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Enu
 import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.core_pure_router_operations_router_operations;
+import org.finos.legend.pure.m3.coreinstance.meta.external.store.model.PureInstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EnumerationMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.InstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
-import org.finos.legend.pure.m3.coreinstance.meta.external.store.model.PureInstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
@@ -77,7 +77,7 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
     @Override
     public SetImplementation visit(PureInstanceClassMapping classMapping)
     {
-        PureInstanceSetImplementation s = (PureInstanceSetImplementation) parentMapping._classMappings().select(c -> c._id().equals(HelperMappingBuilder.getClassMappingId(classMapping, this.context))).getFirst();
+        PureInstanceSetImplementation s = (PureInstanceSetImplementation) this.parentMapping._classMappings().select(c -> c._id().equals(HelperMappingBuilder.getClassMappingId(classMapping, this.context))).getFirst();
         s._propertyMappings().forEachWithIndex((ObjectIntProcedure<PropertyMapping>) ((p, i) ->
         {
             org.finos.legend.pure.m3.coreinstance.meta.external.store.model.PurePropertyMapping pm = (org.finos.legend.pure.m3.coreinstance.meta.external.store.model.PurePropertyMapping) p;
@@ -91,8 +91,8 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
                 SetImplementation setImplementation;
                 if (p._targetSetImplementationId() != null && !p._targetSetImplementationId().equals(""))
                 {
-                    setImplementation = Root_meta_pure_mapping__classMappingByIdRecursive_Mapping_1__String_MANY__SetImplementation_MANY_(parentMapping, Lists.fixedSize.with(p._targetSetImplementationId()), this.context.pureModel.getExecutionSupport()).getFirst();
-                    boolean allowComplexPropertyMappingPassThrough = setImplementation == null && HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), context.pureModel.getExecutionSupport()).replaceAll("::", "_").equals(p._targetSetImplementationId()) && checkTransformTypeMatchesPropertyType(property, last, context);
+                    setImplementation = Root_meta_pure_mapping__classMappingByIdRecursive_Mapping_1__String_MANY__SetImplementation_MANY_(this.parentMapping, Lists.fixedSize.with(p._targetSetImplementationId()), this.context.pureModel.getExecutionSupport()).getFirst();
+                    boolean allowComplexPropertyMappingPassThrough = setImplementation == null && HelperModelBuilder.getTypeFullPath(property._genericType()._rawType(), "_", this.context.pureModel.getExecutionSupport()).equals(p._targetSetImplementationId()) && checkTransformTypeMatchesPropertyType(property, last, context);
                     if (allowComplexPropertyMappingPassThrough)
                     {
                         // We need to have this as we have been adding defaultId to property mappings when users don't provide something explicitly. This is valid now but having it raises wrong warning
@@ -102,12 +102,12 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
                 }
                 else
                 {
-                    setImplementation = Root_meta_pure_mapping__classMappingByClass_Mapping_1__Class_1__SetImplementation_MANY_(parentMapping, (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<Object>) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()).getFirst();
+                    setImplementation = Root_meta_pure_mapping__classMappingByClass_Mapping_1__Class_1__SetImplementation_MANY_(this.parentMapping, (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?>) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()).getFirst();
                     boolean allowComplexPropertyMappingPassThrough = setImplementation == null && checkTransformTypeMatchesPropertyType(property, last, context);
                     Assert.assertTrue((setImplementation != null) || (allowComplexPropertyMappingPassThrough), () -> "Can't find class mapping for '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()) + "'", pSourceInformation, EngineErrorType.COMPILATION);
                 }
 
-                List<? extends InstanceSetImplementation> setImpls = setImplementation != null ? core_pure_router_operations_router_operations.Root_meta_pure_router_routing_resolveOperation_SetImplementation_MANY__Mapping_1__InstanceSetImplementation_MANY_(Lists.immutable.of(setImplementation), parentMapping, this.context.pureModel.getExecutionSupport()).toList() : Collections.emptyList();
+                List<? extends InstanceSetImplementation> setImpls = setImplementation != null ? core_pure_router_operations_router_operations.Root_meta_pure_router_routing_resolveOperation_SetImplementation_MANY__Mapping_1__InstanceSetImplementation_MANY_(Lists.immutable.of(setImplementation), this.parentMapping, this.context.pureModel.getExecutionSupport()).toList() : Collections.emptyList();
                 typesToCheck = setImpls.stream().map(setImpl -> ((PureInstanceSetImplementation) setImpl)._srcClass()).collect(Collectors.toList());
             }
             else if (((org.finos.legend.pure.m3.coreinstance.meta.external.store.model.PurePropertyMapping) p)._transformer() != null)
@@ -146,12 +146,12 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
             typesToCheck.stream().filter(Objects::nonNull).forEach(t -> checkPureMappingCompatibility(this.context,
                     last._genericType()._rawType(),
                     t,
-                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
+                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(this.parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
                     lines.get(lines.size() - 1).sourceInformation));
 
             HelperModelBuilder.checkMultiplicityCompatibility(last._multiplicity(),
                     multiplicityToCheck,
-                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
+                    "Error in class mapping '" + HelperModelBuilder.getElementFullPath(this.parentMapping, this.context.pureModel.getExecutionSupport()) + "' for property '" + pm._property()._name() + "'",
                     lines.get(lines.size() - 1).sourceInformation);
         }));
         return s;
@@ -170,7 +170,7 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
         //In a pure mapping. The src implementation  can be anywhere in the class hierarchy of the return type
         if (signatureType != null && !actualReturnType.equals(signatureType) && !org.finos.legend.pure.m3.navigation.type.Type.subTypeOf(actualReturnType, signatureType, context.pureModel.getExecutionSupport().getProcessorSupport()) && !org.finos.legend.pure.m3.navigation.type.Type.subTypeOf(signatureType, actualReturnType, context.pureModel.getExecutionSupport().getProcessorSupport()))
         {
-            throw new EngineException(errorStub + " - Type error: '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) actualReturnType, context.pureModel.getExecutionSupport()) + "' is not in the class hierarchy of '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) signatureType, context.pureModel.getExecutionSupport()) + "'", errorSourceInformation, EngineErrorType.COMPILATION);
+            throw new EngineException(errorStub + " - Type error: '" + HelperModelBuilder.getTypeFullPath(actualReturnType, context.pureModel.getExecutionSupport()) + "' is not in the class hierarchy of '" + HelperModelBuilder.getTypeFullPath(signatureType, context.pureModel.getExecutionSupport()) + "'", errorSourceInformation, EngineErrorType.COMPILATION);
         }
     }
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperModelBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperModelBuilder.java
@@ -25,7 +25,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Property;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.Variable;
 import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.*;
 import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.engine.shared.core.operational.logs.LogInfo;
@@ -41,6 +40,7 @@ import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_generics_Ge
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_ClassConstraintValueSpecificationContext_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_ExpressionSequenceValueSpecificationContext_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl;
+import org.finos.legend.pure.generated.platform_pure_essential_meta_graph_elementToPath;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningFunctions;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PropertyOwner;
@@ -51,11 +51,13 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.proper
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecificationContext;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
 import org.slf4j.Logger;
@@ -65,8 +67,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
-import static org.finos.legend.pure.generated.platform_pure_essential_meta_graph_elementToPath.Root_meta_pure_functions_meta_elementToPath_PackageableElement_1__String_1__String_1_;
 
 public class HelperModelBuilder
 {
@@ -188,7 +188,7 @@ public class HelperModelBuilder
     {
         if (signatureType != null && !actualReturnType.equals(signatureType) && !org.finos.legend.pure.m3.navigation.type.Type.subTypeOf(actualReturnType, signatureType, context.pureModel.getExecutionSupport().getProcessorSupport()))
         {
-            throw new EngineException(errorStub + " - Type error: '" + getElementFullPath((PackageableElement) actualReturnType, context.pureModel.getExecutionSupport()) + "' is not a subtype of '" + getElementFullPath((PackageableElement) signatureType, context.pureModel.getExecutionSupport()) + "'", errorSourceInformation, EngineErrorType.COMPILATION);
+            throw new EngineException(errorStub + " - Type error: '" + getTypeFullPath(actualReturnType, context.pureModel.getExecutionSupport()) + "' is not a subtype of '" + getTypeFullPath(signatureType, context.pureModel.getExecutionSupport()) + "'", errorSourceInformation, EngineErrorType.COMPILATION);
         }
     }
 
@@ -549,6 +549,24 @@ public class HelperModelBuilder
         return o._name() == p.name && isCompatibleDerivedPropertyWithParameters(o, Lists.mutable.of(new Variable()).withAll(p.parameters));
     }
 
+    public static String getTypeFullPath(Type type, CompiledExecutionSupport executionSupport)
+    {
+        return getTypeFullPath(type, "::", executionSupport);
+    }
+
+    public static String getTypeFullPath(Type type, String separator, CompiledExecutionSupport executionSupport)
+    {
+        if (type instanceof PackageableElement)
+        {
+            return getElementFullPath((PackageableElement) type, separator, executionSupport);
+        }
+        if (type instanceof Unit)
+        {
+            return Measure.getUserPathForUnit(type, separator);
+        }
+        throw new IllegalArgumentException("Unsupported type: " + type);
+    }
+
     public static String getElementFullPath(PackageableElement element, CompiledExecutionSupport executionSupport)
     {
         return getElementFullPath(element, "::", executionSupport);
@@ -561,6 +579,6 @@ public class HelperModelBuilder
             return "ModelStore";
         }
         // TODO: we might want to fix a bugs here where if we pass in element without ID/package + name, we might get `cannot cast a collection of multiplicity [0] to [1]` or so
-        return Root_meta_pure_functions_meta_elementToPath_PackageableElement_1__String_1__String_1_(element, separator, executionSupport);
+        return platform_pure_essential_meta_graph_elementToPath.Root_meta_pure_functions_meta_elementToPath_PackageableElement_1__String_1__String_1_(element, separator, executionSupport);
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/Milestoning.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/Milestoning.java
@@ -17,13 +17,11 @@ package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Functions;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
@@ -39,8 +37,8 @@ import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecificati
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningFunctions;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningStereotype;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningStereotypeEnum;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PropertyOwner;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.ElementWithStereotypes;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Stereotype;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.AbstractProperty;
@@ -49,6 +47,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.proper
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.SimpleFunctionExpression;
@@ -192,7 +191,8 @@ public class Milestoning
 
     private static MilestoningPropertyTransformation milestoningPropertyTransformations(Property<?, ?> originalProperty, CompileContext context, Class<?> sourceClass, PropertyOwner propertyOwner)
     {
-        MilestoningStereotype returnTypeMilestoningStereotype = temporalStereotypes(((PackageableElement) originalProperty._genericType()._rawType())._stereotypes());
+        Type rawType = originalProperty._genericType()._rawType();
+        MilestoningStereotype returnTypeMilestoningStereotype = (rawType instanceof ElementWithStereotypes) ? temporalStereotypes(((ElementWithStereotypes) rawType)._stereotypes()) : null;
         MilestoningPropertyTransformation milestoningPropertyTransformation = new MilestoningPropertyTransformation(originalProperty);
 
         if (returnTypeMilestoningStereotype != null)
@@ -267,7 +267,7 @@ public class Milestoning
         LambdaFunction filterLambda = new Root_meta_pure_metamodel_function_LambdaFunction_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::function::LambdaFunction"))
                 ._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
                         ._rawType(context.pureModel.getType("meta::pure::metamodel::function::LambdaFunction"))
-                        ._typeArguments(FastList.newListWith(functionType)))
+                        ._typeArguments(Lists.mutable.with(functionType)))
                 ._openVariables(Lists.fixedSize.of("this"))
                 ._expressionSequence(Lists.fixedSize.of(equalExpression));
 
@@ -350,7 +350,7 @@ public class Milestoning
         LambdaFunction filterLambda = new Root_meta_pure_metamodel_function_LambdaFunction_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::function::LambdaFunction"))
                 ._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
                         ._rawType(context.pureModel.getType("meta::pure::metamodel::function::LambdaFunction"))
-                        ._typeArguments(FastList.newListWith(functionType)))
+                        ._typeArguments(Lists.mutable.with(functionType)))
                 ._openVariables(returnTypeMilestoningStereotype.getTemporalDatePropertyNames())
                 ._expressionSequence(Lists.fixedSize.of(equalExpression));
 
@@ -386,7 +386,7 @@ public class Milestoning
 
         GenericType classifierGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
                 ._rawType(context.pureModel.getType("meta::pure::metamodel::function::property::QualifiedProperty"))
-                ._typeArguments(Lists.fixedSize.of(PureModel.buildFunctionType(Lists.mutable.of(thisVar).withAll(datesToCompare.collect(Functions.firstOfPair())), qualifiedProperty._genericType(), originalProperty._multiplicity(), context.pureModel)));
+                ._typeArguments(Lists.fixedSize.of(PureModel.buildFunctionType(Lists.mutable.of(thisVar).withAll(datesToCompare.collect(Pair::getOne)), qualifiedProperty._genericType(), originalProperty._multiplicity(), context.pureModel)));
 
         qualifiedProperty._classifierGenericType(classifierGenericType);
         qualifiedProperty._expressionSequence(Lists.fixedSize.of(finalExpression));

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFirstPassBuilder.java
@@ -69,6 +69,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 
 import java.util.List;
 
@@ -138,13 +139,15 @@ public class PackageableElementFirstPassBuilder implements PackageableElementVis
         this.context.pureModel.typesIndex.put(fullPath, targetMeasure);
         GenericType genericType = newGenericType(targetMeasure);
         this.context.pureModel.typesGenericTypeIndex.put(fullPath, genericType);
-        targetMeasure._classifierGenericType(newGenericType(this.context.pureModel.getType("meta::pure::metamodel::type::Measure")));
-        HelperMeasureBuilder.processUnitPackageableElementFirstPass(measure.canonicalUnit, this.context);
+        targetMeasure._classifierGenericType(newGenericType(this.context.pureModel.getType(M3Paths.Measure)));
+        if (measure.canonicalUnit != null)
+        {
+            HelperMeasureBuilder.processUnitPackageableElementFirstPass(measure.canonicalUnit, this.context);
+        }
         measure.nonCanonicalUnits.forEach(ncu -> HelperMeasureBuilder.processUnitPackageableElementFirstPass(ncu, this.context));
         return setNameAndPackage(targetMeasure, measure);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public PackageableElement visit(Association srcAssociation)
     {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
@@ -36,8 +36,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.PackageableRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.SectionIndex;
-import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.*;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_Connection;
 import org.finos.legend.pure.generated.Root_meta_pure_data_DataElement;
@@ -206,8 +204,10 @@ public class PackageableElementSecondPassBuilder implements PackageableElementVi
     public PackageableElement visit(Measure measure)
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure targetMeasure = this.context.pureModel.getMeasure(this.context.pureModel.buildPackageString(measure._package, measure.name), measure.sourceInformation);
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit canonicalUnit = HelperMeasureBuilder.processUnitPackageableElementSecondPass(measure.canonicalUnit, this.context);
-        targetMeasure._canonicalUnit(canonicalUnit);
+        if (measure.canonicalUnit != null)
+        {
+            targetMeasure._canonicalUnit(HelperMeasureBuilder.processUnitPackageableElementSecondPass(measure.canonicalUnit, this.context));
+        }
         targetMeasure._nonCanonicalUnits(ListIterate.collect(measure.nonCanonicalUnits, ncu -> HelperMeasureBuilder.processUnitPackageableElementSecondPass(ncu, this.context)));
         return targetMeasure;
     }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -15,13 +15,13 @@
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function3;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.Handlers;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.inference.MostCommonType;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecificationVisitor;
@@ -30,10 +30,42 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.applica
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.application.AppliedProperty;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.application.AppliedQualifiedProperty;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.application.UnknownAppliedFunction;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CBoolean;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CByteArray;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CDateTime;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CDecimal;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CFloat;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CInteger;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CLatestDate;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CStrictDate;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CStrictTime;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.CString;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Class;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.ClassInstance;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Collection;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Enum;
-import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.*;
-import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.*;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.EnumValue;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.GenericTypeInstance;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.HackedUnit;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.KeyExpression;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.MappingInstance;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.PackageableElementPtr;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.PrimitiveType;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.UnitInstance;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.UnitType;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Whatever;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.AggregateValue;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.ExecutionContextInstance;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.Pair;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.PureList;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.RuntimeInstance;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.SerializationConfig;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.TDSAggregateValue;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.TDSColumnInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.TDSSortInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.TdsOlapAggregation;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.TdsOlapRank;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.graph.PropertyGraphFetchTree;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.graph.RootGraphFetchTree;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.path.Path;
@@ -43,7 +75,31 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.cla
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.classInstance.relation.RelationStoreAccessor;
 import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
-import org.finos.legend.pure.generated.*;
+import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime;
+import org.finos.legend.pure.generated.Root_meta_pure_functions_collection_AggregateValue_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_functions_collection_Pair_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_functions_lang_KeyExpression_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_graphFetch_execution_AlloySerializationConfig;
+import org.finos.legend.pure.generated.Root_meta_pure_graphFetch_execution_AlloySerializationConfig_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_path_Path_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_path_PropertyPathElement_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relation_AggColSpecArray_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relation_AggColSpec_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relation_ColSpecArray_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relation_FuncColSpecArray_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relation_FuncColSpec_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_PrimitiveType_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_generics_GenericType_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_runtime_ExecutionContext;
+import org.finos.legend.pure.generated.Root_meta_pure_tds_AggregateValue_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_tds_BasicColumnSpecification_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_tds_SortInformation_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_tds_TdsOlapAggregation_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_tds_TdsOlapRank_Impl;
+import org.finos.legend.pure.generated.core_pure_corefunctions_metaExtension;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.AbstractProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
@@ -53,8 +109,13 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.FuncCo
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.RelationType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.*;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.SimpleFunctionExpression;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecificationAccessor;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
@@ -69,10 +130,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.Handlers.*;
-import static org.finos.legend.pure.generated.core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_functionReturnType_Function_1__GenericType_1_;
-
-public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification>
+public class ValueSpecificationBuilder implements ValueSpecificationVisitor<ValueSpecification>
 {
     private final CompileContext context;
     private final MutableList<String> openVariables;
@@ -96,37 +154,43 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     }
 
     @Override
-    public ValueSpecification visit(org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.PackageableElementPtr packageableElementPtr)
+    public ValueSpecification visit(PackageableElementPtr packageableElementPtr)
     {
+        if (packageableElementPtr.fullPath.contains("~"))
+        {
+            // for backward compatibility, since some protocol versions use PackageableElementPtr for units
+            return visit(new UnitType(packageableElementPtr.fullPath, packageableElementPtr.sourceInformation));
+        }
+
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement packageableElement = this.context.resolvePackageableElement(packageableElementPtr.fullPath, packageableElementPtr.sourceInformation);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(packageableElementPtr.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(packageableElementPtr.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(packageableElement._classifierGenericType())
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(packageableElement));
+                ._values(Lists.immutable.with(packageableElement));
     }
 
     @Override
     public ValueSpecification visit(Whatever whatever)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(whatever.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.resolveType(whatever._class, whatever.sourceInformation)))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(whatever.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.resolveType(whatever._class, whatever.sourceInformation)))
                 ._multiplicity(this.context.pureModel.getMultiplicity(whatever.multiplicity))
-                ._values(FastList.newListWith());
+                ._values(Lists.immutable.empty());
     }
 
     @Override
     public ValueSpecification visit(CString cString)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cString.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cString.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("String"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cString.multiplicity))
-                ._values(FastList.newListWith(cString.value));
+                ._values(Lists.immutable.with(cString.value));
     }
 
     @Override
     public ValueSpecification visit(CDateTime cDateTime)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cDateTime.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cDateTime.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("DateTime"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cDateTime.multiplicity))
                 ._values(Lists.immutable.of(DateFormat.parsePureDate(cDateTime.value)));
@@ -135,7 +199,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     @Override
     public ValueSpecification visit(CLatestDate cLatestDate)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cLatestDate.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cLatestDate.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("LatestDate"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cLatestDate.multiplicity))
                 ._values(Lists.immutable.of(LatestDate.instance));
@@ -144,7 +208,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     @Override
     public ValueSpecification visit(CStrictDate cStrictDate)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cStrictDate.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cStrictDate.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("StrictDate"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cStrictDate.multiplicity))
                 ._values(Lists.immutable.of(DateFormat.parseStrictDate(cStrictDate.value)));
@@ -153,7 +217,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     @Override
     public ValueSpecification visit(CStrictTime cStrictTime)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cStrictTime.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cStrictTime.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("StrictTime"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cStrictTime.multiplicity))
                 ._values(Lists.immutable.of(StrictTimeFormat.parsePureStrictTime(cStrictTime.value)));
@@ -161,36 +225,36 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
 
     public ValueSpecification processClassInstance(AggregateValue aggregateValue)
     {
-        LambdaFunction l = (LambdaFunction) ((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue) aggregateValue.mapFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
-        LambdaFunction o = (LambdaFunction) ((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue) aggregateValue.aggregateFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(aggregateValue.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        LambdaFunction<?> l = (LambdaFunction<?>) ((InstanceValue) aggregateValue.mapFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
+        LambdaFunction<?> o = (LambdaFunction<?>) ((InstanceValue) aggregateValue.aggregateFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(aggregateValue.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::functions::collection::AggregateValue"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(Lists.mutable.of(new Root_meta_pure_functions_collection_AggregateValue_Impl("", SourceInformationHelper.toM3SourceInformation(aggregateValue.sourceInformation), context.pureModel.getClass("meta::pure::functions::collection::AggregateValue"))._mapFn(l)._aggregateFn(o)));
+                ._values(Lists.immutable.with(new Root_meta_pure_functions_collection_AggregateValue_Impl("", SourceInformationHelper.toM3SourceInformation(aggregateValue.sourceInformation), this.context.pureModel.getClass("meta::pure::functions::collection::AggregateValue"))._mapFn(l)._aggregateFn(o)));
     }
 
     @Override
     public ValueSpecification visit(Class aClass)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(aClass.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::metamodel::type::Class"))._typeArguments(FastList.newListWith(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.resolveType(aClass.fullPath, aClass.sourceInformation)))))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(aClass.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType(M3Paths.Class))._typeArguments(Lists.immutable.with(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.resolveType(aClass.fullPath, aClass.sourceInformation)))))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(this.processingContext.peek().equals("Applying new") ? FastList.newList() : FastList.newListWith(this.context.resolveType(aClass.fullPath, aClass.sourceInformation))); //Align with pure graph, first instance value of new function used for inference only (i.e only need the typeArgument, values should be empty)
+                ._values(this.processingContext.peek().equals("Applying new") ? Lists.immutable.empty() : Lists.immutable.with(this.context.resolveType(aClass.fullPath, aClass.sourceInformation))); //Align with pure graph, first instance value of new function used for inference only (i.e only need the typeArgument, values should be empty)
     }
 
     @Override
     public ValueSpecification visit(CBoolean cBoolean)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cBoolean.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cBoolean.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("Boolean"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cBoolean.multiplicity))
-                ._values(FastList.newListWith(cBoolean.value));
+                ._values(Lists.immutable.with(cBoolean.value));
     }
 
     @Override
     public ValueSpecification visit(UnknownAppliedFunction unknownAppliedFunction)
     {
-        return new Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl("", SourceInformationHelper.toM3SourceInformation(unknownAppliedFunction.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::SimpleFunctionExpression"))
+        return new Root_meta_pure_metamodel_valuespecification_SimpleFunctionExpression_Impl("", SourceInformationHelper.toM3SourceInformation(unknownAppliedFunction.sourceInformation), this.context.pureModel.getClass(M3Paths.SimpleFunctionExpression))
                 ._func((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function<? extends java.lang.Object>) null)
                 ._functionName(null)
                 ._genericType(this.context.resolveGenericType(unknownAppliedFunction.returnType, unknownAppliedFunction.sourceInformation))
@@ -200,29 +264,29 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     @Override
     public ValueSpecification visit(Enum anEnum)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(anEnum.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::metamodel::type::Enumeration"))._typeArguments(FastList.newListWith(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.resolveType(anEnum.fullPath, anEnum.sourceInformation)))))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(anEnum.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType(M3Paths.Enumeration))._typeArguments(Lists.immutable.with(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.resolveType(anEnum.fullPath, anEnum.sourceInformation)))))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(this.context.resolveType(anEnum.fullPath, anEnum.sourceInformation)));
+                ._values(Lists.immutable.with(this.context.resolveType(anEnum.fullPath, anEnum.sourceInformation)));
     }
 
     @Override
     public ValueSpecification visit(EnumValue enumValue)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(enumValue.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(enumValue.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                         ._rawType(this.context.resolveEnumeration(enumValue.fullPath, enumValue.sourceInformation)))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(this.context.resolveEnumValue(enumValue.fullPath, enumValue.value, enumValue.sourceInformation, enumValue.sourceInformation)));
+                ._values(Lists.immutable.with(this.context.resolveEnumValue(enumValue.fullPath, enumValue.value, enumValue.sourceInformation, enumValue.sourceInformation)));
     }
 
     public ValueSpecification processClassInstance(RuntimeInstance runtimeInstance)
     {
         Root_meta_core_runtime_Runtime _runtime = HelperRuntimeBuilder.buildPureRuntime(runtimeInstance.runtime, this.context);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(runtimeInstance.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::core::runtime::Runtime")))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(runtimeInstance.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType("meta::core::runtime::Runtime")))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(_runtime));
+                ._values(Lists.immutable.with(_runtime));
     }
 
 
@@ -237,51 +301,91 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         switch (iv.type)
         {
             case "path":
+            {
                 return processClassInstance((Path) iv.value);
+            }
             case "rootGraphFetchTree":
+            {
                 return processClassInstance((RootGraphFetchTree) iv.value);
+            }
             case ">":
+            {
                 return processRelationStoreAccessor((RelationStoreAccessor) iv.value);
+            }
             case "colSpec":
+            {
                 return proccessColSpec((ColSpec) iv.value);
+            }
             case "colSpecArray":
+            {
                 return proccessColSpecArray((ColSpecArray) iv.value);
+            }
             case "propertyGraphFetchTree":
+            {
                 return processClassInstance((PropertyGraphFetchTree) iv.value);
+            }
             case "keyExpression":
+            {
                 return visit((KeyExpression) iv.value);
+            }
             case "primitiveType":
+            {
                 return visit((PrimitiveType) iv.value);
+            }
             case "listInstance":
+            {
                 return processClassInstance((PureList) iv.value);
+            }
             case "aggregateValue":
+            {
                 return processClassInstance((AggregateValue) iv.value);
+            }
             case "pair":
+            {
                 return processClassInstance((Pair) iv.value);
+            }
             case "runtimeInstance":
+            {
                 return processClassInstance((RuntimeInstance) iv.value);
+            }
             case "executionContextInstance":
+            {
                 return processClassInstance((ExecutionContextInstance) iv.value);
+            }
             case "alloySerializationConfig":
+            {
                 return processClassInstance((SerializationConfig) iv.value);
+            }
             case "tdsAggregateValue":
+            {
                 return processClassInstance((TDSAggregateValue) iv.value);
+            }
             case "tdsColumnInformation":
+            {
                 return processClassInstance((TDSColumnInformation) iv.value);
+            }
             case "tdsSortInformation":
+            {
                 return processClassInstance((TDSSortInformation) iv.value);
+            }
             case "tdsOlapRank":
+            {
                 return processClassInstance((TdsOlapRank) iv.value);
+            }
             case "tdsOlapAggregation":
+            {
                 return processClassInstance((TdsOlapAggregation) iv.value);
+            }
             default:
+            {
                 throw new RuntimeException("/* Unsupported instance value " + iv.type + " */");
+            }
         }
     }
 
     private ValueSpecification proccessColSpecArray(ColSpecArray value)
     {
-        ProcessorSupport processorSupport = context.pureModel.getExecutionSupport().getProcessorSupport();
+        ProcessorSupport processorSupport = this.context.pureModel.getExecutionSupport().getProcessorSupport();
 
         MutableList<ValueSpecification> cols = ListIterate.collect(value.colSpecs, this::proccessColSpec);
         RichIterable<?> processedValues = cols.flatCollect(v -> ((InstanceValue) v)._values());
@@ -293,7 +397,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
                         "meta::pure::metamodel::relation::AggColSpecArray" :
                         "meta::pure::metamodel::relation::FuncColSpecArray";
 
-        GenericType inferredType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+        GenericType inferredType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                 ._rawType(
                         _RelationType.build(
                                 cols.collect(c ->
@@ -319,7 +423,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         {
             colSpecGT = buildColArrayGenType(className,
                     Lists.mutable.with(
-                            MostCommonType.mostCommon(processedValues.collect(x -> ((FuncColSpec<?, ?>) x)._function()._classifierGenericType()).toList(), context.pureModel)._typeArguments().getFirst(),
+                            MostCommonType.mostCommon(processedValues.collect(x -> ((FuncColSpec<?, ?>) x)._function()._classifierGenericType()).toList(), this.context.pureModel)._typeArguments().getFirst(),
                             inferredType
                     )
             );
@@ -331,8 +435,8 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         {
             colSpecGT = buildColArrayGenType(className,
                     Lists.mutable.with(
-                            MostCommonType.mostCommon(processedValues.collect(x -> ((AggColSpec<?, ?, ?>) x)._map()._classifierGenericType()).toList(), context.pureModel)._typeArguments().getFirst(),
-                            MostCommonType.mostCommon(processedValues.collect(x -> ((AggColSpec<?, ?, ?>) x)._reduce()._classifierGenericType()).toList(), context.pureModel)._typeArguments().getFirst(),
+                            MostCommonType.mostCommon(processedValues.collect(x -> ((AggColSpec<?, ?, ?>) x)._map()._classifierGenericType()).toList(), this.context.pureModel)._typeArguments().getFirst(),
+                            MostCommonType.mostCommon(processedValues.collect(x -> ((AggColSpec<?, ?, ?>) x)._reduce()._classifierGenericType()).toList(), this.context.pureModel)._typeArguments().getFirst(),
                             inferredType
                     )
             );
@@ -345,7 +449,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
             throw new RuntimeException("Not Possible: " + resO.getClass());
         }
 
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._multiplicity(context.pureModel.getMultiplicity("one"))
                 ._genericType(colSpecGT)
                 ._values(Lists.mutable.with(
@@ -356,34 +460,34 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
 
     private GenericType buildColArrayGenType(String className, MutableList<GenericType> args)
     {
-        return new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+        return new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                 ._rawType(context.pureModel.getClass(className))
                 ._typeArguments(args);
     }
 
     private ValueSpecification proccessColSpec(ColSpec colSpec)
     {
-        ProcessorSupport processorSupport = context.pureModel.getExecutionSupport().getProcessorSupport();
+        ProcessorSupport processorSupport = this.context.pureModel.getExecutionSupport().getProcessorSupport();
         if (colSpec.function1 == null)
         {
-            return wrapInstanceValue(buildColSpec(colSpec.name, colSpec.type == null ? null : context.pureModel.getGenericType(colSpec.type, colSpec.sourceInformation), (Multiplicity) org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.newMultiplicity(0, 1, processorSupport), context.pureModel, context.pureModel.getExecutionSupport().getProcessorSupport()), context.pureModel);
+            return Handlers.wrapInstanceValue(Handlers.buildColSpec(colSpec.name, colSpec.type == null ? null : this.context.pureModel.getGenericType(colSpec.type, colSpec.sourceInformation), (Multiplicity) org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.newMultiplicity(0, 1, processorSupport), this.context.pureModel, this.context.pureModel.getExecutionSupport().getProcessorSupport()), this.context.pureModel);
         }
         else if (colSpec.function2 == null)
         {
             InstanceValue funcVS = (InstanceValue) colSpec.function1.accept(new ValueSpecificationBuilder(context, openVariables, processingContext));
             org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?> func = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?>) funcVS._values().getFirst();
 
-            FunctionType func1Type = (FunctionType) org.finos.legend.pure.m3.navigation.function.Function.computeFunctionType(func, context.pureModel.getExecutionSupport().getProcessorSupport());
+            FunctionType func1Type = (FunctionType) org.finos.legend.pure.m3.navigation.function.Function.computeFunctionType(func, this.context.pureModel.getExecutionSupport().getProcessorSupport());
 
-            GenericType colSpecGT = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass(M3Paths.GenericType))
+            GenericType colSpecGT = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                     ._rawType(context.pureModel.getClass("meta::pure::metamodel::relation::FuncColSpec"))
                     ._typeArguments(
-                            Lists.mutable.with(
-                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass(M3Paths.GenericType))._rawType(func1Type),
-                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass(M3Paths.GenericType))
+                            Lists.immutable.with(
+                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(func1Type),
+                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                                             ._rawType(
                                                     _RelationType.build(
-                                                            Lists.mutable.with(_Column.getColumnInstance(colSpec.name, false, funcReturnType(funcVS, context.pureModel), funcReturnMul(funcVS, context.pureModel), null, processorSupport)),
+                                                            Lists.immutable.with(_Column.getColumnInstance(colSpec.name, false, Handlers.funcReturnType(funcVS, this.context.pureModel), Handlers.funcReturnMul(funcVS, this.context.pureModel), null, processorSupport)),
                                                             null,
                                                             processorSupport
                                                     )
@@ -391,11 +495,11 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
                             )
                     );
 
-            return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+            return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, this.context.pureModel.getClass(M3Paths.InstanceValue))
                     ._multiplicity(context.pureModel.getMultiplicity("one"))
                     ._genericType(colSpecGT)
-                    ._values(Lists.mutable.with(
-                                    new Root_meta_pure_metamodel_relation_FuncColSpec_Impl<>("", null, context.pureModel.getClass("meta::pure::metamodel::relation::FuncColSpec"))
+                    ._values(Lists.immutable.with(
+                                    new Root_meta_pure_metamodel_relation_FuncColSpec_Impl<>("", null, this.context.pureModel.getClass("meta::pure::metamodel::relation::FuncColSpec"))
                                             ._classifierGenericType(colSpecGT)
                                             ._name(colSpec.name)
                                             ._function(func)
@@ -410,19 +514,19 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
             InstanceValue func2VS = (InstanceValue) colSpec.function2.accept(new ValueSpecificationBuilder(context, openVariables, processingContext));
             org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?> func2 = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?>) func2VS._values().getFirst();
 
-            FunctionType func1Type = (FunctionType) org.finos.legend.pure.m3.navigation.function.Function.computeFunctionType(func1, context.pureModel.getExecutionSupport().getProcessorSupport());
-            FunctionType func2Type = (FunctionType) org.finos.legend.pure.m3.navigation.function.Function.computeFunctionType(func2, context.pureModel.getExecutionSupport().getProcessorSupport());
+            FunctionType func1Type = (FunctionType) org.finos.legend.pure.m3.navigation.function.Function.computeFunctionType(func1, this.context.pureModel.getExecutionSupport().getProcessorSupport());
+            FunctionType func2Type = (FunctionType) org.finos.legend.pure.m3.navigation.function.Function.computeFunctionType(func2, this.context.pureModel.getExecutionSupport().getProcessorSupport());
 
-            GenericType aggColSpecGT = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+            GenericType aggColSpecGT = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                     ._rawType(context.pureModel.getClass("meta::pure::metamodel::relation::AggColSpec"))
                     ._typeArguments(
-                            Lists.mutable.with(
-                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(func1Type),
-                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(func2Type),
-                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+                            Lists.immutable.with(
+                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(func1Type),
+                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(func2Type),
+                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                                             ._rawType(
                                                     _RelationType.build(
-                                                            Lists.mutable.with(_Column.getColumnInstance(colSpec.name, false, funcReturnType(func2VS, context.pureModel), funcReturnMul(func2VS, context.pureModel), null, processorSupport)),
+                                                            Lists.immutable.with(_Column.getColumnInstance(colSpec.name, false, Handlers.funcReturnType(func2VS, this.context.pureModel), Handlers.funcReturnMul(func2VS, this.context.pureModel), null, processorSupport)),
                                                             null,
                                                             processorSupport
                                                     )
@@ -430,11 +534,11 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
                             )
                     );
 
-            return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+            return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, this.context.pureModel.getClass(M3Paths.InstanceValue))
                     ._multiplicity(context.pureModel.getMultiplicity("one"))
                     ._genericType(aggColSpecGT)
-                    ._values(Lists.mutable.with(
-                                    new Root_meta_pure_metamodel_relation_AggColSpec_Impl<>("", null, context.pureModel.getClass("meta::pure::metamodel::relation::AggColSpec"))
+                    ._values(Lists.immutable.with(
+                                    new Root_meta_pure_metamodel_relation_AggColSpec_Impl<>("", null, this.context.pureModel.getClass("meta::pure::metamodel::relation::AggColSpec"))
                                             ._classifierGenericType(aggColSpecGT)
                                             ._name(colSpec.name)
                                             ._map(func1)
@@ -447,12 +551,12 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     private ValueSpecification processRelationStoreAccessor(RelationStoreAccessor value)
     {
         String element = value.path.get(0);
-        Store store = context.pureModel.getStore(element, value.sourceInformation);
+        Store store = this.context.pureModel.getStore(element, value.sourceInformation);
         return this.context.getCompilerExtensions().getExtraRelationStoreAccessorProcessors().stream()
                 .map(processor -> processor.value(value, store, this.context, this.processingContext))
                 .filter(Objects::nonNull)
                 .findFirst()
-                .orElseThrow(() -> new UnsupportedOperationException("Unsupported store '" + value.path.get(0) + " (type:" + store._classifierGenericType()._rawType().getName() + ")' for RelationStoreAccessor '" + Lists.mutable.withAll(value.path).makeString(".") + "'"));
+                .orElseThrow(() -> new UnsupportedOperationException("Unsupported store '" + value.path.get(0) + "' (type:" + store._classifierGenericType()._rawType().getName() + ") for RelationStoreAccessor '" + Iterate.makeString(value.path, ".") + "'"));
     }
 
     public ValueSpecification processClassInstance(Path path)
@@ -461,7 +565,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         TypeAndList res = ListIterate.injectInto(new TypeAndList(cl), path.path, (a, b) ->
                 {
                     AbstractProperty<?> property = HelperModelBuilder.getAppliedProperty(this.context, (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?>) a.currentClass, Optional.empty(), ((PropertyPathElement) b).property);
-                    GenericType genericType = Root_meta_pure_functions_meta_functionReturnType_Function_1__GenericType_1_(property, this.context.pureModel.getExecutionSupport());
+                    GenericType genericType = core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_functionReturnType_Function_1__GenericType_1_(property, this.context.pureModel.getExecutionSupport());
                     MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.PathElement> result = a.result;
                     org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.PropertyPathElement ppe = new Root_meta_pure_metamodel_path_PropertyPathElement_Impl("", SourceInformationHelper.toM3SourceInformation(b.sourceInformation), null);
                     RichIterable<ValueSpecification> params = ListIterate.collect(((PropertyPathElement) b).parameters, p -> p.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)));
@@ -472,17 +576,17 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
 
         // Should be the max of all the properties multiplicities!!!
         Multiplicity mul = ((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.PropertyPathElement) res.result.getLast())._property()._multiplicity();
-        GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+        GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                 ._rawType(this.context.pureModel.getType("meta::pure::metamodel::path::Path"))
-                ._typeArguments(FastList.newListWith(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(cl),
-                        new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(res.currentClass)))
-                ._multiplicityArguments(FastList.newListWith(mul));
+                ._typeArguments(Lists.immutable.with(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(cl),
+                        new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(res.currentClass)))
+                ._multiplicityArguments(Lists.immutable.with(mul));
 
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(path.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(path.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(genericType)
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
                 ._values(
-                        FastList.newListWith(
+                        Lists.immutable.with(
                                 new Root_meta_pure_metamodel_path_Path_Impl<>("", SourceInformationHelper.toM3SourceInformation(path.sourceInformation), null)
                                         ._classifierGenericType(genericType)
                                         ._start(this.context.resolveGenericType(path.startType, path.sourceInformation))
@@ -513,33 +617,33 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     @Override
     public ValueSpecification visit(CInteger cInteger)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cInteger.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cInteger.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("Integer"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cInteger.multiplicity))
-                ._values(FastList.newListWith(cInteger.value));
+                ._values(Lists.immutable.with(cInteger.value));
     }
 
     @Override
     public ValueSpecification visit(CDecimal cDecimal)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cDecimal.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cDecimal.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("Decimal"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cDecimal.multiplicity))
-                ._values(FastList.newListWith(cDecimal.value));
+                ._values(Lists.immutable.with(cDecimal.value));
     }
 
     @Override
     public ValueSpecification visit(CByteArray cByteArray)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cByteArray.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cByteArray.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("Byte"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("zeroMany"))
-                ._values(FastList.newListWith(new ByteArrayInputStream(cByteArray.value)));
+                ._values(Lists.immutable.with(new ByteArrayInputStream(cByteArray.value)));
     }
 
     public ValueSpecification processClassInstance(SerializationConfig serializationConfig)
     {
-        Root_meta_pure_graphFetch_execution_AlloySerializationConfig config = new Root_meta_pure_graphFetch_execution_AlloySerializationConfig_Impl("", SourceInformationHelper.toM3SourceInformation(serializationConfig.sourceInformation), context.pureModel.getClass("meta::pure::graphFetch::execution::AlloySerializationConfig"));
+        Root_meta_pure_graphFetch_execution_AlloySerializationConfig config = new Root_meta_pure_graphFetch_execution_AlloySerializationConfig_Impl("", SourceInformationHelper.toM3SourceInformation(serializationConfig.sourceInformation), this.context.pureModel.getClass("meta::pure::graphFetch::execution::AlloySerializationConfig"));
         config._includeType(serializationConfig.includeType);
         config._typeKeyName(serializationConfig.typeKeyName);
         config._includeEnumType(serializationConfig.includeEnumType);
@@ -548,17 +652,17 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         config._removePropertiesWithEmptySets(serializationConfig.removePropertiesWithEmptySets);
         config._fullyQualifiedTypePath(serializationConfig.fullyQualifiedTypePath);
         config._includeObjectReference(serializationConfig.includeObjectReference);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(serializationConfig.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(serializationConfig.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::graphFetch::execution::AlloySerializationConfig"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(Lists.mutable.of(config));
+                ._values(Lists.immutable.of(config));
     }
 
     @Override
     public ValueSpecification visit(Lambda glambda)
     {
-        LambdaFunction lambda = HelperValueSpecificationBuilder.buildLambdaWithContext(glambda.body, glambda.parameters, this.context, processingContext);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(glambda.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        LambdaFunction<?> lambda = HelperValueSpecificationBuilder.buildLambdaWithContext(glambda.body, glambda.parameters, this.context, processingContext);
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(glambda.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(lambda._classifierGenericType())
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
                 ._values(Lists.fixedSize.of(lambda));
@@ -567,32 +671,32 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     public ValueSpecification processClassInstance(ExecutionContextInstance executionContextInstance)
     {
         Root_meta_pure_runtime_ExecutionContext _executionContext = HelperValueSpecificationBuilder.processExecutionContext(executionContextInstance.executionContext, this.context);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(executionContextInstance.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::runtime::ExecutionContext")))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(executionContextInstance.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType("meta::pure::runtime::ExecutionContext")))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(_executionContext));
+                ._values(Lists.immutable.with(_executionContext));
     }
 
     public ValueSpecification processClassInstance(Pair pair)
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification f = pair.first.accept(new ValueSpecificationBuilder(this.context, Lists.mutable.empty(), processingContext));
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification s = pair.second.accept(new ValueSpecificationBuilder(this.context, Lists.mutable.empty(), processingContext));
-        GenericType gt = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::functions::collection::Pair"))
-                ._typeArguments(FastList.newListWith(f._genericType(), s._genericType()));
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(pair.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        GenericType gt = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType(M3Paths.Pair))
+                ._typeArguments(Lists.immutable.with(f._genericType(), s._genericType()));
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(pair.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(gt)
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(
-                        new Root_meta_pure_functions_collection_Pair_Impl("", SourceInformationHelper.toM3SourceInformation(pair.sourceInformation), context.pureModel.getClass("meta::pure::functions::collection::Pair"))
+                ._values(Lists.immutable.with(
+                        new Root_meta_pure_functions_collection_Pair_Impl<>("", SourceInformationHelper.toM3SourceInformation(pair.sourceInformation), this.context.pureModel.getClass(M3Paths.Pair))
                                 ._classifierGenericType(gt)
-                                ._first(((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue) f)._values().getFirst())
-                                ._second(((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue) s)._values().getFirst())));
+                                ._first(((InstanceValue) f)._values().getFirst())
+                                ._second(((InstanceValue) s)._values().getFirst())));
     }
 
     public ValueSpecification processClassInstance(PureList pureList)
     {
         return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl(" ", SourceInformationHelper.toM3SourceInformation(pureList.sourceInformation), null)
-                ._genericType(this.context.pureModel.getGenericType("meta::pure::functions::collection::List"))
+                ._genericType(this.context.pureModel.getGenericType(M3Paths.List))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
                 ._values(ListIterate.collect(pureList.values, v -> v.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext))));
     }
@@ -603,16 +707,16 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         openVariables.add(variable.name);
         if ((variable._class != null || variable.relationType != null) && variable.multiplicity != null)
         {
-            VariableExpression ve = new Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl("", SourceInformationHelper.toM3SourceInformation(variable.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::VariableExpression"))
+            VariableExpression ve = new Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl("", SourceInformationHelper.toM3SourceInformation(variable.sourceInformation), this.context.pureModel.getClass(M3Paths.VariableExpression))
                     ._name(variable.name);
             GenericType genericType =
                     // Bad Hack to compensate the fact that 'generics' are not supported in the type system ...
                     variable.relationType != null && variable._class != null ?
-                            new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+                            new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                                     ._rawType(context.pureModel.getClass(variable._class.path))
-                                    ._typeArguments(Lists.mutable.with(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(RelationTypeHelper.convert(variable.relationType, context.pureModel.getExecutionSupport().getProcessorSupport(), null)))) :
+                                    ._typeArguments(Lists.immutable.with(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(RelationTypeHelper.convert(variable.relationType, this.context.pureModel.getExecutionSupport().getProcessorSupport(), null)))) :
                             variable.relationType != null ?
-                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(RelationTypeHelper.convert(variable.relationType, context.pureModel.getExecutionSupport().getProcessorSupport(), null)) :
+                                    new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(RelationTypeHelper.convert(variable.relationType, this.context.pureModel.getExecutionSupport().getProcessorSupport(), null)) :
                                     this.context.resolveGenericType(this.context.pureModel.addPrefixToTypeReference(variable._class.path), variable.sourceInformation);
             ve._genericType(genericType);
             ve._multiplicity(this.context.pureModel.getMultiplicity(variable.multiplicity));
@@ -633,19 +737,19 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     @Override
     public ValueSpecification visit(CFloat cFloat)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cFloat.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(cFloat.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("Float"))
                 ._multiplicity(this.context.pureModel.getMultiplicity(cFloat.multiplicity))
-                ._values(FastList.newListWith(cFloat.value));
+                ._values(Lists.immutable.with(cFloat.value));
     }
 
     @Override
     public ValueSpecification visit(MappingInstance mappingInstance)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(mappingInstance.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::mapping::Mapping")))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(mappingInstance.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType("meta::pure::mapping::Mapping")))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(this.context.resolveMapping(mappingInstance.fullPath, mappingInstance.sourceInformation)));
+                ._values(Lists.immutable.with(this.context.resolveMapping(mappingInstance.fullPath, mappingInstance.sourceInformation)));
     }
 
     @Override
@@ -656,37 +760,33 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         {
             return proccessColSpecArray((ColSpecArray) ((ClassInstance) genericTypeInstance.typeArguments.get(0)).value);
         }
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.resolveType(genericTypeInstance.fullPath, genericTypeInstance.sourceInformation)))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.resolveType(genericTypeInstance.fullPath, genericTypeInstance.sourceInformation)))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"));
     }
 
     @Override
     public ValueSpecification visit(Collection collection)
     {
-        MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification> transformed = ListIterate.collect(collection.values, new Function<org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification, ValueSpecification>()
+        MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification> transformed = ListIterate.collect(collection.values, expression ->
         {
-            @Override
-            public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification valueOf(org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification expression)
+            ValueSpecification res = expression.accept(new ValueSpecificationBuilder(context, openVariables, processingContext));
+            if (res._multiplicity()._lowerBound()._value() != 1 || res._multiplicity()._upperBound()._value() == null || res._multiplicity()._upperBound()._value() != 1)
             {
-                org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification res = expression.accept(new ValueSpecificationBuilder(context, openVariables, processingContext));
-                if (res._multiplicity()._lowerBound()._value() != 1 || res._multiplicity()._upperBound()._value() == null || res._multiplicity()._upperBound()._value() != 1)
-                {
-                    throw new EngineException("Collection element must have a multiplicity [1] - Context:" + processingContext.getStack() + ", multiplicity:" + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(res._multiplicity()), expression.sourceInformation, EngineErrorType.COMPILATION);
-                }
-                return res;
+                throw new EngineException("Collection element must have a multiplicity [1] - Context:" + processingContext.getStack() + ", multiplicity:" + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(res._multiplicity()), expression.sourceInformation, EngineErrorType.COMPILATION);
             }
+            return res;
         });
         GenericType _genericType = collection.values.isEmpty()
                 ? this.context.pureModel.getGenericType(M3Paths.Nil)
                 : MostCommonType.mostCommon(transformed.collect(ValueSpecificationAccessor::_genericType).distinct(), this.context.pureModel);
         _genericType._classifierGenericType(this.context.pureModel.getGenericType(M3Paths.GenericType));
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(_genericType)
                 ._multiplicity(this.context.pureModel.getMultiplicity(collection.multiplicity))
                 ._values(transformed.collect(valueSpecification ->
                         {
-                            if (valueSpecification instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue && ((InstanceValue) valueSpecification)._values().size() == 1)
+                            if (valueSpecification instanceof InstanceValue && ((InstanceValue) valueSpecification)._values().size() == 1)
                             {
                                 return ((InstanceValue) valueSpecification)._values().getFirst();
                             }
@@ -704,7 +804,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
         {
             MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification> vs = ListIterate.collect(appliedFunction.parameters, expression -> expression.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)));
             String letName = ((CString) appliedFunction.parameters.get(0)).value;
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification ve = new Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl("", SourceInformationHelper.toM3SourceInformation(appliedFunction.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::VariableExpression"))._name(letName);
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification ve = new Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl("", SourceInformationHelper.toM3SourceInformation(appliedFunction.sourceInformation), this.context.pureModel.getClass(M3Paths.VariableExpression))._name(letName);
             ve._genericType(vs.get(1)._genericType());
             ve._multiplicity(vs.get(1)._multiplicity());
             processingContext.addInferredVariables(letName, ve);
@@ -730,23 +830,23 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     public ValueSpecification processClassInstance(PropertyGraphFetchTree propertyGraphFetchTree)
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.graphFetch.GraphFetchTree tree = HelperValueSpecificationBuilder.buildGraphFetchTree(propertyGraphFetchTree, this.context, null, openVariables, processingContext);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(propertyGraphFetchTree.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::graphFetch::PropertyGraphFetchTree")))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(propertyGraphFetchTree.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType("meta::pure::graphFetch::PropertyGraphFetchTree")))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(tree));
+                ._values(Lists.immutable.with(tree));
     }
 
     public ValueSpecification processClassInstance(RootGraphFetchTree rootGraphFetchTree)
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.graphFetch.GraphFetchTree tree = HelperValueSpecificationBuilder.buildGraphFetchTree(rootGraphFetchTree, this.context, null, openVariables, processingContext);
-        GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+        GenericType genericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                 ._rawType(this.context.pureModel.getType("meta::pure::graphFetch::RootGraphFetchTree"))
-                ._typeArguments(FastList.newListWith(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))
+                ._typeArguments(Lists.immutable.with(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))
                         ._rawType(context.resolveClass(rootGraphFetchTree._class, rootGraphFetchTree.sourceInformation))));
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(rootGraphFetchTree.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(rootGraphFetchTree.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(genericType)
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(tree));
+                ._values(Lists.immutable.with(tree));
     }
 
     @Override
@@ -757,83 +857,76 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
 
     public ValueSpecification processClassInstance(TdsOlapAggregation tdsOlapAggregation)
     {
-        LambdaFunction lambda = HelperValueSpecificationBuilder.buildLambdaWithContext(tdsOlapAggregation.function, this.context, processingContext);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsOlapAggregation.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        LambdaFunction<?> lambda = HelperValueSpecificationBuilder.buildLambdaWithContext(tdsOlapAggregation.function, this.context, processingContext);
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsOlapAggregation.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::tds::TdsOlapAggregation"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(Lists.mutable.of(new Root_meta_pure_tds_TdsOlapAggregation_Impl<>("")._func(lambda)._colName(tdsOlapAggregation.columnName)));
+                ._values(Lists.immutable.of(new Root_meta_pure_tds_TdsOlapAggregation_Impl<>("")._func(lambda)._colName(tdsOlapAggregation.columnName)));
     }
 
     public ValueSpecification processClassInstance(TDSAggregateValue tdsAggregateValue)
     {
-        LambdaFunction l = (LambdaFunction) ((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue) tdsAggregateValue.mapFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
-        LambdaFunction o = (LambdaFunction) ((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue) tdsAggregateValue.aggregateFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsAggregateValue.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        LambdaFunction<?> l = (LambdaFunction<?>) ((InstanceValue) tdsAggregateValue.mapFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
+        LambdaFunction<?> o = (LambdaFunction<?>) ((InstanceValue) tdsAggregateValue.aggregateFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsAggregateValue.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::tds::AggregateValue"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(Lists.mutable.of(new Root_meta_pure_tds_AggregateValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsAggregateValue.sourceInformation), context.pureModel.getClass("meta::pure::tds::AggregateValue"))._name(tdsAggregateValue.name)._mapFn(l)._aggregateFn(o)));
+                ._values(Lists.immutable.of(new Root_meta_pure_tds_AggregateValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsAggregateValue.sourceInformation), this.context.pureModel.getClass("meta::pure::tds::AggregateValue"))._name(tdsAggregateValue.name)._mapFn(l)._aggregateFn(o)));
     }
 
     public ValueSpecification processClassInstance(TDSSortInformation tdsSortInformation)
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum dirEnum = this.context.pureModel.getEnumValue("meta::pure::tds::SortDirection", tdsSortInformation.direction);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsSortInformation.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsSortInformation.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::tds::SortInformation"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(Lists.mutable.of(new Root_meta_pure_tds_SortInformation_Impl("", SourceInformationHelper.toM3SourceInformation(tdsSortInformation.sourceInformation), context.pureModel.getClass("meta::pure::tds::SortInformation"))._column(tdsSortInformation.column)._direction(dirEnum)));
+                ._values(Lists.immutable.of(new Root_meta_pure_tds_SortInformation_Impl("", SourceInformationHelper.toM3SourceInformation(tdsSortInformation.sourceInformation), this.context.pureModel.getClass("meta::pure::tds::SortInformation"))._column(tdsSortInformation.column)._direction(dirEnum)));
     }
 
     public ValueSpecification processClassInstance(TDSColumnInformation tdsColumnInformation)
     {
-        LambdaFunction l = (LambdaFunction) ((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue) tdsColumnInformation.columnFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsColumnInformation.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        LambdaFunction<?> l = (LambdaFunction<?>) ((InstanceValue) tdsColumnInformation.columnFn.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext)))._values().getFirst();
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsColumnInformation.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::tds::BasicColumnSpecification"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(Lists.mutable.of(new Root_meta_pure_tds_BasicColumnSpecification_Impl("", SourceInformationHelper.toM3SourceInformation(tdsColumnInformation.sourceInformation), context.pureModel.getClass("meta::pure::tds::BasicColumnSpecification"))._name(tdsColumnInformation.name)._func(l)));
+                ._values(Lists.immutable.of(new Root_meta_pure_tds_BasicColumnSpecification_Impl("", SourceInformationHelper.toM3SourceInformation(tdsColumnInformation.sourceInformation), this.context.pureModel.getClass("meta::pure::tds::BasicColumnSpecification"))._name(tdsColumnInformation.name)._func(l)));
     }
 
     public ValueSpecification processClassInstance(TdsOlapRank tdsOlapRank)
     {
-        LambdaFunction lambda = HelperValueSpecificationBuilder.buildLambdaWithContext(tdsOlapRank.function, this.context, processingContext);
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsOlapRank.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        LambdaFunction<?> lambda = HelperValueSpecificationBuilder.buildLambdaWithContext(tdsOlapRank.function, this.context, processingContext);
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(tdsOlapRank.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.pureModel.getGenericType("meta::pure::tds::TdsOlapRank"))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(Lists.mutable.of(new Root_meta_pure_tds_TdsOlapRank_Impl("", SourceInformationHelper.toM3SourceInformation(tdsOlapRank.sourceInformation), context.pureModel.getClass("meta::pure::tds::TdsOlapRank"))._func(lambda)));
+                ._values(Lists.immutable.of(new Root_meta_pure_tds_TdsOlapRank_Impl("", SourceInformationHelper.toM3SourceInformation(tdsOlapRank.sourceInformation), this.context.pureModel.getClass("meta::pure::tds::TdsOlapRank"))._func(lambda)));
     }
 
     @Override
     public ValueSpecification visit(HackedUnit hackedUnit)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(hackedUnit.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(hackedUnit.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.resolveGenericType(hackedUnit.fullPath, hackedUnit.sourceInformation))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newList());
+                ._values(Lists.immutable.empty());
     }
 
     @Override
     public ValueSpecification visit(UnitInstance unitInstance)
     {
-        FastList<Long> values = FastList.newList();
-        if (unitInstance.unitValue != null)
-        {
-            values.add(unitInstance.unitValue);
-        }
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(unitInstance.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(unitInstance.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(this.context.resolveGenericType(unitInstance.unitType, unitInstance.sourceInformation))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(values);
+                ._values((unitInstance.unitValue == null) ? Lists.immutable.empty() : Lists.immutable.with(unitInstance.unitValue));
     }
 
     @Override
     public ValueSpecification visit(UnitType unitType)
     {
-        FastList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit> values = FastList.newList();
-        values.add((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit) this.context.resolveType(unitType.fullPath, unitType.sourceInformation));
-        GenericType unitGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::metamodel::type::Unit"));
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(unitType.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        GenericType unitGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType(M3Paths.Unit));
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(unitType.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(unitGenericType)
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(values);
+                ._values(Lists.immutable.with((Unit) this.context.resolveType(unitType.fullPath, unitType.sourceInformation)));
     }
 
     @Override
@@ -841,22 +934,20 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<org.
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification key = keyExpression.key.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext));
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification expression = keyExpression.expression.accept(new ValueSpecificationBuilder(this.context, openVariables, processingContext));
-        FastList<org.finos.legend.pure.m3.coreinstance.meta.pure.functions.lang.KeyExpression> values = FastList.newList();
-        values.add(new Root_meta_pure_functions_lang_KeyExpression_Impl("", SourceInformationHelper.toM3SourceInformation(keyExpression.sourceInformation), context.pureModel.getClass("meta::pure::functions::lang::KeyExpression"))._add(keyExpression.add)._key((InstanceValue) key)._expression(expression));
-        GenericType keyExpressionGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::functions::lang::KeyExpression"));
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(keyExpression.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
+        GenericType keyExpressionGenericType = new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType(M3Paths.KeyExpression));
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(keyExpression.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(keyExpressionGenericType)
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(values);
+                ._values(Lists.immutable.with(new Root_meta_pure_functions_lang_KeyExpression_Impl("", SourceInformationHelper.toM3SourceInformation(keyExpression.sourceInformation), this.context.pureModel.getClass(M3Paths.KeyExpression))._add(keyExpression.add)._key((InstanceValue) key)._expression(expression)));
     }
 
     @Override
     public ValueSpecification visit(PrimitiveType primitiveType)
     {
-        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(primitiveType.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::valuespecification::InstanceValue"))
-                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(this.context.pureModel.getType("meta::pure::metamodel::type::PrimitiveType")))
+        return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", SourceInformationHelper.toM3SourceInformation(primitiveType.sourceInformation), this.context.pureModel.getClass(M3Paths.InstanceValue))
+                ._genericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, this.context.pureModel.getClass(M3Paths.GenericType))._rawType(this.context.pureModel.getType(M3Paths.PrimitiveType)))
                 ._multiplicity(this.context.pureModel.getMultiplicity("one"))
-                ._values(FastList.newListWith(new Root_meta_pure_metamodel_type_PrimitiveType_Impl("", SourceInformationHelper.toM3SourceInformation(primitiveType.sourceInformation), context.pureModel.getClass("meta::pure::metamodel::type::PrimitiveType"))
+                ._values(Lists.immutable.with(new Root_meta_pure_metamodel_type_PrimitiveType_Impl("", SourceInformationHelper.toM3SourceInformation(primitiveType.sourceInformation), this.context.pureModel.getClass(M3Paths.PrimitiveType))
                         ._name(primitiveType.fullPath)));
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtensions.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtensions.java
@@ -95,7 +95,6 @@ public class CompilerExtensions
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Function.class,
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Measure.class,
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Profile.class,
-            org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Unit.class,
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.PackageableRuntime.class,
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.SectionIndex.class,
             org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store.class

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestCompilationFromGrammar.java
@@ -15,11 +15,6 @@
 package org.finos.legend.engine.language.pure.compiler.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.tuple.Pair;
@@ -35,12 +30,16 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.*;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TestCompilationFromGrammar
 {
@@ -123,6 +122,10 @@ public class TestCompilationFromGrammar
                 MatcherAssert.assertThat(EngineException.buildPrettyErrorMessage(e.getMessage(), e.getSourceInformation(),
                         e.getErrorType()), CoreMatchers.startsWith(expectedErrorMsg));
                 return null;
+            }
+            catch (RuntimeException e)
+            {
+                throw e;
             }
             catch (Exception e)
             {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -15,34 +15,27 @@
 package org.finos.legend.engine.language.pure.compiler.test.fromGrammar;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.test.TestCompilationFromGrammar;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.Milestoning;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
-import org.finos.legend.pure.generated.Root_meta_pure_metamodel_function_property_Property_Impl;
-import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl;
-import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_FunctionType_Impl;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.SimpleFunctionExpression;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Arrays;
 
 public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite
 {
@@ -73,7 +66,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "###Pure\n" +
                 "Class anything::somethingelse\n" +
                 "{\n" +
-                "}\n", Arrays.asList("COMPILATION error at [5:1-7:1]: Duplicated element 'anything::somethingelse'"));
+                "}\n", Lists.fixedSize.with("COMPILATION error at [5:1-7:1]: Duplicated element 'anything::somethingelse'"));
     }
 
     @Test
@@ -125,9 +118,9 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         // Function
         test(initialGraph +
                 "###Pure\n" +
-                "function anything::somethingelse(a:String[1]):String[1]" +
-                "{" +
-                "   'hiiii'" +
+                "function anything::somethingelse(a:String[1]):String[1]\n" +
+                "{\n" +
+                "   'hiiii'\n" +
                 "}\n");
         // Measure
         test(initialGraph +
@@ -147,7 +140,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         String code =
                 "function example::testMaxInteger(input: Integer[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1,$input]->meta::pure::functions::math::max();" +
+                        "   [1,$input]->meta::pure::functions::math::max();\n" +
                         "}\n";
         test(code);
     }
@@ -158,7 +151,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         String code =
                 "function example::testMaxInteger(input: Integer[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1,$input]->max();" +
+                        "   [1,$input]->max();\n" +
                         "}\n";
         test(code);
     }
@@ -169,17 +162,17 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         String code =
                 "function example::testMaxInteger(input: Integer[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1,$input]->max();" +
+                        "   [1,$input]->max();\n" +
                         "}\n" +
                         "function example::testMaxInteger():Any[0..1]\n" +
                         "{\n" +
-                        "   [1,2]->max();" +
+                        "   [1,2]->max();\n" +
                         "}\n" + "###Pure\n" +
                         "import example::*;\n" +
                         "function example::test::go():Any[0..1]\n" +
                         "{\n" +
-                        "   testMaxInteger(1);" +
-                        "   testMaxInteger();" +
+                        "   testMaxInteger(1);\n" +
+                        "   testMaxInteger();\n" +
                         "}\n";
         test(code);
     }
@@ -190,30 +183,30 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         String code =
                 "function example::testMaxInteger(input: Integer[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1,$input]->max();" +
+                        "   [1,$input]->max();\n" +
                         "}\n" +
                         "function example::testMaxInteger(input: Number[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1,2]->max();" +
+                        "   [1,2]->max();\n" +
                         "}\n" +
                         "function example::testMaxInteger(f: Float[1], d: Float[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1, $f, $d]->max();" +
+                        "   [1, $f, $d]->max();\n" +
                         "}\n" +
                         "function example::testMaxInteger():Any[0..1]\n" +
                         "{\n" +
-                        "   [1,2]->max();" +
+                        "   [1,2]->max();\n" +
                         "}\n" +
                         "function example::test::testMaxInteger():Any[0..1]\n" +
                         "{\n" +
-                        "   [1,2]->max();" +
+                        "   [1,2]->max();\n" +
                         "}\n" +
                         "function example::test::go():Any[0..1]\n" +
                         "{\n" +
-                        "   example::testMaxInteger(1);" +
-                        "   example::testMaxInteger();" +
-                        "   example::test::testMaxInteger();" +
-                        "   example::testMaxInteger(1.0, 1.123);" +
+                        "   example::testMaxInteger(1);\n" +
+                        "   example::testMaxInteger();\n" +
+                        "   example::test::testMaxInteger();\n" +
+                        "   example::testMaxInteger(1.0, 1.123);\n" +
                         "}\n";
         test(code);
     }
@@ -224,13 +217,13 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         String code =
                 "function example::testMaxInteger(input: Integer[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1,$input]->max();" +
+                        "   [1,$input]->max();\n" +
                         "}\n" +
                         "function example::testMaxInteger(input: Integer[1]):Any[0..1]\n" +
                         "{\n" +
-                        "   [1,2]->max();" +
+                        "   [1,2]->max();\n" +
                         "}\n";
-        test(code, "COMPILATION error at [4:1-6:17]: Duplicated element 'example::testMaxInteger_Integer_1__Any_$0_1$_'");
+        test(code, "COMPILATION error at [5:1-8:1]: Duplicated element 'example::testMaxInteger_Integer_1__Any_$0_1$_'");
     }
 
     @Test
@@ -266,47 +259,47 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
-    public void testDuplicateProfileTagAndStereotypeWarning() throws Exception
+    public void testDuplicateProfileTagAndStereotypeWarning()
     {
-        Pair<PureModelContextData, PureModel> res = test("Profile test::A\n" +
+        test("Profile test::A\n" +
                 "{\n" +
                 "   tags : [doc, doc];\n" +
                 "   stereotypes : [modifier, modifier, accessorType, accessorType];\n" +
-                "}\n", null, Arrays.asList("COMPILATION error at [1:1-5:1]: Found duplicated stereotype 'accessorType' in profile 'test::A'", "COMPILATION error at [1:1-5:1]: Found duplicated stereotype 'modifier' in profile 'test::A'", "COMPILATION error at [1:1-5:1]: Found duplicated tag 'doc' in profile 'test::A'"));
+                "}\n", null, Lists.fixedSize.with("COMPILATION error at [1:1-5:1]: Found duplicated stereotype 'accessorType' in profile 'test::A'", "COMPILATION error at [1:1-5:1]: Found duplicated stereotype 'modifier' in profile 'test::A'", "COMPILATION error at [1:1-5:1]: Found duplicated tag 'doc' in profile 'test::A'"));
     }
 
     @Test
-    public void testDuplicateEnumValueWarning() throws Exception
+    public void testDuplicateEnumValueWarning()
     {
-        Pair<PureModelContextData, PureModel> res = test("Enum test::A\n" +
+        test("Enum test::A\n" +
                 "{\n" +
                 "   TEA,COFFEE,TEA,TEA,COFFEE\n" +
-                "}\n", null, Arrays.asList("COMPILATION error at [3:4-6]: Found duplicated value 'TEA' in enumeration 'test::A'", "COMPILATION error at [3:8-13]: Found duplicated value 'COFFEE' in enumeration 'test::A'"));
+                "}\n", null, Lists.fixedSize.with("COMPILATION error at [3:4-6]: Found duplicated value 'TEA' in enumeration 'test::A'", "COMPILATION error at [3:8-13]: Found duplicated value 'COFFEE' in enumeration 'test::A'"));
     }
 
     @Test
-    public void testDuplicateAssociationPropertyWarning() throws Exception
+    public void testDuplicateAssociationPropertyWarning()
     {
-        Pair<PureModelContextData, PureModel> res = test("Class test::A {}\n" +
+        test("Class test::A {}\n" +
                 "Class test::B {}\n" +
                 "Association test::C\n" +
                 "{\n" +
                 "   property1: test::A[0..1];\n" +
                 "   property1: test::B[1];\n" +
-                "}\n", null, Arrays.asList("COMPILATION error at [5:4-28]: Found duplicated property 'property1' in association 'test::C'"));
+                "}\n", null, Lists.fixedSize.with("COMPILATION error at [5:4-28]: Found duplicated property 'property1' in association 'test::C'"));
     }
 
     @Test
-    public void testDuplicateClassPropertyWarning() throws Exception
+    public void testDuplicateClassPropertyWarning()
     {
-        Pair<PureModelContextData, PureModel> res = test("Class test::A\n" +
+        test("Class test::A\n" +
                 "{\n" +
                 "   property : Integer[0..1];\n" +
                 "   property : String[1];\n" +
                 "   other : String[1];\n" +
                 "   ok : String[1];\n" +
                 "   other: String[1];\n" +
-                "}\n", null, Arrays.asList("COMPILATION error at [3:4-28]: Found duplicated property 'property' in class 'test::A'", "COMPILATION error at [5:4-21]: Found duplicated property 'other' in class 'test::A'"));
+                "}\n", null, Lists.fixedSize.with("COMPILATION error at [3:4-28]: Found duplicated property 'property' in class 'test::A'", "COMPILATION error at [5:4-21]: Found duplicated property 'other' in class 'test::A'"));
     }
 
     @Test
@@ -326,7 +319,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "   other : String[1];\n" +
                 "   ok : String[1];\n" +
                 "   other: String[1];\n" +
-                "}\n", null, Arrays.asList("COMPILATION error at [5:4-28]: Found duplicated property 'property1' in association 'test::C'", "COMPILATION error at [10:4-28]: Found duplicated property 'property' in class 'test::D'", "COMPILATION error at [12:4-21]: Found duplicated property 'other' in class 'test::D'"));
+                "}\n", null, Lists.fixedSize.with("COMPILATION error at [5:4-28]: Found duplicated property 'property1' in association 'test::C'", "COMPILATION error at [10:4-28]: Found duplicated property 'property' in class 'test::D'", "COMPILATION error at [12:4-21]: Found duplicated property 'other' in class 'test::D'"));
     }
 
     @Test
@@ -353,7 +346,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "}\n" +
                 "Class test::B \n" +
                 "{\n" +
-                " good : Integer[0..1];" +
+                " good : Integer[0..1];\n" +
                 "}\n"
         );
     }
@@ -549,8 +542,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "   a : String[1];\n" +
                 "   b : String[1];\n" +
                 "   c : String[1];\n" +
-                "}\n" +
-                "\n", "COMPILATION error at [1:1-6:1]: Expected 2 properties for an association 'test::FaultyAssociation'"
+                "}\n", "COMPILATION error at [1:1-6:1]: Expected 2 properties for an association 'test::FaultyAssociation'"
         );
     }
 
@@ -650,34 +642,34 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                         "}\n",
                 "COMPILATION error at [4:21-22]: Can't find the packageable element 'ok'");
         test("Class test::A\n" +
-                "[" +
-                "   ok" +
-                "]" +
+                "[\n" +
+                "   ok\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}", "COMPILATION error at [2:5-6]: Can't find the packageable element 'ok'");
+                "}", "COMPILATION error at [3:4-5]: Can't find the packageable element 'ok'");
         test("Class test::b\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}" +
+                "}\n" +
                 "Class test::A\n" +
-                "[" +
-                "   test::a" +
-                "]" +
+                "[\n" +
+                "   test::a\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}", "COMPILATION error at [5:5-11]: Can't find the packageable element 'test::a'");
+                "}", "COMPILATION error at [7:4-10]: Can't find the packageable element 'test::a'");
         test("Class test::b\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}" +
+                "}\n" +
                 "Class test::A\n" +
-                "[" +
-                "   test::b" +
-                "]" +
+                "[\n" +
+                "   test::b\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}", "COMPILATION error at [5:5-11]: Constraint must be of type 'Boolean'");
+                "}", "COMPILATION error at [7:4-10]: Constraint must be of type 'Boolean'");
     }
 
     @Test
@@ -690,39 +682,39 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "}\n", "COMPILATION error at [4:21-22]: Can't find the packageable element 'ok'");
         test("Enum test::b\n" +
                 "{\n" +
-                "   names" +
-                "}" +
+                "   names\n" +
+                "}\n" +
                 "Class test::A\n" +
-                "[" +
-                "   test::b.c" +
-                "]" +
+                "[\n" +
+                "   test::b.c\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}", "COMPILATION error at [4:13]: Can't find enum value 'c' in enumeration 'test::b'");
+                "}", "COMPILATION error at [7:12]: Can't find enum value 'c' in enumeration 'test::b'");
         test("Class test::b\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}" +
+                "}\n" +
                 "Class test::A\n" +
-                "[" +
-                "   test::b.c" +
-                "]" +
+                "[\n" +
+                "   test::b.c\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}", "COMPILATION error at [5:13]: Can't find property 'c' in class 'meta::pure::metamodel::type::Class'");
+                "}", "COMPILATION error at [7:12]: Can't find property 'c' in class 'meta::pure::metamodel::type::Class'");
     }
 
     @Test
     public void testMissingAssociationProperty()
     {
-        test("Class test::A {\n" +
+        test("Class test::A\n" +
+                "{\n" +
                 "}\n" +
                 "Association test::FaultyAssociation\n" +
                 "{\n" +
                 "   a : test::A[1];\n" +
                 "   b : someClass[1];\n" +
-                "}\n" +
-                "\n", "COMPILATION error at [6:4-20]: Can't find class 'someClass'");
+                "}\n", "COMPILATION error at [7:4-20]: Can't find class 'someClass'");
     }
 
     @Test
@@ -896,618 +888,619 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "Class test::D\n" +
                 "{\n" +
                 "   xza(s: String[1]){$src}:String[1];\n" +
-                "}\n", Arrays.asList("COMPILATION error at [7:31-43]: Can't find property 'WhoopsfuncDog' in class 'test::Dog'", "COMPILATION error at [19:22-25]: Can't find variable class for variable 'src' in the graph"));
+                "}\n", Lists.fixedSize.with("COMPILATION error at [7:31-43]: Can't find property 'WhoopsfuncDog' in class 'test::Dog'", "COMPILATION error at [19:22-25]: Can't find variable class for variable 'src' in the graph"));
     }
 
     @Test
     public void testMapLambdaInferenceWithPrimitive()
     {
-        test("Class test::A" +
-                "{" +
-                "   p(){[1,2]->map(a|$a+1)}:Integer[*];" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   p(){[1,2]->map(a|$a+1)}:Integer[*];\n" +
                 "}"
         );
-        test("Class test::A" +
-                "{" +
-                "   p(){[1,2]->map(a|$a+'1')}:String[1];" +
-                "}", "COMPILATION error at [1:37-40]: Can't find a match for function 'plus(Any[2])'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   p(){[1,2]->map(a|$a+'1')}:String[1];\n" +
+                "}", "COMPILATION error at [3:23-26]: Can't find a match for function 'plus(Any[2])'");
     }
 
     @Test
     public void testMapLambdaInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->map(a|$a.name)}:String[*];" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->map(a|$a.name)}:String[*];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->map(a|$a.nam)}:String[*];" +
-                "}", "COMPILATION error at [1:81-83]: Can't find property 'nam' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->map(a|$a.nam)}:String[*];\n" +
+                "}", "COMPILATION error at [8:32-34]: Can't find property 'nam' in class 'test::A'");
     }
 
     @Test
     public void testPackageableElementMismatchNotFoundWithGetAll()
     {
-        test("Class test::B" +
-                "{" +
-                "   z(){test::A.all()->map(a|$a.nam)}:String[*];" +
-                "}", "COMPILATION error at [1:22-28]: Can't find the packageable element 'test::A'");
+        test("Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->map(a|$a.nam)}:String[*];\n" +
+                "}", "COMPILATION error at [3:8-14]: Can't find the packageable element 'test::A'");
     }
 
     @Test
     public void testPackageableElementMismatchWithGetAll()
     {
         test("###Pure\n" +
-                "Class test::A" +
-                "{ prop : String[1];" +
-                "}" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::MyMapping.all()->map(a|$a.nam)}:String[*];" +
+                "Class test::A\n" +
+                "{\n" +
+                "   prop : String[1];\n" +
+                "}\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::MyMapping.all()->map(a|$a.nam)}:String[*];\n" +
                 "}\n" +
                 "###Mapping\n" +
                 "Mapping test::MyMapping\n" +
                 "(\n" +
-                ")\n", "COMPILATION error at [2:70-75]: Can't find a match for function 'getAll(Mapping[1])'");
+                ")\n", "COMPILATION error at [8:23-28]: Can't find a match for function 'getAll(Mapping[1])'");
     }
 
     @Test
     public void testSortByLambdaInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->sortBy(a|$a.name)}:test::A[*];" +
-                "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->sortBy(a|$a.nam)}:test::A[*];" +
-                "}", "COMPILATION error at [1:84-86]: Can't find property 'nam' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->sortBy(a|$a.name)}:test::A[*];\n" +
+                "}\n");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->sortBy(a|$a.nam)}:test::A[*];\n" +
+                "}", "COMPILATION error at [8:35-37]: Can't find property 'nam' in class 'test::A'");
     }
 
     @Test
     public void testPartialCompilationPackageableElementMismatchWithGetAllAndSortByLambdaInferenceWithClass()
     {
         partialCompilationTest("###Pure\n" +
-                "Class test::A" +
-                "{ prop : String[1];" +
-                "}" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::MyMapping.all()->map(a|$a.nam)}:String[*];" +
+                "Class test::A\n" +
+                "{\n" +
+                "   prop : String[1];\n" +
                 "}\n" +
-                "Class test::C" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::D" +
-                "{" +
-                "   z(){test::C.all()->sortBy(a|$a.nam)}:test::C[*];" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::MyMapping.all()->map(a|$a.nam)}:String[*];\n" +
+                "}\n" +
+                "Class test::C\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::D\n" +
+                "{\n" +
+                "   z(){test::C.all()->sortBy(a|$a.nam)}:test::C[*];\n" +
                 "}\n" +
                 "###Mapping\n" +
                 "Mapping test::MyMapping\n" +
                 "(\n" +
-                ")\n", Arrays.asList("COMPILATION error at [2:70-75]: Can't find a match for function 'getAll(Mapping[1])'", "COMPILATION error at [3:84-86]: Can't find property 'nam' in class 'test::C'"));
+                ")\n", Lists.fixedSize.with("COMPILATION error at [8:23-28]: Can't find a match for function 'getAll(Mapping[1])'", "COMPILATION error at [17:35-37]: Can't find property 'nam' in class 'test::C'"));
     }
 
     @Test
     public void testFilterLambdaInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->filter(a|$a.name == 'yeah')}:test::A[*];" +
-                "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->filter(a|$a.nam == 'ohoh')}:test::A[*];" +
-                "}", "COMPILATION error at [1:84-86]: Can't find property 'nam' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->filter(a|$a.name == 'yeah')}:test::A[*];\n" +
+                "}\n");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->filter(a|$a.nam == 'ohoh')}:test::A[*];\n" +
+                "}", "COMPILATION error at [8:35-37]: Can't find property 'nam' in class 'test::A'");
     }
 
     @Test
     public void testGroupByLambdaInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->groupBy(a|$a.name, agg(x|$x.name, z|$z->count()), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->groupBy(a|$a.name, agg(x|$x.name, z|$z->count()), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->groupBy(a|$a.nae, agg(x|$x.name, z|$z->count()), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:85-87]: Can't find property 'nae' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->groupBy(a|$a.name, agg(x|$x.nae, z|$z->count()), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:100-102]: Can't find property 'nae' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->groupBy(a|$a.name, agg(x|$x.name, z|$z->map(k|$k+1)), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:120-121]: Can't find a match for function 'plus(Any[2])'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->groupBy(a|$a.nae, agg(x|$x.name, z|$z->count()), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:36-38]: Can't find property 'nae' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->groupBy(a|$a.name, agg(x|$x.nae, z|$z->count()), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:51-53]: Can't find property 'nae' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->groupBy(a|$a.name, agg(x|$x.name, z|$z->map(k|$k+1)), ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:71-72]: Can't find a match for function 'plus(Any[2])'");
     }
 
     @Test
     public void testGroupByWithWindowLambdaInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->groupByWithWindowSubset(a|$a.name, agg(x|$x.name, z|$z->count()), ['a', 'b'], ['a'], ['b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->groupByWithWindowSubset(a|$a.name, agg(x|$x.namex, z|$z->count()), ['a', 'b'], ['a'], ['b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:116-120]: Can't find property 'namex' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->groupByWithWindowSubset(a|$a.name, agg(x|$x.name, z|$z->count()), ['a', 'b'], ['a'], ['b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}\n");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->groupByWithWindowSubset(a|$a.name, agg(x|$x.namex, z|$z->count()), ['a', 'b'], ['a'], ['b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:67-71]: Can't find property 'namex' in class 'test::A'");
     }
 
     @Test
     public void testProjectInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project([a|$a.name], ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "   g(){test::A.all()->project(a|$a.name, ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project([a|$a.name.name], ['a'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:91-94]: The property 'name' can't be accessed on primitive types. Inferred primitive type is String");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project([a|$a.nawme], ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:86-90]: Can't find property 'nawme' in class 'test::A'");
-        test("Class  test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project(a|$a.nawme, ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:86-90]: Can't find property 'nawme' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project([a|$a.name], ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "   g(){test::A.all()->project(a|$a.name, ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}\n");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project([a|$a.name.name], ['a'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:42-45]: The property 'name' can't be accessed on primitive types. Inferred primitive type is String");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project([a|$a.nawme], ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:37-41]: Can't find property 'nawme' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project(a|$a.nawme, ['a', 'b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:36-40]: Can't find property 'nawme' in class 'test::A'");
     }
 
     @Test
     public void testProjectColInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project([col(a|$a.name, 'a')])}:meta::pure::tds::TabularDataSet[1];" +
-                "   y(){test::A.all()->project(col(a|$a.name, 'a'))}:meta::pure::tds::TabularDataSet[1];" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project([col(a|$a.name, 'a')])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "   y(){test::A.all()->project(col(a|$a.name, 'a'))}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project([col(a|$a.naxme, 'a')])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:90-94]: Can't find property 'naxme' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project(col(a|$a.naxme, 'a'))}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:89-93]: Can't find property 'naxme' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project([col(a|$a.naxme, 'a')])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:41-45]: Can't find property 'naxme' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project(col(a|$a.naxme, 'a'))}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:40-44]: Can't find property 'naxme' in class 'test::A'");
     }
 
     @Test
     public void testProjectWithSubsetColInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->projectWithColumnSubset([col(a|$a.name, 'a')], ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "   y(){test::A.all()->projectWithColumnSubset(col(a|$a.name, 'a'), ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "   h(){test::A.all()->projectWithColumnSubset([a|$a.name], 'a', ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "   j(){test::A.all()->projectWithColumnSubset(a|$a.name, 'a' , ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->projectWithColumnSubset([col(a|$a.name, 'a')], ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "   y(){test::A.all()->projectWithColumnSubset(col(a|$a.name, 'a'), ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "   h(){test::A.all()->projectWithColumnSubset([a|$a.name], 'a', ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "   j(){test::A.all()->projectWithColumnSubset(a|$a.name, 'a' , ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
 
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->projectWithColumnSubset([col(a|$a.xname, 'a')], ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:106-110]: Can't find property 'xname' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   y(){test::A.all()->projectWithColumnSubset(col(a|$a.xname, 'a'), ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:105-109]: Can't find property 'xname' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   h(){test::A.all()->projectWithColumnSubset([a|$a.xname], 'a', ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:102-106]: Can't find property 'xname' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   j(){test::A.all()->projectWithColumnSubset(a|$a.xname, 'a' , ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", "COMPILATION error at [1:101-105]: Can't find property 'xname' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->projectWithColumnSubset([col(a|$a.xname, 'a')], ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:57-61]: Can't find property 'xname' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   y(){test::A.all()->projectWithColumnSubset(col(a|$a.xname, 'a'), ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:56-60]: Can't find property 'xname' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   h(){test::A.all()->projectWithColumnSubset([a|$a.xname], 'a', ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:53-57]: Can't find property 'xname' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   j(){test::A.all()->projectWithColumnSubset(a|$a.xname, 'a' , ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", "COMPILATION error at [8:52-56]: Can't find property 'xname' in class 'test::A'");
     }
 
     @Test
     public void testPartialCompilationProjectColInferenceWithClassAndProjectWithSubsetColInferenceWithClass()
     {
-        partialCompilationTest("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project([col(a|$a.name, 'a')])}:meta::pure::tds::TabularDataSet[1];" +
-                "   y(){test::A.all()->project(col(a|$a.name, 'a'))}:meta::pure::tds::TabularDataSet[1];" +
+        partialCompilationTest("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project([col(a|$a.name, 'a')])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "   y(){test::A.all()->project(col(a|$a.name, 'a'))}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}", null);
 
-        partialCompilationTest("Class test::C" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::D" +
-                "{" +
-                "   z(){test::C.all()->project([col(c|$c.naxme, 'c')])}:meta::pure::tds::TabularDataSet[1];" +
+        partialCompilationTest("Class test::C\n" +
+                "{\n" +
+                "   name : String[1];\n" +
                 "}\n" +
-                "Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->projectWithColumnSubset([col(a|$a.xname, 'a')], ['a','b'])}:meta::pure::tds::TabularDataSet[1];" +
-                "}", Arrays.asList("COMPILATION error at [1:90-94]: Can't find property 'naxme' in class 'test::C'", "COMPILATION error at [2:106-110]: Can't find property 'xname' in class 'test::A'"));
+                "\n" +
+                "Class test::D\n" +
+                "{\n" +
+                "   z(){test::C.all()->project([col(c|$c.naxme, 'c')])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}\n" +
+                "Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->projectWithColumnSubset([col(a|$a.xname, 'a')], ['a','b'])}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", Lists.fixedSize.with("COMPILATION error at [8:41-45]: Can't find property 'naxme' in class 'test::C'", "COMPILATION error at [17:57-61]: Can't find property 'xname' in class 'test::A'"));
 
-        partialCompilationTest("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->project(col(a|$a.naxme, 'a'))}:meta::pure::tds::TabularDataSet[1];" +
-                "}", Arrays.asList("COMPILATION error at [1:89-93]: Can't find property 'naxme' in class 'test::A'"));
+        partialCompilationTest("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->project(col(a|$a.naxme, 'a'))}:meta::pure::tds::TabularDataSet[1];\n" +
+                "}", Lists.fixedSize.with("COMPILATION error at [8:40-44]: Can't find property 'naxme' in class 'test::A'"));
     }
 
     @Test
     public void testExistsLambdaInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->exists(a|$a.name == 'yeah')}:Boolean[1];" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->exists(a|$a.name == 'yeah')}:Boolean[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->exists(a|$a.nam == 'ohoh')}:test::A[*];" +
-                "}", "COMPILATION error at [1:84-86]: Can't find property 'nam' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->exists(a|$a.nam == 'ohoh')}:test::A[*];\n" +
+                "}", "COMPILATION error at [8:35-37]: Can't find property 'nam' in class 'test::A'");
     }
 
     @Test
     public void testTDSContainsInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->filter(a|$a->tdsContains([p|$p.name], test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];" +
-                "   k(){test::A.all()->filter(a|$a->tdsContains(p|$p.name, test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];" +
-                "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   z(){test::A.all()->filter(a|$a->tdsContains([p|$p.xname], test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];" +
-                "}", "COMPILATION error at [1:103-107]: Can't find property 'xname' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   k(){test::A.all()->filter(a|$a->tdsContains(p|$p.xname, test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];" +
-                "}", "COMPILATION error at [1:102-106]: Can't find property 'xname' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->filter(a|$a->tdsContains([p|$p.name], test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];\n" +
+                "   k(){test::A.all()->filter(a|$a->tdsContains(p|$p.name, test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];\n" +
+                "}\n");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   z(){test::A.all()->filter(a|$a->tdsContains([p|$p.xname], test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];\n" +
+                "}", "COMPILATION error at [8:54-58]: Can't find property 'xname' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   k(){test::A.all()->filter(a|$a->tdsContains(p|$p.xname, test::A.all()->project(col(a|$a.name, 'ww'))))}:test::A[*];\n" +
+                "}", "COMPILATION error at [8:53-57]: Can't find property 'xname' in class 'test::A'");
     }
 
     @Test
     public void testTDSContainsWithLambdaInferenceWithClass()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->filter(v|$v->tdsContains([p|$p.name], ['a'], test::A.all()->project(col(a|$a.name, 'ww')), {a,b | $a.isNotNull('name') && $b.isNotNull('Addr_Name')}))}:test::A[*];\n" +
                 "   z(){test::A.all()->filter(v|$v->tdsContains(p|$p.name, ['a'], test::A.all()->project(col(a|$a.name, 'ww')), {a,b | $a.isNotNull('name') && $b.isNotNull('Addr_Name')}))}:test::A[*];\n" +
-                "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+                "}\n");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->filter(v|$v->tdsContains([p|$p.name], ['a'], test::A.all()->project(col(a|$a.ncame, 'ww')), {a,b | $a.isNotXNull('name') && $b.isNotNull('Addr_Name')}))}:test::A[*];\n" +
-                "}", "COMPILATION error at [1:149-153]: Can't find property 'ncame' in class 'test::A'");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+                "}", "COMPILATION error at [8:100-104]: Can't find property 'ncame' in class 'test::A'");
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->filter(v|$v->tdsContains([p|$p.name], ['a'], test::A.all()->project(col(a|$a.name, 'ww')), {a,b | $a.isNotXNull('name') && $b.isNotNull('Addr_Name')}))}:test::A[*];\n" +
-                "}", "COMPILATION error at [1:173-182]: Can't find property 'isNotXNull' in class 'meta::pure::tds::TDSRow'");
+                "}", "COMPILATION error at [8:124-133]: Can't find property 'isNotXNull' in class 'meta::pure::tds::TDSRow'");
     }
 
     @Test
     public void testGroupByTDS()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(a|$a.name, 'Account_No')])->groupBy('prodName', agg('sum', x|$x.getFloat('quantity')*$x.getInteger('quantity'), y| $y->sum()))}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(a|$a.name, 'Account_No')])->groupBy('prodName', agg('sum', x|$x.getwFloat('quantity')*$x.getInteger('quantity'), y| $y->sum()))}:meta::pure::tds::TabularDataSet[1];\n" +
-                "}", "COMPILATION error at [1:149-157]: Can't find property 'getwFloat' in class 'meta::pure::tds::TDSRow'");
+                "}", "COMPILATION error at [8:100-108]: Can't find property 'getwFloat' in class 'meta::pure::tds::TDSRow'");
     }
 
     @Test
     public void testOlapGroupByTDS()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy( ['age'],desc('age'), func(y|$y->count()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy( ['age'],desc('age'), y|$y->count(),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(a|$a.name, 'Account_No')])->olapGroupBy( ['age'],desc('age'), func('age', y|$y->count()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy( ['age'], func(y|$y->rank()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy( ['age'], y|$y->rank(),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy( ['age'], func('age', y|$y->max()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy(desc('age'), func( y|$y->denseRank()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy(asc('age'), y|$y->count(),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy(desc('age'), func('age', y|$y->max()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
 
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy(func(y|$y->count()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy(y|$y->count(),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "   age : Integer[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   age : Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){test::A.all()->project([col(p|$p.name, 'Name'), col(p|$p.age, 'Age')])->olapGroupBy(func('age',y|$y->min()),'testCol')}:meta::pure::tds::TabularDataSet[1];\n" +
                 "}");
-
     }
 
     @Test
@@ -1534,19 +1527,19 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     public void testConstraint()
     {
         test("Class test::A\n" +
-                "[" +
-                "   $this.names->isNotEmpty()" +
-                "]" +
+                "[\n" +
+                "   $this.names->isNotEmpty()\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
                 "}");
         test("Class test::A\n" +
-                "[" +
-                "   $this.names->at(0)" +
-                "]" +
+                "[\n" +
+                "   $this.names->at(0)\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}", "COMPILATION error at [2:18-19]: Constraint must be of type 'Boolean'");
+                "}", "COMPILATION error at [3:17-18]: Constraint must be of type 'Boolean'");
     }
 
     @Test
@@ -1562,7 +1555,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "{\n" +
                 "   names : String[*];\n" +
                 "   prop() {$this.names + 'ok'} : String[1];\n" +
-                "}", Arrays.asList("COMPILATION error at [4:18-22]: Collection element must have a multiplicity [1] - Context:[Class 'test::A' Fourth Pass, Qualified Property prop, Applying plus], multiplicity:[*]"));
+                "}", Lists.fixedSize.with("COMPILATION error at [4:18-22]: Collection element must have a multiplicity [1] - Context:[Class 'test::A' Fourth Pass, Qualified Property prop, Applying plus], multiplicity:[*]"));
 
         partialCompilationTest("Class test::A\n" +
                 "{\n" +
@@ -1570,12 +1563,12 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "   prop() {$this.names + 'ok'} : String[1];\n" +
                 "}\n" +
                 "Class test::B\n" +
-                "[" +
-                "   $this.names->at(0)" +
-                "]" +
+                "[\n" +
+                "   $this.names->at(0)\n" +
+                "]\n" +
                 "{\n" +
                 "   names : String[*];\n" +
-                "}", Arrays.asList("COMPILATION error at [4:18-22]: Collection element must have a multiplicity [1] - Context:[Class 'test::A' Fourth Pass, Qualified Property prop, Applying plus], multiplicity:[0..1]", "COMPILATION error at [7:18-19]: Constraint must be of type 'Boolean'"));
+                "}", Lists.fixedSize.with("COMPILATION error at [4:18-22]: Collection element must have a multiplicity [1] - Context:[Class 'test::A' Fourth Pass, Qualified Property prop, Applying plus], multiplicity:[0..1]", "COMPILATION error at [8:17-18]: Constraint must be of type 'Boolean'"));
     }
 
     @Test
@@ -1611,62 +1604,62 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testEval1Param()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){ {a|$a+1}->eval(1);}:Integer[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){ {a|$a+'1'}->eval(1);}:Integer[1];\n" +
-                "}", "COMPILATION error at [1:63-66]: Can't find a match for function 'plus(Any[2])'");
+                "}", "COMPILATION error at [8:14-17]: Can't find a match for function 'plus(Any[2])'");
     }
 
     @Test
     public void testEval2Param()
     {
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){ {a,b|$a+$b}->eval(1,2);}:Integer[1];\n" +
                 "}");
-        test("Class test::A" +
-                "{" +
-                "   name : String[1];" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
                 "   z(){ {a,b|$a+$b}->eval(1,'a');}:Integer[1];\n" +
-                "}", "COMPILATION error at [1:65-67]: Can't find a match for function 'plus(Any[2])'");
+                "}", "COMPILATION error at [8:16-18]: Can't find a match for function 'plus(Any[2])'");
     }
 
 
     @Test
     public void testPropertyPostFunction()
     {
-        test("Class test::Firm" +
-                "{" +
-                "   employees:test::Person[*];" +
-                "   emp(){$this.employees->first().lastName}:String[0..1];" +
-                "}" +
-                "" +
-                "Class test::Person" +
-                "{" +
-                "   lastName : String[1];" +
+        test("Class test::Firm\n" +
+                "{\n" +
+                "   employees:test::Person[*];\n" +
+                "   emp(){$this.employees->first().lastName}:String[0..1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::Person\n" +
+                "{\n" +
+                "   lastName : String[1];\n" +
                 "}");
     }
 
@@ -1680,14 +1673,14 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testEnum()
     {
-        test("Enum test::A" +
-                "{" +
-                "   A,B" +
-                "}" +
-                "" +
-                "Class test::B" +
-                "{" +
-                "   e:test::A[1];" +
+        test("Enum test::A\n" +
+                "{\n" +
+                "   A,B\n" +
+                "}\n" +
+                "\n" +
+                "Class test::B\n" +
+                "{\n" +
+                "   e:test::A[1];\n" +
                 "   z(){ $this.e.name}:String[1];\n" +
                 "}"
         );
@@ -1696,38 +1689,37 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testFunction()
     {
-        PureModel model = test("Class test::A" +
-                "{" +
-                "   s:String[1];" +
-                "}" +
-                "" +
-                "function test::f(a:test::A[1]):String[1]" +
-                "{" +
-                "   $a.s;" +
+        PureModel model = test("Class test::A\n" +
+                "{\n" +
+                "   s:String[1];\n" +
+                "}\n" +
+                "\n" +
+                "function test::f(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   $a.s;\n" +
                 "}"
         ).getTwo();
 
-        Function<?> f = model.getConcreteFunctionDefinition("test::f_A_1__String_1_", null);
-        Assert.assertTrue(f instanceof ConcreteFunctionDefinition);
-        ConcreteFunctionDefinition<?> cfd = (ConcreteFunctionDefinition<?>) f;
-        Assert.assertEquals("f_A_1__String_1_", cfd._name());
+        ConcreteFunctionDefinition<?> f = model.getConcreteFunctionDefinition("test::f_A_1__String_1_", null);
+        Assert.assertNotNull(f);
+        Assert.assertEquals("f_A_1__String_1_", f._name());
     }
 
     @Test
     public void testUserDefinedFunctionMatching()
     {
-        test("Class test::A" +
-                "{" +
-                "   s:String[1];" +
-                "}" +
-                "function test::other(a:test::A[1]):String[1]" +
-                "{" +
-                "   test::f($a)" +
-                "}" +
-                "" +
-                "function test::f(a:test::A[1]):String[1]" +
-                "{" +
-                "   $a.s;" +
+        test("Class test::A\n" +
+                "{\n" +
+                "   s:String[1];\n" +
+                "}\n" +
+                "function test::other(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   test::f($a)\n" +
+                "}\n" +
+                "\n" +
+                "function test::f(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   $a.s;\n" +
                 "}"
         );
     }
@@ -1735,42 +1727,42 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testUserDefinedFunctionMatchingError()
     {
-        test("Class test::A" +
-                        "{" +
-                        "   s:String[1];" +
-                        "}" +
-                        "function test::other(a:test::A[1]):String[1]" +
-                        "{" +
-                        "   test::f('test')" +
-                        "}" +
-                        "" +
-                        "function test::f(a:test::A[1]):String[1]" +
-                        "{" +
-                        "   $a.s;" +
+        test("Class test::A\n" +
+                        "{\n" +
+                        "   s:String[1];\n" +
+                        "}\n" +
+                        "function test::other(a:test::A[1]):String[1]\n" +
+                        "{\n" +
+                        "   test::f('test')\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::f(a:test::A[1]):String[1]\n" +
+                        "{\n" +
+                        "   $a.s;\n" +
                         "}",
-                "COMPILATION error at [1:79-85]: Can't find a match for function 'test::f(String[1])'"
+                "COMPILATION error at [7:4-10]: Can't find a match for function 'test::f(String[1])'"
         );
     }
 
     @Test
     public void testUserDefinedFunctionMatchingInheritance()
     {
-        test("Class test::B" +
-                "{" +
-                "   s:String[1];" +
-                "}" +
-                "" +
-                "Class test::A extends test::B" +
-                "{" +
-                "}" +
-                "function test::other(a:test::A[1]):String[1]" +
-                "{" +
-                "   test::f($a)" +
-                "}" +
-                "" +
-                "function test::f(a:test::B[1]):String[1]" +
-                "{" +
-                "   $a.s;" +
+        test("Class test::B\n" +
+                "{\n" +
+                "   s:String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::A extends test::B\n" +
+                "{\n" +
+                "}\n" +
+                "function test::other(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   test::f($a)\n" +
+                "}\n" +
+                "\n" +
+                "function test::f(a:test::B[1]):String[1]\n" +
+                "{\n" +
+                "   $a.s;\n" +
                 "}"
         );
     }
@@ -1778,40 +1770,40 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testUserDefinedFunctionMatchingInheritanceError()
     {
-        test("Class test::B" +
-                "{" +
-                "   s:String[1];" +
-                "}" +
-                "" +
-                "Class test::A extends test::B" +
-                "{" +
-                "}" +
-                "function test::other(a:test::B[1]):String[1]" +
-                "{" +
-                "   test::f($a)" +
-                "}" +
-                "" +
-                "function test::f(a:test::A[1]):String[1]" +
-                "{" +
-                "   $a.s;" +
-                "}", "COMPILATION error at [1:110-116]: Can't find a match for function 'test::f(B[1])'"
+        test("Class test::B\n" +
+                "{\n" +
+                "   s:String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::A extends test::B\n" +
+                "{\n" +
+                "}\n" +
+                "function test::other(a:test::B[1]):String[1]\n" +
+                "{\n" +
+                "   test::f($a)\n" +
+                "}\n" +
+                "\n" +
+                "function test::f(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   $a.s;\n" +
+                "}", "COMPILATION error at [11:4-10]: Can't find a match for function 'test::f(B[1])'"
         );
     }
 
     @Test
     public void testUserDefinedFunctionMatchingMultiplicity()
     {
-        test("Class test::A" +
-                "{" +
-                "}" +
-                "function test::other(a:test::A[1]):String[1]" +
-                "{" +
-                "   test::f($a)" +
-                "}" +
-                "" +
-                "function test::f(a:test::A[*]):String[1]" +
-                "{" +
-                "   'bogus';" +
+        test("Class test::A\n" +
+                "{\n" +
+                "}\n" +
+                "function test::other(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   test::f($a)\n" +
+                "}\n" +
+                "\n" +
+                "function test::f(a:test::A[*]):String[1]\n" +
+                "{\n" +
+                "   'bogus';\n" +
                 "}"
         );
     }
@@ -1819,46 +1811,46 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testUserDefinedFunctionMatchingMultiplicityError()
     {
-        test("Class test::A" +
-                "{" +
-                "}" +
-                "function test::other(a:test::A[*]):String[1]" +
-                "{" +
-                "   test::f($a)" +
-                "}" +
-                "" +
-                "function test::f(a:test::A[1]):String[1]" +
-                "{" +
-                "   'yo';" +
-                "}", "COMPILATION error at [1:64-70]: Can't find a match for function 'test::f(A[*])'"
+        test("Class test::A\n" +
+                "{\n" +
+                "}\n" +
+                "function test::other(a:test::A[*]):String[1]\n" +
+                "{\n" +
+                "   test::f($a)\n" +
+                "}\n" +
+                "\n" +
+                "function test::f(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   'yo';\n" +
+                "}", "COMPILATION error at [6:4-10]: Can't find a match for function 'test::f(A[*])'"
         );
     }
 
     @Test
     public void testFunctionReturnError()
     {
-        test("Class test::A" +
-                "{" +
-                "   s:String[1];" +
-                "}" +
-                "" +
-                "function test::f(a:test::A[1]):String[1]" +
-                "{" +
-                "   $a;" +
-                "}", "COMPILATION error at [1:75-76]: Error in function 'test::f_A_1__String_1_' - Type error: 'test::A' is not a subtype of 'String'"
+        test("Class test::A\n" +
+                "{\n" +
+                "   s:String[1];\n" +
+                "}\n" +
+                "\n" +
+                "function test::f(a:test::A[1]):String[1]\n" +
+                "{\n" +
+                "   $a;\n" +
+                "}", "COMPILATION error at [8:4-5]: Error in function 'test::f_A_1__String_1_' - Type error: 'test::A' is not a subtype of 'String'"
         );
     }
 
     @Test
     public void testFunctionReferenceBeforeFunctionDefinition()
     {
-        test("function b::myFunction():String[1]" +
-                "{" +
-                "   z::otherFunction();" +
-                "}" +
-                "function z::otherFunction():String[1]" +
-                "{" +
-                "   'ok';" +
+        test("function b::myFunction():String[1]\n" +
+                "{\n" +
+                "   z::otherFunction();\n" +
+                "}\n" +
+                "function z::otherFunction():String[1]\n" +
+                "{\n" +
+                "   'ok';\n" +
                 "}"
         );
     }
@@ -1866,18 +1858,18 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testDeepfetch()
     {
-        test("Class test::Person" +
-                "{" +
-                "   firstName:String[1];" +
-                "   lastName:String[1];" +
-                "}" +
-                "Class test::Firm" +
-                "{" +
-                "   employees:test::Person[*];" +
-                "}" +
-                "Class test::Test" +
-                "{" +
-                "   x(){test::Person.all()->graphFetch(#{test::Person{firstName,lastName}}#);true;}:Boolean[1];" +
+        test("Class test::Person\n" +
+                "{\n" +
+                "   firstName:String[1];\n" +
+                "   lastName:String[1];\n" +
+                "}\n" +
+                "Class test::Firm\n" +
+                "{\n" +
+                "   employees:test::Person[*];\n" +
+                "}\n" +
+                "Class test::Test\n" +
+                "{\n" +
+                "   x(){test::Person.all()->graphFetch(#{test::Person{firstName,lastName}}#);true;}:Boolean[1];\n" +
                 "}");
     }
 
@@ -1936,7 +1928,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "   x(){test::Person.all()->graphFetch(#{\n" +
                 "       test::Person{\n" +
                 "                first}}#);true;}:Boolean[1];\n" +
-                "}\n", Arrays.asList("COMPILATION error at [10:37-41]: Can't find property 'name2' in class 'test::trial'", "COMPILATION error at [30:17-21]: Can't find property 'first' in [Person, Any]"));
+                "}\n", Lists.fixedSize.with("COMPILATION error at [10:37-41]: Can't find property 'name2' in class 'test::trial'", "COMPILATION error at [30:17-21]: Can't find property 'first' in [Person, Any]"));
     }
 
     @Test
@@ -1962,19 +1954,19 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     {
         test("function example::testMaxString():Any[0..1]\n" +
                 "{\n" +
-                "   ['string1', 'string2']->max();" +
+                "   ['string1', 'string2']->max();\n" +
                 "}\n" +
                 "function example::testMaxInteger():Any[0..1]\n" +
                 "{\n" +
-                "   [1,2]->max();" +
+                "   [1,2]->max();\n" +
                 "}\n" +
                 "function example::testMaxFloat():Any[0..1]\n" +
                 "{\n" +
-                "   [1.0,2.0]->max();" +
+                "   [1.0,2.0]->max();\n" +
                 "}\n" +
                 "function example::testMaxDate():Any[0..1]\n" +
                 "{\n" +
-                "   [%1999-01-01,%2000-01-01]->max();" +
+                "   [%1999-01-01,%2000-01-01]->max();\n" +
                 "}\n"
         );
     }
@@ -2205,14 +2197,14 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "{\n" +
                 "  stereotypes: [test];\n" +
                 "  tags: [doc, todo];\n" +
-                "}" +
+                "}\n" +
                 "Association <<goes.test>> {goes.doc = 'Tag Value for assoc prop'} ahh::myAsso\n" +
                 "{\n" +
                 // `String` won't be valid here as we specifically look for a class
                 "  <<goes.test>> {goes.doc = 'Tag Value for assoc prop'} a: String[1];\n" +
                 "  <<goes.test>> {goes.doc = 'Tag Value for assoc prop'} b: goes2[1];\n" +
                 "}\n" +
-                "\n", "COMPILATION error at [11:3-69]: Can't find class 'String'");
+                "\n", "COMPILATION error at [12:3-69]: Can't find class 'String'");
         test("import anything::*;\n" +
                 "Class anything::goes2\n" +
                 "{\n" +
@@ -2228,8 +2220,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 // Association property tagged values, stereotypes, and type
                 "  <<goes.test>> {goes.doc = 'Tag Value for assoc prop'} a: goes2[1];\n" +
                 "  <<goes.test>> {goes.doc = 'Tag Value for assoc prop'} b: goes2[1];\n" +
-                "}\n" +
-                "\n");
+                "}\n");
     }
 
     @Test
@@ -2258,16 +2249,13 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     {
         test("Class my::Class\n" +
                 "{\n" +
-                "\n" +
                 "}\n" +
                 "\n" +
                 "Association my::association\n" +
                 "{\n" +
-                "\n" +
-                "toAny:Any[1];\n" +
-                "toClass:my::Class[1]; \n" +
-                "\n" +
-                "}", "COMPILATION error at [6:1-12:1]: Associations to Any are not allowed. Found in 'my::association'");
+                "    toAny:Any[1];\n" +
+                "    toClass:my::Class[1];\n" +
+                "}", "COMPILATION error at [5:1-9:1]: Associations to Any are not allowed. Found in 'my::association'");
 
     }
 
@@ -2330,48 +2318,35 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     @Test
     public void testClassWithInvalidStrictTime()
     {
-        try
-        {
-            test("Class apps::Trade\n" +
-                    "{\n" +
-                    "   time : StrictTime[1];\n" +
-                    "   testStrictTime(){\n" +
-                    "       $this.time == %200:12:22.88;\n" +
-                    "   } : Boolean[1];\n" +
-                    "}\n");
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Invalid hour: 200", e.getMessage());
-        }
-        try
-        {
-            test("Class apps::Trade\n" +
-                    "{\n" +
-                    "   time : StrictTime[1];\n" +
-                    "   testStrictTime(){\n" +
-                    "       $this.time == %20:122:22.88;\n" +
-                    "   } : Boolean[1];\n" +
-                    "}\n");
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Invalid minute: 122", e.getMessage());
-        }
-        try
-        {
-            test("Class apps::Trade\n" +
-                    "{\n" +
-                    "   time : StrictTime[1];\n" +
-                    "   testStrictTime(){\n" +
-                    "       $this.time == %20:12:61.88;\n" +
-                    "   } : Boolean[1];\n" +
-                    "}\n");
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Invalid second: 61", e.getMessage());
-        }
+        Exception e1 = Assert.assertThrows(Exception.class, () -> test(
+                "Class apps::Trade\n" +
+                        "{\n" +
+                        "   time : StrictTime[1];\n" +
+                        "   testStrictTime(){\n" +
+                        "       $this.time == %200:12:22.88;\n" +
+                        "   } : Boolean[1];\n" +
+                        "}\n"));
+        Assert.assertEquals("Invalid hour: 200", e1.getMessage());
+
+        Exception e2 = Assert.assertThrows(Exception.class, () -> test(
+                "Class apps::Trade\n" +
+                        "{\n" +
+                        "   time : StrictTime[1];\n" +
+                        "   testStrictTime(){\n" +
+                        "       $this.time == %20:122:22.88;\n" +
+                        "   } : Boolean[1];\n" +
+                        "}\n"));
+        Assert.assertEquals("Invalid minute: 122", e2.getMessage());
+
+        Exception e3 = Assert.assertThrows(Exception.class, () -> test(
+                "Class apps::Trade\n" +
+                        "{\n" +
+                        "   time : StrictTime[1];\n" +
+                        "   testStrictTime(){\n" +
+                        "       $this.time == %20:12:61.88;\n" +
+                        "   } : Boolean[1];\n" +
+                        "}\n"));
+        Assert.assertEquals("Invalid second: 61", e3.getMessage());
     }
 
     @Test
@@ -2424,22 +2399,20 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                         "  employs: apps::Employee[*]; \n" +
                         "} \n");
         PureModel model = modelWithInput.getTwo();
-        Type clazz = model.getType("apps::Employee", SourceInformation.getUnknownSourceInformation());
-        Root_meta_pure_metamodel_type_Class_Impl<?> type = (Root_meta_pure_metamodel_type_Class_Impl<?>) clazz;
-        org.eclipse.collections.api.block.function.Function<Class, RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property>> originalMilestonedPropertiesGetter = org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.ClassAccessor::_originalMilestonedProperties;
-        RichIterable<? extends Property> firmProperty = originalMilestonedPropertiesGetter.valueOf(type).select(p -> p.getName().equals("firm"));
-        Assert.assertTrue("Missing firm property in _originalMilestonedProperties", firmProperty.size() == 1);
-        RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property> worksForProperty = originalMilestonedPropertiesGetter.valueOf(type).select(p -> p.getName().equals("worksFor"));
-        Assert.assertTrue("Missing worksFor property in _originalMilestonedProperties", worksForProperty.size() == 1);
+        Class<?> type = model.getClass("apps::Employee", SourceInformation.getUnknownSourceInformation());
+        RichIterable<? extends Property<?, ?>> firmProperty = type._originalMilestonedProperties().select(p -> p.getName().equals("firm"));
+        Assert.assertEquals("Missing firm property in _originalMilestonedProperties", 1, firmProperty.size());
+        RichIterable<? extends Property<?, ?>> worksForProperty = type._originalMilestonedProperties().select(p -> p.getName().equals("worksFor"));
+        Assert.assertEquals("Missing worksFor property in _originalMilestonedProperties", 1, worksForProperty.size());
 
         Association association = model.getAssociation("apps::Employee_Firm", SourceInformation.getUnknownSourceInformation());
-        RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property> worksForPropertyFromAssoc = association._originalMilestonedProperties().select(p -> p.getName().equals("worksFor"));
-        Assert.assertTrue("Missing worksFor property in _originalMilestonedProperties for association", worksForPropertyFromAssoc.size() == 1);
+        RichIterable<? extends Property<?, ?>> worksForPropertyFromAssoc = association._originalMilestonedProperties().select(p -> p.getName().equals("worksFor"));
+        Assert.assertEquals("Missing worksFor property in _originalMilestonedProperties for association", 1, worksForPropertyFromAssoc.size());
     }
 
     public String getMilestoningModelWithDatePropagationAndInheritance()
     {
-        String model = "###Pure\n" +
+        return "###Pure\n" +
                 "Class <<temporal.businesstemporal>> {doc.doc = 'Account class'} my::domainModel::migration::test::account::AccountValue\n" +
                 "{\n" +
                 "  value: String[1];\n" +
@@ -2463,25 +2436,22 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
                 "{\n" +
                 "  productType: my::domainModel::migration::test::product::ProductType[1];\n" +
                 "}\n";
-        return model;
     }
 
     @Test
-    public void testCompilationOfBusinesstemporalDatePropagationWithInheritance()
+    public void testCompilationOfBusinessTemporalDatePropagationWithInheritance()
     {
         String grammar = getMilestoningModelWithDatePropagationAndInheritance();
         Pair<PureModelContextData, PureModel> modelWithInput = test(grammar);
         PureModel model = modelWithInput.getTwo();
-        Type collectionsClazz = model.getType("my::domainModel::migration::test::product::Collections", SourceInformation.getUnknownSourceInformation());
-        Root_meta_pure_metamodel_type_Class_Impl<?> collectionsType = (Root_meta_pure_metamodel_type_Class_Impl<?>) collectionsClazz;
-        org.eclipse.collections.api.block.function.Function<Class, RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty>> updatedQualifiedProperties = org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.ClassAccessor::_qualifiedProperties;
-        RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty> collectionsQPs = updatedQualifiedProperties.valueOf(collectionsType);
+        Class<?> collectionsClass = model.getClass("my::domainModel::migration::test::product::Collections", SourceInformation.getUnknownSourceInformation());
+        RichIterable<? extends QualifiedProperty<?>> collectionsQPs = collectionsClass._qualifiedProperties();
         Assert.assertEquals(3, collectionsQPs.size());
-        RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty> singleDateQPWithArgAndNoArg = collectionsQPs.select(p -> p.getName().equals("productType"));
-        Assert.assertTrue("Missing productType property for Class in my::domainModel::migration::test::product::Collections _qualifiedProperties", singleDateQPWithArgAndNoArg.size() == 2);
-        Assert.assertTrue("One of the productType properties for Class in my::domainModel::migration::test::product::Collections _qualifiedProperties should contain one argument for Date", ListIterate.anySatisfy(singleDateQPWithArgAndNoArg.toList(), qp -> ((Root_meta_pure_metamodel_type_FunctionType_Impl) (qp._classifierGenericType()._typeArguments().getFirst()._rawType()))._parameters.size() == 2));
-        Assert.assertTrue("One of the productType properties for Class in my::domainModel::migration::test::product::Collections _qualifiedProperties should not contain one argument for Date", ListIterate.anySatisfy(singleDateQPWithArgAndNoArg.toList(), qp -> ((Root_meta_pure_metamodel_type_FunctionType_Impl) qp._classifierGenericType()._typeArguments().getFirst()._rawType())._parameters.size() == 1));
-        Property<?, ?> edgePointProp = collectionsType._properties().select(r -> ((Root_meta_pure_metamodel_function_property_Property_Impl) r).getName().equals("productTypeAllVersions")).getFirst();
+        RichIterable<? extends QualifiedProperty<?>> singleDateQPWithArgAndNoArg = collectionsQPs.select(p -> p.getName().equals("productType"));
+        Assert.assertEquals("Missing productType property for Class in my::domainModel::migration::test::product::Collections _qualifiedProperties", 2, singleDateQPWithArgAndNoArg.size());
+        Assert.assertTrue("One of the productType properties for Class in my::domainModel::migration::test::product::Collections _qualifiedProperties should contain one argument for Date", ListIterate.anySatisfy(singleDateQPWithArgAndNoArg.toList(), qp -> ((FunctionType) (qp._classifierGenericType()._typeArguments().getFirst()._rawType()))._parameters().size() == 2));
+        Assert.assertTrue("One of the productType properties for Class in my::domainModel::migration::test::product::Collections _qualifiedProperties should not contain one argument for Date", ListIterate.anySatisfy(singleDateQPWithArgAndNoArg.toList(), qp -> ((FunctionType) qp._classifierGenericType()._typeArguments().getFirst()._rawType())._parameters().size() == 1));
+        Property<?, ?> edgePointProp = collectionsClass._properties().detect(p -> "productTypeAllVersions".equals(p.getName()));
         Assert.assertEquals("Multiplicity", edgePointProp._multiplicity().getClassifier().getName());
     }
 
@@ -2489,21 +2459,18 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
 
 
     @Test
-    public void testCompilationOfNonMilestonedClasstoMilestonedClass()
+    public void testCompilationOfNonMilestonedClassToMilestonedClass()
     {
         String grammar = getMilestoningModelWithDatePropagationAndInheritance();
         test(grammar);
         Pair<PureModelContextData, PureModel> modelWithInput = test(grammar);
         PureModel model = modelWithInput.getTwo();
-        Type collectionsClazz = model.getType("my::domainModel::migration::test::product::Classification", SourceInformation.getUnknownSourceInformation());
-        Root_meta_pure_metamodel_type_Class_Impl<?> collectionsType = (Root_meta_pure_metamodel_type_Class_Impl<?>) collectionsClazz;
-        org.eclipse.collections.api.block.function.Function<Class, RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty>> updatedQualifiedProperties = org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.ClassAccessor::_qualifiedProperties;
-        RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty> collectionsQPs = updatedQualifiedProperties.valueOf(collectionsType);
+        Class<?> collectionsType = model.getClass("my::domainModel::migration::test::product::Classification", SourceInformation.getUnknownSourceInformation());
+        RichIterable<? extends QualifiedProperty<?>> collectionsQPs = collectionsType._qualifiedProperties();
         Assert.assertEquals(2, collectionsQPs.size());
-        Assert.assertTrue("Missing productType property for Class in my::domainModel::migration::test::product::Classification _qualifiedProperties", collectionsQPs.select(p -> p.getName().equals("productType")).size() == 1);
-        RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty> singleDateQPWithArgAndNoArg = collectionsQPs.select(p -> p.getName().equals("productType"));
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty singleDateQP = singleDateQPWithArgAndNoArg.getFirst();
-        Assert.assertTrue("The productType property for Class in my::domainModel::migration::test::product::Classification _qualifiedProperties should contain one argument for Date", ((Root_meta_pure_metamodel_type_FunctionType_Impl) singleDateQP._classifierGenericType()._typeArguments().getFirst()._rawType())._parameters.size() == 2);
+        Assert.assertEquals("Missing productType property for Class in my::domainModel::migration::test::product::Classification _qualifiedProperties", 1, collectionsQPs.select(p -> p.getName().equals("productType")).size());
+        QualifiedProperty<?> singleDateQP = collectionsQPs.detect(p -> p.getName().equals("productType"));
+        Assert.assertEquals("The productType property for Class in my::domainModel::migration::test::product::Classification _qualifiedProperties should contain one argument for Date", 2, ((FunctionType) singleDateQP._classifierGenericType()._typeArguments().getFirst()._rawType())._parameters().size());
     }
 
     @Test
@@ -2591,25 +2558,22 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         Assert.assertTrue("Qualfied expression generated for processingTemporalAddress should have toOne() as topLevel functionExpression", checkQualifiedExpressionForprocessingTemporalAddress1);
         Assert.assertTrue("Qualfied expression generated for BusinessTemporalAddress should have toOne() as topLevel functionExpression", checkQualifiedExpressionForbusinessTemporalAddress1);
         Assert.assertTrue("Qualfied expression generated for BiTemporalAddress should have toOne() as topLevel functionExpression", checkQualifiedExpressionForbiTemporalAddress1);
-        Assert.assertTrue("Qualfied expression generated for processingTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForprocessingTemporalAddress2);
-        Assert.assertTrue("Qualfied expression generated for BusinessTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbusinessTemporalAddress2);
-        Assert.assertTrue("Qualfied expression generated for BiTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbiTemporalAddress2);
-        Assert.assertTrue("Qualfied expression generated for processingTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForprocessingTemporalAddress3);
-        Assert.assertTrue("Qualfied expression generated for BusinessTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbusinessTemporalAddress3);
-        Assert.assertTrue("Qualfied expression generated for BiTemporalAddress should not have toOne() as topLevel functionExpression", !checkQualifiedExpressionForbiTemporalAddress3);
-
-
-
+        Assert.assertFalse("Qualfied expression generated for processingTemporalAddress should not have toOne() as topLevel functionExpression", checkQualifiedExpressionForprocessingTemporalAddress2);
+        Assert.assertFalse("Qualfied expression generated for BusinessTemporalAddress should not have toOne() as topLevel functionExpression", checkQualifiedExpressionForbusinessTemporalAddress2);
+        Assert.assertFalse("Qualfied expression generated for BiTemporalAddress should not have toOne() as topLevel functionExpression", checkQualifiedExpressionForbiTemporalAddress2);
+        Assert.assertFalse("Qualfied expression generated for processingTemporalAddress should not have toOne() as topLevel functionExpression", checkQualifiedExpressionForprocessingTemporalAddress3);
+        Assert.assertFalse("Qualfied expression generated for BusinessTemporalAddress should not have toOne() as topLevel functionExpression", checkQualifiedExpressionForbusinessTemporalAddress3);
+        Assert.assertFalse("Qualfied expression generated for BiTemporalAddress should not have toOne() as topLevel functionExpression", checkQualifiedExpressionForbiTemporalAddress3);
     }
 
-    private boolean checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(QualifiedProperty generatedMilestoningClassQualifiedProperty)
+    private boolean checkQualifiedExpressionForToOneAsTopLevelFunctionExpression(QualifiedProperty<?> generatedMilestoningClassQualifiedProperty)
     {
         FunctionExpression topLevelExpression = ((FunctionExpression) generatedMilestoningClassQualifiedProperty._expressionSequence().getFirst());
         return topLevelExpression._func()._functionName().equals("toOne");
     }
 
     @Test
-    public void testMilestoningSimplePropertiesAreNotOverridenByUserProperties()
+    public void testMilestoningSimplePropertiesAreNotOverriddenByUserProperties()
     {
         String grammar = "###Pure\n" +
                 "Class <<temporal.processingtemporal>> test::ProcessingTemporalAddress\n" +
@@ -2641,47 +2605,47 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
 
         )).getTwo();
 
-        java.util.function.Function<Property, Boolean> isGeneratedMilestoningProperty = p -> p._stereotypes().anySatisfy(s -> s._value().equals(Milestoning.GeneratedMilestoningStereotype.generatedmilestoningdateproperty.name()));
+        java.util.function.Function<Property<?, ?>, Boolean> isGeneratedMilestoningProperty = p -> p._stereotypes().anySatisfy(s -> s._value().equals(Milestoning.GeneratedMilestoningStereotype.generatedmilestoningdateproperty.name()));
 
-        Property processingDateProperty = pm.getClass("test::ProcessingTemporalAddress")._properties().select(p -> p.getName().equals("processingDate")).getOnly();
-        Property businessDateProperty = pm.getClass("test::BusinessTemporalAddress")._properties().select(p -> p.getName().equals("businessDate")).getOnly();
+        Property<?, ?> processingDateProperty = pm.getClass("test::ProcessingTemporalAddress")._properties().select(p -> p.getName().equals("processingDate")).getOnly();
+        Property<?, ?> businessDateProperty = pm.getClass("test::BusinessTemporalAddress")._properties().select(p -> p.getName().equals("businessDate")).getOnly();
 
         Assert.assertTrue(isGeneratedMilestoningProperty.apply(processingDateProperty));
         Assert.assertTrue(isGeneratedMilestoningProperty.apply(businessDateProperty));
         RichIterable<? extends QualifiedProperty<?>> personQualifiedProperties = pm.getClass("test::Person")._qualifiedProperties();
 
-        boolean classProcessingDatePropertyIsUsedInMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(processingDateProperty, personQualifiedProperties.detect(p -> p.getName().equals("processingTemporalAddress")));
-        boolean classBusinessPropertyIsUsedInMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(businessDateProperty, personQualifiedProperties.detect(p -> p.getName().equals("businessTemporalAddress")));
+        boolean classProcessingDatePropertyIsUsedInMiletoningExpression = generatedMilestoningQualifiedPropertyUsesGeneratedMilestoningProperty(processingDateProperty, personQualifiedProperties.detect(p -> p.getName().equals("processingTemporalAddress")));
+        boolean classBusinessPropertyIsUsedInMiletoningExpression = generatedMilestoningQualifiedPropertyUsesGeneratedMilestoningProperty(businessDateProperty, personQualifiedProperties.detect(p -> p.getName().equals("businessTemporalAddress")));
         Assert.assertTrue("Class generated milestoning processingDate property should be used in the generated milestoning expression", classProcessingDatePropertyIsUsedInMiletoningExpression);
         Assert.assertTrue("Class generated milestoning businessDate property should be used in the generated milestoning expression", classBusinessPropertyIsUsedInMiletoningExpression);
 
-        RichIterable<? extends Property<?, ?>> biTemporalMilestoningDateProperties = pm.getClass("test::BiTemporalAddress")._properties().select(p -> Arrays.asList("businessDate", "processingDate").contains(p.getName()));
+        RichIterable<? extends Property<?, ?>> biTemporalMilestoningDateProperties = pm.getClass("test::BiTemporalAddress")._properties().select(p -> Lists.fixedSize.with("businessDate", "processingDate").contains(p.getName()));
         Assert.assertTrue(biTemporalMilestoningDateProperties.size() == 2 && biTemporalMilestoningDateProperties.anySatisfy(p -> p.getName().equals("businessDate")) && biTemporalMilestoningDateProperties.anySatisfy(p -> p.getName().equals("processingDate")));
-        Assert.assertTrue(biTemporalMilestoningDateProperties.allSatisfy(p -> isGeneratedMilestoningProperty.apply(p)));
-        boolean classProcessingDatePropertyIsUsedInBiTemporalMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(biTemporalMilestoningDateProperties.detect(p -> p.getName().equals("processingDate")), personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress")));
-        boolean classBusinessPropertyIsUsedInBiTemporalMiletoningExpression = generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(biTemporalMilestoningDateProperties.detect(p -> p.getName().equals("businessDate")), personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress")));
+        Assert.assertTrue(biTemporalMilestoningDateProperties.allSatisfy(isGeneratedMilestoningProperty::apply));
+        boolean classProcessingDatePropertyIsUsedInBiTemporalMiletoningExpression = generatedMilestoningQualifiedPropertyUsesGeneratedMilestoningProperty(biTemporalMilestoningDateProperties.detect(p -> p.getName().equals("processingDate")), personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress")));
+        boolean classBusinessPropertyIsUsedInBiTemporalMiletoningExpression = generatedMilestoningQualifiedPropertyUsesGeneratedMilestoningProperty(biTemporalMilestoningDateProperties.detect(p -> p.getName().equals("businessDate")), personQualifiedProperties.detect(p -> p.getName().equals("biTemporalAddress")));
         Assert.assertTrue("Class generated milestoning processingDate property should be used in the generated milestoning expression", classProcessingDatePropertyIsUsedInBiTemporalMiletoningExpression);
         Assert.assertTrue("Class generated milestoning businessDate property should be used in the generated milestoning expression", classBusinessPropertyIsUsedInBiTemporalMiletoningExpression);
     }
 
-    private boolean generatedMilestoningQualifgiedPropertyUsesGeneratedMilestoningProperty(Property generatedMilestoningClassSimpleProperty, QualifiedProperty generatedMilestoningClassQualifiedProperty)
+    private boolean generatedMilestoningQualifiedPropertyUsesGeneratedMilestoningProperty(Property<?, ?> generatedMilestoningClassSimpleProperty, QualifiedProperty<?> generatedMilestoningClassQualifiedProperty)
     {
         FunctionExpression topLevelExpression = ((FunctionExpression) generatedMilestoningClassQualifiedProperty._expressionSequence().getFirst());
         FunctionExpression simplifiedExpression;
         if (topLevelExpression._func()._functionName().equals("toOne"))
         {
-            simplifiedExpression = (FunctionExpression) ((LambdaFunction) ((InstanceValue) ((FunctionExpression) (topLevelExpression._parametersValues().toList().get(0)))._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
+            simplifiedExpression = (FunctionExpression) ((LambdaFunction<?>) ((InstanceValue) ((FunctionExpression) (topLevelExpression._parametersValues().toList().get(0)))._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
         }
         else
         {
-            simplifiedExpression = (FunctionExpression) ((LambdaFunction) ((InstanceValue) topLevelExpression._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
+            simplifiedExpression = (FunctionExpression) ((LambdaFunction<?>) ((InstanceValue) topLevelExpression._parametersValues().toList().get(1))._values().getOnly())._expressionSequence().getOnly();
         }
         if (simplifiedExpression._func()._functionName().equals("and"))
         {
             int idx = generatedMilestoningClassSimpleProperty.getName().equals("processingDate") ? 0 : 1;
             simplifiedExpression = (FunctionExpression) simplifiedExpression._parametersValues().toList().get(idx);
         }
-        Property filterMilestoningDateProperty = (Property) ((FunctionExpression) simplifiedExpression._parametersValues().toList().get(0))._func();
+        Property<?, ?> filterMilestoningDateProperty = (Property<?, ?>) ((FunctionExpression) simplifiedExpression._parametersValues().toList().get(0))._func();
         return generatedMilestoningClassSimpleProperty.equals(filterMilestoningDateProperty);
     }
 
@@ -2733,10 +2697,10 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
 
         String WALK_TREE = "main::walkTree_String_$2_MANY$__Person_MANY__String_MANY_";
 
-        ConcreteFunctionDefinition walkTree = pureModel.getConcreteFunctionDefinition(WALK_TREE, null);
+        ConcreteFunctionDefinition<?> walkTree = pureModel.getConcreteFunctionDefinition(WALK_TREE, null);
         SimpleFunctionExpression fold = (SimpleFunctionExpression) walkTree._expressionSequence().getFirst();
-        InstanceValue iv = (InstanceValue) ((FastList) fold._parametersValues()).get(1);
-        SimpleFunctionExpression concat = (SimpleFunctionExpression) ((LambdaFunction) iv._values().getFirst())._expressionSequence().getFirst();
+        InstanceValue iv = (InstanceValue) fold._parametersValues().toList().get(1);
+        SimpleFunctionExpression concat = (SimpleFunctionExpression) ((LambdaFunction<?>) iv._values().getFirst())._expressionSequence().getFirst();
         Assert.assertEquals(pureModel.getType("String"), fold._genericType()._rawType());
         Assert.assertEquals(pureModel.getType("String"), concat._genericType()._rawType());
 
@@ -3078,25 +3042,19 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
         // This is added to test legacy Binary primitive type usages
         test("Class demo::Class\n" +
                 "{\n" +
-                "   binary: Binary[1];" +
+                "   binary: Binary[1];\n" +
                 "}\n");
     }
 
     @Test
     public void testCompilationOfRelationStoreAccessor()
     {
-        try
-        {
-            test("function my::func():Any[*]" +
-                    "{" +
-                    "   #>{my::Store}#->filter(c|$c.val);" +
-                    "}");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("The store 'my::Store' can't be found.", e.getMessage());
-        }
+        Exception e = Assert.assertThrows(Exception.class, () -> test(
+                "function my::func():Any[*]\n" +
+                        "{\n" +
+                        "   #>{my::Store}#->filter(c|$c.val);\n" +
+                        "}\n"));
+        Assert.assertEquals("The store 'my::Store' can't be found.", e.getMessage());
     }
 
     @Test

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/mapping/PureInstanceClassMappingParseTreeWalker.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/mapping/PureInstanceClassMappingParseTreeWalker.java
@@ -32,7 +32,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.m
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 
-import java.util.ArrayList;
 import java.util.Collections;
 
 public class PureInstanceClassMappingParseTreeWalker
@@ -111,7 +110,7 @@ public class PureInstanceClassMappingParseTreeWalker
         ValueSpecification valueSpecification = parser.parseCombinedExpression(lambdaString, combineExpressionSourceInformation, this.parserContext);
         // add source parameter
         Lambda lambda = new Lambda();
-        lambda.body = new ArrayList<>();
+        lambda.body = Lists.mutable.empty();
         lambda.body.add(valueSpecification);
         lambda.parameters = Lists.mutable.empty();
         return lambda;
@@ -126,4 +125,3 @@ public class PureInstanceClassMappingParseTreeWalker
         return m;
     }
 }
-

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperDomainGrammarComposer.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperDomainGrammarComposer.java
@@ -50,8 +50,7 @@ import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarCompos
 
 public class HelperDomainGrammarComposer
 {
-
-    private static String DEFAULT_TESTABLE_ID = "default";
+    private static final String DEFAULT_TESTABLE_ID = "default";
     private static final String APPLICATION_JSON = "application/json";
     private static final String APPLICATION_XML = "application/xml";
 
@@ -78,8 +77,7 @@ public class HelperDomainGrammarComposer
 
     public static String renderUnit(Unit unit, DEPRECATED_PureGrammarComposerCore transformer)
     {
-        String unitName = PureGrammarComposerUtility.convertIdentifier(unit.name);
-        return (unitName.startsWith("'") ? "'" : "") + unitName.substring(unitName.lastIndexOf("~") + 1) + (unit.conversionFunction == null ? ";" : ": " + renderUnitLambda(unit.conversionFunction, transformer) + ";");
+        return PureGrammarComposerUtility.convertIdentifier(unit.name) + (unit.conversionFunction == null ? ";" : ": " + renderUnitLambda(unit.conversionFunction, transformer) + ";");
     }
 
     public static String renderUnitLambda(Lambda conversionFunction, DEPRECATED_PureGrammarComposerCore transformer)
@@ -229,7 +227,7 @@ public class HelperDomainGrammarComposer
     {
         StringBuilder dataStrBuilder = new StringBuilder();
         dataStrBuilder.append(getTabString(currentInt));
-        dataStrBuilder.append(HelperRuntimeGrammarComposer.renderStoreProviderPointer(storeTestData.store) + ":");
+        dataStrBuilder.append(HelperRuntimeGrammarComposer.renderStoreProviderPointer(storeTestData.store)).append(":");
         EmbeddedData embeddedData = storeTestData.data;
         if (embeddedData instanceof DataElementReference)
         {
@@ -310,6 +308,4 @@ public class HelperDomainGrammarComposer
             return "(" + externalFormatData.contentType + ") " + PureGrammarComposerUtility.convertString(externalFormatData.data, true);
         }
     }
-
-
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/CorePureProtocolExtension.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/CorePureProtocolExtension.java
@@ -43,7 +43,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Function;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Measure;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Profile;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Unit;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.externalFormat.Binding;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.externalFormat.ExternalFormatSchemaSet;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.function.FunctionTest;
@@ -67,11 +66,11 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.Asse
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertPass;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertionStatus;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.EqualToJsonAssertFail;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestDebug;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
-import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
-import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestDebug;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionPlanDebug;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 
 import java.util.List;
 import java.util.Map;
@@ -100,7 +99,6 @@ public class CorePureProtocolExtension implements PureProtocolExtension
                         .withSubtype(Association.class, "association")
                         .withSubtype(Function.class, "function")
                         .withSubtype(Measure.class, "measure")
-                        .withSubtype(Unit.class, "unit")
                         .withSubtype(ExternalFormatSchemaSet.class, "externalFormatSchemaSet")
                         .withSubtype(Binding.class, "binding")
                         .withSubtype(RelationalMapper.class, "relationalMapper")
@@ -176,7 +174,6 @@ public class CorePureProtocolExtension implements PureProtocolExtension
                 .withKeyValue(PackageableConnection.class, "meta::pure::runtime::PackageableConnection")
                 .withKeyValue(PackageableRuntime.class, "meta::pure::runtime::PackageableRuntime")
                 .withKeyValue(Profile.class, "meta::pure::metamodel::extension::Profile")
-                .withKeyValue(Unit.class, "meta::pure::metamodel::type::Unit")
                 .withKeyValue(DataElement.class, "meta::pure::data::DataElement")
                 .withKeyValue(ExternalFormatSchemaSet.class, "meta::external::format::shared::metamodel::SchemaSet")
                 .withKeyValue(Binding.class, "meta::external::format::shared::binding::Binding")

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/domain/Unit.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/domain/Unit.java
@@ -14,19 +14,53 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain;
 
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElementVisitor;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 
-public class Unit extends PackageableElement
+public class Unit
 {
+    public String name;
     public String measure;
     public Lambda conversionFunction;
-    public String superType;
+    public SourceInformation sourceInformation;
 
-    @Override
-    public <T> T accept(PackageableElementVisitor<T> visitor)
+    @Deprecated
+    public Unit()
     {
-        return visitor.visit(this);
+    }
+
+    private Unit(String name, String measure, Lambda conversionFunction, SourceInformation sourceInformation)
+    {
+        this.name = name;
+        this.measure = measure;
+        this.conversionFunction = conversionFunction;
+        this.sourceInformation = sourceInformation;
+    }
+
+    public static Unit newUnit(String name, String measure, Lambda conversionFunction, SourceInformation sourceInformation)
+    {
+        return new Unit(name, measure, conversionFunction, sourceInformation);
+    }
+
+    public static Unit newUnit(String name, String measure, SourceInformation sourceInformation)
+    {
+        return newUnit(name, measure, null, sourceInformation);
+    }
+
+    @JsonCreator
+    public static Unit newUnit(
+            @JsonProperty("name") String name,
+            @JsonProperty("measure") String measure,
+            @JsonProperty("conversionFunction") Lambda conversionFunction,
+            @JsonProperty("sourceInformation") SourceInformation sourceInformation,
+            // for backward compatibility
+            @Deprecated @JsonProperty("_type") String type,
+            @Deprecated @JsonProperty("package") String _package,
+            @Deprecated @JsonProperty("superType") String superType
+    )
+    {
+        return newUnit(name, measure, conversionFunction, sourceInformation);
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/valueSpecification/raw/UnitInstance.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/valueSpecification/raw/UnitInstance.java
@@ -19,7 +19,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSp
 public class UnitInstance extends DataTypeValueSpecification
 {
     public String unitType;
-    public Long unitValue;
+    public Number unitValue;
 
     @Override
     public <T> T accept(ValueSpecificationVisitor<T> visitor)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/valueSpecification/raw/UnitType.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/valueSpecification/raw/UnitType.java
@@ -25,18 +25,26 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSp
 
 import java.io.IOException;
 
-@Deprecated
 @JsonDeserialize(using = UnitType.UnitTypeDeserializer.class)
-public class UnitType extends PackageableElementPtr
+public class UnitType extends One
 {
+    public String fullPath;
+
+    public UnitType(String fullPath, SourceInformation sourceInformation)
+    {
+        this.fullPath = fullPath;
+        this.sourceInformation = sourceInformation;
+    }
+
+    public UnitType(String fullPath)
+    {
+        this(fullPath, null);
+    }
+
     @Override
     public <T> T accept(ValueSpecificationVisitor<T> visitor)
     {
         return visitor.visit(this);
-    }
-
-    private UnitType()
-    {
     }
 
     public static class UnitTypeDeserializer extends JsonDeserializer<ValueSpecification>
@@ -46,21 +54,10 @@ public class UnitType extends PackageableElementPtr
         {
             JsonNode node = jsonParser.getCodec().readTree(jsonParser);
             JsonNode unitType = node.get("unitType");
-            ValueSpecification result;
-            if (unitType != null)
-            {
-                result = new PackageableElementPtr(unitType.asText());
-            }
-            else
-            {
-                result = new PackageableElementPtr(node.get("fullPath").asText());
-            }
+            String fullPath = ((unitType == null) ? node.get("fullPath") : unitType).asText();
             JsonNode sourceInformation = node.get("sourceInformation");
-            if (sourceInformation != null)
-            {
-                result.sourceInformation = om.treeToValue(sourceInformation, SourceInformation.class);
-            }
-            return result;
+            SourceInformation sourceInfo = (sourceInformation == null) ? null : jsonParser.getCodec().treeToValue(sourceInformation, SourceInformation.class);
+            return new UnitType(fullPath, sourceInfo);
         }
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/test/TestCompatibilityAndMigration.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/test/java/org/finos/legend/engine/protocol/test/TestCompatibilityAndMigration.java
@@ -253,7 +253,7 @@ public class TestCompatibilityAndMigration
                         "          ]\n" +
                         "        },\n" +
                         "        \"measure\": \"test::NewMeasure\",\n" +
-                        "        \"name\": \"NewMeasure~UnitOne\",\n" +
+                        "        \"name\": \"UnitOne\",\n" +
                         "        \"package\": \"test\"\n" +
                         "      },\n" +
                         "      \"name\": \"NewMeasure\",\n" +
@@ -292,8 +292,7 @@ public class TestCompatibilityAndMigration
                         "    \"_type\" : \"measure\",\n" +
                         "    \"name\" : \"NewMeasure\",\n" +
                         "    \"canonicalUnit\" : {\n" +
-                        "      \"_type\" : \"unit\",\n" +
-                        "      \"name\" : \"NewMeasure~UnitOne\",\n" +
+                        "      \"name\" : \"UnitOne\",\n" +
                         "      \"measure\" : \"test::NewMeasure\",\n" +
                         "      \"conversionFunction\" : {\n" +
                         "        \"_type\" : \"lambda\",\n" +
@@ -305,8 +304,7 @@ public class TestCompatibilityAndMigration
                         "          \"_type\" : \"var\",\n" +
                         "          \"name\" : \"x\"\n" +
                         "        } ]\n" +
-                        "      },\n" +
-                        "      \"package\" : \"test\"\n" +
+                        "      }\n" +
                         "    },\n" +
                         "    \"package\" : \"test\"\n" +
                         "  }, {\n" +
@@ -318,7 +316,7 @@ public class TestCompatibilityAndMigration
                         "      \"upperBound\" : 1\n" +
                         "    },\n" +
                         "    \"body\" : [ {\n" +
-                        "      \"_type\" : \"packageableElementPtr\",\n" +
+                        "      \"_type\" : \"unitType\",\n" +
                         "      \"sourceInformation\" : {\n" +
                         "        \"startLine\" : 8,\n" +
                         "        \"startColumn\" : 3,\n" +

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/platformBinding/typeInfo/typeInfo.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/platformBinding/typeInfo/typeInfo.pure
@@ -695,8 +695,8 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo
 
 function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::isNotTypeFn(type:Type[1]):Function<{Type[1]->Boolean[1]}>[1]
 {
-   let path = $type->cast(@PackageableElement)->elementToPath();
-   {t:Type[1] | ($type != $t) && ($path != $t->cast(@PackageableElement)->elementToPath())};
+   let path = $type->elementToPath();
+   {t:Type[1] | ($type != $t) && ($path != $t->elementToPath())};
 }
 
 function <<access.private>> meta::pure::executionPlan::platformBinding::typeInfo::isNotClassFn(class:Class<Any>[1]):Function<{Class<Any>[1]->Boolean[1]}>[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/metamodel_diagram.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/metamodel_diagram.pure
@@ -665,14 +665,6 @@ Diagram meta::pure::Pure_Diagram(width=0.0, height=0.0)
         lineWidth=-1.0,
         lineStyle=SIMPLE)
 
-    GeneralizationView gview_16(
-        source=cview_32,
-        target=cview_2,
-        points=[(702.43940,592.99207),(702.21595,456.28667)],
-        label='',
-        color=#000000,
-        lineWidth=-1.0,
-        lineStyle=SIMPLE)
 
     GeneralizationView gview_17(
         source=cview_33,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_18_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_18_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_18_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions)
    ])
 }
@@ -123,7 +122,7 @@ function meta::protocols::pure::v1_18_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_18_0::transformation::fromPureGraph::transformLambda($extensions)
    );
@@ -219,5 +218,3 @@ function meta::protocols::pure::v1_18_0::transformation::fromPureGraph::transfor
       postConstraints  = $f.postConstraints->map(c |$c->meta::protocols::pure::v1_18_0::transformation::fromPureGraph::domain::transformConstraint($extensions))
    )
 }
-
-

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_19_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_19_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_19_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions)
    ])
 }
@@ -123,7 +122,7 @@ function meta::protocols::pure::v1_19_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_19_0::transformation::fromPureGraph::transformLambda($extensions)
    );
@@ -219,5 +218,3 @@ function meta::protocols::pure::v1_19_0::transformation::fromPureGraph::transfor
       postConstraints  = $f.postConstraints->map(c |$c->meta::protocols::pure::v1_19_0::transformation::fromPureGraph::domain::transformConstraint($extensions))
    )
 }
-
-

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_20_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_20_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_20_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -124,7 +123,7 @@ function meta::protocols::pure::v1_20_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_20_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_21_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_21_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_21_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_21_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_21_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_22_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_22_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_22_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_22_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_22_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_23_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_23_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_23_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_23_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_23_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_24_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_24_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_24_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_24_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_24_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_25_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_25_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_25_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_25_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_25_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_26_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_26_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_26_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_27_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_27_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_27_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_27_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_27_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_28_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_28_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_28_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_28_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_28_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_29_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_29_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_29_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_29_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_29_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_30_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_30_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_30_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_30_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_30_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_31_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_31_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_31_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_31_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_31_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_32_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_32_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_32_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_32_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_32_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_33_0/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/v1_33_0/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::v1_33_0::transformation::fromPureGraph::domain::
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -135,7 +134,7 @@ function meta::protocols::pure::v1_33_0::transformation::fromPureGraph::domain::
    (
       _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
+      package = if($measure.package->isEmpty(),|[],|$measure.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::v1_33_0::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/models/metamodel.pure
@@ -247,8 +247,9 @@ Class meta::protocols::pure::vX_X_X::metamodel::domain::Measure extends meta::pr
    nonCanonicalUnits : meta::protocols::pure::vX_X_X::metamodel::domain::Unit[*];
 }
 
-Class meta::protocols::pure::vX_X_X::metamodel::domain::Unit extends meta::protocols::pure::vX_X_X::metamodel::PackageableElement
+Class meta::protocols::pure::vX_X_X::metamodel::domain::Unit
 {
+   name : String[1];
    measure : String[1];
    conversionFunction : meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::Lambda[0..1];
 }
@@ -425,6 +426,11 @@ Class meta::protocols::pure::vX_X_X::metamodel::valueSpecification::ClassInstanc
 {
    type : String[1];
    value : Any[1];
+}
+
+Class meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::UnitType extends meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::RawValue
+{
+   fullPath : String[1];
 }
 
 Class meta::protocols::pure::vX_X_X::metamodel::valueSpecification::UnitInstance extends meta::protocols::pure::vX_X_X::metamodel::valueSpecification::ValueSpecification

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/metamodel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/metamodel.pure
@@ -31,7 +31,6 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::domain::t
      assoc:Association[1]            | transformAssociation($assoc, $extensions),
      enum:Enumeration<Any>[1]        | transformEnum($enum),
      meas:Measure[1]                 | transformMeasure($meas, $extensions),
-     unit:Unit[1]                    | transformUnit($unit, $extensions),
      func:ConcreteFunctionDefinition<Any>[1] | transformFunction($func, $extensions),
      prof:Profile[1]                 | transformProfile($prof, $extensions)
    ])
@@ -133,9 +132,7 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::domain::t
 
    ^meta::protocols::pure::vX_X_X::metamodel::domain::Unit
    (
-      _type = 'unit',
       name = $unit.name->toOne(),
-      package = if($unit.package->isEmpty(),|[],|$unit.package->toOne()->elementToPath()),
       measure = $measure->toOne()->elementToPath(),
       conversionFunction = $conversionFunction->toOne()->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::transformLambda($extensions)
    );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/valueSpecification.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/valueSpecification.pure
@@ -166,12 +166,12 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpec
                         if($i->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::isClassFunctionParameter(true),
                            |$i->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformHackedClass(),
                            | if($i->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::isClassFunctionParameter(false),
-                                |$i.genericType.typeArguments.rawType->toOne()->meta::protocols::pure::vX_X_X::transformation ::fromPureGraph::valueSpecification::transformAny($inScope, $open, $i.multiplicity, 0 , [],$useAppliedFunction, $extensions),
+                                |$i.genericType.typeArguments.rawType->toOne()->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, $i.multiplicity, 0, [], $useAppliedFunction, $extensions),
                                 |if($i->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::isHackedUnit(),
                                   |$i->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformHackedUnit(),
                                   |if($i->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::isUnitType(),
                                       |$i->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformUnitInstance(),
-                                      |$i.values->meta::protocols::pure::vX_X_X::transformation ::fromPureGraph::valueSpecification::transformAny($inScope, $open, $i.multiplicity, 0 , [],$useAppliedFunction, $extensions)))));,
+                                      |$i.values->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformAny($inScope, $open, $i.multiplicity, 0, [], $useAppliedFunction, $extensions)))));,
          v:VariableExpression[1]|
             if ($inScope->contains($v.name),
                 |meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformVar($v,$isParameter),
@@ -356,9 +356,9 @@ function <<access.private>> meta::protocols::pure::vX_X_X::transformation::fromP
                         fullPath = $e->elementToPath()
                      ),
                   u:Unit[1]|
-                    ^meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::PackageableElementPtr
+                    ^meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::UnitType
                     (
-                       _type = 'packageableElementPtr',
+                       _type = 'unitType',
                        fullPath = $u->elementToPath()
                     ),
                   v:ValueSpecification[1]|$v->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformValueSpecification($inScope, $open,false,$useAppliedFunction, $extensions),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-compiled-functions-json/src/main/resources/org/finos/legend/pure/runtime/java/extension/external/json/compiled/JsonGen.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-compiled-functions-json/src/main/resources/org/finos/legend/pure/runtime/java/extension/external/json/compiled/JsonGen.java
@@ -88,7 +88,7 @@ public class JsonGen
     @SuppressWarnings("unchecked")
     public static <T> T _fromJson(String json, Class<T> clazz, String _typeKeyName, boolean _failOnUnknownProperties, final SourceInformation si, final CompiledExecutionSupport es, final ConstraintsOverride constraintsHandler, RichIterable<? extends Pair<? extends String, ? extends String>> _typeLookup)
     {
-        String targetClassName = JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(clazz);
+        String targetClassName = JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(clazz, es.getProcessorSupport());
         try
         {
             es.getClassLoader().loadClass(targetClassName);
@@ -129,11 +129,18 @@ public class JsonGen
             @Override
             public <T extends Any> T newUnitInstance(CoreInstance propertyType, String unitTypeString, Number unitValue)
             {
-                CoreInstance unitRetrieved = es.getProcessorSupport().package_getByUserPath(unitTypeString);
+                CoreInstance unitRetrieved = Measure.getUnitByUserPath(unitTypeString, es.getProcessorSupport());
                 if (!es.getProcessorSupport().type_subTypeOf(unitRetrieved, propertyType))
                 {
                     StringBuilder builder = new StringBuilder("Cannot match unit type: ").append(unitTypeString).append(" as subtype of type: ");
-                    PackageableElement.writeUserPathForPackageableElement(builder, propertyType);
+                    if (Measure.isUnit(propertyType, es.getProcessorSupport()))
+                    {
+                        Measure.writeUserPathForUnit(builder, propertyType);
+                    }
+                    else
+                    {
+                        PackageableElement.writeUserPathForPackageableElement(builder, propertyType);
+                    }
                     throw new PureExecutionException(builder.toString());
                 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-interpreted-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/interpreted/natives/FromJson.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-interpreted-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/interpreted/natives/FromJson.java
@@ -111,11 +111,18 @@ public class FromJson extends NativeFunction
             @Override
             public <T extends Any> T newUnitInstance(CoreInstance propertyType, String unitTypeString, Number unitValue)
             {
-                CoreInstance retrievedUnit = processorSupport.package_getByUserPath(unitTypeString);
+                CoreInstance retrievedUnit = Measure.getUnitByUserPath(unitTypeString, processorSupport);
                 if (!processorSupport.type_subTypeOf(retrievedUnit, propertyType))
                 {
                     StringBuilder builder = new StringBuilder("Cannot match unit type: ").append(unitTypeString).append(" as subtype of type: ");
-                    PackageableElement.writeUserPathForPackageableElement(builder, propertyType);
+                    if (Measure.isUnit(propertyType, processorSupport))
+                    {
+                        Measure.writeUserPathForUnit(builder, propertyType);
+                    }
+                    else
+                    {
+                        PackageableElement.writeUserPathForPackageableElement(builder, propertyType);
+                    }
                     throw new PureExecutionException(builder.toString());
                 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonClassSerialization.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonClassSerialization.java
@@ -25,6 +25,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.As
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.extension.external.shared.conversion.ClassConversion;
@@ -143,6 +144,10 @@ public class JsonClassSerialization<T extends CoreInstance> extends ClassConvers
         if ((jsonSerializationContext.isSerializePackageableElementName() && pureObject instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) || MetamodelSerializationOverrides.shouldSerializeAsElementToPath(pureObject))
         {
             return MetamodelSerializationOverrides.serializePackageableElement(pureObject, jsonSerializationContext.isSerializeMultiplicityAsNumber());
+        }
+        if ((jsonSerializationContext.isSerializePackageableElementName() && pureObject instanceof Unit))
+        {
+            return MetamodelSerializationOverrides.serializeUnit((Unit) pureObject);
         }
         jsonSerializationContext.getVisitedInstances().push(pureObject);
         JSONObject json = new JSONObject();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonUnitSerialization.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonUnitSerialization.java
@@ -17,9 +17,11 @@ package org.finos.legend.pure.runtime.java.extension.external.json.shared;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.extension.external.shared.conversion.ConversionContext;
 import org.finos.legend.pure.runtime.java.extension.external.shared.conversion.UnitConversion;
@@ -43,7 +45,7 @@ public class JsonUnitSerialization<T extends CoreInstance> extends UnitConversio
     private String getUnitId(InstanceValue unitInstance)
     {
         Type type = unitInstance._genericType()._rawType();
-        return PackageableElement.getUserPathForPackageableElement(type);
+        return (type instanceof Unit) ? Measure.getUserPathForUnit(type) : PackageableElement.getUserPathForPackageableElement(type);
     }
 
     private Number getValue(InstanceValue unitInstance)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/MetamodelSerializationOverrides.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/MetamodelSerializationOverrides.java
@@ -23,9 +23,11 @@ import org.finos.legend.pure.m3.coreinstance.Package;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.extension.external.shared.conversion.PropertyConversion;
 
@@ -76,5 +78,10 @@ class MetamodelSerializationOverrides
     static Object serializePackageableElement(CoreInstance pureObject, boolean serializeMultiplicityAsNumber)
     {
         return serializeMultiplicityAsNumber && pureObject instanceof Multiplicity ? serializeMultiplicityAsNumber((Multiplicity)pureObject) : PackageableElement.getUserPathForPackageableElement(pureObject);
+    }
+
+    static Object serializeUnit(Unit unit)
+    {
+        return Measure.getUserPathForUnit(unit);
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/meta/value4Tag.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/meta/value4Tag.pure
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function meta::pure::functions::meta::value4Tag(f:Type[1], tagName:String[1], profile:Profile[1]):TaggedValue[*]
+function meta::pure::functions::meta::value4Tag(type:Type[1], tagName:String[1], profile:Profile[1]):TaggedValue[*]
 {
-    $f->cast(@ElementWithTaggedValues)->value4Tag($tagName, $profile);
+    $type->match([
+                  e:ElementWithTaggedValues[1] | $e->value4Tag($tagName, $profile),
+                  a:Any[1] | []
+                 ])
 }
 
 function meta::pure::functions::meta::value4Tag(f:ElementWithTaggedValues[1], tagName:String[1], profile:Profile[1]):TaggedValue[*]

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
@@ -362,9 +362,11 @@ function meta::external::language::java::transform::identifier(conventions: Conv
    $conventions.identifierFactory->eval($name);
 }
 
-function meta::external::language::java::transform::className(conventions: Conventions[1], pe:meta::pure::metamodel::type::Type[1]): meta::external::language::java::metamodel::Class[1]
+function meta::external::language::java::transform::className(conventions: Conventions[1], type:meta::pure::metamodel::type::Type[1]): meta::external::language::java::metamodel::Class[1]
 {
-    meta::external::language::java::transform::className($conventions, $pe->cast(@PackageableElement));
+    if($conventions->isProvidedType($type),
+       | $conventions->getProvidedType($type),
+       | $conventions->generateClassName($type, 'app', ''))
 }
 
 function meta::external::language::java::transform::className(conventions: Conventions[1], pe:PackageableElement[1]): meta::external::language::java::metamodel::Class[1]
@@ -375,14 +377,42 @@ function meta::external::language::java::transform::className(conventions: Conve
    );
 }
 
-function meta::external::language::java::transform::implClassName(conventions: Conventions[1], pe:meta::pure::metamodel::type::Type[1]): meta::external::language::java::metamodel::Class[1]
+function meta::external::language::java::transform::implClassName(conventions: Conventions[1], type:meta::pure::metamodel::type::Type[1]): meta::external::language::java::metamodel::Class[1]
 {
-   $conventions->generateClassName($pe->cast(@PackageableElement), 'internal', '_Impl');
+   $conventions->generateClassName($type, 'internal', '_Impl');
 }
 
 function meta::external::language::java::transform::implClassName(conventions: Conventions[1], pe:PackageableElement[1]): meta::external::language::java::metamodel::Class[1]
 {
    $conventions->generateClassName($pe, 'internal', '_Impl');
+}
+
+function <<access.private>> meta::external::language::java::transform::generateClassName(conventions:Conventions[1], type:meta::pure::metamodel::type::Type[1], zone:String[1], suffix:String[1]): meta::external::language::java::metamodel::Class[1]
+{
+   assert(!$conventions->isProvidedType($type), 'Cannot provide implementation for provided types');
+   assert($type != Function, 'Cannot handle function, should use pureTypeToJavaType with generic type');
+
+   let packageAndName = if($conventions.typeAndPackageNameStrategy->isEmpty(),
+    |let zoneRoot    = $conventions.basePackageName + '.' + $zone + '.';
+     let package     = $type->match([
+                           u:Unit[1]                                    | $u.measure.package,
+                           mc:meta::pure::mapping::MappingClass<Any>[1] | $mc.generalizations.general->cast(@GenericType).rawType->cast(@meta::pure::metamodel::type::Class<Any>).package,
+                           pe:PackageableElement[1]                     | $pe.package
+                       ])->toOne();
+     let javaPkgName = $zoneRoot + $conventions->identifier($package->elementToPath('.'));
+     let typeName = $type->match([
+                        u:Unit[1]                | $u.name,
+                        pe:PackageableElement[1] | $pe.name
+                    ])->toOne();
+     let name = $conventions->identifier($typeName)->toUpperFirstCharacter()->toOne() + $suffix;
+     pair($javaPkgName, $name);,
+    |$conventions.typeAndPackageNameStrategy->toOne()->eval($type, $conventions)
+   );
+
+   if($type->instanceOf(meta::pure::metamodel::type::Enumeration),
+      | javaEnum(javaPackage($packageAndName.first), $packageAndName.second),
+      | javaClass(javaPackage($packageAndName.first), $packageAndName.second);
+   );
 }
 
 function <<access.private>> meta::external::language::java::transform::generateClassName(conventions:Conventions[1], pe:PackageableElement[1], zone:String[1], suffix:String[1]): meta::external::language::java::metamodel::Class[1]
@@ -393,7 +423,7 @@ function <<access.private>> meta::external::language::java::transform::generateC
    let packageAndName = if ($conventions.typeAndPackageNameStrategy->isEmpty(),
     |let zoneRoot    = $conventions.basePackageName + '.' + $zone + '.';
      let package     = if($pe->instanceOf(meta::pure::mapping::MappingClass), | $pe->cast(@meta::pure::mapping::MappingClass<Any>).generalizations.general->cast(@GenericType).rawType->cast(@meta::pure::metamodel::type::Class<Any>).package->toOne(), | $pe.package->toOne());
-     let javaPkgName = $zoneRoot + $conventions->identifier($package->elementToPath()->replace('::', '.'));
+     let javaPkgName = $zoneRoot + $conventions->identifier($package->elementToPath('.'));
      let name = $conventions->identifier($pe.name->toOne())->toUpperFirstCharacter()->toOne() + $suffix;
      pair($javaPkgName, $name);,
     | $conventions.typeAndPackageNameStrategy->toOne()->eval($pe->cast(@meta::pure::metamodel::type::Type), $conventions)

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchJson.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchJson.pure
@@ -444,7 +444,7 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
 
    javaMethod('private', $javaType, 'accept'+$type.name->toOne(), $nodeParameter,
       [
-        $errorMessage->j_declare(j_string('Unexpected node type:')->j_plus($nodeParameter->j_invoke('getNodeType', [], jsonNodeType())->j_plus(j_string(' for PURE ' + $type.name->toOne())))),
+        $errorMessage->j_declare(j_string('Unexpected node type:')->j_plus($nodeParameter->j_invoke('getNodeType', [], jsonNodeType())->j_plus(j_string(' for PURE ' + $type->elementToPath())))),
         $jThis->j_invoke('check', [javaArrays()->j_invoke('asList', $acceptableNodes, javaList(jsonNodeType())), $nodeParameter->j_invoke('getNodeType', [], jsonNodeType()), $errorMessage], javaVoid()),
 
         j_return($conventions->jsonNodeGetter($nodeParameter, $type))
@@ -472,19 +472,19 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
     let simpleJavaName          = $conventions->identifier($type.name->toOne());
     let fullJavaName            = $conventions->identifier($javaType->meta::external::language::java::serialization::typeToString());
     let acceptibleTokens        = $conventions->jacksonTokenTypesFor($type);
-    let getCurrentTokenErrorMsg = '"Unexpected " + parser.getCurrentToken() + " for PURE '+ $type.name->toOne()+'"';
-    let getNextTokenErrorMsg    = '"Unexpected " + parser.nextToken() + " for PURE '+ $type.name->toOne()+'"';
+    let getCurrentTokenErrorMsg = '"Unexpected " + parser.getCurrentToken() + " for PURE ' + $type->elementToPath() + '"';
+    let getNextTokenErrorMsg    = '"Unexpected " + parser.nextToken() + " for PURE ' + $type->elementToPath() + '"';
     let appendToRecord          = '    this.appendToRecord();\n';
     let nodeParameter           = j_parameter(jsonNode(), 'node');
 
     javaMethod('private', $javaType, 'accept' + $simpleJavaName, $nodeParameter,
-       '    check(JsonNodeType.OBJECT, node.getNodeType(), "Unexpected " + node.getNodeType() + " for PURE '+ $type.name->toOne()+'");\n' +
-       '    check(JsonNodeType.ARRAY, node.path("unit").getNodeType(), "Unexpected unit" + node.path("unit").getNodeType() + " for PURE '+ $type.name->toOne()+'");\n' +
-       '    check(JsonNodeType.STRING, node.path("unit").path(0).path("unitId").getNodeType(), "Unexpected unitId" + node.path("unit").path(0).path("unitId").getNodeType() + " for PURE '+ $type.name->toOne()+'");\n' +
-       '    check(JsonNodeType.NUMBER, node.path("unit").path(0).path("exponentValue").getNodeType(), "Unexpected exponentValue" + node.path("unit").path(0).path("exponentValue").getNodeType() + " for PURE '+ $type.name->toOne()+'");\n' +
+       '    check(JsonNodeType.OBJECT, node.getNodeType(), "Unexpected " + node.getNodeType() + " for PURE ' + $type->elementToPath() + '");\n' +
+       '    check(JsonNodeType.ARRAY, node.path("unit").getNodeType(), "Unexpected unit" + node.path("unit").getNodeType() + " for PURE ' + $type->elementToPath() + '");\n' +
+       '    check(JsonNodeType.STRING, node.path("unit").path(0).path("unitId").getNodeType(), "Unexpected unitId" + node.path("unit").path(0).path("unitId").getNodeType() + " for PURE ' + $type->elementToPath() + '");\n' +
+       '    check(JsonNodeType.NUMBER, node.path("unit").path(0).path("exponentValue").getNodeType(), "Unexpected exponentValue" + node.path("unit").path(0).path("exponentValue").getNodeType() + " for PURE ' + $type->elementToPath() + '");\n' +
 
 
-       '    check(JsonNodeType.NUMBER, node.path("value").getNodeType(), "Unexpected value" + node.path("value").getNodeType() + " for PURE '+ $type.name->toOne()+'");\n' +
+       '    check(JsonNodeType.NUMBER, node.path("value").getNodeType(), "Unexpected value" + node.path("value").getNodeType() + " for PURE ' + $type->elementToPath() + '");\n' +
        '    Double unitValue = node.path("value").doubleValue();\n' +
        '    ' +$fullJavaName+' value = new ' + $simpleJavaName +'_Impl(unitValue);\n' +
 

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchXml.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchXml.pure
@@ -466,7 +466,7 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
   let tokenStream   = $jThis->j_field('xmlTokenStream');
   let currentToken  = $tokenStream->j_invoke('getCurrentToken', [], javaInt());
   let accept        = $jThis->j_invoke('accept', j_true(), javaVoid());
-  let errorMessage  = j_string('Unexpected ')->j_plus($currentToken)->j_plus(j_string(' for PURE '+ $type.name->toOne()));
+  let errorMessage  = j_string('Unexpected ')->j_plus($currentToken)->j_plus(j_string(' for PURE '+ $type->elementToPath()));
   let check         = {c:Code[1] | $jThis->j_invoke('check', [$c, $errorMessage], javaVoid())};
 
   let acceptXmlType = if($xmlType == XmlType.Element,

--- a/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/src/main/resources/core_external_format_json_java_platform_binding/legendJavaPlatformBinding/internalize/jsonReader.pure
+++ b/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/src/main/resources/core_external_format_json_java_platform_binding/legendJavaPlatformBinding/internalize/jsonReader.pure
@@ -336,7 +336,7 @@ function <<access.private>> meta::external::format::json::executionPlan::platfor
 {
   let javaType             = $conventions->pureTypeToJavaType($type, PureOne);
   let simpleJavaName       = $conventions->identifier($type.name->toOne());
-  let typeName             = j_string($type.name->toOne());
+  let typeName             = j_string($type->elementToPath());
   let nodeParameter        = j_parameter(jsonNode(), 'node');
   let nodeTypeInvoke       = {param:Code[1] | $param->j_invoke('getNodeType', [], jsonNodeType())};
   let checkMethodInvokeGen = {params:Code[3] | j_this($javaInterface)->j_invoke('check', $params, javaVoid())};

--- a/legend-engine-xts-json/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/executionPlan/tests/resources/allTypesBadDataResult.json
+++ b/legend-engine-xts-json/legend-engine-xt-json-pure/src/main/resources/core_external_format_json/executionPlan/tests/resources/allTypesBadDataResult.json
@@ -274,7 +274,7 @@
       {
         "id": null,
         "externalId": null,
-        "message": "optionalMeasure: Unexpected NUMBER for PURE Mass~Kilogram",
+        "message": "optionalMeasure: Unexpected NUMBER for PURE meta::pure::unit::Mass~Kilogram",
         "enforcementLevel": "Error",
         "ruleType": "InvalidInput",
         "ruleDefinerPath": "meta::external::format::json::executionPlan::test::types::AllTypes",

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/src/main/resources/core_nonrelational_mongodb_java_platform_binding/mongodbStoreLegendJavaPlatformBindingExtension.pure
@@ -362,7 +362,7 @@ function <<access.private>> meta::external::store::mongodb::executionPlan::platf
 
    let newAcceptMethod = javaMethod('private', $javaType, $methodName, $nodeParameter,
       [
-        $errorMessage->j_declare(j_string('Unexpected node type:')->j_plus($nodeParameter->j_invoke('getNodeType', [], jsonNodeType())->j_plus(j_string(' for PURE ' + $type.name->toOne())))),
+        $errorMessage->j_declare(j_string('Unexpected node type:')->j_plus($nodeParameter->j_invoke('getNodeType', [], jsonNodeType())->j_plus(j_string(' for PURE ' + $type->elementToPath())))),
         $jThis->j_invoke('check', [javaArrays()->j_invoke('asList', $acceptableNodes, javaList(jsonNodeType())), $nodeParameter->j_invoke('getNodeType', [], jsonNodeType()), $errorMessage], javaVoid()),
         j_if(j_and($nodeParameter->j_invoke('has',[$dateKey], javaBoolean()), $nodeParameter->j_invoke('get', [$dateKey], jsonNode())->j_invoke('isLong',[],javaBoolean())), j_return($conventions->codeType($pureDate)->j_invoke('fromDate', [javaDate()->j_new([$nodeParameter->j_invoke('get', [$dateKey], jsonNode())->j_invoke('longValue',[], javaLong())])], $pureDate)), j_throw(j_new(javaIllegalArgumentException(), j_string('Failed to parse $date from Mongo ISO Date field'))))
       ]->j_try(j_catch($exception, $conventions->className(DataParsingException)->j_new($exception->j_invoke('getMessage', [], javaString()))->j_throw()))

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -1462,7 +1462,7 @@ public class HelperRelationalBuilder
 
         if (propertyMapping.target == null && property._genericType()._rawType() instanceof Class)
         {
-            return HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), "_", context.pureModel.getExecutionSupport());
+            return HelperModelBuilder.getTypeFullPath(property._genericType()._rawType(), "_", context.pureModel.getExecutionSupport());
         }
         return HelperMappingBuilder.getPropertyMappingTargetId(propertyMapping);
     }
@@ -1484,7 +1484,7 @@ public class HelperRelationalBuilder
         if ((parent._id() == null) && (owner instanceof Association))
         {
             Property<?, ?> prop = ((Class<?>) property._genericType()._rawType())._propertiesFromAssociations().detect(p -> owner.equals(p._owner()));
-            return HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) prop._genericType()._rawType(), "_", context.pureModel.getExecutionSupport());
+            return HelperModelBuilder.getTypeFullPath(prop._genericType()._rawType(), "_", context.pureModel.getExecutionSupport());
         }
         return parent._id();
     }

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreClassMappingBuilder.java
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperServiceStoreClassMappingBuilder.java
@@ -15,10 +15,10 @@
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.external.shared.format.model.ExternalFormatExtension;
@@ -75,7 +75,6 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EmbeddedSetImplem
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMappingsImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Generalization;
@@ -86,11 +85,9 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.G
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder.getElementFullPath;
 import static org.finos.legend.pure.generated.platform_pure_essential_meta_graph_elementToPath.Root_meta_pure_functions_meta_elementToPath_PackageableElement_1__String_1_;
 
 public class HelperServiceStoreClassMappingBuilder
@@ -115,9 +112,9 @@ public class HelperServiceStoreClassMappingBuilder
         validateRootServiceStoreClassMapping(res, serviceStoreClassMapping);
 
         MutableList<EmbeddedSetImplementation> embeddedSetImplementations = Lists.mutable.empty();
-        Set<Class<?>> processedClasses = new HashSet<>();
+        Set<Class<?>> processedClasses = Sets.mutable.empty();
         List<PropertyMapping> generatePropertyMappings = generatePropertyMappingsForClassMapping(res, embeddedSetImplementations, serviceStoreClassMapping, processedClasses, context);
-        res._propertyMappings(FastList.newList(generatePropertyMappings).toImmutable());
+        res._propertyMappings(Lists.immutable.withAll(generatePropertyMappings));
 
         return Tuples.pair(res, embeddedSetImplementations);
     }
@@ -174,7 +171,7 @@ public class HelperServiceStoreClassMappingBuilder
 
     private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.Path compilePath(Path pathOffset, Root_meta_external_store_service_metamodel_Service service, CompileContext ctx)
     {
-        pathOffset.startType = getElementFullPath(service._response()._type(), ctx.pureModel.getExecutionSupport());
+        pathOffset.startType = HelperModelBuilder.getElementFullPath(service._response()._type(), ctx.pureModel.getExecutionSupport());
 
         Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl instanceValue = (Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl)new ValueSpecificationBuilder(ctx, Lists.mutable.empty(), new ProcessingContext("")).processClassInstance(pathOffset);
 
@@ -251,7 +248,7 @@ public class HelperServiceStoreClassMappingBuilder
         String mappingPath = Root_meta_pure_functions_meta_elementToPath_PackageableElement_1__String_1_(owner._parent(), context.pureModel.getExecutionSupport()).replace("::", "_");
         ctx.flushVariable("src");
         return new Root_meta_pure_metamodel_function_LambdaFunction_Impl(id, new org.finos.legend.pure.m4.coreinstance.SourceInformation(mappingPath, 0, 0, 0, 0), null)
-                ._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(context.pureModel.getType("meta::pure::metamodel::function::LambdaFunction"))._typeArguments(FastList.newListWith(functionType)))
+                ._classifierGenericType(new Root_meta_pure_metamodel_type_generics_GenericType_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::type::generics::GenericType"))._rawType(context.pureModel.getType("meta::pure::metamodel::function::LambdaFunction"))._typeArguments(Lists.mutable.with(functionType)))
                 ._openVariables(cleanedOpenVariables)
                 ._expressionSequence(valueSpecifications);
     }
@@ -287,7 +284,7 @@ public class HelperServiceStoreClassMappingBuilder
         RichIterable<Property> nonPrimitiveProperties = properties.select(prop -> !core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_isPrimitiveValueProperty_AbstractProperty_1__Boolean_1_(prop, context.getExecutionSupport()));
 
         List<PropertyMapping> primitivePropertyMappings = primitiveProperties.collect(prop -> buildPrimitivePropertyMapping(prop, sourceSetId, context)).toList();
-        List<PropertyMapping> nonPrimitivePropertyMappings = nonPrimitiveProperties.collect(prop -> buildNonPrimitivePropertyMapping(prop, sourceSetId, bindingDetail, owner._parent(), embeddedSetImplementations, owner, sourceInformation, new HashSet<>(processedClasses), context)).toList();
+        List<PropertyMapping> nonPrimitivePropertyMappings = nonPrimitiveProperties.collect(prop -> buildNonPrimitivePropertyMapping(prop, sourceSetId, bindingDetail, owner._parent(), embeddedSetImplementations, owner, sourceInformation, Sets.mutable.withAll(processedClasses), context)).toList();
 
         List<PropertyMapping> allPropertyMapping = Lists.mutable.empty();
         allPropertyMapping.addAll(primitivePropertyMappings);
@@ -322,7 +319,7 @@ public class HelperServiceStoreClassMappingBuilder
         propertyMapping._sourceSetImplementationId(sourceSetId);
         propertyMapping._targetSetImplementationId(id);
 
-        propertyMapping._propertyMappings(FastList.newList(generatePropertyMappings(bindingDetail, pureClass, id, embeddedSetImplementations, propertyMapping, sourceInformation, new HashSet<>(processedClasses), context)).toImmutable());
+        propertyMapping._propertyMappings(Lists.immutable.withAll(generatePropertyMappings(bindingDetail, pureClass, id, embeddedSetImplementations, propertyMapping, sourceInformation, Sets.mutable.withAll(processedClasses), context)));
 
         embeddedSetImplementations.add(propertyMapping);
         return propertyMapping;
@@ -346,7 +343,7 @@ public class HelperServiceStoreClassMappingBuilder
         }
     }
 
-    private static void validateServiceMapping(Root_meta_external_store_service_metamodel_mapping_ServiceMapping serviceMapping, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class pureClass, SourceInformation sourceInformation, CompileContext context)
+    private static void validateServiceMapping(Root_meta_external_store_service_metamodel_mapping_ServiceMapping serviceMapping, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?> pureClass, SourceInformation sourceInformation, CompileContext context)
     {
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type sourceDataType;
         if (serviceMapping._pathOffset() == null)
@@ -360,11 +357,11 @@ public class HelperServiceStoreClassMappingBuilder
 
         if (sourceDataType != pureClass)
         {
-            throw new EngineException("Response type of source service should match mapping class. Found response type : " + getElementFullPath((PackageableElement) sourceDataType, context.pureModel.getExecutionSupport()) + " does not match mapping class : " + getElementFullPath(pureClass, context.pureModel.getExecutionSupport()), sourceInformation, EngineErrorType.COMPILATION);
+            throw new EngineException("Response type of source service should match mapping class. Found response type : " + HelperModelBuilder.getTypeFullPath(sourceDataType, context.pureModel.getExecutionSupport()) + " does not match mapping class : " + HelperModelBuilder.getElementFullPath(pureClass, context.pureModel.getExecutionSupport()), sourceInformation, EngineErrorType.COMPILATION);
         }
 
         RichIterable<String> requiredServiceParameters = serviceMapping._service()._parameters().collectIf(Root_meta_external_store_service_metamodel_ServiceParameter::_required, Root_meta_external_store_service_metamodel_ServiceParameter::_name);
-        RichIterable<String> mappedParameters = (serviceMapping._requestBuildInfo() == null) || (serviceMapping._requestBuildInfo()._requestParametersBuildInfo() == null) ? FastList.newList() : serviceMapping._requestBuildInfo()._requestParametersBuildInfo()._parameterBuildInfoList().collect(pm -> pm._serviceParameter()._name());
+        RichIterable<String> mappedParameters = (serviceMapping._requestBuildInfo() == null) || (serviceMapping._requestBuildInfo()._requestParametersBuildInfo() == null) ? Lists.mutable.empty() : serviceMapping._requestBuildInfo()._requestParametersBuildInfo()._parameterBuildInfoList().collect(pm -> pm._serviceParameter()._name());
 
         List<String> parametersMappedMoreThanOnce = mappedParameters.select(e -> Collections.frequency(mappedParameters.toList(), e) > 1).toSet().toList();
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>5.17.0</legend.pure.version>
+        <legend.pure.version>5.18.0</legend.pure.version>
         <legend.shared.version>0.25.6</legend.shared.version>
         <legend.web-application.version>12.40.0</legend.web-application.version>
 


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Update legend-engine for changes to units in legend-pure. See [legend-pure PR 864](https://github.com/finos/legend-pure/pull/864) for more details on those changes. Importantly, the syntax for defining and referencing units remains the same. So for ordinary usage of units, there will be no difference to users.

#### Does this PR introduce a user-facing change?

No