### PR TITLE
[Legend SQL] Handle failure in session

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/pom.xml
@@ -19,7 +19,6 @@
                     <plugin>
                         <groupId>com.google.cloud.tools</groupId>
                         <artifactId>jib-maven-plugin</artifactId>
-                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <phase>deploy</phase>
@@ -53,7 +52,6 @@
                     <plugin>
                         <groupId>com.google.cloud.tools</groupId>
                         <artifactId>jib-maven-plugin</artifactId>
-                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <phase>deploy</phase>
@@ -87,7 +85,6 @@
                     <plugin>
                         <groupId>com.google.cloud.tools</groupId>
                         <artifactId>jib-maven-plugin</artifactId>
-                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <phase>deploy</phase>
@@ -301,6 +298,11 @@
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-logback-mdc-1.0</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <!-- OPEN TELEMETRY -->
 
         <!-- WIREMOCK -->
@@ -409,15 +411,31 @@
             <dependency>
                 <groupId>io.opentelemetry.semconv</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
-                <version>1.23.1-alpha</version>
+                <version>1.27.0-alpha</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-logback-mdc-1.0</artifactId>
+                <version>2.8.0-alpha</version>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.36.0</version>
+                <version>1.42.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <version>3.4.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
@@ -302,7 +302,7 @@ public class Session implements AutoCloseable
         }
     }
 
-    CompletableFuture<?> execute(String portalName, int maxRows, Function<String, ResultSetReceiver> resultSetReceiverProvider)
+    CompletableFuture<Void> execute(String portalName, int maxRows, Function<String, ResultSetReceiver> resultSetReceiverProvider)
     {
         Tracer tracer = OpenTelemetryUtil.getTracer();
         Span span = tracer.spanBuilder("Session Execute").startSpan();
@@ -324,7 +324,7 @@ public class Session implements AutoCloseable
             if (preparedStatement == null)
             {
                 resultSetReceiver.allFinished();
-                return CompletableFuture.completedFuture(Boolean.TRUE);
+                return CompletableFuture.completedFuture(null);
             }
             preparedStatement.setMaxRows(maxRows);
             PreparedStatementExecutionTask task = new PreparedStatementExecutionTask(preparedStatement, resultSetReceiver);
@@ -345,7 +345,7 @@ public class Session implements AutoCloseable
     }
 
 
-    CompletableFuture<?> executeSimple(String query, Supplier<ResultSetReceiver> resultSetReceiverProvider)
+    CompletableFuture<Void> executeSimple(String query, Supplier<ResultSetReceiver> resultSetReceiverProvider)
     {
 
         if (LOGGER.isDebugEnabled())

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/Session.java
@@ -60,9 +60,6 @@ public class Session implements AutoCloseable
     private final ExecutorService executorService;
     private final Identity identity;
 
-    private CompletableFuture<?> activeExecution;
-
-
     public Session(SessionHandler dataSessionHandler, SessionHandler metaDataSessionHandler, ExecutorService executorService, Identity identity)
     {
         this.executorService = executorService;
@@ -70,7 +67,6 @@ public class Session implements AutoCloseable
         this.identity = identity;
         OpenTelemetryUtil.ACTIVE_SESSIONS.add(1);
         OpenTelemetryUtil.TOTAL_SESSIONS.add(1);
-        activeExecution = CompletableFuture.completedFuture(null);
     }
 
     public Identity getIdentity()
@@ -78,27 +74,13 @@ public class Session implements AutoCloseable
         return identity;
     }
 
-    public void setActiveExecution(CompletableFuture<?> activeExecution)
-    {
-        this.activeExecution = activeExecution;
-    }
-
-    public CompletableFuture<?> sync()
+    public void sync()
     {
         //TODO do we need to handle batch requests?
         LOGGER.info("Sync");
-        return activeExecution;
     }
 
-    public CompletableFuture<?> parseAsync(String statementName, String query, List<Integer> paramTypes)
-    {
-        LOGGER.debug("got request to parse");
-        activeExecution = activeExecution.thenRunAsync(() -> parse(statementName, query, paramTypes), executorService);
-        LOGGER.debug("done queuing parse");
-        return activeExecution;
-    }
-
-    private void parse(String statementName, String query, List<Integer> paramTypes)
+    void parse(String statementName, String query, List<Integer> paramTypes)
     {
         if (LOGGER.isDebugEnabled())
         {
@@ -162,17 +144,7 @@ public class Session implements AutoCloseable
         return stmt.paramType[idx];
     }
 
-
-    public CompletableFuture<?> bindAsync(String portalName, String statementName, List<Object> params,
-                                          FormatCodes.FormatCode[] resultFormatCodes)
-    {
-        LOGGER.debug("got request to bind");
-        activeExecution = activeExecution.thenRunAsync(() -> bind(portalName, statementName, params, resultFormatCodes), executorService);
-        LOGGER.debug("done queuing bind");
-        return activeExecution;
-    }
-
-    private void bind(String portalName, String statementName, List<Object> params, FormatCodes.FormatCode[] resultFormatCodes)
+    void bind(String portalName, String statementName, List<Object> params, FormatCodes.FormatCode[] resultFormatCodes)
     {
         if (LOGGER.isDebugEnabled())
         {
@@ -198,17 +170,7 @@ public class Session implements AutoCloseable
         }
     }
 
-
-    public CompletableFuture<DescribeResult> describeAsync(char type, String portalOrStatement)
-    {
-        LOGGER.debug("got request to describe");
-        CompletableFuture<DescribeResult> describeCompletionFuture = activeExecution.thenApplyAsync(ignored -> describe(type, portalOrStatement), executorService);
-        activeExecution = describeCompletionFuture;
-        LOGGER.debug("done queuing describe");
-        return describeCompletionFuture;
-    }
-
-    private DescribeResult describe(char type, String portalOrStatement)
+    DescribeResult describe(char type, String portalOrStatement)
     {
         if (LOGGER.isDebugEnabled())
         {
@@ -340,19 +302,7 @@ public class Session implements AutoCloseable
         }
     }
 
-    CompletableFuture<?> executeAsync(String portalName, int maxRows, Function<String, ResultSetReceiver> resultSetReceiverProvider)
-    {
-        LOGGER.debug("got request to execute");
-        activeExecution = activeExecution.thenComposeAsync(ignored ->
-        {
-            LOGGER.debug("execute: previous stage response is {}", ignored);
-            return execute(portalName, maxRows, resultSetReceiverProvider);
-        }, executorService);
-        LOGGER.debug("done queuing execute");
-        return activeExecution;
-    }
-
-    private CompletableFuture<?> execute(String portalName, int maxRows, Function<String, ResultSetReceiver> resultSetReceiverProvider)
+    CompletableFuture<?> execute(String portalName, int maxRows, Function<String, ResultSetReceiver> resultSetReceiverProvider)
     {
         Tracer tracer = OpenTelemetryUtil.getTracer();
         Span span = tracer.spanBuilder("Session Execute").startSpan();
@@ -380,8 +330,7 @@ public class Session implements AutoCloseable
             PreparedStatementExecutionTask task = new PreparedStatementExecutionTask(preparedStatement, resultSetReceiver);
             // Task does not wait for any future since it is always chained asynchronously
             CompletableFuture.runAsync(task::call, executorService);
-            activeExecution = resultSetReceiver.completionFuture();
-            return activeExecution;
+            return resultSetReceiver.completionFuture();
         }
         catch (Exception e)
         {
@@ -409,14 +358,9 @@ public class Session implements AutoCloseable
         {
             PostgresStatement statement = getSessionHandler(query).createStatement();
             span.addEvent("submit StatementExecutionTask");
-            activeExecution = activeExecution
-                    .thenComposeAsync(ignored ->
-                    {
-                        ResultSetReceiver resultSetReceiver = resultSetReceiverProvider.get();
-                        Context.taskWrapping(executorService).submit(new StatementExecutionTask(statement, query, resultSetReceiver));
-                        return resultSetReceiver.completionFuture();
-                    }, executorService);
-            return activeExecution;
+            ResultSetReceiver resultSetReceiver = resultSetReceiverProvider.get();
+            Context.taskWrapping(executorService).submit(new StatementExecutionTask(statement, query, resultSetReceiver));
+            return resultSetReceiver.completionFuture();
         }
         catch (Exception e)
         {

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -209,6 +209,63 @@ public class PostgresServerTest
     }
 
     @Test
+    public void testSuccessAfterFailure() throws SQLException
+    {
+        Properties info = new Properties();
+        PGProperty.USER.set(info, "dummy");
+        PGProperty.PASSWORD.set(info, "dummy");
+        PGProperty.LOG_SERVER_ERROR_DETAIL.set(info, "false");
+
+        try (
+                Connection connection1 = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                        info);
+                PreparedStatement statement1 = connection1.prepareStatement("SELECT * FROM service.\"/personServiceNonExistent\"");
+                PreparedStatement statement2 = connection1.prepareStatement("SELECT * FROM service.\"/personService\"")
+        )
+        {
+
+            PSQLException exception = Assert.assertThrows(PSQLException.class, statement1::executeQuery);
+            Assert.assertEquals("ERROR: IllegalArgumentException: No Service found for pattern '/personServiceNonExistent'", exception.getMessage());
+            int rows2 = 0;
+            ResultSet resultSet2 = statement2.executeQuery();
+            while (resultSet2.next())
+            {
+                rows2++;
+            }
+            Assert.assertEquals(4, rows2);
+        }
+    }
+
+    @Test
+    public void testSuccessAfterFailureInSimple() throws SQLException
+    {
+        Properties info = new Properties();
+        PGProperty.USER.set(info, "dummy");
+        PGProperty.PASSWORD.set(info, "dummy");
+        PGProperty.PREFER_QUERY_MODE.set(info, "simple");
+        PGProperty.LOG_SERVER_ERROR_DETAIL.set(info, "false");
+
+        try (
+                Connection connection1 = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                        info);
+                PreparedStatement statement1 = connection1.prepareStatement("SELECT * FROM service.\"/personServiceNonExistent\"");
+                PreparedStatement statement2 = connection1.prepareStatement("SELECT * FROM service.\"/personService\"")
+        )
+        {
+
+            PSQLException exception = Assert.assertThrows(PSQLException.class, statement1::executeQuery);
+            Assert.assertEquals("ERROR: IllegalArgumentException: No Service found for pattern '/personServiceNonExistent'", exception.getMessage());
+            int rows2 = 0;
+            ResultSet resultSet2 = statement2.executeQuery();
+            while (resultSet2.next())
+            {
+                rows2++;
+            }
+            Assert.assertEquals(4, rows2);
+        }
+    }
+
+    @Test
     public void testTableFunctionSyntax() throws SQLException
     {
         try (


### PR DESCRIPTION
So that subsequent queries are successful

#### What type of PR is this?
Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
Currently if one query fails in a session, all subsequent queries also give same error message even before they get executed.
This PR isolates each query so that queries are run irrespective of previous failures.
<!--
Describe change being introduced by this PR.
-->

#### Does this PR introduce a user-facing change?
No
<!--
-->
