### PR TITLE
Add compiled state integrity tests for several modules

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/pom.xml
@@ -205,7 +205,6 @@
                         <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-unclassified</artifactId>
                         <version>${project.version}</version>
                     </dependency>
-
                 </dependencies>
             </plugin>
         </plugins>
@@ -251,14 +250,6 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.finos.legend.pure</groupId>-->
-<!--            <artifactId>legend-pure-runtime-java-engine-shared</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.finos.legend.pure</groupId>-->
-<!--            <artifactId>legend-pure-runtime-java-extension-shared-functions-conversion</artifactId>-->
-<!--        </dependency>-->
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -303,16 +294,7 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-json</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.finos.legend.engine</groupId>-->
-<!--            <artifactId>legend-engine-pure-platform-store-relational-java</artifactId>-->
-<!--        </dependency>-->
 
-
-<!--        <dependency>-->
-<!--            <groupId>org.finos.legend.pure</groupId>-->
-<!--            <artifactId>legend-pure-runtime-java-extension-functions</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-extension-compiled-store-relational</artifactId>
@@ -444,14 +426,19 @@
                                 <configuration>
                                     <target name="protocol">
                                         <copy todir="${basedir}/src/main/resources/${folderBindingPath}/${protocol.TargetVersion}">
-                                            <fileset dir="${basedir}/src/main/resources/${folderBindingPath}/${protocol.SourceVersion}" />
+                                            <fileset
+                                                    dir="${basedir}/src/main/resources/${folderBindingPath}/${protocol.SourceVersion}"/>
                                         </copy>
-					<replace dir="${basedir}/src/main/resources/${folderBindingPath}/${protocol.TargetVersion}" token="${protocol.SourceVersion}" value="${protocol.TargetVersion}" />
-					<copy todir="${basedir}/src/main/resources/${folderCorePath}/${protocol.TargetVersion}">
-                                            <fileset dir="${basedir}/src/main/resources/${folderCorePath}/${protocol.SourceVersion}" />
+                                        <replace
+                                                dir="${basedir}/src/main/resources/${folderBindingPath}/${protocol.TargetVersion}"
+                                                token="${protocol.SourceVersion}" value="${protocol.TargetVersion}"/>
+                                        <copy todir="${basedir}/src/main/resources/${folderCorePath}/${protocol.TargetVersion}">
+                                            <fileset
+                                                    dir="${basedir}/src/main/resources/${folderCorePath}/${protocol.SourceVersion}"/>
                                         </copy>
-                                        <replace dir="${basedir}/src/main/resources/${folderCorePath}/${protocol.TargetVersion}" token="${protocol.SourceVersion}" value="${protocol.TargetVersion}" />
-
+                                        <replace
+                                                dir="${basedir}/src/main/resources/${folderCorePath}/${protocol.TargetVersion}"
+                                                token="${protocol.SourceVersion}" value="${protocol.TargetVersion}"/>
                                     </target>
                                 </configuration>
                             </execution>
@@ -461,9 +448,4 @@
             </build>
         </profile>
     </profiles>
-
-
-
-
-
 </project>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreCompiledStateIntegrity.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreCompiledStateIntegrity.java
@@ -14,10 +14,6 @@
 
 package org.finos.legend.engine.pure.code.core;
 
-import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -28,8 +24,7 @@ public class TestCoreCompiledStateIntegrity extends AbstractCompiledStateIntegri
     @BeforeClass
     public static void initialize()
     {
-        MutableRepositoryCodeStorage codeStorage = new CompositeCodeStorage(new ClassLoaderCodeStorage(CodeRepositoryProviderHelper.findCodeRepositories()));
-        initialize(codeStorage);
+        initialize("core");
     }
 
     @Test

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/json/TestFunctionsJsonCompiledStateIntegrity.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/json/TestFunctionsJsonCompiledStateIntegrity.java
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.pure.code.core.functions.relation;
+package org.finos.legend.engine.pure.code.core.functions.json;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
 
-public class TestFunctionsRelationCompiledStateStrategy extends AbstractCompiledStateIntegrityTest
+public class TestFunctionsJsonCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
     @BeforeClass
     public static void initialize()
     {
-        initialize("core_functions_relation");
+        initialize("core_functions_json");
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/relation/TestFunctionsRelationCompiledStateIntegrity.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/relation/TestFunctionsRelationCompiledStateIntegrity.java
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.pure.code.core.functions.json;
+package org.finos.legend.engine.pure.code.core.functions.relation;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
 
-public class TestFunctionsJsonCompiledStateStrategy extends AbstractCompiledStateIntegrityTest
+public class TestFunctionsRelationCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
     @BeforeClass
     public static void initialize()
     {
-        initialize("core_functions_json");
+        initialize("core_functions_relation");
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/standard/TestFunctionsStandardCompiledStateIntegrity.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/standard/TestFunctionsStandardCompiledStateIntegrity.java
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.pure.code.core.functions.unclassified;
+package org.finos.legend.engine.pure.code.core.functions.standard;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
 
-public class TestFunctionsUnclassifiedCompiledStateStrategy extends AbstractCompiledStateIntegrityTest
+public class TestFunctionsStandardCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
     @BeforeClass
     public static void initialize()
     {
-        initialize("core_functions_unclassified");
+        initialize("core_functions_standard");
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/unclassified/TestFunctionsUnclassifiedCompiledStateIntegrity.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/unclassified/TestFunctionsUnclassifiedCompiledStateIntegrity.java
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.engine.pure.code.core.functions.standard;
+package org.finos.legend.engine.pure.code.core.functions.unclassified;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
 
-public class TestFunctionsStandardCompiledStateStrategy extends AbstractCompiledStateIntegrityTest
+public class TestFunctionsUnclassifiedCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
     @BeforeClass
     public static void initialize()
     {
-        initialize("core_functions_standard");
+        initialize("core_functions_unclassified");
     }
 }

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-pure-metamodel/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-pure-metamodel/pom.xml
@@ -86,11 +86,6 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.finos.legend.pure</groupId>
-                        <artifactId>legend-pure-m2-dsl-mapping-grammar</artifactId>
-                        <version>${legend.pure.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.finos.legend.pure</groupId>
                         <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
                         <version>${legend.pure.version}</version>
                     </dependency>
@@ -111,6 +106,11 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-pure</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
         </dependency>
         <!-- PURE -->
@@ -126,5 +126,23 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-pure-metamodel/src/test/java/org/finos/legend/pure/code/core/TestCoreDiagramMetamodelCompiledStateIntegrity.java
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-pure-metamodel/src/test/java/org/finos/legend/pure/code/core/TestCoreDiagramMetamodelCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestCoreDiagramMetamodelCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_diagram_metamodel");
+    }
+}

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-pure/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-pure/pom.xml
@@ -158,5 +158,23 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-pure/src/test/java/org/finos/legend/pure/code/core/TestCoreDiagramCompiledStateIntegrity.java
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-pure/src/test/java/org/finos/legend/pure/code/core/TestCoreDiagramCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestCoreDiagramCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_diagram");
+    }
+}

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-featureBased-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-featureBased-pure/pom.xml
@@ -143,12 +143,10 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
         </dependency>
-
         <!-- PURE -->
 
         <!-- ENGINE -->
@@ -193,7 +191,17 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-featureBased-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreExternalLanguageJavaFeatureBasedGenerationCompiledStateIntegrity.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-featureBased-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreExternalLanguageJavaFeatureBasedGenerationCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreExternalLanguageJavaFeatureBasedGenerationCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_external_language_java_feature_based_generation");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/pom.xml
@@ -113,17 +113,17 @@
                     </dependency>
                     <dependency>
                         <groupId>org.finos.legend.pure</groupId>
+                        <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+                        <version>${legend.pure.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.pure</groupId>
                         <artifactId>legend-pure-m2-dsl-graph-grammar</artifactId>
                         <version>${legend.pure.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.finos.legend.pure</groupId>
                         <artifactId>legend-pure-m2-dsl-mapping-grammar</artifactId>
-                        <version>${legend.pure.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.finos.legend.pure</groupId>
-                        <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
                         <version>${legend.pure.version}</version>
                     </dependency>
                     <dependency>
@@ -197,7 +197,27 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-graph-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-path-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreExternalLanguageJavaCompiledStateIntegrity.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreExternalLanguageJavaCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreExternalLanguageJavaCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_external_language_java");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/pom.xml
@@ -151,7 +151,6 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
         </dependency>
-
         <!-- PURE -->
 
         <!-- ENGINE -->
@@ -196,11 +195,21 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <scope>test</scope>
         </dependency>
-
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreJavaPlatformBindingExternalFormatCompiledStateIntegrity.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreJavaPlatformBindingExternalFormatCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreJavaPlatformBindingExternalFormatCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_java_platform_binding_external_format");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/pom.xml
@@ -230,11 +230,21 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <scope>test</scope>
         </dependency>
-
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreJavaPlatformBindingCompiledStateIntegrity.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/test/java/org/finos/legend/engine/pure/code/core/TestCoreJavaPlatformBindingCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreJavaPlatformBindingCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_java_platform_binding");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/pom.xml
@@ -245,5 +245,16 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/src/test/java/org/finos/legend/engine/pure/code/core/json/binding/TestCoreExternalFormatJsonJavaPlatformBindingCompiledStateIntegrity.java
+++ b/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/src/test/java/org/finos/legend/engine/pure/code/core/json/binding/TestCoreExternalFormatJsonJavaPlatformBindingCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core.json.binding;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreExternalFormatJsonJavaPlatformBindingCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_external_format_json_java_platform_binding");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-engine-xts-json/legend-engine-xt-json-pure/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-pure/pom.xml
@@ -219,14 +219,26 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/legend-engine-xts-json/legend-engine-xt-json-pure/src/test/java/org/finos/legend/engine/pure/code/core/json/TestCoreExternalFormatJsonCompiledStateIntegrity.java
+++ b/legend-engine-xts-json/legend-engine-xt-json-pure/src/test/java/org/finos/legend/engine/pure/code/core/json/TestCoreExternalFormatJsonCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core.json;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreExternalFormatJsonCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_external_format_json");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-engine-xts-text/legend-engine-xt-text-pure-metamodel/pom.xml
+++ b/legend-engine-xts-text/legend-engine-xt-text-pure-metamodel/pom.xml
@@ -102,5 +102,18 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-text/legend-engine-xt-text-pure-metamodel/src/test/java/org/finos/legend/engine/pure/code/core/text/TestCoreTextMetamodelCompiledStateIntegrity.java
+++ b/legend-engine-xts-text/legend-engine-xt-text-pure-metamodel/src/test/java/org/finos/legend/engine/pure/code/core/text/TestCoreTextMetamodelCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core.text;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestCoreTextMetamodelCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_text_metamodel");
+    }
+}

--- a/legend-engine-xts-xml/legend-engine-xt-xml-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-javaPlatformBinding-pure/pom.xml
@@ -240,11 +240,21 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <scope>test</scope>
         </dependency>
-
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-xml/legend-engine-xt-xml-javaPlatformBinding-pure/src/test/java/org/finos/legend/engine/pure/code/core/xml/binding/TestCoreExternalFormatXmlJavaPlatformBindingCompiledStateIntegrity.java
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-javaPlatformBinding-pure/src/test/java/org/finos/legend/engine/pure/code/core/xml/binding/TestCoreExternalFormatXmlJavaPlatformBindingCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.pure.code.core.xml.binding;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreExternalFormatXmlJavaPlatformBindingCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_external_format_xml_java_platform_binding");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-engine-xts-xml/legend-engine-xt-xml-pure/pom.xml
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-pure/pom.xml
@@ -193,6 +193,17 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <scope>test</scope>

--- a/legend-engine-xts-xml/legend-engine-xt-xml-pure/src/test/java/org/finos/legend/pure/code/core/external/format/xml/TestCoreExternalFormatXmlCompiledStateIntegrity.java
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-pure/src/test/java/org/finos/legend/pure/code/core/external/format/xml/TestCoreExternalFormatXmlCompiledStateIntegrity.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.code.core.external.format.xml;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreExternalFormatXmlCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("core_external_format_xml");
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Add compiled state integrity tests for several modules. Ideally, every module which defines a Pure repo should have such a test.

In passing, fix typos in the names of some existing compiled state integrity tests, and clean up the test for core.

#### Does this PR introduce a user-facing change?

No