### PR TITLE
Avoid loading extensions from classpath

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/connection/ConnectionParseTreeWalker.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/connection/ConnectionParseTreeWalker.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.language.pure.grammar.from.connection;
 
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserContext;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserUtility;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.connection.ConnectionParserGrammar;
 import org.finos.legend.engine.language.pure.grammar.from.extension.ConnectionValueParser;
@@ -94,7 +95,7 @@ public class ConnectionParseTreeWalker
         // only add current walker source information column offset if this is the first line
         int columnOffset = (startLine == 1 ? walkerSourceInformation.getColumnOffset() : 0) + ctx.BRACE_OPEN().getSymbol().getCharPositionInLine() + ctx.BRACE_OPEN().getSymbol().getText().length();
         ParseTreeWalkerSourceInformation connectionValueWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation.getSourceId(), lineOffset, columnOffset).withReturnSourceInfo(this.walkerSourceInformation.getReturnSourceInfo()).build();
-        ConnectionValueSourceCode connectionValueSourceCode = new ConnectionValueSourceCode(connectionValueCode, connectionType, sourceInformation, connectionValueWalkerSourceInformation, isProcessingEmbeddedConnection);
+        ConnectionValueSourceCode connectionValueSourceCode = new ConnectionValueSourceCode(connectionValueCode, connectionType, sourceInformation, connectionValueWalkerSourceInformation, isProcessingEmbeddedConnection, new PureGrammarParserContext(this.extensions));
         ConnectionValueParser connectionValueParser = this.extensions.getConnectionValueParser(connectionType);
         if (connectionValueParser == null)
         {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/connection/ConnectionValueSourceCode.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/connection/ConnectionValueSourceCode.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.language.pure.grammar.from.connection;
 
 import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserContext;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 
 public class ConnectionValueSourceCode
@@ -24,13 +25,15 @@ public class ConnectionValueSourceCode
     public final SourceInformation sourceInformation;
     public final ParseTreeWalkerSourceInformation walkerSourceInformation;
     public final boolean isEmbedded;
+    public final PureGrammarParserContext context;
 
-    public ConnectionValueSourceCode(String code, String connectionType, SourceInformation sourceInformation, ParseTreeWalkerSourceInformation walkerSourceInformation, boolean isEmbedded)
+    public ConnectionValueSourceCode(String code, String connectionType, SourceInformation sourceInformation, ParseTreeWalkerSourceInformation walkerSourceInformation, boolean isEmbedded, PureGrammarParserContext context)
     {
         this.code = code;
         this.connectionType = connectionType;
         this.sourceInformation = sourceInformation;
         this.walkerSourceInformation = walkerSourceInformation;
         this.isEmbedded = isEmbedded;
+        this.context = context;
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtensions.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtensions.java
@@ -62,6 +62,11 @@ public class PureGrammarParserExtensions
         return this.extensions.castToList();
     }
 
+    public <T extends PureGrammarParserExtension> List<T> getExtensionsOfType(Class<T> ofType)
+    {
+        return this.extensions.selectInstancesOf(ofType).castToList();
+    }
+
     public SectionParser getExtraSectionParser(String type)
     {
         return this.sectionParsers.get(type);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/IRelationalGrammarParserExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/IRelationalGrammarParserExtension.java
@@ -43,9 +43,9 @@ import java.util.function.Function;
 
 public interface IRelationalGrammarParserExtension extends PureGrammarParserExtension
 {
-    static List<IRelationalGrammarParserExtension> getExtensions()
+    static List<IRelationalGrammarParserExtension> getExtensions(PureGrammarParserContext context)
     {
-        return Lists.mutable.withAll(ServiceLoader.load(IRelationalGrammarParserExtension.class));
+        return context.getPureGrammarParserExtensions().getExtensionsOfType(IRelationalGrammarParserExtension.class);
     }
 
     static DatasourceSpecification process(DataSourceSpecificationSourceCode code, List<Function<DataSourceSpecificationSourceCode, DatasourceSpecification>> processors)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalDatabaseConnectionParseTreeWalker.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalDatabaseConnectionParseTreeWalker.java
@@ -35,9 +35,11 @@ import java.util.function.Function;
 public class RelationalDatabaseConnectionParseTreeWalker
 {
     private final ParseTreeWalkerSourceInformation walkerSourceInformation;
+    private final PureGrammarParserContext context;
 
-    public RelationalDatabaseConnectionParseTreeWalker(ParseTreeWalkerSourceInformation walkerSourceInformation)
+    public RelationalDatabaseConnectionParseTreeWalker(PureGrammarParserContext context, ParseTreeWalkerSourceInformation walkerSourceInformation)
     {
+        this.context = context;
         this.walkerSourceInformation = walkerSourceInformation;
     }
 
@@ -91,7 +93,7 @@ public class RelationalDatabaseConnectionParseTreeWalker
     private void handleLocalMode(RelationalDatabaseConnection connectionValue)
     {
         connectionValue.localMode = true;
-        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();
+        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions(context);
         try
         {
             connectionValue.datasourceSpecification = IRelationalGrammarParserExtension.process(
@@ -111,7 +113,7 @@ public class RelationalDatabaseConnectionParseTreeWalker
     private List<PostProcessor> visitRelationalPostProcessors(RelationalDatabaseConnectionParserGrammar.RelationalPostProcessorsContext postProcessorsContext)
     {
         List<RelationalDatabaseConnectionParserGrammar.SpecificationContext> specifications = postProcessorsContext.specification();
-        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();
+        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions(context);
         List<Function<PostProcessorSpecificationSourceCode, PostProcessor>> parsers = ListIterate.flatCollect(extensions, IRelationalGrammarParserExtension::getExtraPostProcessorParsers);
         return ListIterate.collect(specifications, spec -> visitRelationalPostProcessor(spec, parsers));
     }
@@ -149,7 +151,7 @@ public class RelationalDatabaseConnectionParseTreeWalker
                 ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, ctx.getStart())
         );
 
-        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();
+        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions(context);
         DatasourceSpecification ds = IRelationalGrammarParserExtension.process(code, ListIterate.flatCollect(extensions, IRelationalGrammarParserExtension::getExtraDataSourceSpecificationParsers));
 
         if (ds == null)
@@ -173,7 +175,7 @@ public class RelationalDatabaseConnectionParseTreeWalker
                 ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, ctx.getStart())
         );
 
-        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();
+        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions(context);
         AuthenticationStrategy auth = IRelationalGrammarParserExtension.process(code, ListIterate.flatCollect(extensions, IRelationalGrammarParserExtension::getExtraAuthenticationStrategyParsers));
 
         if (auth == null)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -95,17 +95,19 @@ public class RelationalParseTreeWalker
     private final DefaultCodeSection section;
 
     private static final ImmutableSet<String> JOIN_TYPES = Sets.immutable.with("INNER", "OUTER");
+    private final PureGrammarParserContext context;
 
-    public RelationalParseTreeWalker(ParseTreeWalkerSourceInformation walkerSourceInformation)
+    public RelationalParseTreeWalker(ParseTreeWalkerSourceInformation walkerSourceInformation, PureGrammarParserContext context)
     {
-        this(walkerSourceInformation, null, null);
+        this(walkerSourceInformation, null, null, context);
     }
 
-    public RelationalParseTreeWalker(ParseTreeWalkerSourceInformation walkerSourceInformation, Consumer<PackageableElement> elementConsumer, DefaultCodeSection section)
+    public RelationalParseTreeWalker(ParseTreeWalkerSourceInformation walkerSourceInformation, Consumer<PackageableElement> elementConsumer, DefaultCodeSection section, PureGrammarParserContext context)
     {
         this.walkerSourceInformation = walkerSourceInformation;
         this.elementConsumer = elementConsumer;
         this.section = section;
+        this.context = context;
     }
 
     public void visit(RelationalParserGrammar.DefinitionContext ctx)
@@ -464,7 +466,7 @@ public class RelationalParseTreeWalker
                 ParseTreeWalkerSourceInformation.offset(walkerSourceInformation, ctx.getStart())
         );
 
-        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions();
+        List<IRelationalGrammarParserExtension> extensions = IRelationalGrammarParserExtension.getExtensions(context);
         Milestoning milestoning = IRelationalGrammarParserExtension.process(code, ListIterate.flatCollect(extensions, IRelationalGrammarParserExtension::getExtraMilestoningParsers));
 
         if (milestoning == null)


### PR DESCRIPTION
Avoid loading extensions over and over when parsing relational connections, and use the already loaded parser extensions.