### PR TITLE
Persistence Component : Iceberg tables - Fix dataset Reference to have dataset optional properties

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/DatasetReferenceImplAbstract.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/logicalplan/datasets/DatasetReferenceImplAbstract.java
@@ -17,6 +17,8 @@ package org.finos.legend.engine.persistence.components.logicalplan.datasets;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 
+import java.util.Optional;
+
 @Immutable
 @Style(
     typeAbstract = "*Abstract",
@@ -27,4 +29,5 @@ import org.immutables.value.Value.Style;
 )
 public interface DatasetReferenceImplAbstract extends DatasetReference
 {
+    Optional<DatasetAdditionalProperties> datasetAdditionalProperties();
 }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/RelationalSchemaEvolutionServiceTest.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/src/test/java/org/finos/legend/engine/persistence/components/RelationalSchemaEvolutionServiceTest.java
@@ -18,9 +18,7 @@ import org.finos.legend.engine.persistence.components.ingestmode.AppendOnly;
 import org.finos.legend.engine.persistence.components.ingestmode.audit.DateTimeAuditing;
 import org.finos.legend.engine.persistence.components.ingestmode.deduplication.FilterDuplicates;
 import org.finos.legend.engine.persistence.components.ingestmode.digest.UserProvidedDigestGenStrategy;
-import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetDefinition;
-import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetReference;
-import org.finos.legend.engine.persistence.components.logicalplan.datasets.DatasetReferenceImpl;
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.*;
 import org.finos.legend.engine.persistence.components.relational.CaseConversion;
 import org.finos.legend.engine.persistence.components.relational.api.RelationalSchemaEvolutionService;
 import org.finos.legend.engine.persistence.components.relational.api.SchemaEvolutionServiceResult;
@@ -98,7 +96,13 @@ class RelationalSchemaEvolutionServiceTest extends BaseTest
     {
         DatasetDefinition mainTable = TestUtils.getSchemaEvolutionAddColumnMainTableUpperCase(); // This is only used to create a database table in upper case
         DatasetDefinition stagingTable = TestUtils.getBasicStagingTable();
-        DatasetReference mainTableDatasetReference = DatasetReferenceImpl.builder().group(testSchemaName).name(mainTableName).build(); // This is the model user has
+        DatasetReference mainTableDatasetReference = DatasetReferenceImpl.builder().group(testSchemaName)
+                .name(mainTableName)
+                .datasetAdditionalProperties(DatasetAdditionalProperties.builder().tableOrigin(TableOrigin.ICEBERG).build())
+                .build(); // This is the model user has
+
+        Assertions.assertEquals(DatasetAdditionalProperties.builder().tableOrigin(TableOrigin.ICEBERG).build(),
+                mainTableDatasetReference.datasetAdditionalProperties().get());
 
         // Create staging table
         createStagingTable(stagingTable);


### PR DESCRIPTION
#### What type of PR is this?
- Improvement

#### What does this PR do / why is it needed ?
Fix DatasetReference to have dataset optional properties. Currently users were not able to set this parameter.
This will enable us to evolve the schema of iceberg tables

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
NO
