### PR TITLE
Fix property sequence on routing

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -149,7 +149,8 @@ function meta::pure::mapping::allEnumerationMappings(m: Mapping[1]): Enumeration
 function meta::pure::mapping::valueTransformerEquality(a:ValueTransformer<Any>[0..1], b:ValueTransformer<Any>[0..1]):Boolean[1]
 {
   ($a->isEmpty() && $b->isEmpty()) || ($a->isNotEmpty() && $b->isNotEmpty() && $a->type() == $b->type() && $a->match([
-                                                                                                                      i:EnumerationMapping<Any>[1]| $i.enumeration == $b->cast(@EnumerationMapping<Any>).enumeration && enumValueMappingsEquality($i.enumValueMappings->zip($b->cast(@EnumerationMapping<Any>).enumValueMappings));
+                                                                                                                      i:EnumerationMapping<Any>[1]| $i.enumeration == $b->cast(@EnumerationMapping<Any>).enumeration && enumValueMappingsEquality($i.enumValueMappings->zip($b->cast(@EnumerationMapping<Any>).enumValueMappings));,
+                                                                                                                      v:ValueTransformer<Any>[1]| false
                                                                                                                     ]))
 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -148,13 +148,9 @@ function meta::pure::mapping::allEnumerationMappings(m: Mapping[1]): Enumeration
 
 function meta::pure::mapping::valueTransformerEquality(a:ValueTransformer<Any>[0..1], b:ValueTransformer<Any>[0..1]):Boolean[1]
 {
-  if($a->isEmpty() && $b->isEmpty(),
-      | true,
-      | if($a->isNotEmpty() && $b->isNotEmpty() && $a->type() == $b->type(),
-            | $a->match([
-                          i:EnumerationMapping<Any>[1]| $i.enumeration == $b->cast(@EnumerationMapping<Any>).enumeration && enumValueMappingsEquality($i.enumValueMappings->zip($b->cast(@EnumerationMapping<Any>).enumValueMappings));
-                        ]),
-            | false));
+  ($a->isEmpty() && $b->isEmpty()) || ($a->isNotEmpty() && $b->isNotEmpty() && $a->type() == $b->type() && $a->match([
+                                                                                                                      i:EnumerationMapping<Any>[1]| $i.enumeration == $b->cast(@EnumerationMapping<Any>).enumeration && enumValueMappingsEquality($i.enumValueMappings->zip($b->cast(@EnumerationMapping<Any>).enumValueMappings));
+                                                                                                                    ]))
 }
 
 function meta::pure::mapping::enumValueMappingsEquality(pairs:Pair<EnumValueMapping,EnumValueMapping>[*]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -150,7 +150,7 @@ function meta::pure::mapping::valueTransformerEquality(a:ValueTransformer<Any>[0
 {
   ($a->isEmpty() && $b->isEmpty()) || ($a->isNotEmpty() && $b->isNotEmpty() && $a->type() == $b->type() && $a->match([
                                                                                                                       i:EnumerationMapping<Any>[1]| $i.enumeration == $b->cast(@EnumerationMapping<Any>).enumeration && enumValueMappingsEquality($i.enumValueMappings->zip($b->cast(@EnumerationMapping<Any>).enumValueMappings));,
-                                                                                                                      v:ValueTransformer<Any>[1]| false
+                                                                                                                      v:ValueTransformer<Any>[1]| fail('UnSupported Operation: Only supports EnumerationMapping')
                                                                                                                     ]))
 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -146,6 +146,22 @@ function meta::pure::mapping::allEnumerationMappings(m: Mapping[1]): Enumeration
   $m.enumerationMappings->concatenate($m.includes->map(i | $i.included->allEnumerationMappings()))
 }
 
+function meta::pure::mapping::valueTransformerEquality(a:ValueTransformer<Any>[0..1], b:ValueTransformer<Any>[0..1], extensions : meta::pure::extension::Extension[*]):Boolean[1]
+{
+  if($a->isEmpty() && $b->isEmpty(),
+      | true,
+      | if($a->isNotEmpty() && $b->isNotEmpty() && $a->type() == $b->type(),
+            | $a->match([
+                          i:EnumerationMapping<Any>[1]| $i.enumeration == $b->cast(@EnumerationMapping<Any>).enumeration && enumValueMappingsEquality($i.enumValueMappings->zip($b->cast(@EnumerationMapping<Any>).enumValueMappings));
+                        ]),
+            | false));
+}
+
+function meta::pure::mapping::enumValueMappingsEquality(pairs:Pair<EnumValueMapping,EnumValueMapping>[*]):Boolean[1]
+{  
+  $pairs.first.enum == $pairs.second.enum && $pairs.first.sourceValues == $pairs.second.sourceValues
+}
+
 function meta::pure::mapping::allSuperSetImplementations(set :PropertyMappingsImplementation[1], m:Mapping[1]):PropertyMappingsImplementation[*]
 {
       if ($set.superSetImplementationId->isEmpty(),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -146,7 +146,7 @@ function meta::pure::mapping::allEnumerationMappings(m: Mapping[1]): Enumeration
   $m.enumerationMappings->concatenate($m.includes->map(i | $i.included->allEnumerationMappings()))
 }
 
-function meta::pure::mapping::valueTransformerEquality(a:ValueTransformer<Any>[0..1], b:ValueTransformer<Any>[0..1], extensions : meta::pure::extension::Extension[*]):Boolean[1]
+function meta::pure::mapping::valueTransformerEquality(a:ValueTransformer<Any>[0..1], b:ValueTransformer<Any>[0..1]):Boolean[1]
 {
   if($a->isEmpty() && $b->isEmpty(),
       | true,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -646,7 +646,7 @@ function meta::pure::router::routing::resolveVar(va:VariableExpression[1], state
    let res = $state.propertyMap.v->filter(p|$p.first == $va.name);
    let fullRes = if (!$res->isEmpty(),
                      |let routed = $res.second->evaluateAndDeactivate()->cast(@ExtendedRoutedValueSpecification)->at(0)->toOne();
-                      ^$state(value=^$routed(value = $va));,
+                      ^$state(value=^$routed(value = $va, genericType = $va.genericType));,
                      |^$state(value=$va)
                  );
    print(if($debug.debug,|$debug.space+'~>V) ('+$fullRes.routingStrategy.toString()+') '+$fullRes.value->evaluateAndDeactivate()->cast(@ValueSpecification)->toOne()->asString()+'\n',|''));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -3501,7 +3501,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::process
    let distinctTransformers = $propertyMappings->filter(m|$m->instanceOf(RelationalPropertyMapping))->cast(@RelationalPropertyMapping).transformer->distinct();
    let semiStructuredMappings = $propertyMappings->filter(m|$m->instanceOf(RelationalPropertyMapping))->forAll(x|$x->instanceOf(SemiStructuredRelationalPropertyMapping));
 
-   assertFalse($distinctTransformers->size() > 1, 'Unable to determine a unique Enum property mapping for an if stmt (returning an Enum)');
+   assertFalse($distinctTransformers->size() > 1 && ($distinctTransformers->removeDuplicates({t1, t2 | meta::pure::mapping::valueTransformerEquality($t1, $t2, $extensions)})->size() > 1), 'Unable to determine a unique Enum property mapping for an if stmt (returning an Enum)');
    if ($semiStructuredMappings,
        | print(if(!$context.debug, |'', |$context.space+'  Ignoring distinct transformer check as all property mappings are semi structured property mappings\n'));,
        | assertFalse($distinctTransformers->isEmpty(), 'Unable to determine the Enum property mapping for an if stmt (returning an Enum)');

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -3501,7 +3501,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::process
    let distinctTransformers = $propertyMappings->filter(m|$m->instanceOf(RelationalPropertyMapping))->cast(@RelationalPropertyMapping).transformer->distinct();
    let semiStructuredMappings = $propertyMappings->filter(m|$m->instanceOf(RelationalPropertyMapping))->forAll(x|$x->instanceOf(SemiStructuredRelationalPropertyMapping));
 
-   assertFalse($distinctTransformers->size() > 1 && ($distinctTransformers->removeDuplicates({t1, t2 | meta::pure::mapping::valueTransformerEquality($t1, $t2, $extensions)})->size() > 1), 'Unable to determine a unique Enum property mapping for an if stmt (returning an Enum)');
+   assertFalse($distinctTransformers->size() > 1 && ($distinctTransformers->removeDuplicates({t1, t2 | meta::pure::mapping::valueTransformerEquality($t1, $t2)})->size() > 1), 'Unable to determine a unique Enum property mapping for an if stmt (returning an Enum)');
    if ($semiStructuredMappings,
        | print(if(!$context.debug, |'', |$context.space+'  Ignoring distinct transformer check as all property mappings are semi structured property mappings\n'));,
        | assertFalse($distinctTransformers->isEmpty(), 'Unable to determine the Enum property mapping for an if stmt (returning an Enum)');

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMapping.pure
@@ -449,3 +449,72 @@ function <<test.Test>> meta::relational::tests::projection::enumeration::testTds
   let tds = $result.values->at(0);
   assertSize($tds.rows, 3);
 }
+
+function <<test.Test>> meta::relational::tests::projection::enumeration::testEnumValueReturnedInIfExp():Boolean[1]
+{  
+  let result =  execute({|Employee.all()->project(
+                            [
+                              x|$x.type,
+                              x|if(true,
+                                  | $x.type,
+                                  | $x.type
+                                  )
+                            ],
+                            [
+                              'Type' ,
+                              'Type If'
+                            ]
+                          );
+                        }, employeeTestMapping, enumTestRuntime(), meta::relational::extension::relationalExtensions()
+                      );
+  assertSameElements($result.values.rows.getEnum('Type If'), $result.values.rows.getEnum('Type'));
+  let tds = $result.values->at(0);
+  assertSize($tds.rows, 3);
+}
+
+function <<test.Test>> meta::relational::tests::projection::enumeration::testEnumValueReturnedInIfExpNotDistinctTransformers():Boolean[1]
+{  
+  let result =  execute({|EmployeeTypeInfo.all()->project(
+                            [
+                              x|$x.type,
+                              x|if(true,
+                                  | $x.type,
+                                  | if(true,
+                                        | $x.type,
+                                        | $x.employeeType
+                                        )
+                                  )
+                            ],
+                            [
+                              'Type' ,
+                              'Type If'
+                            ]
+                          );
+                        }, employeeTypeInfoNonDistinctTransformersMapping, enumTestRuntime(), meta::relational::extension::relationalExtensions()
+                      );
+  assertSameElements($result.values.rows.getEnum('Type If'), $result.values.rows.getEnum('Type'));
+  let tds = $result.values->at(0);
+  assertSize($tds.rows, 3);
+}
+
+function <<test.Test>> meta::relational::tests::projection::enumeration::testEnumValueReturnedInIfExpWithDistinctTransformers():Boolean[1]
+{  
+   assertError(|execute({|EmployeeTypeInfo.all()->project(
+                            [
+                              x|$x.type,
+                              x|if(true,
+                                  | $x.type,
+                                  | if(true,
+                                        | $x.type,
+                                        | $x.employeeType
+                                        )
+                                  )
+                            ],
+                            [
+                              'Type' ,
+                              'Type If'
+                            ]
+                          );
+                        }, employeeTypeInfoDistinctTransformersMapping, enumTestRuntime(), meta::relational::extension::relationalExtensions()), 
+                'Unable to determine a unique Enum property mapping for an if stmt (returning an Enum)');
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMapping.pure
@@ -496,25 +496,3 @@ function <<test.Test>> meta::relational::tests::projection::enumeration::testEnu
   let tds = $result.values->at(0);
   assertSize($tds.rows, 3);
 }
-
-function <<test.Test>> meta::relational::tests::projection::enumeration::testEnumValueReturnedInIfExpWithDistinctTransformers():Boolean[1]
-{  
-   assertError(|execute({|EmployeeTypeInfo.all()->project(
-                            [
-                              x|$x.type,
-                              x|if(true,
-                                  | $x.type,
-                                  | if(true,
-                                        | $x.type,
-                                        | $x.employeeType
-                                        )
-                                  )
-                            ],
-                            [
-                              'Type' ,
-                              'Type If'
-                            ]
-                          );
-                        }, employeeTypeInfoDistinctTransformersMapping, enumTestRuntime(), meta::relational::extension::relationalExtensions()), 
-                'Unable to determine a unique Enum property mapping for an if stmt (returning an Enum)');
-}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMappingDomain.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMappingDomain.pure
@@ -250,26 +250,6 @@ Mapping meta::relational::tests::mapping::enumeration::model::mapping::employeeT
     }
 )
 
-Mapping meta::relational::tests::mapping::enumeration::model::mapping::employeeTypeInfoDistinctTransformersMapping
-(
-  include meta::relational::tests::mapping::enumeration::model::mapping::employeeTestMapping
-
-    EmployeeType: EnumerationMapping Foo3
-    {
-        CONTRACT:  ['FTC', 'FTO', 'FTP'],
-        FULL_TIME: 'FTE'
-    }
-
-    EmployeeTypeInfo: Relational
-    {
-        scope([myDB]default.employeeTable)
-        (
-            type : EnumerationMapping Foo : type,
-            employeeType : EnumerationMapping Foo3 : type
-        )
-    }
-)
-
 Mapping meta::relational::tests::mapping::enumeration::model::mapping::employeeTestMapping2
 (
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMappingDomain.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/enumeration/testEnumerationMappingDomain.pure
@@ -39,6 +39,11 @@ Class meta::relational::tests::mapping::enumeration::model::domain::Employee
     skills:Skills[*];
 }
 
+Class meta::relational::tests::mapping::enumeration::model::domain::EmployeeTypeInfo extends Employee
+{
+    employeeType: EmployeeType[0..1];
+}
+
 Class meta::relational::tests::mapping::enumeration::model::domain::ConciseEmployee
 {
     name: String[1];
@@ -221,6 +226,46 @@ Mapping meta::relational::tests::mapping::enumeration::model::mapping::employeeT
             dateOfHire: doh,
             type : EnumerationMapping Foo : type,
             active : EnumerationMapping Active : active
+        )
+    }
+)
+
+Mapping meta::relational::tests::mapping::enumeration::model::mapping::employeeTypeInfoNonDistinctTransformersMapping
+(
+  include meta::relational::tests::mapping::enumeration::model::mapping::employeeTestMapping
+
+    EmployeeType: EnumerationMapping Foo2
+    {
+        CONTRACT:  ['FTC', 'FTO'],
+        FULL_TIME: 'FTE'
+    }
+
+    EmployeeTypeInfo: Relational
+    {
+        scope([myDB]default.employeeTable)
+        (
+            type : EnumerationMapping Foo : type,
+            employeeType : EnumerationMapping Foo2 : type
+        )
+    }
+)
+
+Mapping meta::relational::tests::mapping::enumeration::model::mapping::employeeTypeInfoDistinctTransformersMapping
+(
+  include meta::relational::tests::mapping::enumeration::model::mapping::employeeTestMapping
+
+    EmployeeType: EnumerationMapping Foo3
+    {
+        CONTRACT:  ['FTC', 'FTO', 'FTP'],
+        FULL_TIME: 'FTE'
+    }
+
+    EmployeeTypeInfo: Relational
+    {
+        scope([myDB]default.employeeTable)
+        (
+            type : EnumerationMapping Foo : type,
+            employeeType : EnumerationMapping Foo3 : type
         )
     }
 )


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?

- Fix property sequence on routing when resolving variable to also update the generic type along with value on ExtendedRoutedValueSpecification
- Update the assert on processIfForEnum to correctly identify the distinct Enum transformers by doing an equality check only on the relevant properties 
