### PR TITLE
Review schema support relation

### DIFF
--- a/.gs-project.yml
+++ b/.gs-project.yml
@@ -1,1 +1,1 @@
-productGuid: "product::315850"
+productGuid: "product::776807"

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-client/src/main/java/org/finos/legend/engine/repl/autocomplete/parser/ParserFixer.java
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-client/src/main/java/org/finos/legend/engine/repl/autocomplete/parser/ParserFixer.java
@@ -207,13 +207,13 @@ public class ParserFixer
             }
             if (content.contains("{") && !content.contains("}"))
             {
-                return value + "}#";
+                return value + magicToken + "}#";
             }
             if (content.contains("{") && content.contains("}"))
             {
                 return value + "#";
             }
-            return value + "{}#";
+            return value + "{" + magicToken + "}#";
         }
         return value;
 

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-relational/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-relational/pom.xml
@@ -31,11 +31,7 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-repl-client</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-m4</artifactId>
-        </dependency>
+        
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
@@ -150,6 +146,14 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-relational/src/test/java/org/finos/legend/engine/repl/TestCompleter.java
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-relational/src/test/java/org/finos/legend/engine/repl/TestCompleter.java
@@ -26,12 +26,16 @@ public class TestCompleter
     @Test
     public void testRelationAccessor()
     {
-        Assert.assertEquals("[a::A , >{a::A]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>")));
-        Assert.assertEquals("[a::other , >{a::other], [a::ABC , >{a::ABC]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a")));
-        Assert.assertEquals("[a::ABC , >{a::ABC]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A")));
-        Assert.assertEquals("[a::ABC , >{a::ABC]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC")));
-        Assert.assertEquals("[t , t}]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC.")));
-        Assert.assertEquals("[tab , tab}]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table co(val INTEGER) Table tab(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t")));
+        Assert.assertEquals("[a::A , >{a::A.]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>")));
+        Assert.assertEquals("[a::other , >{a::other.], [a::ABC , >{a::ABC.]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a")));
+        Assert.assertEquals("[a::ABC , >{a::ABC.]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A")));
+        Assert.assertEquals("[a::ABC , >{a::ABC.]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC")));
+        Assert.assertEquals("[t , t}#]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Table t(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC.")));
+        Assert.assertEquals("[at , at}#], [t , t}#], [ts , ts.]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Schema ts(Table t(col VARCHAR(200))) Table t(col VARCHAR(200)) Table at(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC.")));
+        Assert.assertEquals("[t , t}#], [ts , ts.]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Schema ts(Table t(col VARCHAR(200))) Table t(col VARCHAR(200)) Table at(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC.t")));
+        Assert.assertEquals("[ts , ts.]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Schema ts(Table t(col VARCHAR(200))) Table t(col VARCHAR(200)) Table at(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC.ts")));
+        Assert.assertEquals("[t , t}#]", checkResultNoException(new Completer("###Relational\nDatabase a::ABC(Schema ts(Table t(col VARCHAR(200))) Table t(col VARCHAR(200)) Table at(col VARCHAR(200)))\nDatabase a::other(Table t(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::ABC.ts.")));
+        Assert.assertEquals("[tab , tab}#]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table co(val INTEGER) Table tab(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t")));
         Assert.assertEquals("", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table tab(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.x")));
         Assert.assertEquals("", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table co(val INTEGER) Table tab(col VARCHAR(200)))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.tab}#")));
     }
@@ -189,8 +193,8 @@ public class TestCompleter
     @Test
     public void testJoin()
     {
-        Assert.assertEquals("[a::A , >{a::A]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->join(#>")));
-        Assert.assertEquals("[t , t}]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->join(#>{a::A.")));
+        Assert.assertEquals("[a::A , >{a::A.]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->join(#>")));
+        Assert.assertEquals("[t , t}#]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->join(#>{a::A.")));
         Assert.assertEquals("[JoinKind , JoinKind.]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->join(#>{a::A.t}#, ")));
         Assert.assertEquals("[LEFT , LEFT], [INNER , INNER]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->join(#>{a::A.t}#, JoinKind.")));
         Assert.assertEquals("[col , col], [val , val]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->join(#>{a::A.t}#, JoinKind.INNER, {a,b|$a.")));
@@ -205,8 +209,8 @@ public class TestCompleter
     @Test
     public void testAsOfJoin()
     {
-        Assert.assertEquals("[a::A , >{a::A]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->asOfJoin(#>")));
-        Assert.assertEquals("[t , t}]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->asOfJoin(#>{a::A.")));
+        Assert.assertEquals("[a::A , >{a::A.]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->asOfJoin(#>")));
+        Assert.assertEquals("[t , t}#]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->asOfJoin(#>{a::A.")));
         Assert.assertEquals("[col , col], [val , val]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->asOfJoin(#>{a::A.t}#, {a,b|$a.")));
         Assert.assertEquals("", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->asOfJoin(#>{a::A.t}#,")));
         Assert.assertEquals("[k , k], [o , o]", checkResultNoException(new Completer("###Relational\nDatabase a::A(Table t2(k VARCHAR(200), o INT) Table t(col VARCHAR(200), val INT))", Lists.mutable.with(new RelationalCompleterExtension())).complete("#>{a::A.t}#->asOfJoin(#>{a::A.t2}#, {a,b|$a.col == $b.")));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -271,8 +271,13 @@ public class HelperRelationalBuilder
 
     public static Schema getSchema(Database db, final String _schema)
     {
+        return getSchema(db, _schema, SourceInformation.getUnknownSourceInformation());
+    }
+
+    public static Schema getSchema(Database db, final String _schema, SourceInformation sourceInformation)
+    {
         Schema s = db._schemas().detect(schema -> _schema.equals(schema.getName()));
-        Assert.assertTrue(s != null, () -> "Can't find schema '" + _schema + "' in database '" + db.getName() + "'");
+        Assert.assertTrue(s != null, () -> "Can't find schema '" + _schema + "' in database '" + db.getName() + "'", sourceInformation, EngineErrorType.COMPILATION);
         return s;
     }
 
@@ -379,7 +384,7 @@ public class HelperRelationalBuilder
         return tables;
     }
 
-    private static boolean schemaExists(Database database, String schemaName)
+    public static boolean schemaExists(Database database, String schemaName)
     {
         return DEFAULT_SCHEMA_NAME.equals(schemaName) || schemaExists(Sets.mutable.empty(), database, schemaName);
     }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
@@ -788,20 +788,11 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
                 }
                 org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database ds = (org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database) store;
 
-                String schemaName = (accessor.path.size() == 3) ? accessor.path.get(1) : null;
+                String schemaName = (accessor.path.size() == 3) ? accessor.path.get(1) : "default";
                 String tableName = (accessor.path.size() == 3) ? accessor.path.get(2) : accessor.path.get(1);
 
-                org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Schema schema = schemaName == null ? ds._schemas().getFirst() : ds._schemas().select(c -> c.getName().equals(schemaName)).getFirst();
-                if (schema == null)
-                {
-                    throw new EngineException(schemaName == null ? "The database " + store._name() + " has no schemas" : "The schema " + schemaName + " can't be found in the store " + store._name(), accessor.sourceInformation, EngineErrorType.COMPILATION);
-                }
-                Table table = schema._tables().select(c -> c.getName().equals(tableName)).getFirst();
-                if (table == null)
-                {
-                    throw new EngineException("The table " + accessor.path.get(1) + " can't be found in the store " + store._name(), accessor.sourceInformation, EngineErrorType.COMPILATION);
-                }
-
+                org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Schema schema = HelperRelationalBuilder.getSchema(ds, schemaName, accessor.sourceInformation);
+                Table table = (Table) HelperRelationalBuilder.getRelation(schema, tableName, accessor.sourceInformation);
                 ProcessorSupport processorSupport = context.pureModel.getExecutionSupport().getProcessorSupport();
 
                 org.finos.legend.pure.m4.coreinstance.SourceInformation sourceInformation = null;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationStoreAccessorFromGrammar.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationStoreAccessorFromGrammar.java
@@ -123,34 +123,27 @@ public class TestRelationStoreAccessorFromGrammar extends TestCompilationFromGra
                 "  #>{my::Store.SchemaMissing.myTable}#->filter(\n" +
                 "    c|$c.name == 'ok'\n" +
                 "  )\n" +
-                "}\n", "COMPILATION error at [19:3-38]: The schema SchemaMissing can't be found in the store Store");
+                "}\n", "COMPILATION error at [19:3-38]: Can't find schema 'SchemaMissing' in database 'Store'");
     }
 
     @Test
     public void testCompilationOfRelationStoreAccessorUnknownTable()
     {
-        try
-        {
-            test("###Relational\n" +
-                    "Database my::Store" +
-                    "(" +
-                    "   Table myTable" +
-                    "   (" +
-                    "       id INT," +
-                    "       name VARCHAR(200)" +
-                    "   )" +
-                    ")\n" +
-                    "###Pure\n" +
-                    "function my::func():Any[*]" +
-                    "{" +
-                    "   #>{my::Store.myTabe}#->filter(c|$c.name == 'ok');" +
-                    "}");
-            Assert.fail();
-        }
-        catch (EngineException e)
-        {
-            Assert.assertEquals("COMPILATION error at [4:31-51]: The table myTabe can't be found in the store Store", e.toPretty());
-        }
+        test("###Relational\n" +
+                "Database my::Store" +
+                "(" +
+                "   Table myTable" +
+                "   (" +
+                "       id INT," +
+                "       name VARCHAR(200)" +
+                "   )" +
+                ")\n" +
+                "###Pure\n" +
+                "function my::func():Any[*]" +
+                "{" +
+                "   #>{my::Store.myTabe}#->filter(c|$c.name == 'ok');" +
+                "}",
+                "COMPILATION error at [4:31-51]: Can't find table 'myTabe' in schema 'default' and database 'Store'");
     }
 
     @Test
@@ -184,28 +177,22 @@ public class TestRelationStoreAccessorFromGrammar extends TestCompilationFromGra
     @Test
     public void testCompilationErrorMissingTable()
     {
-        try
-        {
-            test("###Relational\n" +
-                    "Database my::Store" +
-                    "(" +
-                    "   Table myTable" +
-                    "   (" +
-                    "       id INT," +
-                    "       name VARCHAR(200)" +
-                    "   )" +
-                    ")\n" +
-                    "###Pure\n" +
-                    "function my::func():Any[*]" +
-                    "{" +
-                    "   #>{my::Store}#->filter(c|$c.naeme == 'ok');" +
-                    "}");
-            Assert.fail();
-        }
-        catch (EngineException e)
-        {
-            Assert.assertEquals("COMPILATION error at [4:31-44]: Error in the accessor definition. Please provide a table.", e.toPretty());
-        }
+        test("###Relational\n" +
+                "Database my::Store" +
+                "(" +
+                "   Table myTable" +
+                "   (" +
+                "       id INT," +
+                "       name VARCHAR(200)" +
+                "   )" +
+                ")\n" +
+                "###Pure\n" +
+                "function my::func():Any[*]" +
+                "{" +
+                "   #>{my::Store}#->filter(c|$c.naeme == 'ok');" +
+                "}",
+                "COMPILATION error at [4:31-44]: Error in the accessor definition. Please provide a table."
+        );
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Fix how schema looks ups are done on relation accessor.  The code currently assumes the first schema on the DB was is the `"default"` schema.  This fix explicitly uses schema named "default".  This also improve completions to look into default schema, and also suggest schema names.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
