### PR TITLE
Persistence Component: Fix NPE in BulkLoad stats

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
@@ -620,10 +620,26 @@ public class SnowflakeSink extends AnsiSqlSink
                     switch ((String) queryStats.get(QueryStatsLogicalPlanUtils.OPERATOR_TYPE_ALIAS))
                     {
                         case QueryStatsLogicalPlanUtils.EXTERNAL_SCAN_STAGE:
-                            stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, queryStats.get(QueryStatsLogicalPlanUtils.EXTERNAL_BYTES_SCANNED_ALIAS));
+                            Object externalScan = queryStats.get(QueryStatsLogicalPlanUtils.EXTERNAL_BYTES_SCANNED_ALIAS);
+                            if (externalScan != null)
+                            {
+                                stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, externalScan);
+                            }
+                            else
+                            {
+                                stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, 0);
+                            }
                             break;
                         case QueryStatsLogicalPlanUtils.INSERT_STAGE:
-                            stats.put(StatisticName.INCOMING_RECORD_COUNT, queryStats.get(QueryStatsLogicalPlanUtils.INPUT_ROWS_ALIAS));
+                            Object insert = queryStats.get(QueryStatsLogicalPlanUtils.INPUT_ROWS_ALIAS);
+                            if (insert != null)
+                            {
+                                stats.put(StatisticName.INCOMING_RECORD_COUNT, insert);
+                            }
+                            else
+                            {
+                                stats.put(StatisticName.INCOMING_RECORD_COUNT, 0);
+                            }
                             break;
                     }
                 });


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:

The new BulkLoad stats: bytes scanned and incoming record count return null results when the file is empty. Adding null checks around.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
