### PR TITLE
Route ValueSpecification rather than FunctionExpression

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphFetchExecutionPlan.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphFetchExecutionPlan.pure
@@ -116,7 +116,7 @@ function meta::pure::graphFetch::executionPlan::nodeIsMerged(node:LocalGraphFetc
 function meta::pure::graphFetch::executionPlan::planGraphFetchExecution(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: Extension[*], debug: DebugContext[1]): ExecutionNode[1]
 {
    print(if($debug.debug,|$debug.space+'>Generating Graph Fetch Execution Plan:\n',|''));
-   let fe = $sq.fe->evaluateAndDeactivate();
+   let fe = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    let resultSize = $fe.parametersValues->evaluateAndDeactivate()->at(0)->match([rvs:ExtendedRoutedValueSpecification[1] | $rvs.value.multiplicity->toOne(),
                                                                                  vs: ValueSpecification[1] | $fe.multiplicity->toOne()]);
    assert($fe.func->in(graphFetchFunctions()) || $fe->isUnionOnGraphFetch(true));
@@ -194,7 +194,7 @@ function meta::pure::graphFetch::executionPlan::enrichTargetTreeForFilterPropert
 
 function meta::pure::graphFetch::executionPlan::planStoreUnionGraphFetchExecution(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], sets: InstanceSetImplementation[*], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: meta::pure::extension::Extension[*], debug: DebugContext[1]): ExecutionNode[1]
 {
-   let fe     = $sq.fe->evaluateAndDeactivate();
+   let fe     = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    let params = $fe.parametersValues->evaluateAndDeactivate();
    let p1     = $params->at(0);
    let p2     = $params->at(1)->cast(@InstanceValue);
@@ -214,12 +214,12 @@ function meta::pure::graphFetch::executionPlan::planStoreUnionGraphFetchExecutio
       )->evaluateAndDeactivate()
    }, $rf->eval($sets->at(0)));
 
-   planRouterUnionGraphFetchExecution(^$sq(fe = $newFe), $ext, $mapping, $runtime, $exeCtx, $extensions, $debug);
+   planRouterUnionGraphFetchExecution(^$sq(vs = $newFe), $ext, $mapping, $runtime, $exeCtx, $extensions, $debug);
 }
 
 function meta::pure::graphFetch::executionPlan::planRouterUnionGraphFetchExecution(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: Extension[*], debug: DebugContext[1]): ExecutionNode[1]
 {
-   let fe = $sq.fe->evaluateAndDeactivate();
+   let fe = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    assert($fe->isUnionOnGraphFetch(true), | 'Non union graphFetch function encountered');
 
    let subClusters  = $fe.parametersValues->evaluateAndDeactivate()->map({p | $p->meta::pure::router::clustering::cluster($mapping, $runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug).cluster->evaluateAndDeactivate()})->cast(@meta::pure::router::metamodel::clustering::ClusteredValueSpecification);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/lineage/scanProject.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/lineage/scanProject.pure
@@ -53,19 +53,11 @@ function <<access.private>> meta::pure::lineage::scanProject::scanProjectRecursi
                                                             );
                                                       ),
                                                       pair('meta::pure::tds::project_T_MANY__ColumnSpecification_MANY__TabularDataSet_1_',
-                                                           |let ins = $fe.parametersValues->at(1)->evaluateAndDeactivate();
-                                                            $ins->match(
-                                                               [
-                                                                 i:InstanceValue[1] |
-                                                                  let cols = $i.values->evaluateAndDeactivate()->cast(@SimpleFunctionExpression);
-                                                                  let colSpecs = $cols->map(c | $c->reactivate($vars)->cast(@BasicColumnSpecification<Any>));
-                                                                  ^Project(projectfuncEntryPoint = $fe,
-                                                                           columns = zip($colSpecs.name, $colSpecs.func->cast(@FunctionDefinition<Any>)));,
-                                                                 a:Any[*]|[]
-                                                               ]
-                                                            );
-
-                                                      ),
+                                                           |let cols = $fe.parametersValues->at(1)->evaluateAndDeactivate();
+                                                            let columns =  $cols->map(c|$c->meta::pure::lineage::scanProject::extractCol($vars));
+                                                            ^Project(projectfuncEntryPoint = $fe,
+                                                                     columns = zip($columns.name, $columns.func->cast(@FunctionDefinition<Any>)));
+                                                                     ),
                                                       pair('meta::pure::tds::groupBy_K_MANY__Function_MANY__AggregateValue_MANY__String_MANY__TabularDataSet_1_',
                                                         | let funcs = $fe.parametersValues->at(1)->match([s:InstanceValue[1]|$s.values, a:Any[*]|^Unknown()]);
                                                           let aggregateFuncs = $fe.parametersValues->at(2)->scanAggregateValue();
@@ -107,6 +99,18 @@ function <<access.private>> meta::pure::lineage::scanProject::scanProjectRecursi
       a:Any[1]|$project
    ]
   );
+}
+
+function <<access.private>> meta::pure::lineage::scanProject::extractCol(vs:ValueSpecification[1],vars:Map<String, List<Any>>[1]):BasicColumnSpecification<Any>[*]
+{ 
+ $vs->match(
+          [
+            i:InstanceValue[1] |   let cols = $i.values->evaluateAndDeactivate()->cast(@SimpleFunctionExpression);
+                                   let colSpecs = $cols->map(c | $c->reactivate($vars)->cast(@BasicColumnSpecification<Any>));,
+            s:SimpleFunctionExpression[1] |   $s->reactivate($vars)->cast(@BasicColumnSpecification<Any>);,
+            a:Any[*]| [] ;
+          ]
+      );
 }
 
 function <<access.private>> meta::pure::lineage::scanProject::scanRootGraphFetchTree(root:meta::pure::graphFetch::RootGraphFetchTree<Any>[1]):Pair<String, FunctionDefinition<Any>>[*]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -42,7 +42,7 @@ Class meta::pure::mapping::MappingInstanceData
 
 Class meta::pure::mapping::StoreQuery
 {
-    fe : FunctionExpression[1];
+    vs : ValueSpecification[1];
     inScopeVars : Map<String, List<Any>>[1];
     store : Store[1];
     //sets : Pair<String, List<Any>>[*]; //inputs to either cross store ( query )

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
@@ -248,7 +248,7 @@ Class meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryCros
 
 function meta::pure::mapping::modelToModel::graphFetch::executionPlan::planInMemoryGraphFetchExecution(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: Extension[*], debug: DebugContext[1]): ExecutionNode[1]
 {
-   let fe = $sq.fe->evaluateAndDeactivate();
+   let fe = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    if ($fe->meta::pure::router::utils::isUnionOnGraphFetch(true),
        | planRouterUnionGraphFetchExecution($sq, $ext, $mapping->toOne(), $runtime->toOne(), $exeCtx, $extensions, $debug),
        | assert($fe.func->in(graphFetchFunctions()), | 'Non graphFetch function encountered');
@@ -270,7 +270,7 @@ function meta::pure::mapping::modelToModel::graphFetch::executionPlan::planInMem
 function meta::pure::mapping::modelToModel::graphFetch::executionPlan::planRootGraphFetchExecutionInMemory(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], clusteredTree: StoreMappingClusteredGraphFetchTree[1], orderedPaths: String[*], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], enableConstraints: Boolean[1], checked: Boolean[1], extensions: meta::pure::extension::Extension[*], debug: DebugContext[1]): InMemoryRootGraphFetchExecutionNode[1]
 {
    let store       = $sq.store;
-   let fe          = $sq.fe->evaluateAndDeactivate();
+   let fe          = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    let rootTree    = $clusteredTree->byPassClusteringInfo()->cast(@RoutedRootGraphFetchTree<Any>);
    let batchSize   = if($fe.func == graphFetch_T_MANY__RootGraphFetchTree_1__Integer_1__T_MANY_ || $fe.func == graphFetchChecked_T_MANY__RootGraphFetchTree_1__Integer_1__Checked_MANY_,
                       | $fe->instanceValuesAtParameter(2, $sq.inScopeVars)->toOne()->cast(@Integer),
@@ -582,7 +582,7 @@ function meta::pure::mapping::modelToModel::graphFetch::executionPlan::generateP
 function <<access.private>> meta::pure::mapping::modelToModel::graphFetch::executionPlan::planInMemoryStoreMergeGraphFetchExecution(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], sets: InstanceSetImplementation[*], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: meta::pure::extension::Extension[*], debug: DebugContext[1]): ExecutionNode[1]
 {
    $mapping->meta::pure::mapping::modelToModel::validateMergeMapping();
-   let fe     = $sq.fe->evaluateAndDeactivate();
+   let fe     = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    let params = $fe.parametersValues->evaluateAndDeactivate();
    let p1     = $params->at(0);
    let p2     = $params->at(1)->cast(@InstanceValue);
@@ -603,7 +603,7 @@ function <<access.private>> meta::pure::mapping::modelToModel::graphFetch::execu
                                            values = $sets->map(set |  $rf->eval($set))->evaluateAndDeactivate())
       )->evaluateAndDeactivate();
 
-   planInMemoryRouterMergeGraphFetchExecution(^$sq(fe = $newFe), $ext, $mapping, $runtime, $exeCtx, $extensions, $debug,$sq,$tree);
+   planInMemoryRouterMergeGraphFetchExecution(^$sq(vs = $newFe), $ext, $mapping, $runtime, $exeCtx, $extensions, $debug,$sq,$tree);
 }
 function <<access.protected>> meta::pure::mapping::modelToModel::validateMergeMapping(mapping:Mapping[1]):Boolean[1]
 {
@@ -621,7 +621,7 @@ function <<access.protected>> meta::pure::mapping::modelToModel::validateMergeMa
 
 function <<access.private>> meta::pure::mapping::modelToModel::graphFetch::executionPlan::planInMemoryRouterMergeGraphFetchExecution(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: Extension[*], debug: DebugContext[1],rootSQ:StoreQuery[1],rootTree:ClusteredGraphFetchTree[1]): ExecutionNode[1]
 {
-   let fe = $sq.fe->evaluateAndDeactivate();
+   let fe = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
   let subClusters  = $fe.parametersValues->at(0)->evaluateAndDeactivate()->cast(@InstanceValue).values->cast(@ValueSpecification)->map({p | $p->cluster($mapping, $runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug).cluster->evaluateAndDeactivate()})->cast(@StoreMappingClusteredValueSpecification);
 
    let firstCluster = $subClusters->at(0);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/platform/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/platform/executionPlan/executionPlan_generation.pure
@@ -38,7 +38,8 @@ function meta::pure::platform::executionPlan::generation::processValueSpecificat
       f:SimpleFunctionExpression[1]         | $f->getFunctionProcessor($extensions)->eval($f, $state, $extensions, $debug),
       c:ClusteredValueSpecification[1]      | $c->plan($state.inScopeVars, $state.exeCtx, $extensions, $debug),
       e:ExtendedRoutedValueSpecification[1] | $e.value->processValueSpecification($state, $extensions, $debug),
-      i:InstanceValue[1]                    | [],
+      i:InstanceValue[1]                    | $i->processInstanceValue($state, $extensions, $debug),
+      v:VariableExpression[1]               | $v->processVariableExpression($state, $extensions, $debug),
       v:ValueSpecification[1]               | []
    ]);
 }
@@ -58,7 +59,29 @@ function <<access.private>> meta::pure::platform::executionPlan::generation::def
       requiredVariableInputs = $variableExpressionInputs->concatenate($varPlaceHolderInputs),
       resultSizeRange = $fe.multiplicity,
       executionNodes = $children,
-      fromCluster = generatePlatformClusterForFunction($fe, $state.inScopeVars)
+      fromCluster = generatePlatformCluster($fe, $state.inScopeVars)
+   );
+}
+
+function <<access.private>> meta::pure::platform::executionPlan::generation::processVariableExpression(var:VariableExpression[1], state:PlatformPlanGenerationState[1], extensions : Extension[*], debug:DebugContext[1]):ExecutionNode[1]
+{
+   ^VariableResolutionExecutionNode
+   (
+      varName = $var.name->toOne(),
+      resultType = ^ResultType(type=if($var.genericType.rawType->isEmpty(),|Any,|$var.genericType.rawType->toOne())),      
+      resultSizeRange = $var.multiplicity,      
+      fromCluster = generatePlatformCluster($var, $state.inScopeVars)
+   );
+}
+
+function <<access.private>> meta::pure::platform::executionPlan::generation::processInstanceValue(iv:InstanceValue[1], state:PlatformPlanGenerationState[1], extensions : Extension[*], debug:DebugContext[1]):ExecutionNode[1]
+{
+   ^PureExpressionPlatformExecutionNode
+   (
+      expression = $iv,
+      resultType = ^ResultType(type=if($iv.genericType.rawType->isEmpty(),|Any,|$iv.genericType.rawType->toOne())),      
+      resultSizeRange = $iv.multiplicity,      
+      fromCluster = generatePlatformCluster($iv, $state.inScopeVars)
    );
 }
 
@@ -76,7 +99,7 @@ function <<access.private>> meta::pure::platform::executionPlan::generation::ser
       expression = ^$fe(parametersValues=$substitute->concatenate($params->tail())),
       resultType = ^ResultType(type=$fe.genericType.rawType->toOne()),
       executionNodes = $children,
-      fromCluster = generatePlatformClusterForFunction($fe, $state.inScopeVars)
+      fromCluster = generatePlatformCluster($fe, $state.inScopeVars)
    );
 }
 
@@ -92,7 +115,7 @@ function <<access.private>> meta::pure::platform::executionPlan::generation::uni
       resultType = ^ResultType(type=$fe.genericType.rawType->toOne()),
       isChildrenExecutionParallelizable = true,
       executionNodes = $updatedChildren,
-      fromCluster = generatePlatformClusterForFunction($fe, $state.inScopeVars)
+      fromCluster = generatePlatformCluster($fe, $state.inScopeVars)
    );
 }
 
@@ -119,13 +142,13 @@ function <<access.private>> meta::pure::platform::executionPlan::generation::let
    );
 }
 
-function <<access.private>> meta::pure::platform::executionPlan::generation::generatePlatformClusterForFunction(fe:FunctionExpression[1], inScopeVars : Map<String, List<Any>>[1]):PlatformClusteredValueSpecification[1]
+function <<access.private>> meta::pure::platform::executionPlan::generation::generatePlatformCluster(vs:ValueSpecification[1], inScopeVars : Map<String, List<Any>>[1]):PlatformClusteredValueSpecification[1]
 {
    ^PlatformClusteredValueSpecification(
-      val = $fe,
+      val = $vs,
       executable=true,
-      multiplicity = $fe.multiplicity,
-      genericType  = $fe.genericType,
+      multiplicity = $vs.multiplicity,
+      genericType  = $vs.genericType,
       openVars = $inScopeVars
    );
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/metamodel/clustering.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/metamodel/clustering.pure
@@ -40,27 +40,27 @@ import meta::pure::router::utils::*;
 import meta::core::runtime::*;
 function meta::pure::router::clustering::generateExecutionNodeFromCluster(cluster:ClusteredValueSpecification[1], inScopeVars:Map<String, List<Any>>[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionNode[1]
 {
-  let fe = $cluster.val->byPassValueSpecificationWrapper()->cast(@FunctionExpression);
+  let vs = $cluster.val->byPassValueSpecificationWrapper();
 
   $cluster->match([
       sc:StoreMappingClusteredValueSpecification[1] |
           //This is required to populate the setup sql for test connections where csv data has been supplied. It is done here to ensure that the plan generation is always
           //the only place where sql is generated for this case.
-          $sc->buildExecutionNodeForStoreClusteredVS($fe, $sc.mapping, $inScopeVars, $context, $extensions, $debugContext),
+          $sc->buildExecutionNodeForStoreClusteredVS($vs, $sc.mapping, $inScopeVars, $context, $extensions, $debugContext),
       sc:StoreClusteredValueSpecification[1] |
           //This is required to populate the setup sql for test connections where csv data has been supplied. It is done here to ensure that the plan generation is always
           //the only place where sql is generated for this case.
-          $sc->buildExecutionNodeForStoreClusteredVS($fe, [], $inScopeVars, $context, $extensions, $debugContext),
+          $sc->buildExecutionNodeForStoreClusteredVS($vs, [], $inScopeVars, $context, $extensions, $debugContext),
       ef:ExternalFormatClusteredValueSpecification[1] |
           let state = ^meta::external::format::shared::executionPlan::ExternalFormatPlanGenerationState(inScopeVars = $inScopeVars, exeCtx = $ef.exeCtx->toOne(), binding = $ef.binding);
-          $fe->meta::external::format::shared::executionPlan::processValueSpecification($state, $extensions, $debugContext)->toOne();,
+          $vs->meta::external::format::shared::executionPlan::processValueSpecification($state, $extensions, $debugContext)->toOne();,
       pl:PlatformClusteredValueSpecification[1] |
           let state = ^meta::pure::platform::executionPlan::generation::PlatformPlanGenerationState(inScopeVars = $inScopeVars, exeCtx = $pl.exeCtx->toOne());
-          $fe->meta::pure::platform::executionPlan::generation::processValueSpecification($state, $extensions, $debugContext)->toOne();
+          $vs->meta::pure::platform::executionPlan::generation::processValueSpecification($state, $extensions, $debugContext)->toOne();
   ]);
 }
 
-function meta::pure::router::clustering::buildExecutionNodeForStoreClusteredVS(sc:StoreClusteredValueSpecification[1], fe:FunctionExpression[1], mapping:meta::pure::mapping::Mapping[0..1], inScopeVars:Map<String, List<Any>>[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionNode[1]
+function meta::pure::router::clustering::buildExecutionNodeForStoreClusteredVS(sc:StoreClusteredValueSpecification[1], vs:ValueSpecification[1], mapping:meta::pure::mapping::Mapping[0..1], inScopeVars:Map<String, List<Any>>[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionNode[1]
 {
     //This is required to populate the setup sql for test connections where csv data has been supplied. It is done here to ensure that the plan generation is always
     //the only place where sql is generated for this case.
@@ -74,7 +74,7 @@ function meta::pure::router::clustering::buildExecutionNodeForStoreClusteredVS(s
       ),      
       r:Runtime[0..1] | $r
     ]);
-    let query = ^meta::pure::mapping::StoreQuery(store=$sc.store, fe=$fe, inScopeVars=$inScopeVars);
+    let query = ^meta::pure::mapping::StoreQuery(store=$sc.store, vs=$vs, inScopeVars=$inScopeVars);
     let res = $sc.s.planExecution->toOne()->eval($query, $sc.val->match([r:RoutedValueSpecification[1]|$r, a:Any[*]|[]])->cast(@RoutedValueSpecification), $mapping, $rt, if ($sc.exeCtx->isEmpty(), | $context, | $sc.exeCtx->toOne()), $extensions, $debugContext);
     ^$res(fromCluster=$sc);
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/platform/routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/platform/routing.pure
@@ -95,7 +95,7 @@ function meta::pure::router::platform::routing::enrichPlatformRoutedValueSpecifi
 
 function meta::pure::router::platform::clustering::cluster(v:ValueSpecification[1], openVariables:Map<String, List<Any>>[1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):ValueSpecification[*]
 {
-   $v->match([f:FunctionExpression[1]                | let params         = $f.parametersValues->evaluateAndDeactivate()->map(v|$v->cluster($openVariables, $exeCtx, $extensions, ^$debug(space = $debug.space+'   ')));
+   $v->match([f:FunctionExpression[1]                | let params         = $f.parametersValues->evaluateAndDeactivate()->map(v|$v->cluster($openVariables, $exeCtx, $extensions, ^$debug(space = $debug.space+'   ')));                                
                                                        let uniqueClusters = $params->filter(p | $p->instanceOf(ClusteredValueSpecification))->cast(@ClusteredValueSpecification)->removeDuplicates({x, y | areClustersCompatible($x, $y, $extensions)});
                                                        if($uniqueClusters->size() == 1 && $uniqueClusters->toOne()->isFunctionSupportedByCluster($f),
                                                           |let uniqueCluster = $uniqueClusters->toOne();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_execution.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_execution.pure
@@ -97,7 +97,7 @@ function meta::pure::router::execution::executeExpression(clusters:ClusteredValu
 
 function <<access.private>> meta::pure::router::execution::getStoreQuery(store: Store[1], fe : FunctionExpression[1], inScopeVars : Map<String, List<Any>>[1]):meta::pure::mapping::StoreQuery[1]
 {
-   ^meta::pure::mapping::StoreQuery(store=$store, fe=$fe, inScopeVars=$inScopeVars);
+   ^meta::pure::mapping::StoreQuery(store=$store, vs=$fe, inScopeVars=$inScopeVars);
 }
 
 function meta::pure::router::execution::resolve(v:Container[1], openVariables:Map<String, List<Any>>[1], extensions:Extension[*], debug:DebugContext[1]):Container[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
@@ -133,11 +133,11 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], routing
                                   $fOpenVariables->putAll($inScopeVars->toOne()->keyValues());,
                                 | $fOpenVariables);
 
-   let functionExpressions = $f.expressionSequence->evaluateAndDeactivate()->cast(@FunctionExpression);
+   let valueSpecifications = $f.expressionSequence->evaluateAndDeactivate();
 
    // Enriching Function Expressions with relevant info (mapping / binding / platform)
    print(if($debug.debug,|'\n'+$debug.space+'Enriching Function Expressions with relevant info (mapping / binding / platform) and assigning routing strategy:\n',|''));
-   let enrichedExpressions = enrichFunctionExpressions($functionExpressions, $routingStrategy, $exeCtx, $openVariables, $graphFetchFlow, $extensions, $debug);   
+   let enrichedExpressions = enrichFunctionExpressions($valueSpecifications, $routingStrategy, $exeCtx, $openVariables, $graphFetchFlow, $extensions, $debug);   
 
    // Enriching Function Expressions with more information based on type of expression (subTypes of ExtendedRoutedValueSpecification)
    print(if($debug.debug,|'\n'+$debug.space+'Enriching Function Expressions with strategy based info (mapping / binding / platform):\n',|''));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -51,7 +51,7 @@ Class meta::pure::router::routing::PropertyMap
    v : Pair<String,Any>[*];
 }
 
-function meta::pure::router::routing::enrichFunctionExpressions(expressions:FunctionExpression[*], routingStrategy:RoutingStrategy[1], executionContext:meta::pure::runtime::ExecutionContext[1], inScopeVars:Map<String, List<Any>>[1], graphFetchFlow: Boolean[0..1],extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):ExtendedRoutedValueSpecification[*]
+function meta::pure::router::routing::enrichFunctionExpressions(expressions:ValueSpecification[*], routingStrategy:RoutingStrategy[1], executionContext:meta::pure::runtime::ExecutionContext[1], inScopeVars:Map<String, List<Any>>[1], graphFetchFlow: Boolean[0..1],extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):ExtendedRoutedValueSpecification[*]
 {
    let processedFunctions = processCollection(^RoutingState(shouldBeRouted=false, lambdaContext=[], counter=0, depth='', propertyMap = ^PropertyMap(), routingStrategy = $routingStrategy, graphFetchFlow = $graphFetchFlow),
                                               $expressions,
@@ -124,7 +124,7 @@ function <<access.private>> meta::pure::router::routing::routePath(state:Routing
    ^$state(value=^$path(path=$newPathElements));
 }
 
-function <<access.private>> meta::pure::router::routing::routeValueSpecification(state:RoutingState[1], executionContext:meta::pure::runtime::ExecutionContext[1], vars:Map<VariableExpression, ValueSpecification>[1], inScopeVars:Map<String, List<Any>>[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):RoutingState[1]
+function meta::pure::router::routing::routeValueSpecification(state:RoutingState[1], executionContext:meta::pure::runtime::ExecutionContext[1], vars:Map<VariableExpression, ValueSpecification>[1], inScopeVars:Map<String, List<Any>>[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):RoutingState[1]
 {
    $state.value->evaluateAndDeactivate()->match(
       [

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
@@ -345,14 +345,14 @@ function  meta::pure::router::store::routing::specializedFunctionExpressionRoute
                                                                                                                                               $r->reactivate($inScopeVars);,
                                                                                                                      i:InstanceValue[1]      |$i.values]));
                 let fromRuntime            = $resolvedParameters->at(0)->cast(@Runtime);
-                routeFunctionExpression(
-                    $fe.parametersValues->at(0)->cast(@FunctionExpression),
-                    ^$state(routingStrategy = getRoutingStrategyFromRuntime($fromRuntime)),
-                    $executionContext,
-                    $vars,
-                    $inScopeVars,
-                    $extensions,
-                    $debug
+                routeValueSpecification(
+                  ^$state(value = $fe.parametersValues->at(0), 
+                  routingStrategy = getRoutingStrategyFromRuntime($fromRuntime)), 
+                  $executionContext,
+                  $vars,
+                  $inScopeVars,
+                  $extensions,
+                  $debug
                 );
         }
     ),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/aggregationAware/aggregationAware.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/aggregationAware/aggregationAware.pure
@@ -38,7 +38,7 @@ Class meta::pure::mapping::aggregationAware::AggregationAwareActivity extends me
    rewrittenQuery: String[1];
 }
 
-function meta::pure::mapping::aggregationAware::reprocessFunction(f:FunctionExpression[1], openVars: Map<String, List<Any>>[1], e:RoutedValueSpecification[0..1], m:Mapping[1], debug:DebugContext[1]):LambdaFunction<{->Any[*]}>[1]
+function meta::pure::mapping::aggregationAware::reprocessFunction(vs:ValueSpecification[1], openVars: Map<String, List<Any>>[1], e:RoutedValueSpecification[0..1], m:Mapping[1], debug:DebugContext[1]):LambdaFunction<{->Any[*]}>[1]
 {
    let existingsVars = $openVars->keyValues()->filter(v|!$v.second.values->at(0)->instanceOf(PlanVarPlaceHolder)).first->map(k|
                                                 let inScopeVarValue = $openVars->get($k).values;
@@ -51,12 +51,12 @@ function meta::pure::mapping::aggregationAware::reprocessFunction(f:FunctionExpr
                                                 let placeholderLet = {| let placeHolder = $rightSide } ->evaluateAndDeactivate().expressionSequence ->cast(@SimpleFunctionExpression)->toOne();
                                                 ^$placeholderLet( parametersValues = [ $leftSide, $rightSide ] );
                                               );
-   let reprocessedFunction = ^LambdaFunction<{->Any[*]}>(expressionSequence =  $existingsVars->concatenate($f->rewriteQuery($openVars, $e, $m, $debug))->toOneMany());
+   let reprocessedFunction = ^LambdaFunction<{->Any[*]}>(expressionSequence =  $existingsVars->concatenate($vs->rewriteQuery($openVars, $e, $m, $debug))->toOneMany());
 }
 
-function meta::pure::mapping::aggregationAware::rewriteQuery(f:FunctionExpression[1], inScopeVars: Map<String, List<Any>>[1], r:RoutedValueSpecification[0..1], mappings:Mapping[1], debug:DebugContext[1]):FunctionExpression[1]
+function meta::pure::mapping::aggregationAware::rewriteQuery(vs:ValueSpecification[1], inScopeVars: Map<String, List<Any>>[1], r:RoutedValueSpecification[0..1], mappings:Mapping[1], debug:DebugContext[1]):ValueSpecification[1]
 {
-   $f->reprocessVS()->reprocessVSWithInScopeVars($inScopeVars)->rewriteValueSpecification($mappings, ^Map<String, ProjectPath>(), $inScopeVars, $debug)->cast(@FunctionExpression);
+   $vs->reprocessVS()->reprocessVSWithInScopeVars($inScopeVars)->rewriteValueSpecification($mappings, ^Map<String, ProjectPath>(), $inScopeVars, $debug)->cast(@FunctionExpression);
 }
 
 function meta::pure::mapping::aggregationAware::reprocessLambda(f:FunctionDefinition<Any>[1]):FunctionDefinition<Any>[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/aggregationAware/storeContract.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/aggregationAware/storeContract.pure
@@ -41,14 +41,14 @@ function meta::pure::mapping::aggregationAware::contract::aggregationAwareStoreC
 
 function meta::pure::mapping::aggregationAware::contract::planExecution(f:meta::pure::mapping::StoreQuery[1], e:RoutedValueSpecification[0..1], m:Mapping[0..1], runtime:Runtime[0..1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
-   let reprocessedFunction = reprocessFunction($f.fe->evaluateAndDeactivate(), $f.inScopeVars, $e, $m->toOne(), $debug);
+   let reprocessedFunction = reprocessFunction($f.vs->evaluateAndDeactivate(), $f.inScopeVars, $e, $m->toOne(), $debug);
    let node = meta::pure::executionPlan::executionPlan($reprocessedFunction, $m->toOne(), $runtime->toOne(), $exeCtx, $extensions, $debug).rootExecutionNode;
    ^AggregationAwareExecutionNode(executionNodes = $node, resultType = $node.resultType, aggregationAwareActivity = $reprocessedFunction->asString());
 }
 
 function meta::pure::mapping::aggregationAware::contract::execution(f:meta::pure::mapping::StoreQuery[1], e:RoutedValueSpecification[0..1], m:Mapping[1], runtime:Runtime[1], exeCtx:meta::pure::runtime::ExecutionContext[1],  extensions:Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
-   let reprocessedFunction = reprocessFunction($f.fe->evaluateAndDeactivate(), $f.inScopeVars, $e, $m, $debug);
+   let reprocessedFunction = reprocessFunction($f.vs->evaluateAndDeactivate(), $f.inScopeVars, $e, $m, $debug);
    print(if($debug.debug,|$reprocessedFunction->evaluateAndDeactivate()->asString()->debug($debug.space+'Agg Aware Reprocessed Function: '),|''));
    let result = execute($reprocessedFunction, $m, $runtime, $exeCtx, $extensions, $debug);
    let aggregationAwareActivity = ^AggregationAwareActivity(rewrittenQuery = $reprocessedFunction->asString());

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/chain.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/chain.pure
@@ -31,9 +31,9 @@ import meta::pure::router::utils::*;
 
 function meta::pure::mapping::modelToModel::chain::executeChain(f:StoreQuery[1], e:StoreMappingRoutedValueSpecification[0..1], mapping:Mapping[1], mcc:ModelChainConnection[1], runtime:Runtime[1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
-   let returnType = $f.fe.genericType.rawType->toOne();
+   let returnType = $f.vs.genericType.rawType->toOne();
    print(if(!$debug.debug, |'',|$debug.space+'Mappings: ['+$mapping->concatenate($mcc.mappings->init())->makeString(', ')+']\n'));
-   let processed = $f.fe->allReprocess($e, $mapping->concatenate($mcc.mappings->init()), $extensions, $debug);
+   let processed = $f.vs->allReprocess($e, $mapping->concatenate($mcc.mappings->init()), $extensions, $debug);
    let existingsVars =   $f.inScopeVars->keys()->map(k|
                                                      let inScopeVarValue = $f.inScopeVars->get($k).values;
                                                      let rightValue = $inScopeVarValue->evaluateAndDeactivate();
@@ -66,7 +66,7 @@ function meta::pure::mapping::modelToModel::chain::executeChain(f:StoreQuery[1],
          c : Class<Any>[1] |
             if ($c->_subTypeOf(TabularDataSet),
                 |let tds = $results.values->cast(@TabularDataSet)->toOne();
-                 let enumColumns = $f.fe->identifyTDSColumns($extensions)->filter(t|$t.type->toOne()->instanceOf(Enumeration))->map(t|pair($t.type->toOne()->cast(@Enumeration<Any>), $t.offset->toOne()));
+                 let enumColumns = $f.vs->cast(@FunctionExpression)->identifyTDSColumns($extensions)->filter(t|$t.type->toOne()->instanceOf(Enumeration))->map(t|pair($t.type->toOne()->cast(@Enumeration<Any>), $t.offset->toOne()));
                   if ($enumColumns->isEmpty(),
                       |$results.values,
                       |^$tds(rows = $tds.rows->map(r|$enumColumns->fold({b,a|let val = $a.values;
@@ -103,12 +103,12 @@ function meta::pure::mapping::modelToModel::chain::executeChain(f:StoreQuery[1],
 
 function meta::pure::mapping::modelToModel::chain::planExecutionChain(sq:StoreQuery[1], e:StoreMappingRoutedValueSpecification[0..1], mapping:Mapping[0..1], mcc:ModelChainConnection[1], runtime:Runtime[0..1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
-   let returnType = $sq.fe.genericType.rawType->toOne();
+   let returnType = $sq.vs.genericType.rawType->toOne();
    assert($returnType->_subTypeOf(TabularDataSet), 'Non TDS return type not supported for Model Connections');
 
    print(if(!$debug.debug, |'',|$debug.space+'Mappings: ['+$mapping->concatenate($mcc.mappings->init())->makeString(', ')+']\n'));
 
-   let processed = $sq.fe->allReprocess($e, $mapping->concatenate($mcc.mappings->init()), $extensions, $debug);
+   let processed = $sq.vs->allReprocess($e, $mapping->concatenate($mcc.mappings->init()), $extensions, $debug);
    let f = ^LambdaFunction<{->Any[*]}>(expressionSequence = $processed.res->cast(@FunctionExpression))->toOne()->cast(@FunctionDefinition<Any>);
 
    let m = $mcc.mappings->last()->toOne();
@@ -141,11 +141,11 @@ function meta::pure::mapping::modelToModel::chain::planExecutionChain(sq:StoreQu
 
 Class meta::pure::mapping::modelToModel::chain::Container
 {
-   res : FunctionExpression[1];
+   res : ValueSpecification[1];
    ex : StoreMappingRoutedValueSpecification[*];
 }
 
-function meta::pure::mapping::modelToModel::chain::allReprocess(f:FunctionExpression[1], r:StoreMappingRoutedValueSpecification[0..1], mappings:Mapping[*], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):Container[1]
+function meta::pure::mapping::modelToModel::chain::allReprocess(vs:ValueSpecification[1], r:StoreMappingRoutedValueSpecification[0..1], mappings:Mapping[*], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):Container[1]
 {
    $mappings->fold(
                      {a,b|
@@ -157,13 +157,13 @@ function meta::pure::mapping::modelToModel::chain::allReprocess(f:FunctionExpres
 
                            [
                               e:StoreMappingRoutedValueSpecification[1]|pair(list($e), $e.value->cast(@FunctionExpression)->toOne()->reprocess($e, $a, $mappings, [], $extensions).newExpression);,
-                              f:FunctionExpression[1]|pair(list($r), $f->reprocess($r, $a, $mappings, [], $extensions).newExpression);
+                              f:FunctionExpression[1]|pair(list($r), $vs->reprocess($r, $a, $mappings, [], $extensions).newExpression);
                            ]
                         );
                         print(if(!$debug.debug, |'', | $debug.space+'  Chain Reprocessed Query: '+$res.second->cast(@ValueSpecification)->asString()+'\n'));
                         ^Container(res=$res.second->cast(@FunctionExpression), ex=$b.ex->concatenate($res.first.values));
                      },
-                     ^Container(res=$f)
+                     ^Container(res=$vs)
                    );
 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/inMemory.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/inMemory.pure
@@ -343,11 +343,12 @@ function meta::pure::mapping::modelToModel::inMemory::getter(o:Any[1], property:
 
 function meta::pure::mapping::modelToModel::inMemory::planExecutionInMemory(sq:meta::pure::mapping::StoreQuery[1], e:StoreMappingRoutedValueSpecification[0..1], mapping: Mapping[0..1], mc:ModelConnection[1], runtime:Runtime[0..1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
-   let jsonFeWithPpt = if($sq.fe.func.name == 'toJSON_T_MANY__LambdaFunction_MANY__String_1_',
-                          | let inputFeToJson = $sq.fe.parametersValues->at(0)->byPassRouterInfo()->cast(@FunctionExpression);
-                            let jsonPropertyPaths = $sq.fe.parametersValues->at(1)->byPassRouterInfo()->cast(@InstanceValue).values->cast(@LambdaFunction<{Nil[1]->Any[*]}>);
+   let queryFe = $sq.vs->cast(@FunctionExpression); 
+   let jsonFeWithPpt = if($queryFe.func.name == 'toJSON_T_MANY__LambdaFunction_MANY__String_1_',
+                          | let inputFeToJson = $queryFe.parametersValues->at(0)->byPassRouterInfo()->cast(@FunctionExpression);
+                            let jsonPropertyPaths = $queryFe.parametersValues->at(1)->byPassRouterInfo()->cast(@InstanceValue).values->cast(@LambdaFunction<{Nil[1]->Any[*]}>);
                             ^JsonFeWithPropertyPaths(fe=$inputFeToJson, jsonPropertyPaths=$jsonPropertyPaths);,
-                          | ^JsonFeWithPropertyPaths(fe=$sq.fe)
+                          | ^JsonFeWithPropertyPaths(fe=$queryFe)
                        );
 
    let fe = $jsonFeWithPpt.fe;

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/storeContract.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/storeContract.pure
@@ -48,7 +48,7 @@ function meta::pure::mapping::modelToModel::contract::execution(sq:meta::pure::m
    let connection = $runtime->connectionByElement($sq.store);
    $connection->match(
                         [
-                           mc:ModelConnection[1]| executeInMemory($sq.fe, $ext->cast(@StoreMappingRoutedValueSpecification), $m, $mc, $runtime, $exeCtx, $extensions, $debug),
+                           mc:ModelConnection[1]| executeInMemory($sq.vs, $ext->cast(@StoreMappingRoutedValueSpecification), $m, $mc, $runtime, $exeCtx, $extensions, $debug),
                            mcc:ModelChainConnection[1]| executeChain($sq, $ext->cast(@StoreMappingRoutedValueSpecification), $m, $mcc, $runtime, $exeCtx, $extensions, $debug)
                         ]
                );
@@ -85,7 +85,7 @@ function meta::pure::mapping::modelToModel::contract::isPropertyAutoMapped(prope
 
 function meta::pure::mapping::modelToModel::contract::planExecution(sq:meta::pure::mapping::StoreQuery[1], ext:RoutedValueSpecification[0..1], m:Mapping[0..1], runtime:Runtime[0..1], exeCtx:meta::pure::runtime::ExecutionContext[1], extension:Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
-   let fe = $sq.fe->evaluateAndDeactivate()->cast(@FunctionExpression);
+   let fe = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    if ($fe->meta::pure::router::utils::isUnionOnGraphFetch(true) || $fe.func->in(graphFetchFunctions()) || $fe->meta::pure::router::utils::isMergeOnGraphFetch() ,
        | planInMemoryGraphFetchExecution($sq, $ext, $m->toOne(), $runtime->toOne(), $exeCtx, $extension, $debug),
        | planExecutionPure($sq, $ext, $m, $runtime, $exeCtx, $extension, $debug)

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/src/main/resources/core_analytics_lineage/tests/lineageTests.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/src/main/resources/core_analytics_lineage/tests/lineageTests.pure
@@ -542,3 +542,24 @@ function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly
                                           '[employeeName: [PersonTable.PERSON_DETAILS <DynaFunction>], firmName: [FirmTable.ID <JoinTreeNode>, FirmTable.LEGAL_NAME <TableAliasColumn>, PersonTable.PERSON_DETAILS <JoinTreeNode>]]',
                                            $lineage);
 }
+
+###Pure
+import meta::analytics::lineage::*;
+import meta::relational::extension::*;
+import meta::relational::tests::*;
+import meta::relational::tests::model::simple::*;
+function <<meta::pure::profiles::test.Test>> meta::analytics::lineage::tests::relational::testColWithPrimitiveLet():Boolean[1]
+{
+   let fn= {businessDate:Date[1], type:String[1]|
+             let adjustedType = $type+ 'test';
+               meta::relational::tests::milestoning::Product.all($businessDate)->project(col(p|$p.classification($businessDate).type,'type'))->filter(f|$f.getString('type')=='adjustedType');};  
+  let mapping = meta::relational::tests::milestoning::milestoningmap;
+  let runtime = meta::external::store::relational::tests::testRuntime();
+
+  let lineage = computeLineage($fn, $mapping, $runtime, relationalExtensions());
+  
+  meta::analytics::lineage::assertLineage(['Lambda', 'db_db', 'tb_dbdefaultProductClassificationTable', 'tb_dbdefaultProductTable'],
+                                         ['Lambda', 'meta::pure::tds::TDSRow', 'meta::relational::tests::milestoning::Product', 'meta::relational::tests::milestoning::ProductClassification', 'pack_meta::pure::tds', 'pack_meta::relational::tests::milestoning'],  
+                                        '[type: [ProductClassificationTable.type <JoinTreeNode>, ProductClassificationTable.type <TableAliasColumn>, ProductTable.type <JoinTreeNode>]]',
+                                          $lineage);
+}

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/src/main/resources/core_elasticsearch_seven_metamodel/functions/pure_to_elasticsearch.pure
@@ -712,7 +712,7 @@ function meta::external::store::elasticsearch::v7::pureToEs::process(sq:StoreQue
     supportedForPainlessScriptFunctions = supportedForPainlessScriptFunctions()
   );
 
-  let processedReq = $sq.fe->process($req);
+  let processedReq = $sq.vs->process($req);
   let search = $processedReq.search;
   ^$processedReq(search = if($search.size->isEmpty(), | ^$search(size = defaultSize()->literal()), | $search));
 }

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_GrammarFunction_PCT.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_GrammarFunction_PCT.java
@@ -55,8 +55,7 @@ public class Test_JAVA_GrammarFunction_PCT extends PCTReportConfiguration
                 one("meta::pure::functions::collection::tests::first::testFirstOnEmptySet_Function_1__Boolean_1_", "org.finos.legend.engine.shared.javaCompiler.JavaCompileException: 2 errors compiling /_pure/plan/root/Execute.java"),
 
                 // Let
-                one("meta::pure::functions::lang::tests::letFn::testAssignLiteralToVariable_Function_1__Boolean_1_", "\"Cast exception: VariableExpression cannot be cast to FunctionExpression\""),
-                one("meta::pure::functions::lang::tests::letFn::testAssignNewInstance_Function_1__Boolean_1_", "\"Cast exception: VariableExpression cannot be cast to FunctionExpression\""),
+                one("meta::pure::functions::lang::tests::letFn::testAssignNewInstance_Function_1__Boolean_1_", "\"Unhandled value type: meta::pure::functions::lang::tests::model::LA_Person\""),
                 one("meta::pure::functions::lang::tests::letFn::testLetChainedWithAnotherFunction_Function_1__Boolean_1_", "org.finos.legend.engine.shared.javaCompiler.JavaCompileException: 2 errors compiling /_pure/plan/root/n1/Execute.java\n/_pure/plan/root/n1/Execute.java"),
 
                 // Map

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/platform/executionPlanNodes/platform/platform.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/platform/executionPlanNodes/platform/platform.pure
@@ -33,10 +33,10 @@ import meta::pure::graphFetch::execution::*;
 // Prepare
 function meta::pure::executionPlan::platformBinding::legendJava::platform::prepareForPlatformNode(p:PureExpressionPlatformExecutionNode[1], path:String[1], context:GenerationContext[1], extensions : meta::pure::extension::Extension[*], debug:DebugContext[1]):GenerationContext[1]
 {
-   if($p.expression->cast(@FunctionExpression)->isSerialize(),
-      | prepareForSerialize($p, $path, $context, $debug),
-      | prepareForExpression($p, $path, $context, $debug)
-   );
+  $p.expression->match([
+    fe: FunctionExpression[1] | if($fe->isSerialize(), | prepareForSerialize($p, $path, $context, $debug), | prepareForExpression($p, $path, $context, $debug)),
+    vs: ValueSpecification[1] | prepareForExpression($p, $path, $context, $debug)
+  ]);
 }
 
 function <<access.private>> meta::pure::executionPlan::platformBinding::legendJava::platform::prepareForExpression(p:PureExpressionPlatformExecutionNode[1], path:String[1], context:GenerationContext[1], debug:DebugContext[1]):GenerationContext[1]
@@ -59,19 +59,22 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::legendJa
 // Generate
 function meta::pure::executionPlan::platformBinding::legendJava::platform::generateImplementionForPlatformNode(p:PureExpressionPlatformExecutionNode[1], path:String[1], context:GenerationContext[1], extensions : meta::pure::extension::Extension[*], debug:DebugContext[1]):GeneratedCode[1]
 {
-   if($p.expression->cast(@FunctionExpression).func == now__DateTime_1_,
-      | generateImplementionForNow($context.conventions),
-      |
-   if($p.expression->cast(@FunctionExpression).func == currentUserId__String_1_,
-      | generateImplementionForCurrentUserId($context.conventions),
-      |
-   if($p.expression->cast(@FunctionExpression)->isSerialize(),
-      | generateImplementionForSerialize($p, $path, $context, $debug),
-      |
-   if($p.expression->cast(@FunctionExpression)->isParseObjectReferences(),
-      | generateImplementationForParseObjectReferences($p, $path, $context, $extensions, $debug),
-      | generateImplementionForExpression($p, $path, $context, $debug)
-   ))));
+   if ($p.expression->instanceOf(FunctionExpression), 
+    | if($p.expression->cast(@FunctionExpression).func == now__DateTime_1_,
+          | generateImplementionForNow($context.conventions),
+          |
+      if($p.expression->cast(@FunctionExpression).func == currentUserId__String_1_,
+          | generateImplementionForCurrentUserId($context.conventions),
+          |
+      if($p.expression->cast(@FunctionExpression)->isSerialize(),
+          | generateImplementionForSerialize($p, $path, $context, $debug),
+          |
+      if($p.expression->cast(@FunctionExpression)->isParseObjectReferences(),
+          | generateImplementationForParseObjectReferences($p, $path, $context, $extensions, $debug),
+          | generateImplementionForExpression($p, $path, $context, $debug)
+      )))), 
+    | generateImplementionForExpression($p, $path, $context, $debug)
+   );
 }
 
 function <<access.private>> meta::pure::executionPlan::platformBinding::legendJava::platform::generateImplementionForNow(conventions:Conventions[1]):GeneratedCode[1]

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/contract/storeContract.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/contract/storeContract.pure
@@ -58,9 +58,9 @@ function meta::external::store::mongodb::contract::mongoDBStoreContract(): Store
 function meta::external::store::mongodb::contract::planExecution(sq:meta::pure::mapping::StoreQuery[1], ext:RoutedValueSpecification[0..1], m:Mapping[0..1], runtime:Runtime[0..1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:Extension[*], debug:DebugContext[1]): meta::pure::executionPlan::ExecutionNode[1]
 {
     let store = $sq.store->cast(@MongoDatabase);
-    let fe = $sq.fe->evaluateAndDeactivate();
+    let vs = $sq.vs->evaluateAndDeactivate();
 
-    if($fe.func->in([meta::pure::graphFetch::execution::graphFetchFunctions()]),
+    if($vs->instanceOf(FunctionExpression) && $vs->cast(@FunctionExpression).func->in([meta::pure::graphFetch::execution::graphFetchFunctions()]),
       |
         // Graph Fetch Flow
         $sq->meta::pure::graphFetch::executionPlan::planGraphFetchExecution($ext, $m->toOne(), $runtime->toOne(), $exeCtx, $extensions, $debug);,
@@ -75,7 +75,7 @@ function meta::external::store::mongodb::contract::planExecution(sq:meta::pure::
                                   ^$oldRuntime(connectionStores = ^$connectionStore(connection=$dbConn));
                               );
 
-        let databaseCommand = $sq.fe->toDatabaseCommand($m->toOne(), $sq.inScopeVars, $debug, $extensions)->cast(@DatabaseCommand);
+        let databaseCommand = $sq.vs->toDatabaseCommand($m->toOne(), $sq.inScopeVars, $debug, $extensions)->cast(@DatabaseCommand);
 
         let connection = $runtime->toOne()->connectionByElement($store)->cast(@MongoDBConnection);
 

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/graphFetch/mongoDBGraphFetch.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/graphFetch/mongoDBGraphFetch.pure
@@ -33,7 +33,7 @@ import meta::external::format::shared::executionPlan::*;
 
 function meta::external::store::mongodb::graphFetch::executionPlan::planRootGraphFetchExecutionMongoDb(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], clusteredTree: StoreMappingClusteredGraphFetchTree[1], orderedPaths: String[*], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], enableConstraints: Boolean[1], checked: Boolean[1], extensions: Extension[*], debug: DebugContext[1]): LocalGraphFetchExecutionNode[1]
 {
-  let fe = $sq.fe->evaluateAndDeactivate();
+  let fe = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
   let lhsFe = $fe.parametersValues->evaluateAndDeactivate()->at(0)->byPassRouterInfo()->cast(@FunctionExpression);
   let rootTree = $clusteredTree->byPassClusteringInfo()->cast(@RoutedRootGraphFetchTree<Any>);
   let store = $sq.store->cast(@MongoDatabase);

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/pureToDatabaseCommand/pureToDatabaseCommand.pure
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/src/main/resources/core_nonrelational_mongodb/pureToDatabaseCommand/pureToDatabaseCommand.pure
@@ -56,9 +56,9 @@ function meta::external::store::mongodb::functions::pureToDatabaseCommand::findS
    $supportedFunctions->get($fe.func);
 }
 
-function meta::external::store::mongodb::functions::pureToDatabaseCommand::toDatabaseCommand(functionExpression:FunctionExpression[1], mapping:Mapping[1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1], extensions:Extension[*]): MongoDBOperationElement[1]
+function meta::external::store::mongodb::functions::pureToDatabaseCommand::toDatabaseCommand(vs:ValueSpecification[1], mapping:Mapping[1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1], extensions:Extension[*]): MongoDBOperationElement[1]
 {
-   processValueSpecification($functionExpression, ^DatabaseCommand(type='aggregate'), $mapping, $inScopeVars, $debug);
+   processValueSpecification($vs, ^DatabaseCommand(type='aggregate'), $mapping, $inScopeVars, $debug);
 }
 
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/contract/storeContract.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/contract/storeContract.pure
@@ -184,7 +184,7 @@ function meta::relational::contract::relationalStoreContract():StoreContract[1]
 // Execution flow
 function meta::relational::contract::execution(sq:meta::pure::mapping::StoreQuery[1], ext:RoutedValueSpecification[0..1], m:Mapping[1], runtime:Runtime[1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
-   execution($sq.store->cast(@Database), $sq.fe, $ext, $m, $runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug);
+   execution($sq.store->cast(@Database), $sq.vs, $ext, $m, $runtime, $sq.inScopeVars, $exeCtx, $extensions, $debug);
 }
 
 // Functions supported by relational execution
@@ -220,15 +220,16 @@ function meta::relational::contract::supportsStream(f:FunctionExpression[1]):Boo
 function meta::relational::contract::planExecution(sq:meta::pure::mapping::StoreQuery[1], ext:RoutedValueSpecification[0..1], m:Mapping[0..1], runtime:Runtime[0..1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
    let store = $sq.store->cast(@Database);
-   let fe = $sq.fe->evaluateAndDeactivate();
+   let vs = $sq.vs->evaluateAndDeactivate();
+   let func = if($vs->instanceOf(FunctionExpression), |$vs->cast(@FunctionExpression).func, |[]);
    if([
         pair(
-          |$fe.func->in([meta::pure::graphFetch::execution::graphFetchFunctions()]),
+          |$func->in([meta::pure::graphFetch::execution::graphFetchFunctions()]),
           | // Graph Fetch Flow
             $sq->meta::pure::graphFetch::executionPlan::planGraphFetchExecution($ext, $m->toOne(), $runtime->toOne(), $exeCtx, $extensions, $debug);
         ),
         pair(
-          |$fe.func->in(meta::pure::mutation::mutationFunctions()),
+          |$func->in(meta::pure::mutation::mutationFunctions()),
           | // Write Flow
             $sq->meta::relational::mutation::executionPlan::planMutationExecution($ext, $m->toOne(), $runtime->toOne(), $exeCtx, $extensions, $debug);
         )
@@ -245,7 +246,7 @@ function meta::relational::contract::planExecution(sq:meta::pure::mapping::Store
                         );
      
         let queryExeCtx = if($exeCtx->instanceOf(RelationalExecutionContext),|$exeCtx,|[])->cast(@RelationalExecutionContext);
-            let originalQuery = $sq.fe->toSQLQuery($m, $sq.inScopeVars,$debug,$queryExeCtx->relationalExecutionContextToState(defaultState($m, $sq.inScopeVars, $exeCtx, $extensions)),  $extensions);
+            let originalQuery = $sq.vs->toSQLQuery($m, $sq.inScopeVars,$debug,$queryExeCtx->relationalExecutionContextToState(defaultState($m, $sq.inScopeVars, $exeCtx, $extensions)),  $extensions);
             $originalQuery->postProcessSQLQuery($store, $ext, $m, $storeRuntime, $exeCtx, $extensions)
                           ->generateExecutionNodeForPostProcessedResult($sq, $store, $ext, $m, $storeRuntime, $exeCtx, $debug, $extensions);
       );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -364,7 +364,7 @@ function meta::relational::graphFetch::executionPlan::getTempTableStrategyForNon
 function meta::relational::graphFetch::executionPlan::planRootGraphFetchExecutionRelational(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], clusteredTree: StoreMappingClusteredGraphFetchTree[1], orderedPaths: String[*], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], enableConstraints: Boolean[1], checked: Boolean[1], extensions: Extension[*], debug: DebugContext[1]): LocalGraphFetchExecutionNode[1]
 {
    print(if($debug.debug,|$debug.space+'>Relational root graphFetch plan generation:\n',|''));
-   let fe           = $sq.fe->evaluateAndDeactivate();
+   let fe           = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    let lhsFe        = $fe.parametersValues->evaluateAndDeactivate()->at(0)->byPassRouterInfo()->cast(@FunctionExpression);
    let rootTree     = $clusteredTree->byPassClusteringInfo()->cast(@RoutedRootGraphFetchTree<Any>);
    let setImpls     = $rootTree.sets->cast(@RootRelationalInstanceSetImplementation);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelations.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelations.pure
@@ -393,7 +393,7 @@ Class meta::pure::lineage::scanRelations::RelationalTreeAndVars
 }
 
 function <<access.private>> meta::pure::lineage::scanRelations::generatRelationalTrees(f:FunctionDefinition<Any>[1], m:Mapping[1], r:Runtime[1], vars:Pair<String, List<Any>>[*], debug:DebugContext[1], extensions:Extension[*]):RelationalTreeAndVars[1]
-{   
+{  
    let routed         = $f->routeFunction($m, $r, $extensions, $debug);
    let routedFunction = $routed->evaluateAndDeactivate()->toOne();
    let inScopeVars    = $f.expressionSequence->evaluateAndDeactivate()->fold({vs, a |    if ($vs->isLetFunction() ,
@@ -402,8 +402,12 @@ function <<access.private>> meta::pure::lineage::scanRelations::generatRelationa
                                                                                               let inScopeVars = $a->keyValues();
                                                                                               let unavailableVars = $varExprs.name->forAll(var | $var->in($inScopeVars.first));
                                                                                              assert($unavailableVars, 'Unable to resolve var(s): '+ $varExprs.name->filter(var | !$var->in($inScopeVars.first))->joinStrings());
-                                                                                              let re    = $vs->reactivate($a);
-                                                                                              $a->put($varName->toOne(), ^List<Any>(values=$re));,
+                                                                              
+                                                                                            let value = if($vs.genericType.rawType->toOne()->instanceOf(PrimitiveType) &&  !$vs->cast(@SimpleFunctionExpression).parametersValues->at(1)->instanceOf(InstanceValue),
+                                                                                                              | ^PlanVarPlaceHolder(name=$varName->toOne(), type = $vs.genericType.rawType->toOne(), multiplicity=$vs.multiplicity),
+                                                                                                              |  $vs->reactivate($a);
+                                                                                                          );    
+                                                                                              $a->put($varName->toOne(), ^List<Any>(values=$value));,
 
                                                                                            |  $a;
                                                                                         );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/mutation/relationalMutation.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/mutation/relationalMutation.pure
@@ -69,12 +69,14 @@ function <<access.private>> meta::relational::mutation::executionPlan::validateG
 
 function meta::relational::mutation::executionPlan::planMutationExecution(sq: StoreQuery[1], ext: RoutedValueSpecification[0..1], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: Extension[*], debug: DebugContext[1]): ExecutionNode[1]
 {
-  let rootType = $sq.fe.genericType.rawType->toOne();
+  let fe = $sq.vs->cast(@FunctionExpression);
+
+  let rootType = $fe.genericType.rawType->toOne();
 
   // validate mapping is allowed -- currently only simple relational mappings against table columns are supported
   let rootMapping = validateMappingIsSupportedForMutation($mapping, $rootType);
   // validate graph fetch tree -- cannot specify properties deeper than the mapping supports, must include primary key properties
-  let rootGraphFetchTree = $sq.fe.parametersValues->at(1)->cast(@InstanceValue).values->at(0)->cast(@RootGraphFetchTree<Any>)->toOne();
+  let rootGraphFetchTree = $fe.parametersValues->at(1)->cast(@InstanceValue).values->at(0)->cast(@RootGraphFetchTree<Any>)->toOne();
   let propertyNamesInTree = validateGraphFetchTreeForMapping($rootMapping, $rootGraphFetchTree);
 
   let inScopePropertyMappings = $rootMapping.propertyMappings->cast(@RelationalPropertyMapping)->filter(pm | $pm.property.name->in($propertyNamesInTree));
@@ -158,11 +160,11 @@ function meta::relational::mutation::executionPlan::planMutationExecution(sq: St
       equalityStatements = $databaseColumnToFreeMarkerVariable
     )->processOperation($dbConnection.type, $extensions);
 
-  let funcParams = $sq.fe->findVariableExpressionsInValueSpecification()->removeDuplicatesBy(v | $v.name);
+  let funcParams = $fe->findVariableExpressionsInValueSpecification()->removeDuplicatesBy(v | $v.name);
   let varInputs = $funcParams->filter(x| $sq.inScopeVars->get($x.name->toOne())->isNotEmpty())->map(v | ^VariableInput(name = $v.name->toOne(), type = $v.genericType->cast(@GenericType).rawType->toOne(), multiplicity = $v.multiplicity->toOne()));
 
   // node for providing source values
-  let children = $sq.fe.parametersValues->at(0)->toOne()->cast(@ClusteredValueSpecification)->generateExecutionNodeFromCluster($sq.inScopeVars, $exeCtx, $extensions, $debug);
+  let children = $fe.parametersValues->at(0)->toOne()->cast(@ClusteredValueSpecification)->generateExecutionNodeFromCluster($sq.inScopeVars, $exeCtx, $extensions, $debug);
 
   ^RelationalSaveNode(
     resultType = ^ResultType(type=String),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -158,14 +158,14 @@ Class meta::relational::functions::pureToSqlQuery::ColumnGroup
     columns : RelationalOperationElement[*];
 }
 
-function meta::relational::functions::pureToSqlQuery::toSQLQuery(functionExpression:FunctionExpression[1], mapping:Mapping[0..1], inScopeVars:Map<String, List<Any>>[1], execCtx: RelationalExecutionContext[0..1], debug:DebugContext[1], extensions:Extension[*]):SQLQuery[1]
+function meta::relational::functions::pureToSqlQuery::toSQLQuery(vs:ValueSpecification[1], mapping:Mapping[0..1], inScopeVars:Map<String, List<Any>>[1], execCtx: RelationalExecutionContext[0..1], debug:DebugContext[1], extensions:Extension[*]):SQLQuery[1]
 {
-   toSQLQuery($functionExpression, $mapping, $inScopeVars, $debug, $execCtx->relationalExecutionContextToState(defaultState($mapping, $inScopeVars, $execCtx, $extensions)), $extensions);
+   toSQLQuery($vs, $mapping, $inScopeVars, $debug, $execCtx->relationalExecutionContextToState(defaultState($mapping, $inScopeVars, $execCtx, $extensions)), $extensions);
 }
 
-function <<access.private>> meta::relational::functions::pureToSqlQuery::processQuery(functionExpression:FunctionExpression[1], state:State[1], debug:DebugContext[1], extensions:Extension[*]):SelectWithCursor[1]
+function <<access.private>> meta::relational::functions::pureToSqlQuery::processQuery(vs:ValueSpecification[1], state:State[1], debug:DebugContext[1], extensions:Extension[*]):SelectWithCursor[1]
 {
-   processValueSpecification( $functionExpression,
+   processValueSpecification( $vs,
                               [],
                               ^SelectWithCursor(select=^SelectSQLQuery()),
                               newMap([]->cast(@Pair<VariableExpression, ValueSpecification>), VariableExpression->classPropertyByName('name')->cast(@Property<VariableExpression,String|1>)),
@@ -186,12 +186,12 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::applyPo
    ]);
 }
 
-function meta::relational::functions::pureToSqlQuery::toSQLQuery(functionExpression:FunctionExpression[1], mapping:Mapping[0..1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1], state:State[1], extensions:Extension[*]):SQLQuery[1]
+function meta::relational::functions::pureToSqlQuery::toSQLQuery(vs:ValueSpecification[1], mapping:Mapping[0..1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1], state:State[1], extensions:Extension[*]):SQLQuery[1]
 {
-   $functionExpression
+   $vs
       ->processQuery($state, $debug, $extensions)
       ->applyPostProcessingForTempTableAsDriver($state, $debug, $extensions)
-      ->manageDeepMapClassColumns($functionExpression, $debug, $state, $extensions)
+      ->manageDeepMapClassColumns($vs, $debug, $state, $extensions)
       .select
       ->pushSavedFilteringOperation($extensions)
       ->pushExtraFilteringOperation($extensions)
@@ -218,25 +218,29 @@ function meta::relational::functions::pureToSqlQuery::toSelectWithCursor(functio
    );
 }
 
-function <<access.private>> meta::relational::functions::pureToSqlQuery::manageDeepMapClassColumns(sql:SelectWithCursor[1], functionExpression:FunctionExpression[1], context:DebugContext[1], state:State[1], extensions:Extension[*]):SelectWithCursor[1]
+function <<access.private>> meta::relational::functions::pureToSqlQuery::manageDeepMapClassColumns(sql:SelectWithCursor[1], vs:ValueSpecification[1], context:DebugContext[1], state:State[1], extensions:Extension[*]):SelectWithCursor[1]
 {
-   let isMap = $functionExpression.func == map_T_MANY__Function_1__V_MANY_;
-   let isFilter = $functionExpression.func == filter_T_MANY__Function_1__T_MANY_;
-   if ($sql.select.columns->isEmpty() && ($isMap || $isFilter),
-       |
+  $vs->match([
+    functionExpression: FunctionExpression[1] |
+      let isMap = $functionExpression.func == map_T_MANY__Function_1__V_MANY_;
+      let isFilter = $functionExpression.func == filter_T_MANY__Function_1__T_MANY_;
+      if ($sql.select.columns->isEmpty() && ($isMap || $isFilter),
+          |
 
-        let setImplementation = $functionExpression.parametersValues->at(if($isMap,|1,|0))->cast(@StoreMappingRoutedValueSpecification).sets->toOne()->match([r:RootRelationalInstanceSetImplementation[1]|$r, c:CrossSetImplementation[1]|$c->convertCrossSetImplToRelationalSetImpl()]);
-        let getAllSelectWithCursor = processGetAll($setImplementation, $setImplementation.class, '', true, -1, true, [], $state, $context, $extensions)->toOne();
-        let columns = $getAllSelectWithCursor.select.columns->cast(@Alias);
-        assertEquals(1, $columns.relationalElement->cast(@TableAliasColumn).alias->removeDuplicates()->size(), 'Types mapped with joins are not supported yet!');
-        let topNode =$ sql.currentTreeNode->toOne();
-        let newColumns = $columns->map(c|let t = $c.relationalElement->cast(@TableAliasColumn);
-                                         ^$c(relationalElement=^$t(alias=$topNode.alias));
-                                   );
-        let realSql = $sql.select;
-        ^$sql(select = ^$realSql(columns=$newColumns));,
-       |$sql
-   );
+            let setImplementation = $functionExpression.parametersValues->at(if($isMap,|1,|0))->cast(@StoreMappingRoutedValueSpecification).sets->toOne()->match([r:RootRelationalInstanceSetImplementation[1]|$r, c:CrossSetImplementation[1]|$c->convertCrossSetImplToRelationalSetImpl()]);
+            let getAllSelectWithCursor = processGetAll($setImplementation, $setImplementation.class, '', true, -1, true, [], $state, $context, $extensions)->toOne();
+            let columns = $getAllSelectWithCursor.select.columns->cast(@Alias);
+            assertEquals(1, $columns.relationalElement->cast(@TableAliasColumn).alias->removeDuplicates()->size(), 'Types mapped with joins are not supported yet!');
+            let topNode =$ sql.currentTreeNode->toOne();
+            let newColumns = $columns->map(c|let t = $c.relationalElement->cast(@TableAliasColumn);
+                                            ^$c(relationalElement=^$t(alias=$topNode.alias));
+                                      );
+            let realSql = $sql.select;
+            ^$sql(select = ^$realSql(columns=$newColumns));,
+          |$sql
+      );,
+    any: ValueSpecification[1] | $sql
+  ]);
 }
 
 function <<access.private>> meta::relational::functions::pureToSqlQuery::printDebugQuery(select:SelectSQLQuery[1], space:String[1], extensions:Extension[*]):String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
@@ -101,8 +101,8 @@ function meta::relational::mapping::TDSSelectQueryToTDSResultType(class:Type[1],
 
 function meta::relational::mapping::generateInstantiationExecutionNode(sq:meta::pure::mapping::StoreQuery[1], ext:RoutedValueSpecification[0..1], query:SQLQuery[1], node:ExecutionNode[1], m:Mapping[0..1],exeCtx:meta::pure::runtime::ExecutionContext[1]):ExecutionNode[1]
 {
-   let possibleClass = $sq.fe.genericType.rawType->toOne();
-   let class = if ($possibleClass == Any, | let getAllClass = findMainClassInGetAllExpression($sq.fe); if($getAllClass->isEmpty(), | $possibleClass, | $getAllClass);, | $possibleClass );
+   let possibleClass = $sq.vs.genericType.rawType->toOne();
+   let class = if ($possibleClass == Any, | let getAllClass = findMainClassInGetAllExpression($sq.vs); if($getAllClass->isEmpty(), | $possibleClass, | $getAllClass);, | $possibleClass );
    let resultType = if([
                           pair(
                               |$class->_subTypeOf(TabularDataSet),
@@ -113,7 +113,7 @@ function meta::relational::mapping::generateInstantiationExecutionNode(sq:meta::
                               |^TDSResultType
                                (
                                     type = $class,
-                                    tdsColumns = $sq.fe.genericType.typeArguments->at(0).rawType->cast(@meta::pure::metamodel::relation::RelationType<Any>).columns->map(p|
+                                    tdsColumns = $sq.vs.genericType.typeArguments->at(0).rawType->cast(@meta::pure::metamodel::relation::RelationType<Any>).columns->map(p|
                                                                 ^TDSColumn
                                                                 (
                                                                   name = $p.name->toOne(),
@@ -157,9 +157,9 @@ function meta::relational::mapping::generateInstantiationExecutionNode(sq:meta::
 
    $resultType->match([
       t : TDSResultType[1]       | ^RelationalTdsInstantiationExecutionNode(executionNodes = $node, resultType = $t),
-      c : ClassResultType[1]     | ^RelationalClassInstantiationExecutionNode(executionNodes = $node, resultType = $c, resultSizeRange = $sq.fe.multiplicity),
+      c : ClassResultType[1]     | ^RelationalClassInstantiationExecutionNode(executionNodes = $node, resultType = $c, resultSizeRange = $sq.vs.multiplicity),
       r : RelationResultType[1]  | ^RelationalRelationDataInstantiationExecutionNode(executionNodes = $node, resultType = $r, resultSizeRange = ZeroMany),
-      c : DataTypeResultType[1]  | ^RelationalDataTypeInstantiationExecutionNode(executionNodes = $node, resultType = $c, resultSizeRange = $sq.fe.multiplicity)
+      c : DataTypeResultType[1]  | ^RelationalDataTypeInstantiationExecutionNode(executionNodes = $node, resultType = $c, resultSizeRange = $sq.vs.multiplicity)
    ]);
 }
 
@@ -307,7 +307,7 @@ function meta::relational::mapping::utcToTimeZoneSupportFunction():String[1]
 
 
 
-function meta::relational::mapping::execution(store: Database[1], f:FunctionExpression[1], ext:RoutedValueSpecification[0..1], m:Mapping[1], runtime:Runtime[1], inScopeVars:Map<String, List<Any>>[1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
+function meta::relational::mapping::execution(store: Database[1], f:ValueSpecification[1], ext:RoutedValueSpecification[0..1], m:Mapping[1], runtime:Runtime[1], inScopeVars:Map<String, List<Any>>[1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):Result<Any|*>[1]
 {
    let toSqlQueryStart = now();
 

--- a/legend-engine-xts-relationalai/legend-engine-xt-relationalai-pure/src/main/resources/core_external_query_relationalai/mapping/execution.pure
+++ b/legend-engine-xts-relationalai/legend-engine-xt-relationalai-pure/src/main/resources/core_external_query_relationalai/mapping/execution.pure
@@ -31,7 +31,7 @@ function meta::external::store::rel::mapping::execution(
   debug: DebugContext[1]
 ): meta::pure::mapping::Result<Any|*>[1] {
   assert($sq.store->instanceOf(RAIDatabase), 'Rel queries can only be executed against an instance of `RAIDatabase`');
-  $sq.fe->execution($mapping, $debug, $sq.store->cast(@RAIDatabase).config, emptyTrace());
+  $sq.vs->cast(@FunctionExpression)->execution($mapping, $debug, $sq.store->cast(@RAIDatabase).config, emptyTrace());
 }
 
 function <<access.private>> meta::external::store::rel::mapping::execution(

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/contract/storeContract.pure
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/contract/storeContract.pure
@@ -77,7 +77,7 @@ function meta::external::store::service::contract::serviceStoreStoreContract():S
 // Execution Plan
 function meta::external::store::service::contract::planExecution(sq:StoreQuery[1], ext:RoutedValueSpecification[0..1], mapping:Mapping[0..1], runtime:Runtime[0..1], exeCtx:meta::pure::runtime::ExecutionContext[1], extensions:Extension[*], debug:DebugContext[1]):ExecutionNode[1]
 {
-   let fe = $sq.fe->evaluateAndDeactivate()->cast(@FunctionExpression);
+   let fe = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
    assert($fe.func->in(graphFetchFunctions()), 'Service Store supports graphFetch queries only');
    planGraphFetchExecution($sq, $ext, $mapping->toOne(), $runtime->toOne(), $exeCtx, $extensions, $debug);
 }

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
@@ -57,7 +57,7 @@ function meta::external::store::service::executionPlan::generation::planRootGrap
    let store       = $sq.store;
    assert($store->instanceOf(ServiceStore), | 'Expected a ServiceStore. Found - ' + $store->cast(@Store)->elementToPath());
 
-   let fe          = $sq.fe->evaluateAndDeactivate();
+   let fe          = $sq.vs->evaluateAndDeactivate()->cast(@FunctionExpression);
 
    let rootTree    = $clusteredTree->byPassClusteringInfo()->cast(@RoutedRootGraphFetchTree<Any>);
    let batchSize   = if($fe.func == graphFetch_T_MANY__RootGraphFetchTree_1__Integer_1__T_MANY_ || $fe.func == meta::pure::graphFetch::execution::graphFetchChecked_T_MANY__RootGraphFetchTree_1__Integer_1__Checked_MANY_,
@@ -172,7 +172,7 @@ Class <<access.private>> meta::external::store::service::executionPlan::generati
 
 function meta::external::store::service::executionPlan::generation::processServiceStoreQuery(sq:StoreQuery[1], initialMap:Map<String, String>[1], debug: DebugContext[1]):ServiceStoreQueryProcessedState[1]
 {
-   let serviceStoreQuery = $sq.fe->toServiceStoreQuery($sq.inScopeVars, $debug);
+   let serviceStoreQuery = $sq.vs->toServiceStoreQuery($sq.inScopeVars, $debug);
    let paramValues       = $serviceStoreQuery.processedParamValueMap->keyValues();
 
    let literalParams     = $paramValues->filter(p | $p.second->instanceOf(LiteralValue));

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/pureToServiceStoreQuery/pureToServiceStoreQuery.pure
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/main/resources/core_servicestore/pureToServiceStoreQuery/pureToServiceStoreQuery.pure
@@ -45,9 +45,9 @@ Class meta::external::store::service::functions::pureToServiceStoreQuery::PureFu
 {
 }
 
-function meta::external::store::service::functions::pureToServiceStoreQuery::toServiceStoreQuery(functionExpression:FunctionExpression[1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1]):ServiceStoreQuery[1]
+function meta::external::store::service::functions::pureToServiceStoreQuery::toServiceStoreQuery(vs:ValueSpecification[1], inScopeVars:Map<String, List<Any>>[1], debug:DebugContext[1]):ServiceStoreQuery[1]
 {
-   let res = processValueSpecification($functionExpression, ^ServiceStoreQuery(processedParamValueMap = []->newMap()), $inScopeVars, $debug);
+   let res = processValueSpecification($vs, ^ServiceStoreQuery(processedParamValueMap = []->newMap()), $inScopeVars, $debug);
    assert($res.processingParam->isEmpty() && $res.processingValue->isEmpty(), | 'Unexpected result after processing query');
    $res;
 }


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Route ValueSpecification rather than FunctionExpression to ensure any expression is properly routed rather than get cast exception when expressions are not functions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
