### PR TITLE
[Legend SQL] Support second format of transaction isolation query

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/ExecutionDispatcher.java
@@ -20,12 +20,14 @@ import org.finos.legend.engine.language.sql.grammar.from.antlr4.SqlBaseParser;
 import org.finos.legend.engine.language.sql.grammar.from.antlr4.SqlBaseParserBaseVisitor;
 import org.finos.legend.engine.postgres.handler.SessionHandler;
 import org.finos.legend.engine.postgres.handler.empty.EmptySessionHandler;
+import org.finos.legend.engine.postgres.handler.txn.TxnIsolationSessionHandler;
 import org.finos.legend.engine.protocol.sql.metamodel.QualifiedName;
 
 public class ExecutionDispatcher extends SqlBaseParserBaseVisitor<SessionHandler>
 {
     private static final TableNameExtractor EXTRACTOR = new TableNameExtractor();
     private static final SessionHandler EMPTY_SESSION_HANDLER = new EmptySessionHandler();
+    private static final SessionHandler TXN_ISOLATION_HANDLER = new TxnIsolationSessionHandler();
     private final SessionHandler dataSessionHandler;
     private final SessionHandler metaDataSessionHandler;
 
@@ -51,8 +53,7 @@ public class ExecutionDispatcher extends SqlBaseParserBaseVisitor<SessionHandler
     @Override
     public SessionHandler visitShowTransaction(SqlBaseParser.ShowTransactionContext ctx)
     {
-        // TODO: Handle show transaction instead of routing to metadata session handler
-        return metaDataSessionHandler;
+        return TXN_ISOLATION_HANDLER;
     }
 
     /**

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/SystemSchemas.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/SystemSchemas.java
@@ -21,7 +21,8 @@ public enum SystemSchemas
 {
 
     INFORMATION_SCHEMA("information_schema"),
-    PG_CATALOG("pg_catalog");
+    PG_CATALOG("pg_catalog"),
+    PG_TYPE("pg_type");
 
     private final String schemaName;
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/txn/TxnIsolationPreparedStatement.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/txn/TxnIsolationPreparedStatement.java
@@ -1,0 +1,143 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.postgres.handler.txn;
+
+import org.finos.legend.engine.postgres.handler.PostgresPreparedStatement;
+import org.finos.legend.engine.postgres.handler.PostgresResultSet;
+import org.finos.legend.engine.postgres.handler.PostgresResultSetMetaData;
+
+import java.sql.ParameterMetaData;
+import java.sql.Types;
+
+public class TxnIsolationPreparedStatement implements PostgresPreparedStatement
+{
+    private boolean isComplete = false;
+    static final String READ_COMMITTED = "read committed";
+    static final PostgresResultSetMetaData TXN_ISOLATION_RS_META_DATA = new PostgresResultSetMetaData()
+    {
+        @Override
+        public int getColumnCount()
+        {
+            return 1;
+        }
+
+        @Override
+        public String getColumnName(int i)
+        {
+            return "transaction_isolation";
+        }
+
+        @Override
+        public int getColumnType(int i)
+        {
+            return Types.VARCHAR;
+        }
+
+        @Override
+        public int getScale(int i)
+        {
+            return 0;
+        }
+    };
+
+    @Override
+    public void setObject(int i, Object o)
+    {
+        // empty statement doesn't require objects to be set
+    }
+
+    @Override
+    public PostgresResultSetMetaData getMetaData()
+    {
+        return TXN_ISOLATION_RS_META_DATA;
+    }
+
+    @Override
+    public ParameterMetaData getParameterMetaData()
+    {
+        return null;
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        // txn isolation handler doesn't require closure
+    }
+
+    @Override
+    public void setMaxRows(int maxRows)
+    {
+        // txn isolation handler doesn't require max rows
+    }
+
+    @Override
+    public int getMaxRows()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isExecuted()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean execute()
+    {
+        return true;
+    }
+
+    @Override
+    public PostgresResultSet getResultSet()
+    {
+        return new PostgresResultSet()
+        {
+            @Override
+            public PostgresResultSetMetaData getMetaData()
+            {
+                return TXN_ISOLATION_RS_META_DATA;
+            }
+
+            @Override
+            public Object getObject(int i)
+            {
+                return READ_COMMITTED;
+            }
+
+            @Override
+            public boolean next()
+            {
+                if (!isComplete)
+                {
+                    isComplete = true;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            @Override
+            public void close()
+            {
+                // txn isolation result set doesn't require closure
+            }
+        };
+    }
+
+}

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/txn/TxnIsolationSessionHandler.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/txn/TxnIsolationSessionHandler.java
@@ -1,0 +1,35 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.postgres.handler.txn;
+
+import org.finos.legend.engine.postgres.handler.PostgresPreparedStatement;
+import org.finos.legend.engine.postgres.handler.PostgresStatement;
+import org.finos.legend.engine.postgres.handler.SessionHandler;
+
+public class TxnIsolationSessionHandler implements SessionHandler
+{
+    @Override
+    public PostgresPreparedStatement prepareStatement(String query)
+    {
+        return new TxnIsolationPreparedStatement();
+    }
+
+    @Override
+    public PostgresStatement createStatement()
+    {
+        return new TxnIsolationStatement();
+    }
+}

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/txn/TxnIsolationStatement.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/main/java/org/finos/legend/engine/postgres/handler/txn/TxnIsolationStatement.java
@@ -1,0 +1,79 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.postgres.handler.txn;
+
+import org.finos.legend.engine.postgres.handler.PostgresResultSet;
+import org.finos.legend.engine.postgres.handler.PostgresResultSetMetaData;
+import org.finos.legend.engine.postgres.handler.PostgresStatement;
+
+import static org.finos.legend.engine.postgres.handler.txn.TxnIsolationPreparedStatement.READ_COMMITTED;
+import static org.finos.legend.engine.postgres.handler.txn.TxnIsolationPreparedStatement.TXN_ISOLATION_RS_META_DATA;
+
+public class TxnIsolationStatement implements PostgresStatement
+{
+    private boolean isComplete = false;
+
+    @Override
+    public boolean execute(String query)
+    {
+        return true;
+    }
+
+    @Override
+    public PostgresResultSet getResultSet()
+    {
+        return new PostgresResultSet()
+        {
+            @Override
+            public PostgresResultSetMetaData getMetaData()
+            {
+                return TXN_ISOLATION_RS_META_DATA;
+            }
+
+            @Override
+            public Object getObject(int i)
+            {
+                return READ_COMMITTED;
+            }
+
+            @Override
+            public boolean next()
+            {
+                if (!isComplete)
+                {
+                    isComplete = true;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            @Override
+            public void close()
+            {
+                // txn isolation result set doesn't require closure
+            }
+        };
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        // txn isolation handler doesn't require closure
+    }
+}

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/ExecutionDispatcherTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/ExecutionDispatcherTest.java
@@ -44,6 +44,12 @@ public class ExecutionDispatcherTest
     }
 
     @Test
+    public void testSelectPgType()
+    {
+        assertMetadataSessionHandler("SELECT oid, typbasetype FROM pg_type");
+    }
+
+    @Test
     public void testSelectPgCatalog()
     {
         assertMetadataSessionHandler("SELECT * FROM pg_catalog.schemata");

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/ExecutionDispatcherTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/ExecutionDispatcherTest.java
@@ -21,6 +21,7 @@ import org.finos.legend.engine.postgres.handler.PostgresPreparedStatement;
 import org.finos.legend.engine.postgres.handler.PostgresStatement;
 import org.finos.legend.engine.postgres.handler.SessionHandler;
 import org.finos.legend.engine.postgres.handler.empty.EmptySessionHandler;
+import org.finos.legend.engine.postgres.handler.txn.TxnIsolationSessionHandler;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -79,7 +80,8 @@ public class ExecutionDispatcherTest
     @Test
     public void testShowTxnLevel()
     {
-        assertMetadataSessionHandler("SHOW TRANSACTION ISOLATION LEVEL");
+        assertTxnIsoSessionHandler("SHOW TRANSACTION ISOLATION LEVEL");
+        assertTxnIsoSessionHandler("SHOW transaction_isolation");
     }
 
     private static void assertEmptySessionHandler(String query)
@@ -92,6 +94,12 @@ public class ExecutionDispatcherTest
     {
         SessionHandler sessionHandler = getSessionHandler(query);
         Assert.assertSame(metadataSessionHandler, sessionHandler);
+    }
+
+    private static void assertTxnIsoSessionHandler(String query)
+    {
+        SessionHandler sessionHandler = getSessionHandler(query);
+        Assert.assertTrue(sessionHandler instanceof TxnIsolationSessionHandler);
     }
 
     private static void assertDataSessionHandler(String query)

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.postgres.auth.AnonymousIdentityProvider;
 import org.finos.legend.engine.postgres.auth.NoPasswordAuthenticationMethod;
+import org.finos.legend.engine.postgres.config.OpenTelemetryConfig;
 import org.finos.legend.engine.postgres.config.ServerConfig;
 import org.finos.legend.engine.postgres.handler.legend.LegendExecutionService;
 import org.finos.legend.engine.postgres.handler.legend.LegendSessionFactory;
@@ -469,6 +470,25 @@ public class PostgresServerTest
                 rows++;
             }
             Assert.assertEquals(1, rows);
+        }
+    }
+
+    @Test
+    public void testPgType() throws SQLException
+    {
+        try (
+                Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                        "dummy", "dummy");
+                PreparedStatement statement = connection.prepareStatement("SELECT oid, typbasetype FROM pg_type");
+                ResultSet resultSet = statement.executeQuery()
+        )
+        {
+            int rows = 0;
+            while (resultSet.next())
+            {
+                rows++;
+            }
+            Assert.assertEquals(24, rows);
         }
     }
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/src/test/java/org/finos/legend/engine/postgres/PostgresServerTest.java
@@ -43,6 +43,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Properties;
 
 public class PostgresServerTest
@@ -356,6 +357,9 @@ public class PostgresServerTest
         }
     }
 
+    /**
+     * This query format is used by the postgres jdbc driver
+     */
     @Test
     public void testShowTxn() throws SQLException
     {
@@ -372,6 +376,39 @@ public class PostgresServerTest
                 rows++;
             }
             Assert.assertEquals(1, rows);
+        }
+    }
+
+    /**
+     * This query format is used by the postgres odbc driver
+     */
+    @Test
+    public void testShowTxnOdbc() throws SQLException
+    {
+        String sql = "SHOW transaction_isolation";
+        try (
+                Connection connection = DriverManager.getConnection("jdbc:postgresql://127.0.0.1:" + testPostgresServer.getLocalAddress().getPort() + "/postgres",
+                        "dummy", "dummy");
+                PreparedStatement preparedStatement = connection.prepareStatement(sql);
+                ResultSet psResultSet = preparedStatement.executeQuery();
+                Statement statement = connection.createStatement()
+        )
+        {
+            int psRows = 0;
+            while (psResultSet.next())
+            {
+                psRows++;
+            }
+            Assert.assertEquals(1, psRows);
+
+            Assert.assertTrue(statement.execute(sql));
+            ResultSet statementResultSet = statement.getResultSet();
+            int statementRows = 0;
+            while (statementResultSet.next())
+            {
+                statementRows++;
+            }
+            Assert.assertEquals(1, statementRows);
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?
- Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

##### Transaction isolation
Some SQL clients such as Hikari and ODBC driver check transaction isolation level during startup.
The current approach uses in-memory H2 to respond to those queries, and works fine for Hikari/JDBC clients.
However, H2 doesn't support the ODBC query format (`SHOW transaction_isolation`).

This PR introduces a custom handler for transaction isolation queries, so that the ODBC query format can be supported too.

##### `pg_type`
Adds support for system schema `pg_type`, which is queried during ODBC driver startup.
Routed to in-memory H2.

#### Does this PR introduce a user-facing change?
No
<!--
-->
