### PR TITLE
Fix for temp tables with quoted identifiers flag

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/executionPlan/tests/executionPlanTestSnowflake.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/executionPlan/tests/executionPlanTestSnowflake.pure
@@ -159,7 +159,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testInExecut
   assertEquals('tempVarForIn_8', $varName);
 }
 
-function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFetchSnowflakeTempTableDbAndSchemaSpecified():Boolean[1]
+function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFetchSnowflakeTempTableStrategyDbAndSchemaSpecified():Boolean[1]
 {
   let tree = #{
       Person {
@@ -191,11 +191,40 @@ function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFet
   let rootNode2 = $generatedPlan2.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
   let processedTempTableName2 = $rootNode2.processedTempTableName;
   assertEquals('temp_db1.temp_schema1.temp_table_node_0', $processedTempTableName2);
-
-  
+  let tempTableStrategy = $rootNode2.tempTableStrategy;
+  assertEquals('CREATE TEMPORARY TABLE temp_db1.temp_schema1.temp_table_node_0(pk_0 INT);', $tempTableStrategy.createTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('INSERT INTO temp_db1.temp_schema1.temp_table_node_0 VALUES ${temp_table_rows_from_result_set}', $tempTableStrategy.loadTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('Drop table if exists temp_db1.temp_schema1.temp_table_node_0;', $tempTableStrategy.dropTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
 }
 
-function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFetchSnowflakeTempTableDbAndSchemaWithQuoteIdentifiers():Boolean[1]
+function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFetchSnowflakeTempTableStrategyWithQuoteIdentifiers():Boolean[1]
+{
+  let tree = #{
+      Person {
+         firstName,
+         lastName,
+         firm {
+            legalName
+         }
+      }
+   }#;
+  let query = {|Person.all()->graphFetch($tree)->serialize($tree)};
+  let conn = ^RelationalDatabaseConnection(
+                  datasourceSpecification = ^SnowflakeDatasourceSpecification(region = 'us-region-1', warehouseName='warehouseName',databaseName='databaseName',accountName = 'accountName'),
+                  authenticationStrategy = ^SnowflakePublicAuthenticationStrategy(privateKeyVaultReference = 'privatekey', passPhraseVaultReference= 'passphrase', publicUserName = 'public'),
+                  type=DatabaseType.Snowflake, quoteIdentifiers = true
+              );
+  let generatedPlan = executionPlan($query, simpleRelationalMapping, ^Runtime(connectionStores=^ConnectionStore(element = 'database',connection=$conn)), meta::relational::extension::relationalExtensions());
+  let rootNode = $generatedPlan.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
+  let processedTempTableName = $rootNode.processedTempTableName;
+  assertEquals('"LEGEND_TEMP_DB"."LEGEND_TEMP_SCHEMA"."temp_table_node_0"', $processedTempTableName);
+  let tempTableStrategy = $rootNode.tempTableStrategy;
+  assertEquals('CREATE TEMPORARY TABLE "LEGEND_TEMP_DB"."LEGEND_TEMP_SCHEMA"."temp_table_node_0"("pk_0" INT);', $tempTableStrategy.createTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('INSERT INTO "LEGEND_TEMP_DB"."LEGEND_TEMP_SCHEMA"."temp_table_node_0" VALUES ${temp_table_rows_from_result_set}', $tempTableStrategy.loadTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('Drop table if exists "LEGEND_TEMP_DB"."LEGEND_TEMP_SCHEMA"."temp_table_node_0";', $tempTableStrategy.dropTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFetchSnowflakeTempTableStrategyWithDbSchemaAndQuoteIdentifiers():Boolean[1]
 {
   let tree = #{
       Person {
@@ -215,9 +244,14 @@ function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testGraphFet
   let generatedPlan = executionPlan($query, simpleRelationalMapping, ^Runtime(connectionStores=^ConnectionStore(element = 'database',connection=$conn)), meta::relational::extension::relationalExtensions());
   let rootNode = $generatedPlan.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
   let processedTempTableName = $rootNode.processedTempTableName;
-  assertEquals('"temp_db1"."temp_schema1".temp_table_node_0', $processedTempTableName);
+  assertEquals('"temp_db1"."temp_schema1"."temp_table_node_0"', $processedTempTableName);
+  let tempTableStrategy = $rootNode.tempTableStrategy;
+  assertEquals('CREATE TEMPORARY TABLE "temp_db1"."temp_schema1"."temp_table_node_0"("pk_0" INT);', $tempTableStrategy.createTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('INSERT INTO "temp_db1"."temp_schema1"."temp_table_node_0" VALUES ${temp_table_rows_from_result_set}', $tempTableStrategy.loadTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('Drop table if exists "temp_db1"."temp_schema1"."temp_table_node_0";', $tempTableStrategy.dropTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
 }
-function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testCrossStoreGraphFetchSnowflakeTempTableDbAndSchemaSpecified():Boolean[1]
+
+function <<test.Test>> meta::pure::executionPlan::tests::snowflake::testCrossStoreGraphFetchSnowflakeTempTableStrategyDbAndSchemaSpecified():Boolean[1]
 {
    let tree = #{
       meta::relational::graphFetch::tests::crossDatabase::Firm {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -114,16 +114,16 @@ function meta::relational::functions::sqlQueryToString::snowflake::getDDLCommand
 function meta::relational::functions::sqlQueryToString::snowflake::processTempTableNameSnowflake(tempTableName: String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[1]): String[1]
 {
    let dataSourceSpec = if($dc->instanceOf(RelationalDatabaseConnection),| $dc->cast(@RelationalDatabaseConnection).datasourceSpecification->cast(@SnowflakeDatasourceSpecification),| []);
+   let dbConfig = meta::relational::functions::sqlQueryToString::createDbConfig($dc);
 
    if($dataSourceSpec->isNotEmpty() &&
       $dataSourceSpec.tempTableDb->isNotEmpty() &&
       $dataSourceSpec.tempTableSchema->isNotEmpty(),
    |
-    let dbConfig = meta::relational::functions::sqlQueryToString::createDbConfig($dc.type, $dc.timeZone, $dc.quoteIdentifiers);
-    $dbConfig.identifierProcessor($dataSourceSpec.tempTableDb->toOne()) + '.' + $dbConfig.identifierProcessor($dataSourceSpec.tempTableSchema->toOne()) + '.' + $tempTableName;,
+    $dbConfig.identifierProcessor($dataSourceSpec.tempTableDb->toOne()) + '.' + $dbConfig.identifierProcessor($dataSourceSpec.tempTableSchema->toOne()) + '.' + $dbConfig.identifierProcessor($tempTableName);,
    |
     assert($dataSourceSpec.tempTableDb->isEmpty() && $dataSourceSpec.tempTableSchema->isEmpty(), 'One of Database name and schema name for temp tables is missing. Please specify both.');
-    'LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.' + $tempTableName;
+    $dbConfig.identifierProcessor('LEGEND_TEMP_DB') +'.' + $dbConfig.identifierProcessor('LEGEND_TEMP_SCHEMA') + '.' + $dbConfig.identifierProcessor($tempTableName);
    );
 }
 
@@ -147,16 +147,15 @@ function meta::relational::functions::sqlQueryToString::snowflake::loadValuesToD
   if($l.absolutePathToFile->isNotEmpty(),|
                                  let createStage = 'CREATE OR REPLACE TEMPORARY STAGE LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE';
                                  let loadTempTableCommand = 'PUT file://'+$l.absolutePathToFile->toOne()->processOperation($dbConfig.dbType, []) + ' @LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE' + $l.absolutePathToFile->toOne()->processOperation($dbConfig.dbType, []) +  ' PARALLEL= 16 AUTO_COMPRESS=TRUE;';
-                                 let copyIntoCommand = 'COPY INTO ' + $l.table.name->toOne() + ' FROM @LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE' + $l.absolutePathToFile->toOne()->processOperation($dbConfig.dbType, []) + ' file_format = (type= CSV field_optionally_enclosed_by= \'"\');';
+                                 let copyIntoCommand = 'COPY INTO ' + $l.table->tableToString($dbConfig)->toOne() + ' FROM @LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE' + $l.absolutePathToFile->toOne()->processOperation($dbConfig.dbType, []) + ' file_format = (type= CSV field_optionally_enclosed_by= \'"\');';
                                  let dropStage = 'DROP STAGE LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE';
                                  [$createStage, $loadTempTableCommand, $copyIntoCommand, $dropStage];
                               ,| $l->meta::relational::functions::sqlQueryToString::default::loadValuesToDbTableDefault($dbConfig))
 }
 
-function meta::relational::functions::sqlQueryToString::snowflake::translateDropTableStatementForSnowflake(dropTableSQL:DropTableSQL[1], dbConfig: DbConfig[1]) : String[1]
+function meta::relational::functions::sqlQueryToString::snowflake::translateDropTableStatementForSnowflake(d:DropTableSQL[1], dbConfig: DbConfig[1]) : String[1]
 {
-  let t= $dropTableSQL.table;
-  'Drop table if exists '+if($t.schema.name == 'default',|'',|$t.schema.name+'.')+$t.name+';';
+  'Drop table if exists ' + $d.table->tableToString($dbConfig) + ';';
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::getDynaFunctionToSqlForSnowflake(): DynaFunctionToSql[*]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::relational::graphFetch::executionPlan::*;
 import meta::relational::functions::sqlQueryToString::h2::*;
 import meta::pure::alloy::connections::alloy::authentication::*;
 import meta::pure::alloy::connections::alloy::specification::*;
@@ -2627,3 +2628,46 @@ function <<test.Test>> meta::pure::executionPlan::tests::datetime::testPlanWithL
 
 }
 
+function <<test.Test>> meta::pure::executionPlan::tests::testGraphFetchH2TempTableStrategy():Boolean[1]
+{
+  let tree = #{
+      Person {
+         firstName,
+         lastName,
+         firm {
+            legalName
+         }
+      }
+   }#;
+  let query = {|Person.all()->graphFetch($tree)->serialize($tree)};
+  let generatedPlan = executionPlan($query, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+  let rootNode = $generatedPlan.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
+  let processedTempTableName = $rootNode.processedTempTableName;
+  assertEquals('temp_table_node_0', $processedTempTableName);
+  let tempTableStrategy = $rootNode.tempTableStrategy;
+  assertEquals('CREATE LOCAL TEMPORARY TABLE temp_table_node_0(pk_0 INT);', $tempTableStrategy.createTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('INSERT INTO temp_table_node_0 SELECT * FROM CSVREAD(\'${csv_file_location}\');', $tempTableStrategy.loadTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('Drop table if exists temp_table_node_0;', $tempTableStrategy.dropTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::testGraphFetchH2TempTableStrategyWithQuoteIdentifiers():Boolean[1]
+{
+  let tree = #{
+      Person {
+         firstName,
+         lastName,
+         firm {
+            legalName
+         }
+      }
+   }#;
+  let query = {|Person.all()->graphFetch($tree)->serialize($tree)};
+  let generatedPlan = executionPlan($query, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(true), meta::relational::extension::relationalExtensions());
+  let rootNode = $generatedPlan.rootExecutionNode.executionNodes->at(0)->cast(@StoreMappingGlobalGraphFetchExecutionNode).localGraphFetchExecutionNode->cast(@RelationalRootQueryTempTableGraphFetchExecutionNode);
+  let processedTempTableName = $rootNode.processedTempTableName;
+  assertEquals('"temp_table_node_0"', $processedTempTableName);
+  let tempTableStrategy = $rootNode.tempTableStrategy;
+  assertEquals('CREATE LOCAL TEMPORARY TABLE "temp_table_node_0"("pk_0" INT);', $tempTableStrategy.createTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('INSERT INTO "temp_table_node_0" SELECT * FROM CSVREAD(\'${csv_file_location}\');', $tempTableStrategy.loadTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+  assertEquals('Drop table if exists "temp_table_node_0";', $tempTableStrategy.dropTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -168,48 +168,34 @@ function meta::relational::graphFetch::executionPlan::createTable(tempTableName:
         );
 }
 
-function meta::relational::graphFetch::executionPlan::sqlsForTempTableCreation(dbType: DatabaseType[1], temporaryTable: Table[1]): String[*]
+function meta::relational::graphFetch::executionPlan::sqlsForTempTableCreation(temporaryTable: Table[1], dbConfig:DbConfig[1]): String[*]
 {
   let create = ^CreateTableSQL(table = $temporaryTable, isTempTable=true);
-  let dbConfig  = $dbType->createDbConfig([]);
   $create->meta::relational::functions::sqlQueryToString::ddlSqlQueryToString($dbConfig);
 }
 
-function meta::relational::graphFetch::executionPlan::sqlsForTempTableDeletion(dbType: DatabaseType[1], temporaryTable: Table[1]): String[*]
+function meta::relational::graphFetch::executionPlan::sqlsForTempTableDeletion(temporaryTable: Table[1], dbConfig:DbConfig[1]): String[*]
 {
-  let dbConfig  = $dbType->createDbConfig([]);
   ^DropTableSQL(table = $temporaryTable)->meta::relational::functions::sqlQueryToString::ddlSqlQueryToString($dbConfig);
 }
 
-function meta::relational::graphFetch::executionPlan::sqlsForTempTableLoadFromTempFile(dbType: DatabaseType[1], temporaryTable: Table[1]): String[*]
+function meta::relational::graphFetch::executionPlan::sqlsForTempTableLoadFromTempFile(temporaryTable: Table[1], dbConfig:DbConfig[1]): String[*]
 {
     let VarPlaceHolder = 'csv_file_location';
     let load = ^LoadTableSQL(table = $temporaryTable, absolutePathToFile=^VarPlaceHolder(name= $VarPlaceHolder, type = $VarPlaceHolder->type()), columnsToLoad=$temporaryTable.columns->cast(@Column));
-    let dbConfig  = $dbType->createDbConfig([]);
     $load->meta::relational::functions::sqlQueryToString::ddlSqlQueryToString($dbConfig);
 }
 
-function meta::relational::graphFetch::executionPlan::sqlsForTempTableLoadFromSubQuery(dbType: DatabaseType[1], temporaryTable: Table[1], selectSqlStatement: String[1]): String[*]
+function meta::relational::graphFetch::executionPlan::sqlsForTempTableLoadFromSubQuery(temporaryTable: Table[1], dbConfig:DbConfig[1], selectSqlStatement: String[1]): String[*]
 {
-  let tempTableName = getTableName($dbType, $temporaryTable);
+  let tempTableName = $temporaryTable->tableToString($dbConfig);
   let columns = $temporaryTable.columns->map(x|$x->cast(@Column).name);
   [['INSERT INTO ', $tempTableName, '(', $columns->joinStrings(',') ,') SELECT DISTINCT "', $columns->joinStrings('","'),'" FROM ( ',$selectSqlStatement,' );']->joinStrings('')];
 }
 
-function meta::relational::graphFetch::executionPlan::getTableName(dbType: DatabaseType[1], temporaryTable: Table[1]):String[1]
+function meta::relational::graphFetch::executionPlan::sqlsForInsertIntoTableUsingResultSet(temporaryTable: Table[1], dbConfig:DbConfig[1]):String[1]
 {
-      let dbConfig  = $dbType->createDbConfig([]);
-      let schemaName = $dbConfig.schemaNameToIdentifier($temporaryTable.schema.name);
-      let tableName = $dbConfig.tableNameToIdentifier($temporaryTable.name);
-      if($schemaName == 'default', | $dbConfig.identifierProcessor($tableName), | $dbConfig.identifierProcessor($schemaName) + '.' + $dbConfig.identifierProcessor($tableName));
-}
-
-function meta::relational::graphFetch::executionPlan::sqlsForInsertIntoTableUsingResultSet(dbType: DatabaseType[1], temporaryTable: Table[1]):String[1]
-{
-
-  let tempTableName = getTableName($dbType, $temporaryTable);
-  'INSERT INTO '+ $tempTableName + ' VALUES ' +
-  stringToPlaceHolder('temp_table_rows_from_result_set');
+  'INSERT INTO '+ $temporaryTable->tableToString($dbConfig) + ' VALUES ' + stringToPlaceHolder('temp_table_rows_from_result_set');
 }
 
 function <<access.private>> meta::relational::graphFetch::executionPlan::tempTableName(index: Integer[1]):String[1]
@@ -241,9 +227,9 @@ function meta::relational::graphFetch::executionPlan::getTempTableStrategyForNon
   );
 }
 
-function meta::relational::graphFetch::executionPlan::getCreateTempTableNode(dbType:DatabaseType[1], table:Table[1], dbConnection:DatabaseConnection[1], extensions: Extension[*]): SequenceExecutionNode[1]
+function meta::relational::graphFetch::executionPlan::getCreateTempTableNode(table:Table[1], dbConnection:DatabaseConnection[1], extensions: Extension[*]): SequenceExecutionNode[1]
 {
-  let createTempTableSqlExecNodes = sqlsForTempTableCreation($dbType,$table)->map(sql | ^SQLExecutionNode(
+  let createTempTableSqlExecNodes = sqlsForTempTableCreation($table,createDbConfig($dbConnection))->map(sql | ^SQLExecutionNode(
         sqlQuery         = $sql,
         resultType       = ^VoidResultType(type = Any),
         connection       = $dbConnection->meta::relational::mapping::updateConnection($extensions)->cast(@DatabaseConnection),
@@ -255,15 +241,16 @@ function meta::relational::graphFetch::executionPlan::getCreateTempTableNode(dbT
 
 function meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoot(dbType:DatabaseType[1], table:Table[1], dbConnection:DatabaseConnection[1], extensions: Extension[*]): SequenceExecutionNode[1]
 {
+  let dbConfig = createDbConfig($dbConnection);
   let insertIntoTempTableSqlExecNodes = if(($dbType->getTempTableStrategyForRootNode() == TempTableStrategyType.LoadFromTempFileTempTableStrategy),
-    | sqlsForTempTableLoadFromTempFile($dbType,$table)->map(sql | ^SQLExecutionNode(
+    | sqlsForTempTableLoadFromTempFile($table, $dbConfig)->map(sql | ^SQLExecutionNode(
         sqlQuery         = $sql,
         resultType       = ^VoidResultType(type = Any),
         connection       = $dbConnection->meta::relational::mapping::updateConnection($extensions)->cast(@DatabaseConnection),
         supportFunctions = relationalPlanSupportFunctions($dbConnection)
         )
       ),
-    | sqlsForInsertIntoTableUsingResultSet($dbType,$table)->map(sql | ^SQLExecutionNode(
+    | sqlsForInsertIntoTableUsingResultSet($table,$dbConfig)->map(sql | ^SQLExecutionNode(
         sqlQuery         = $sql,
         resultType       = ^VoidResultType(type = Any),
         connection       = $dbConnection->meta::relational::mapping::updateConnection($extensions)->cast(@DatabaseConnection),
@@ -276,8 +263,9 @@ function meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoo
 
 function meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForNonPrimitiveChild(dbType:DatabaseType[1], table:Table[1], dbConnection:DatabaseConnection[1], extensions: Extension[*], selectSqlStatement: String[1]): SequenceExecutionNode[1]
 {
+  let dbConfig = createDbConfig($dbConnection);
   let insertIntoTempTableSqlExecNodes = if(($dbType->getTempTableStrategyForNonPrimitiveChildNode() == TempTableStrategyType.LoadFromResultSetAsValueTuplesTempTableStrategy),
-    | sqlsForInsertIntoTableUsingResultSet($dbType,$table)->map(sql | ^SQLExecutionNode(
+    | sqlsForInsertIntoTableUsingResultSet($table,$dbConfig)->map(sql | ^SQLExecutionNode(
           sqlQuery         = $sql,
           resultType       = ^VoidResultType(type = Any),
           connection       = $dbConnection->meta::relational::mapping::updateConnection($extensions)->cast(@DatabaseConnection),
@@ -285,14 +273,14 @@ function meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForNon
         )
       ),
     | if(($dbType->getTempTableStrategyForNonPrimitiveChildNode() == TempTableStrategyType.LoadFromSubQueryTempTableStrategy),
-      | sqlsForTempTableLoadFromSubQuery($dbType,$table,$selectSqlStatement)->map(sql | ^SQLExecutionNode(
+      | sqlsForTempTableLoadFromSubQuery($table,$dbConfig,$selectSqlStatement)->map(sql | ^SQLExecutionNode(
           sqlQuery         = $sql,
           resultType       = ^VoidResultType(type = Any),
           connection       = $dbConnection->meta::relational::mapping::updateConnection($extensions)->cast(@DatabaseConnection),
           supportFunctions = relationalPlanSupportFunctions($dbConnection)
         )
         ),
-      | sqlsForTempTableLoadFromTempFile($dbType,$table)->map(sql | ^SQLExecutionNode(
+      | sqlsForTempTableLoadFromTempFile($table,$dbConfig)->map(sql | ^SQLExecutionNode(
           sqlQuery         = $sql,
           resultType       = ^VoidResultType(type = Any),
           connection       = $dbConnection->meta::relational::mapping::updateConnection($extensions)->cast(@DatabaseConnection),
@@ -306,7 +294,7 @@ function meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForNon
 
 function meta::relational::graphFetch::executionPlan::getDropTempTableNode(dbType:DatabaseType[1], table: Table[1], dbConnection:DatabaseConnection[1], extensions: Extension[*]): SequenceExecutionNode[1]
 {
-  let dropTempTableSqlExecNodes = sqlsForTempTableDeletion($dbType,$table)->map(sql | ^SQLExecutionNode(
+  let dropTempTableSqlExecNodes = sqlsForTempTableDeletion($table,createDbConfig($dbConnection))->map(sql | ^SQLExecutionNode(
                 sqlQuery         = $sql,
                 resultType       = ^VoidResultType(type = Any),
                 connection       = $dbConnection->meta::relational::mapping::updateConnection($extensions)->cast(@DatabaseConnection),
@@ -403,7 +391,7 @@ function meta::relational::graphFetch::executionPlan::planRootGraphFetchExecutio
    let tempTableName = tempTableName(0);
    let tempTableStrategy = if(($hasChildren && useTempTableStrategy($dbType)),
                             | let table = createTable($tempTableName,$dbConnection,$columns,[],$dbConfig);
-                              let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$table,$dbConnection,$extensions);
+                              let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($table,$dbConnection,$extensions);
                               let loadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoot($dbType,$table,$dbConnection,$extensions);
                               let dropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$table,$dbConnection,$extensions);
                               getTempTableStrategyForRootNode($dbType, $createTempTableNode, $loadTempTableNode, $dropTempTableNode);,
@@ -530,7 +518,7 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::planGra
 
    let tempTableStrategy = if(($hasChildren && useTempTableStrategy($dbType)),
                             | let table = createTable($tempTableName,$dbConnection,$columns,[],$dbConfig);
-                              let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$table,$dbConnection,$extensions);
+                              let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($table,$dbConnection,$extensions);
                               let loadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForNonPrimitiveChild($dbType,$table,$dbConnection,$extensions,$sqlNode.sqlQuery);
                               let dropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$table,$dbConnection,$extensions);
                               getTempTableStrategyForNonPrimitiveChildNode($dbType, $createTempTableNode, $loadTempTableNode, $dropTempTableNode);,
@@ -635,7 +623,7 @@ function meta::relational::graphFetch::executionPlan::planCrossRootGraphFetchExe
 
    let tempTableStrategy = if(($hasChildren && useTempTableStrategy($dbType)),
                             | let table = createTable($tempTableName,$dbConnection,$columns,[],$dbConfig);
-                              let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$table,$dbConnection,$extensions);
+                              let createTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($table,$dbConnection,$extensions);
                               let loadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoot($dbType,$table,$dbConnection,$extensions);
                               let dropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$table,$dbConnection,$extensions);
                               getTempTableStrategyForRootNode($dbType, $createTempTableNode, $loadTempTableNode, $dropTempTableNode);,
@@ -643,7 +631,7 @@ function meta::relational::graphFetch::executionPlan::planCrossRootGraphFetchExe
 
    let parentTempTableColumns = $srcProperties->map(x | ^SQLResultColumn(label = $x.name->toOne(), dataType = $x->crossKeyRelationalType()));
    let parentTable = createTable($parentTempTableName,$dbConnection,$parentTempTableColumns,[],$dbConfig);
-   let parentCreateTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($dbType,$parentTable,$dbConnection,$extensions);
+   let parentCreateTempTableNode = meta::relational::graphFetch::executionPlan::getCreateTempTableNode($parentTable,$dbConnection,$extensions);
    let parentLoadTempTableNode = meta::relational::graphFetch::executionPlan::getLoadTempTableNodeForRoot($dbType,$parentTable,$dbConnection,$extensions);
    let parentDropTempTableNode = meta::relational::graphFetch::executionPlan::getDropTempTableNode($dbType,$parentTable,$dbConnection,$extensions);
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testSimpleRelationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testSimpleRelationalGraphFetch.pure
@@ -12,15 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::external::store::relational::runtime::*;
+import meta::relational::functions::database::*;
 import meta::relational::tests::model::simple::*;
 import meta::pure::executionPlan::profiles::*;
 import meta::pure::graphFetch::execution::*;
 import meta::pure::alloy::connections::*;
-import meta::external::store::relational::runtime::*;
+import meta::relational::metamodel::execute::*;
 
 function <<test.BeforePackage>> meta::relational::graphFetch::tests::simple::setup(): Boolean[1]
 {
    meta::relational::tests::createTablesAndFillDb();
+
+   let connection = meta::external::store::relational::tests::testRuntime().connectionByElement(meta::relational::tests::db)->cast(@meta::external::store::relational::runtime::TestDatabaseConnection);
+
+   executeInDb('Drop table if exists \"personTable\";', $connection);
+   executeInDb('Create Table \"personTable\"(id INT, firstName VARCHAR(200), lastName VARCHAR(200), age INT, addressId INT, firmId INT, managerId INT);', $connection);
+   executeInDb('insert into \"personTable\" (id, firstName, lastName, age, addressId, firmId, managerId) values (1, \'Peter\', \'Smith\',23, 1,1,2);', $connection);
+   executeInDb('insert into \"personTable\" (id, firstName, lastName, age, addressId, firmId, managerId) values (2, \'John\', \'Johnson\',22, 2,1,4);', $connection);
+   executeInDb('insert into \"personTable\" (id, firstName, lastName, age, addressId, firmId, managerId) values (3, \'John\', \'Hill\',12, 3,1,2);', $connection);
+   executeInDb('insert into \"personTable\" (id, firstName, lastName, age, addressId, firmId, managerId) values (4, \'Anthony\', \'Allen\',22, 4,1,null);', $connection);
+   executeInDb('insert into \"personTable\" (id, firstName, lastName, age, addressId, firmId, managerId) values (5, \'Fabrice\', \'Roberts\',34, 5,2,null);', $connection);
+   executeInDb('insert into \"personTable\" (id, firstName, lastName, age, addressId, firmId, managerId) values (6, \'Oliver\', \'Hill\',32, 6,3,null);', $connection);
+   executeInDb('insert into \"personTable\" (id, firstName, lastName, age, addressId, firmId, managerId) values (7, \'David\', \'Harris\',35, 7,4,null);', $connection);
+
+   executeInDb('Drop table if exists \"firmTable\";', $connection);
+   executeInDb('Create Table \"firmTable\"(id INT, legalName VARCHAR(200), addressId INT, ceoId INT);', $connection);
+   executeInDb('insert into \"firmTable\" (id, legalName, addressId, ceoId) values (1, \'Firm X\', 8, 1);', $connection);
+   executeInDb('insert into \"firmTable\" (id, legalName, addressId, ceoId) values (2, \'Firm A\', 9, 5);', $connection);
+   executeInDb('insert into \"firmTable\" (id, legalName, addressId, ceoId) values (3, \'Firm B\', 10, 3);', $connection);
+   executeInDb('insert into \"firmTable\" (id, legalName, addressId, ceoId) values (4, \'Firm C\', 11, 7);', $connection);
+
+   true;
 }
 
 function <<test.BeforePackage>> meta::relational::graphFetch::tests::qualifier::setup(): Boolean[1]
@@ -1348,4 +1371,29 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
    let result = execute($query, $mapping, $runtime, meta::relational::extension::relationalExtensions()).values;
 
    assertJsonStringsEqual('{"students":40,"desks":25}',$result);
+}
+
+function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::relational::graphFetch::tests::simple::testSimpleGraphFetchWithQuoteIdentifiers():Boolean[1]
+{
+  let tree = #{
+    Person {
+      firstName,
+      lastName,
+      firm {
+        legalName
+      }
+    }
+  }#;
+  let query = {|Person.all()->graphFetch($tree)->serialize($tree)};
+  let result = execute($query, meta::relational::tests::simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(true), meta::relational::extension::relationalExtensions());
+  assertJsonStringsEqual(
+    '[{"firstName":"Peter","lastName":"Smith","firm":{"legalName":"Firm X"}},' +
+    '{"firstName":"John","lastName":"Johnson","firm":{"legalName":"Firm X"}},' +
+    '{"firstName":"John","lastName":"Hill","firm":{"legalName":"Firm X"}},' +
+    '{"firstName":"Anthony","lastName":"Allen","firm":{"legalName":"Firm X"}},' +
+    '{"firstName":"Fabrice","lastName":"Roberts","firm":{"legalName":"Firm A"}},' +
+    '{"firstName":"Oliver","lastName":"Hill","firm":{"legalName":"Firm B"}},' +
+    '{"firstName":"David","lastName":"Harris","firm":{"legalName":"Firm C"}}]',
+    $result.values
+  );
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -209,6 +209,11 @@ function meta::relational::functions::sqlQueryToString::createDbConfig( dbType:D
    createDbConfig($dbType, $dbTimeZone, []);
 }
 
+function meta::relational::functions::sqlQueryToString::createDbConfig(dc:DatabaseConnection[1]):DbConfig[1]
+{
+   createDbConfig($dc.type, $dc.timeZone, $dc.quoteIdentifiers);
+}
+
 function meta::relational::functions::sqlQueryToString::createDbConfig( dbType:DatabaseType[1], dbTimeZone:String[0..1], quoteIdentifiers:Boolean[0..1]):DbConfig[1]
 {
    ^DbConfig(
@@ -454,9 +459,13 @@ function meta::relational::functions::sqlQueryToString::processTableAlias(tableA
 
 function meta::relational::functions::sqlQueryToString::tableToString(table:Table[1], dbConfig : DbConfig[1]):String[1]
 {
-   let schemaName = $dbConfig.schemaNameToIdentifier($table.schema.name);
-   let tableName = $dbConfig.tableNameToIdentifier($table.name);
-   if($schemaName == 'default', | $dbConfig.identifierProcessor($tableName), | $dbConfig.schemaIdentifierToString($schemaName) + '.' + $dbConfig.identifierProcessor($tableName));
+  // temp tables have already gone through db-specific processTempTable
+  if($table->isTemporaryTable(),
+    | $table.name,
+    | let schemaName = $dbConfig.schemaNameToIdentifier($table.schema.name);
+      let tableName = $dbConfig.tableNameToIdentifier($table.name);
+      if($schemaName == 'default', | $dbConfig.identifierProcessor($tableName), | $dbConfig.schemaIdentifierToString($schemaName) + '.' + $dbConfig.identifierProcessor($tableName));
+  )
 }
 
 function meta::relational::functions::sqlQueryToString::indent(d:Format[1]):Format[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -553,7 +553,8 @@ function meta::relational::functions::sqlQueryToString::default::getDDLCommandsT
 
 function meta::relational::functions::sqlQueryToString::default::processTempTableNameDefault(tempTableName:String[1], dc: meta::external::store::relational::runtime::DatabaseConnection[1]) : String[1]
 {
-   $tempTableName;
+   let dbConfig = createDbConfig($dc);
+   $dbConfig.identifierProcessor($tempTableName);
 }
 
 function meta::relational::functions::sqlQueryToString::default::translateCreateSchemaStatementDefault(createSchemaSQL:CreateSchemaSQL[1], dbConfig:DbConfig[1]) : String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/testTempTableSqlStatements.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/testSuite/testTempTableSqlStatements.pure
@@ -75,7 +75,7 @@ function meta::relational::functions::sqlQueryToString::tests::getLoadFromResult
   if($dbTypeEnum->isNotEmpty(),
   |let dbType = $dbTypeEnum->at(0)->toOne();
   let temporaryTable = meta::relational::functions::sqlQueryToString::tests::createTable([],$dbType);
-  meta::relational::graphFetch::executionPlan::sqlsForInsertIntoTableUsingResultSet($dbType,$temporaryTable);,|[]);
+  meta::relational::graphFetch::executionPlan::sqlsForInsertIntoTableUsingResultSet($temporaryTable, $dbType->createDbConfig());,|[]);
 }
 
 function meta::relational::functions::sqlQueryToString::tests::getDropTempTableSqlStatements(databaseType: String[1]): String[*]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/relationalSetUp.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/relationalSetUp.pure
@@ -1093,6 +1093,11 @@ function meta::external::store::relational::tests::testRuntime(timeZone:String[1
    meta::external::store::relational::tests::testRuntime(testDatabaseConnection(db, $timeZone))
 }
 
+function meta::external::store::relational::tests::testRuntime(quoteIdentifiers:Boolean[1]):Runtime[1]
+{
+   meta::external::store::relational::tests::testRuntime(testDatabaseConnection(db, [], $quoteIdentifiers))
+}
+
 function meta::external::store::relational::tests::testRuntime(db:Database[1]):Runtime[1]
 {
    meta::external::store::relational::tests::testRuntime(testDatabaseConnection($db, []))
@@ -1109,6 +1114,17 @@ function meta::external::store::relational::tests::testDatabaseConnection(db:Dat
     connection=^meta::external::store::relational::runtime::TestDatabaseConnection(
         type = DatabaseType.H2,
         timeZone = if($timeZone->isEmpty(), |'GMT', |$timeZone)
+    ),
+    element = $db);
+}
+
+function meta::external::store::relational::tests::testDatabaseConnection(db:Database[1], timeZone:String[0..1], quoteIdentifiers:Boolean[0..1]):ConnectionStore[1]
+{
+  ^ConnectionStore(
+    connection=^meta::external::store::relational::runtime::TestDatabaseConnection(
+        type = DatabaseType.H2,
+        timeZone = if($timeZone->isEmpty(), |'GMT', |$timeZone),
+        quoteIdentifiers = if($quoteIdentifiers->isEmpty(), |false, |$quoteIdentifiers->toOne())
     ),
     element = $db);
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
Bug Fix

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->
Currently quotes aren't used for temp tables in graph fetch flow when quoteIdentifiers flag is set on the connection. This MR fixes that for H2 and Snowflake in the Pure flow.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
