### PR TITLE
Route using map rather than fold to prevent state from parameters affecting the outer state

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/pom.xml
@@ -52,6 +52,17 @@
         </dependency>
         <!-- ECLIPSE COLLECTIONS -->
 
+        <!-- JACKSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <!-- JACKSON -->
+
         <!-- COMMONS CODEC -->
         <dependency>
             <groupId>commons-codec</groupId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
@@ -14,6 +14,9 @@
 
 package org.finos.legend.engine.plan.dependencies.domain.date;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.tuple.Tuples;
@@ -40,6 +43,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+@JsonSerialize(using = ToStringSerializer.class)
 public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate, Serializable
 {
     private static final long serialVersionUID = 8608696099577042248L;
@@ -1632,6 +1636,7 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
      * @param string string
      * @return Pure date
      */
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static PureDate parsePureDate(String string)
     {
         return parsePureDate(string, 0, string.length());

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/ConstantResult.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/ConstantResult.java
@@ -35,7 +35,7 @@ public class ConstantResult extends Result implements IConstantResult
         return resultVisitor.visit(this);
     }
 
-    public Object stream() throws IOException
+    public String stream() throws IOException
     {
         return ConstantResultHelper.stream(this.getValue());
     }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/transformer/SetImplTransformers.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/transformer/SetImplTransformers.java
@@ -29,20 +29,11 @@ import java.util.List;
 
 public class SetImplTransformers
 {
-    public static final Function<Object, Object> TEMPORARY_DATATYPE_TRANSFORMER = (Function<Object, Object>) o ->
+    public static final Function<Object, Object> TEMPORARY_DATATYPE_TRANSFORMER = o ->
     {
-        if (o instanceof Timestamp)
-        {
-            return DateFunctions.fromSQLTimestamp((Timestamp) o);
-        }
-        if (o instanceof java.sql.Date)
-        {
-            return StrictDate.fromSQLDate((java.sql.Date) o);
-        }
         if (o instanceof Date)
         {
-            PureDate pureDate = PureDate.fromDate((Date) o);
-            return pureDate.toString();
+            return PureDate.fromDate((Date) o);
         }
         return o;
     };

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/metamodel/clustering.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/metamodel/clustering.pure
@@ -94,7 +94,7 @@ function meta::pure::router::clustering::areClustersCompatible(cluster1:Clustere
 function meta::pure::router::clustering::isFunctionSupportedByCluster(cluster:ClusteredValueSpecification[1], f:FunctionExpression[1]):Boolean[1]
 {
   $cluster->match([
-      sc:StoreMappingClusteredValueSpecification[1] |
+      sc:StoreClusteredValueSpecification[1] |
           $sc.s.supports->toOne()->eval($f->evaluateAndDeactivate()),
       ef:ExternalFormatClusteredValueSpecification[1] |
           $f->meta::pure::router::externalFormat::clustering::externalFormatSupportsFunction(),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -76,36 +76,24 @@ function meta::pure::router::routing::enrichFunctionExpressions(expressions:Func
 
 function meta::pure::router::routing::processCollection(state:RoutingState[1], col:Any[*], executionContext:meta::pure::runtime::ExecutionContext[1], vars:Map<VariableExpression, ValueSpecification>[1], inScopeVars:Map<String, List<Any>>[1], shouldProcess:Function<{Any[1]->Boolean[1]}>[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):RoutingState[*]
 {
-   $col->fold({c,a| let last = $a->last()->toOne();
-                    let newState = if([
-                                        pair( |$c->instanceOf(ValueSpecification) && $shouldProcess->eval($c),
-                                              |^$last(
-                                                value = $c,
-                                                depth = $state.depth,
-                                                propertyMap = $state.propertyMap
-                                              )->routeValueSpecification($executionContext, $vars, $inScopeVars, $extensions, $debug);),
-                                        pair( |$c->instanceOf(Path) && $shouldProcess->eval($c),
-                                              |^$last(
-                                                  value = $c,
-                                                  depth = $state.depth,
-                                                  propertyMap = $state.propertyMap
-                                                )->routePath($executionContext, $vars, $inScopeVars, $extensions, $debug);),
-                                        pair( |$c->instanceOf(KeyExpression) && $shouldProcess->eval($c),
-                                              |let ke = $c->cast(@KeyExpression);
-                                              let routedExpression = ^$last(value = $ke.expression, depth = $state.depth, propertyMap = $state.propertyMap)->routeValueSpecification($executionContext, $vars, $inScopeVars, $extensions, $debug);
-                                              ^$last(value = ^$ke(expression=$routedExpression.value->cast(@ValueSpecification)->toOne()),
-                                                      depth = $state.depth,
-                                                      propertyMap = $state.propertyMap);)
-                                      ],
-                                      |^$last(value = $c,
-                                              depth = $state.depth,
-                                              propertyMap = $state.propertyMap
-                                            )
-                                   );
-                     $a->add($newState);
-               },
-               [$state]->toOneMany()
-   )->tail();
+   $col->map(c |
+                  let a = if([
+                        pair( |$c->instanceOf(ValueSpecification) && $shouldProcess->eval($c),
+                              |^$state(value = $c)->routeValueSpecification($executionContext, $vars, $inScopeVars, $extensions, $debug);
+                            ),
+                        pair( |$c->instanceOf(Path) && $shouldProcess->eval($c),
+                              |^$state(value = $c)->routePath($executionContext, $vars, $inScopeVars, $extensions, $debug);
+                            ),
+                        pair( |$c->instanceOf(KeyExpression) && $shouldProcess->eval($c),
+                              |let ke = $c->cast(@KeyExpression);
+                              let routedExpression = ^$state(value = $ke.expression, depth = $state.depth, propertyMap = $state.propertyMap)->routeValueSpecification($executionContext, $vars, $inScopeVars, $extensions, $debug);
+                              ^$state(value = ^$ke(expression=$routedExpression.value->cast(@ValueSpecification)->toOne()));
+                            )
+                      ],
+                      |^$state(value = $c)
+                    );
+                    $a;
+   );
 }
 
 function <<access.private>> meta::pure::router::routing::routePath(state:RoutingState[1], executionContext:meta::pure::runtime::ExecutionContext[1], vars:Map<VariableExpression, ValueSpecification>[1], inScopeVars:Map<String, List<Any>>[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1]):RoutingState[1]
@@ -294,14 +282,12 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
         let firstPass         = $firstPassResults.value->evaluateAndDeactivate()->cast(@ValueSpecification);
         let routed            = $firstPass->map(fp|$fp->match([f:FunctionRoutedValueSpecification[1]|$f.value,v:ValueSpecification[1]|$v]))->filter(p|!$p->isFunction() && $p->instanceOf(ExtendedRoutedValueSpecification))->cast(@ExtendedRoutedValueSpecification)->concatenate($state.routed->cast(@ExtendedRoutedValueSpecification)->evaluateAndDeactivate());
         // Second pass (lambdas)
-        let preLastFirstPass  = $firstPassResults->last()->toOne();
-        let lastFirstPass     = ^$preLastFirstPass(depth = $f.name->toOne()+'('+$fe.parametersValues->map(p|$p->varToString())->joinStrings(',')+')');
+        let lastFirstPass     = ^$state(depth = $f.name->toOne()+'('+$fe.parametersValues->map(p|$p->varToString())->joinStrings(',')+')');
         let pathPrefix        = $state.pathPrefix->add($fe->varToString())->joinStrings(',');
-        let secondPassResults = $firstPass->fold({p,a|  let currentLast = $a->last()->toOne();
-                                                        if($p->isFunction(),
+        let secondPassResults = $firstPass->map({p | if($p->isFunction(),
                                                           | let i   = $p->byPassRouterInfo()->cast(@InstanceValue);
                                                             let res = if($i.values->size() == 1,
-                                                                        |^$i(values=$i.values->at(0))->match([r:ExtendedRoutedValueSpecification[1]|$r.value,v:ValueSpecification[1]|$v])->cast(@InstanceValue)->processLambda($routed, ^$currentLast(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));,
+                                                                        |^$i(values=$i.values->at(0))->match([r:ExtendedRoutedValueSpecification[1]|$r.value,v:ValueSpecification[1]|$v])->cast(@InstanceValue)->processLambda($routed, ^$lastFirstPass(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));,
                                                                         |$i.values->cast(@Function<Any>)
                                                                                   ->fold(
                                                                                     {f,a| let processOne    = ^$i(values=$f)->match([r:ExtendedRoutedValueSpecification[1]|$r.value,v:ValueSpecification[1]|$v])->cast(@InstanceValue)->processLambda($routed, ^$a(propertyMap=$state.propertyMap), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
@@ -313,13 +299,11 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                                                                                                       )
                                                                                             );
                                                                                     },
-                                                                                    ^$currentLast(value=^$i(values=[]), pathPrefix=$pathPrefix)
+                                                                                    ^$lastFirstPass(value=^$i(values=[]), pathPrefix=$pathPrefix)
                                                                                   );
-                                                                      );
-                                                            $a->concatenate($res);,
+                                                                      );,
                                                           | if($p.genericType.rawType->isNotEmpty() && $p.genericType.rawType != Nil && $p.genericType.rawType->toOne()->_subTypeOf(meta::pure::tds::ColumnSpecification),
-                                                              | let res = $p->processColumnSpecification(^$currentLast(pathPrefix=$pathPrefix, routed+=$routed), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
-                                                                $a->concatenate($res);,
+                                                              | let res = $p->processColumnSpecification(^$lastFirstPass(pathPrefix=$pathPrefix, routed+=$routed), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));,
                                                               | let vsRawType = $p->cast(@ValueSpecification).genericType.rawType;
                                                                 if($vsRawType->in([ meta::pure::functions::collection::AggregateValue,
                                                                                     meta::pure::tds::AggregateValue,
@@ -329,21 +313,21 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                                                                                     meta::pure::metamodel::relation::AggColSpecArray]),                                             
                                                                   | let resolved = $p->match([v:VariableExpression[1]|meta::pure::functions::meta::resolve($v, $vars, $inScopeVars), v:ValueSpecification[1]|$v]);
                                                                     if($resolved->isEmpty(),
-                                                                      |$a->concatenate(^$currentLast(value = $p)),
+                                                                      |^$lastFirstPass(value = $p),
                                                                       |$resolved->match([
-                                                                            fe : FunctionExpression[1] | $a->concatenate($fe->processAggregationFunctionExpression($routed, $currentLast, $executionContext, $vars, $inScopeVars, $extensions, $debug)),
+                                                                            fe : FunctionExpression[1] | $fe->processAggregationFunctionExpression($routed, $lastFirstPass, $executionContext, $vars, $inScopeVars, $extensions, $debug),
                                                                             i : InstanceValue[1] | let fes = $i.values->evaluateAndDeactivate()
                                                                                                                   ->fold({fe,a| let lastState = $a->last()->toOne();
                                                                                                                                 $fe->match([v:VariableExpression[1]|meta::pure::functions::meta::resolve($v, $vars, $inScopeVars)->cast(@InstanceValue).values, v:Any[1]|$v])
                                                                                                                                    ->match(
                                                                                                                                         [
-                                                                                                                                          f:FunctionExpression[1]|$a->concatenate($fe->cast(@FunctionExpression)->processAggregationFunctionExpression($routed, ^$currentLast(routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, $debug));,
+                                                                                                                                          f:FunctionExpression[1]|$a->concatenate($fe->cast(@FunctionExpression)->processAggregationFunctionExpression($routed, ^$lastFirstPass(routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, $debug));,
                                                                                                                                           z:FuncColSpec<Any,Any>[1]|
-                                                                                                                                             let res = prevalFuncColSpec($z, $routed, ^$currentLast(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
+                                                                                                                                             let res = prevalFuncColSpec($z, $routed, ^$lastFirstPass(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
                                                                                                                                              $a->concatenate(^$lastState(value=$res));,
                                                                                                                                           d:FuncColSpecArray<Any,Any>[1]|
                                                                                                                                             let r = $d.funcSpecs->map(z|
-                                                                                                                                                prevalFuncColSpec($z, $routed, ^$currentLast(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
+                                                                                                                                                prevalFuncColSpec($z, $routed, ^$lastFirstPass(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
                                                                                                                                             );
                                                                                                                                             // Rebuild the FuncColSpecArray
                                                                                                                                             let other = $p.genericType->dynamicNew([
@@ -351,11 +335,11 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                                                                                                                                                   ]);
                                                                                                                                             $a->concatenate(^$lastState(value=$other));,
                                                                                                                                           x:AggColSpec<Any,Any,Any>[1]|
-                                                                                                                                            let res = prevalAggColSpec($x, $routed, ^$currentLast(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
+                                                                                                                                            let res = prevalAggColSpec($x, $routed, ^$lastFirstPass(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
                                                                                                                                             $a->concatenate(^$lastState(value=$res));,
                                                                                                                                           x:AggColSpecArray<Any,Any,Any>[1]|
                                                                                                                                             let r = $x.aggSpecs->map(z|
-                                                                                                                                                prevalAggColSpec($z, $routed, ^$currentLast(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
+                                                                                                                                                prevalAggColSpec($z, $routed, ^$lastFirstPass(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
                                                                                                                                             );
                                                                                                                                             // Rebuild the FuncColSpecArray
                                                                                                                                             let other = $p.genericType->dynamicNew([
@@ -363,7 +347,7 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                                                                                                                                                   ]);
                                                                                                                                             $a->concatenate(^$lastState(value=$other));,
                                                                                                                                           agg:meta::pure::functions::collection::AggregateValue<Nil,Any,Any>[1]|
-                                                                                                                                                let mapFn = processAggregationValueFunction($agg.mapFn, $routed, ^$currentLast(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
+                                                                                                                                                let mapFn = processAggregationValueFunction($agg.mapFn, $routed, ^$lastFirstPass(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
                                                                                                                                                 let aggFn = processAggregationValueFunction($agg.aggregateFn, $routed, $mapFn, $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
 
                                                                                                                                                 let d = $p->cast(@ValueSpecification).genericType->dynamicNew(
@@ -378,7 +362,7 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                                                                                                                                                                       );
                                                                                                                                                 $a->concatenate(^$aggFn(value=$d));,
                                                                                                                                           agg:meta::pure::tds::AggregateValue<Any,Any>[1]|
-                                                                                                                                                let mapFn = processAggregationValueFunction($agg.mapFn, $routed, ^$currentLast(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
+                                                                                                                                                let mapFn = processAggregationValueFunction($agg.mapFn, $routed, ^$lastFirstPass(pathPrefix=$pathPrefix, propertyMap=$state.propertyMap, routingStrategy = $lastState.routingStrategy, counter = $lastState.counter), $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
                                                                                                                                                 let aggFn = processAggregationValueFunction($agg.aggregateFn, $routed, $mapFn, $executionContext, $vars, $inScopeVars, $extensions, ^$debug(space = $debug.space+'  '));
 
                                                                                                                                                 let d = $p->cast(@ValueSpecification).genericType->dynamicNew(
@@ -395,19 +379,19 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                                                                                                                                                 $a->concatenate(^$aggFn(value=$d));
                                                                                                                                         ]
                                                                                                                                  );
-                                                                                                                        },$currentLast
+                                                                                                                        },$lastFirstPass
                                                                                                                     )->tail();
                                                                                                 let last = $fes->last()->toOne();
-                                                                                                $a->concatenate(^$last(value=^$i(values=$fes.value)));
+                                                                                                ^$last(value=^$i(values=$fes.value));
                                                                             ]);
                                                                       );,
-                                                                  |$a->concatenate(^$currentLast(value = $p))
+                                                                  |^$lastFirstPass(value = $p)
                                                                 );
                                                         ););
-                                              }, $lastFirstPass->toOneMany());
+                                              });
 
 
-        let secondPassPre = $secondPassResults->tail()->evaluateAndDeactivate();
+        let secondPassPre = $secondPassResults->evaluateAndDeactivate();
 
         let secondPass = if($f->in([meta::pure::functions::lang::subType_Any_m__T_1__T_m_, meta::pure::functions::lang::whenSubType_Any_1__T_1__T_$0_1$_, meta::pure::functions::lang::whenSubType_Any_$0_1$__T_1__T_$0_1$_, meta::pure::functions::lang::whenSubType_Any_MANY__T_1__T_MANY_]) && $secondPassPre->at(0).shouldBeRouted,  // TODO: cleanup needed
                             | let first = $secondPassPre->at(0);
@@ -419,8 +403,8 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                           );
 
 
-        let lastSecondPass = $secondPassResults->last()->toOne();
-
+        let lastSecondPass = $lastFirstPass;
+        
         let returnClass = if($fe.genericType.rawType->first() == Checked,
                               | $fe.genericType.typeArguments->first().rawType,
                               | $fe.genericType.rawType->first()

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
@@ -338,6 +338,26 @@ function <<access.private>> meta::pure::router::store::routing::wrapValueSpecifi
 function  meta::pure::router::store::routing::specializedFunctionExpressionRouterProcessorForStore(extensions:meta::pure::extension::Extension[*]):Pair<Function<{FunctionExpression[1]->Boolean[1]}>, Function<{Function<Any>[1], FunctionExpression[1], RoutingState[1], meta::pure::runtime::ExecutionContext[1], Map<VariableExpression, ValueSpecification>[1], Map<String, List<Any>>[1], meta::pure::extension::Extension[*], DebugContext[1]->RoutingState[1]}>>[*]
 {
   [
+    pair(fe:FunctionExpression[1] | $fe.func == letFunction_String_1__T_m__T_m_,
+        {f:Function<Any>[1], fe:FunctionExpression[1], state:RoutingState[1], executionContext:meta::pure::runtime::ExecutionContext[1], vars:Map<VariableExpression, ValueSpecification>[1], inScopeVars:Map<String, List<Any>>[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1] |
+                
+                let assigmentRouted = routeValueSpecification(
+                  ^$state(value = $fe.parametersValues->at(1)),
+                  $executionContext,
+                  $vars,
+                  $inScopeVars,
+                  $extensions,
+                  $debug
+                );
+
+                let wrappedValueSpec = $assigmentRouted.value->evaluateAndDeactivate()->match([
+                                                          evs: ExtendedRoutedValueSpecification[1] | $evs,
+                                                          vs: ValueSpecification[1]                | $assigmentRouted.routingStrategy.wrapValueSpec($vs, 'from wrapper', $executionContext, $extensions, $debug)
+                                                        ]);
+                let processedLet = ^$fe(parametersValues = $fe.parametersValues->at(0)->concatenate($wrappedValueSpec));
+                ^$state(value = $processedLet, routingStrategy = meta::pure::router::platform::routing::getPlatformRoutingStrategy());
+        }
+    ),
     pair(fe:FunctionExpression[1] | $fe.func->in([meta::pure::mapping::from_T_m__Runtime_1__T_m_]),
         {f:Function<Any>[1], fe:FunctionExpression[1], state:RoutingState[1], executionContext:meta::pure::runtime::ExecutionContext[1], vars:Map<VariableExpression, ValueSpecification>[1], inScopeVars:Map<String, List<Any>>[1], extensions:meta::pure::extension::Extension[*], debug:DebugContext[1] |
                 let resolvedParameters     = $fe.parametersValues->tail()->map(p|$p->evaluateAndDeactivate()->match([v:VariableExpression[1] |let iv = meta::pure::functions::meta::resolve($v, $vars, $inScopeVars)->cast(@InstanceValue).values,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/serialization/toPureGrammar.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/serialization/toPureGrammar.pure
@@ -194,7 +194,7 @@ function meta::pure::metamodel::serialization::grammar::printFunctionExpression(
                                                    |$main
                                                 );
                                    $val->elementToPath() + '.all()';),
-          pair(|$name == 'letFunction',|'let '+$functionExpression.parametersValues->at(0)->cast(@InstanceValue).values->toOne()->toString()+ ' = ' +$functionExpression.parametersValues->at(0)->printValueSpecification($space)),
+          pair(|$name == 'letFunction',|'let '+$functionExpression.parametersValues->at(0)->cast(@InstanceValue).values->toOne()->toString()+ ' = ' +$functionExpression.parametersValues->at(1)->printValueSpecification($space)),
           pair(|$name == 'colSpec', |'~'+$functionExpression.parametersValues->at(0)->cast(@InstanceValue).values->at(0)->toString()->printColName()),
           pair(|$name == 'funcColSpec' || $name == 'funcColSpec2', | '~'+printColSpec($functionExpression, $configuration, $space)),
           pair(|$name == 'aggColSpec' || $name == 'aggColSpec2', | '~'+printColSpec($functionExpression, $configuration, $space)),

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/api/result/ConstantResultHelper.java
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/src/main/java/org/finos/legend/engine/shared/core/api/result/ConstantResultHelper.java
@@ -21,12 +21,12 @@ import java.io.IOException;
 
 public class ConstantResultHelper
 {
-    public static Object stream(Object value) throws IOException
+    public static String stream(Object value) throws IOException
     {
         return ObjectMapperFactory.getNewStandardObjectMapper().writeValueAsString(value);
     }
 
-    public static Object stream(Object value, ObjectMapper objectMapper) throws IOException
+    public static String stream(Object value, ObjectMapper objectMapper) throws IOException
     {
         return objectMapper.writeValueAsString(value);
     }

--- a/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-planExecution/legend-engine-pure-runtime-java-extension-shared-functions-planExecution/src/main/java/org/finos/legend/engine/pure/runtime/execution/shared/LegendExecute.java
+++ b/legend-engine-pure/legend-engine-pure-runtime/legend-engine-pure-runtime-planExecution/legend-engine-pure-runtime-java-extension-shared-functions-planExecution/src/main/java/org/finos/legend/engine/pure/runtime/execution/shared/LegendExecute.java
@@ -21,7 +21,6 @@ import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.plan.execution.result.StreamingResult;
 import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
 import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.IdentityFactory;
 import org.finos.legend.engine.shared.core.kerberos.SubjectTools;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -51,8 +50,7 @@ public class LegendExecute
                 .build();
 
         // execute plan
-        Result result = planExecutor.executeWithArgs(executeArgs);
-        try (AutoCloseable ignore = result::close)
+        try (Result result = planExecutor.executeWithArgs(executeArgs))
         {
             if (result instanceof StreamingResult)
             {
@@ -62,7 +60,7 @@ public class LegendExecute
             }
             else if (result instanceof ConstantResult)
             {
-                return ((ConstantResult) result).stream().toString();
+                return ((ConstantResult) result).stream();
             }
             else
             {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
@@ -452,38 +452,41 @@ function meta::relational::tests::pct::process::reprocess(a:Any[1], state:Proces
 {
   $a->match(
     [
-      z:FunctionExpression[1]| if($z.func == new_Class_1__String_1__KeyExpression_MANY__T_1_,
-                                | meta::relational::tests::pct::process::reprocessNew($z->reactivate()->evaluateAndDeactivate(), $z.genericType.rawType->toOne()->cast(@Class<Any>), $state);,
-                                | if (!$z.func->in(
-                                              [
-                                                  meta::pure::functions::relation::funcColSpecArray_FuncColSpec_MANY__P_1__FuncColSpecArray_1_,
-                                                  meta::pure::functions::relation::funcColSpecArray2_FuncColSpec_MANY__P_1__FuncColSpecArray_1_,
-                                                  meta::pure::functions::relation::funcColSpec_Function_1__String_1__T_1__FuncColSpec_1_,
-                                                  meta::pure::functions::relation::funcColSpec2_Function_1__String_1__T_1__FuncColSpec_1_,
-                                                  meta::pure::functions::relation::aggColSpecArray_AggColSpec_MANY__P_1__AggColSpecArray_1_,
-                                                  meta::pure::functions::relation::aggColSpecArray2_AggColSpec_MANY__P_1__AggColSpecArray_1_,
-                                                  meta::pure::functions::relation::aggColSpec_Function_1__Function_1__String_1__T_1__AggColSpec_1_,
-                                                  meta::pure::functions::relation::aggColSpec2_Function_1__Function_1__String_1__T_1__AggColSpec_1_
-                                              ]),
-                                    | let repro = $z.parametersValues->evaluateAndDeactivate()->map(x|$x->reprocess($state));
-                                      ^$state
-                                      (
-                                          current = ^$z(parametersValues = if ($z->cast(@FunctionExpression).func == write_Relation_1__RelationElementAccessor_1__Integer_1_,
-                                                                              | let reproCurrent = $repro.current->cast(@ValueSpecification);
-                                                                                let tds = $reproCurrent->at(1)->cast(@FunctionExpression).parametersValues->at(0);
-                                                                                $reproCurrent->at(0)->concatenate($tds);,
-                                                                              | $repro.current->cast(@ValueSpecification))
-                                                       )->evaluateAndDeactivate(),
-                                          mapping = $repro.mapping->first(),
-                                          replaced = $repro.replaced,
-                                          csvs = $repro.csvs
-                                      );,
-                                    | ^$state
-                                      (
-                                        current = $z
-                                      )
-                                  )                                  
-                               );,
+      z:FunctionExpression[1]| 
+          let ifElseIf = [
+            pair(
+                |$z.func == new_Class_1__String_1__KeyExpression_MANY__T_1_, 
+                |meta::relational::tests::pct::process::reprocessNew($z->reactivate()->evaluateAndDeactivate(), $z.genericType.rawType->toOne()->cast(@Class<Any>), $state)
+            ),          
+            pair(
+                |!$z.func->in(
+                                [
+                                    meta::pure::functions::relation::funcColSpecArray_FuncColSpec_MANY__P_1__FuncColSpecArray_1_,
+                                    meta::pure::functions::relation::funcColSpecArray2_FuncColSpec_MANY__P_1__FuncColSpecArray_1_,
+                                    meta::pure::functions::relation::funcColSpec_Function_1__String_1__T_1__FuncColSpec_1_,
+                                    meta::pure::functions::relation::funcColSpec2_Function_1__String_1__T_1__FuncColSpec_1_,
+                                    meta::pure::functions::relation::aggColSpecArray_AggColSpec_MANY__P_1__AggColSpecArray_1_,
+                                    meta::pure::functions::relation::aggColSpecArray2_AggColSpec_MANY__P_1__AggColSpecArray_1_,
+                                    meta::pure::functions::relation::aggColSpec_Function_1__Function_1__String_1__T_1__AggColSpec_1_,
+                                    meta::pure::functions::relation::aggColSpec2_Function_1__Function_1__String_1__T_1__AggColSpec_1_
+                                ]
+                            ),
+                |let repro = $z.parametersValues->evaluateAndDeactivate()->map(x|$x->reprocess($state));
+                  ^$state
+                  (
+                      current = ^$z(parametersValues = if ($z->cast(@FunctionExpression).func == write_Relation_1__RelationElementAccessor_1__Integer_1_,
+                                                          | let reproCurrent = $repro.current->cast(@ValueSpecification);
+                                                            let tds = $reproCurrent->at(1)->cast(@FunctionExpression).parametersValues->at(0);
+                                                            $reproCurrent->at(0)->concatenate($tds);,
+                                                          | $repro.current->cast(@ValueSpecification))
+                                    )->evaluateAndDeactivate(),
+                      mapping = $repro.mapping->first(),
+                      replaced = $repro.replaced,
+                      csvs = $repro.csvs
+                  ); 
+            )
+          ];
+          if($ifElseIf, |^$state(current = $z));,
       ix:InstanceValue[1]|
                           let i = $ix->evaluateAndDeactivate();
                           let type = $i.genericType.rawType->toOne();


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Currently, routing does a fold of the parameters of a function, and takes the output of that fold as the state to also route the outer function.

This has two side effect:
 - The firsts parameters affect the routing of subsequent parameters
 - The output of the fold affect the routing of the outer function

One visible outcome is when expressions have multiple `from()`, where these are not properly respected, leading to incorrect routing.

This PR also start treating let as a specialize function to ensure the platform generates the proper allocations nodes.

List of features this would enable:

- [x] let statement routed thru platform to ensure allocation node is created regardless of assignee is routed: 
```
let var = now()->from(runtime)
```
- [ ] let of relation expression and reference it on subsequent expressions:
 ```
let rel = #>{database}#->from(runtime);
$rel->filter(...);
```
- [ ] let of function with multiple expressions
 ```
function hello(): String[1]
{
  let a = 'hello';
  let b = 'world';
  $a + $b;
}

// to route/execute
let r = hello();
$r + '!';
```
- [ ] write with multiple from calls (cross-store)
```
#>{database}#->from(runtimeABC)->write(#>{anotherDatabase}#)->with(runtimeXYZ);
```
- [ ] join with multiple from calls (cross-store)
```
#>{database}#->from(runtimeABC)->join(#>{anotherDatabase}#->from(runtimeXYZ));
```

