### PR TITLE
Persistence Component: Fix staging filters saved as String + Fix new stats for Bulk Load coming as String

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/src/main/java/org/finos/legend/engine/persistence/components/util/SqlUtils.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/src/main/java/org/finos/legend/engine/persistence/components/util/SqlUtils.java
@@ -54,7 +54,6 @@ public class SqlUtils
 
             String doubleQuotedPattern = String.format("\"%s\"", placeholder);
             enrichedSql = enrichedSql.replaceAll(Pattern.quote(doubleQuotedPattern), actualValue);
-
         }
         return enrichedSql.replaceAll(Pattern.quote(placeholder), actualValue);
     }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/src/main/java/org/finos/legend/engine/persistence/components/util/SqlUtils.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/src/main/java/org/finos/legend/engine/persistence/components/util/SqlUtils.java
@@ -21,36 +21,50 @@ import java.util.regex.Pattern;
 
 public class SqlUtils
 {
-
-    public static String getEnrichedSql(Map<String, PlaceholderValue> placeholderKeyValues, String sql)
+    public static String getEnrichedSql(Map<String, PlaceholderValue> placeholderKeyValues, String sql, String batchIdPattern)
     {
         String enrichedSql = sql;
         for (Map.Entry<String, PlaceholderValue> entry : placeholderKeyValues.entrySet())
         {
-            enrichedSql = enrichedSql.replaceAll(Pattern.quote(entry.getKey()), entry.getValue().value());
+            enrichedSql = replacePlaceholderWithActualValue(enrichedSql, entry.getKey(), entry.getValue().value(), batchIdPattern);
         }
         return enrichedSql;
     }
 
-    private static String getEnrichedSqlWithMasking(Map<String, PlaceholderValue> placeholderKeyValues, String sql)
+    private static String getEnrichedSqlWithMasking(Map<String, PlaceholderValue> placeholderKeyValues, String sql, String batchIdPattern)
     {
         String enrichedSql = sql;
         for (Map.Entry<String, PlaceholderValue> entry : placeholderKeyValues.entrySet())
         {
             if (!entry.getValue().isSensitive())
             {
-                enrichedSql = enrichedSql.replaceAll(Pattern.quote(entry.getKey()), entry.getValue().value());
+                enrichedSql = replacePlaceholderWithActualValue(enrichedSql, entry.getKey(), entry.getValue().value(), batchIdPattern);
             }
         }
         return enrichedSql;
     }
 
-    public static void logSql(Logger logger, SqlLogging sqlLogging, String sqlBeforeReplacingPlaceholders, String sqlAfterReplacingPlaceholders, Map<String, PlaceholderValue> placeholderKeyValues)
+    private static String replacePlaceholderWithActualValue(String enrichedSql, String placeholder, String actualValue, String batchIdPattern)
+    {
+        if (placeholder.equals(batchIdPattern))
+        {
+            // These are to address the issue of batch id patterns being quoted in multi-dataset flow
+            String singleQuotedPattern = String.format("'%s'", placeholder);
+            enrichedSql = enrichedSql.replaceAll(Pattern.quote(singleQuotedPattern), actualValue);
+
+            String doubleQuotedPattern = String.format("\"%s\"", placeholder);
+            enrichedSql = enrichedSql.replaceAll(Pattern.quote(doubleQuotedPattern), actualValue);
+
+        }
+        return enrichedSql.replaceAll(Pattern.quote(placeholder), actualValue);
+    }
+
+    public static void logSql(Logger logger, SqlLogging sqlLogging, String sqlBeforeReplacingPlaceholders, String sqlAfterReplacingPlaceholders, Map<String, PlaceholderValue> placeholderKeyValues, String batchIdPattern)
     {
         switch (sqlLogging)
         {
             case MASKED:
-                String maskedSql = getEnrichedSqlWithMasking(placeholderKeyValues, sqlBeforeReplacingPlaceholders);
+                String maskedSql = getEnrichedSqlWithMasking(placeholderKeyValues, sqlBeforeReplacingPlaceholders, batchIdPattern);
                 logger.info(maskedSql);
                 break;
             case UNMASKED:

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/main/java/org/finos/legend/engine/persistence/components/relational/bigquery/executor/BigQueryExecutor.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/src/main/java/org/finos/legend/engine/persistence/components/relational/bigquery/executor/BigQueryExecutor.java
@@ -34,6 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.finos.legend.engine.persistence.components.relational.api.utils.IngestionUtils.BATCH_ID_PATTERN;
+
 public class BigQueryExecutor implements Executor<SqlGen, TabularData, SqlPlan>
 {
     private final BigQuerySink bigQuerySink;
@@ -64,8 +66,8 @@ public class BigQueryExecutor implements Executor<SqlGen, TabularData, SqlPlan>
         {
             for (String sql : sqlList)
             {
-                String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql);
-                SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues);
+                String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql, BATCH_ID_PATTERN);
+                SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues, BATCH_ID_PATTERN);
                 bigQueryHelper.executeQuery(enrichedSql);
             }
         }
@@ -73,8 +75,8 @@ public class BigQueryExecutor implements Executor<SqlGen, TabularData, SqlPlan>
         {
             for (String sql : sqlList)
             {
-                String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql);
-                SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues);
+                String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql, BATCH_ID_PATTERN);
+                SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues, BATCH_ID_PATTERN);
                 bigQueryHelper.executeStatement(enrichedSql);
             }
         }
@@ -82,8 +84,8 @@ public class BigQueryExecutor implements Executor<SqlGen, TabularData, SqlPlan>
 
     public Map<StatisticName, Object> executeLoadPhysicalPlanAndGetStats(SqlPlan physicalPlan, Map<String, PlaceholderValue> placeholderKeyValues)
     {
-        String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, physicalPlan.getSqlList().get(0));
-        SqlUtils.logSql(LOGGER, sqlLogging, physicalPlan.getSqlList().get(0), enrichedSql, placeholderKeyValues);
+        String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, physicalPlan.getSqlList().get(0), BATCH_ID_PATTERN);
+        SqlUtils.logSql(LOGGER, sqlLogging, physicalPlan.getSqlList().get(0), enrichedSql, placeholderKeyValues, BATCH_ID_PATTERN);
         return bigQueryHelper.executeLoadStatement(enrichedSql);
     }
 
@@ -105,8 +107,8 @@ public class BigQueryExecutor implements Executor<SqlGen, TabularData, SqlPlan>
         List<TabularData> resultSetList = new ArrayList<>();
         for (String sql : physicalPlan.getSqlList())
         {
-            String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql);
-            SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues);
+            String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql, BATCH_ID_PATTERN);
+            SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues, BATCH_ID_PATTERN);
             List<Map<String, Object>> queryResult = bigQueryHelper.executeQuery(enrichedSql);
             if (!queryResult.isEmpty())
             {

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/executor/RelationalExecutor.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/executor/RelationalExecutor.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.finos.legend.engine.persistence.components.relational.api.utils.IngestionUtils.BATCH_ID_PATTERN;
+
 public class RelationalExecutor implements Executor<SqlGen, TabularData, SqlPlan>
 {
     private final RelationalSink relationalSink;
@@ -60,8 +62,8 @@ public class RelationalExecutor implements Executor<SqlGen, TabularData, SqlPlan
         List<String> sqlList = physicalPlan.getSqlList();
         for (String sql : sqlList)
         {
-            String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql);
-            SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues);
+            String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql, BATCH_ID_PATTERN);
+            SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues, BATCH_ID_PATTERN);
             relationalExecutionHelper.executeStatement(enrichedSql);
         }
     }
@@ -104,8 +106,8 @@ public class RelationalExecutor implements Executor<SqlGen, TabularData, SqlPlan
         List<TabularData> resultSetList = new ArrayList<>();
         for (String sql : physicalPlan.getSqlList())
         {
-            String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql);
-            SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues);
+            String enrichedSql = SqlUtils.getEnrichedSql(placeholderKeyValues, sql, BATCH_ID_PATTERN);
+            SqlUtils.logSql(LOGGER, sqlLogging, sql, enrichedSql, placeholderKeyValues, BATCH_ID_PATTERN);
             TabularData queryResultData = relationalExecutionHelper.executeQueryAndGetResultsAsTabularData(enrichedSql);
             if (!queryResultData.data().isEmpty())
             {

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
@@ -620,7 +620,7 @@ public class SnowflakeSink extends AnsiSqlSink
                     {
                         case QueryStatsLogicalPlanUtils.EXTERNAL_SCAN_STAGE:
                             Object externalScan = queryStats.get(QueryStatsLogicalPlanUtils.EXTERNAL_BYTES_SCANNED_ALIAS);
-                            if (externalScan != null)
+                            if (externalScan != null && !String.valueOf(externalScan).isEmpty())
                             {
                                 stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, Long.parseLong(String.valueOf(externalScan)));
                             }
@@ -631,7 +631,7 @@ public class SnowflakeSink extends AnsiSqlSink
                             break;
                         case QueryStatsLogicalPlanUtils.INSERT_STAGE:
                             Object insert = queryStats.get(QueryStatsLogicalPlanUtils.INPUT_ROWS_ALIAS);
-                            if (insert != null)
+                            if (insert != null && !String.valueOf(insert).isEmpty())
                             {
                                 stats.put(StatisticName.INCOMING_RECORD_COUNT, Long.parseLong(String.valueOf(insert)));
                             }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
@@ -622,22 +622,22 @@ public class SnowflakeSink extends AnsiSqlSink
                             Object externalScan = queryStats.get(QueryStatsLogicalPlanUtils.EXTERNAL_BYTES_SCANNED_ALIAS);
                             if (externalScan != null)
                             {
-                                stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, externalScan);
+                                stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, Long.parseLong(String.valueOf(externalScan)));
                             }
                             else
                             {
-                                stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, 0);
+                                stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, 0L);
                             }
                             break;
                         case QueryStatsLogicalPlanUtils.INSERT_STAGE:
                             Object insert = queryStats.get(QueryStatsLogicalPlanUtils.INPUT_ROWS_ALIAS);
                             if (insert != null)
                             {
-                                stats.put(StatisticName.INCOMING_RECORD_COUNT, insert);
+                                stats.put(StatisticName.INCOMING_RECORD_COUNT, Long.parseLong(String.valueOf(insert)));
                             }
                             else
                             {
-                                stats.put(StatisticName.INCOMING_RECORD_COUNT, 0);
+                                stats.put(StatisticName.INCOMING_RECORD_COUNT, 0L);
                             }
                             break;
                     }


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

1. In multi-dataset cases, staging filters are saved as strings (hence quoted) instead of numbers. Fixed the placeholder handlings that caused it.
2. Newly added stats for bulk load: bytes scanned and incoming records are coming as strings. Added casting to save them as numbers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
