### PR TITLE
Review jp relgraphfetch

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -499,7 +499,8 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::planGra
                       ->map(x | ^DynaFunction(name = 'isNotNull', parameters =  $x.relationalElement))
                       ->andFilters($extensions);
 
-   //for embedded mappings we want to filter out any rows that have
+   //for embedded mappings we want to filter out any rows that have no values associated with any of the selected
+   //embedded properties. This is to effectively mimic a left outer join which would result in [0] if no join match
    let extraFilters = $setImpls->match([
       e:EmbeddedRelationalInstanceSetImplementation[1] |
         let propertyMappings = getEmbeddedPropertyMappings($currentTree);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/relationalGraphFetch.pure
@@ -493,9 +493,30 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::planGra
    print(if($debug.debug,|$debug.space+'   >Generate local store property query (with properties - '+$simplePrimitiveProperties->map(p|$p.name)->removeDuplicates()->joinStrings('[',', ',']')+'\n',|''));
    let nonPrimitiveQuery   = generateNonPrimitivePropertyQuery($parentSets, $currentTree, $parentTree, $mapping, $inScopeVars, $mc, $simplePrimitiveProperties, $debug->indent(2), $extensions);
    let changedDriverQuery  = $nonPrimitiveQuery->changeDriverToTempWithPkProjection(tempTableName($parentIdx), $parentSets, $extensions);
+
+   let pkFilters = $changedDriverQuery.columns->cast(@Alias)
+                      ->filter(x | $x.name->startsWith('"pk_'))
+                      ->map(x | ^DynaFunction(name = 'isNotNull', parameters =  $x.relationalElement))
+                      ->andFilters($extensions);
+
+   //for embedded mappings we want to filter out any rows that have
+   let extraFilters = $setImpls->match([
+      e:EmbeddedRelationalInstanceSetImplementation[1] |
+        let propertyMappings = getEmbeddedPropertyMappings($currentTree);
+        let pureToSqlState = defaultState($mapping, $inScopeVars);
+        let base = $setImpls->buildBaseQueryForChild($pureToSqlState, $mc, $extensions, $debug);
+
+        let queries = $propertyMappings->map(pm | processPropertyMapping($pm, $pm.property->ownerClass(), $base, ^$pureToSqlState(inGetterFlow = true), JoinType.LEFT_OUTER, '_gftp', ^List<ColumnGroup>(), $debug, $extensions)->cast(@SelectWithCursor););
+
+        $queries.select.columns->map(a | ^DynaFunction(name = 'isNotNull', parameters = $a))->orFilters($extensions);,
+      s:SetImplementation[1] | []
+   ]);
+
+   let filters = $pkFilters->concatenate($extraFilters)->andFilters($extensions);
+
    let pkFilteredQuery     = ^$changedDriverQuery
                              (
-                                filteringOperation = andFilters($changedDriverQuery.filteringOperation->concatenate($changedDriverQuery.columns->cast(@Alias)->filter(x | $x.name->startsWith('"pk_'))->map(x | ^DynaFunction(name = 'isNotNull', parameters =  $x.relationalElement))->andFilters($extensions)), $extensions)
+                                filteringOperation = $changedDriverQuery.filteringOperation->concatenate($filters)->andFilters($extensions)
                              );
    let postProcessorResult = $pkFilteredQuery->postProcessSQLQuery($store, [], $mapping, $runtime, $exeCtx, $extensions);
    let postProcessedQuery  = $postProcessorResult.query->cast(@SelectSQLQuery);
@@ -539,6 +560,20 @@ function <<access.private>> meta::relational::graphFetch::executionPlan::planGra
    );
 }
 
+
+function meta::relational::graphFetch::executionPlan::getEmbeddedPropertyMappings(tree:GraphFetchTree[1]):PropertyMapping[*]
+{
+ $tree->match([
+  g:RoutedPropertyGraphFetchTree[1] |
+  $g.propertyMapping->match([
+    e:EmbeddedRelationalInstanceSetImplementation[1] | $g.subTrees->map(t | getEmbeddedPropertyMappings($t)),
+    r:RelationalPropertyMapping[1] | $r->filter(e | !$e.relationalOperationElement->instanceOf(RelationalOperationElementWithJoin)),
+    p:PropertyMapping[*] | []
+  ]);,
+  g:GraphFetchTree[1] | $g.subTrees->map(t | getEmbeddedPropertyMappings($t))
+ ]);
+}
+
 function meta::relational::graphFetch::executionPlan::planCrossRootGraphFetchExecutionRelational(clusteredTree: StoreMappingClusteredGraphFetchTree[1], orderedPaths: String[*], parentPath: String[1], inScopeVars: Map<String, List<Any>>[1], mapping: Mapping[1], runtime: Runtime[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions: Extension[*], debug: DebugContext[1]): RelationalCrossRootQueryTempTableGraphFetchExecutionNode[1]
 {
    print(if($debug.debug,|$debug.space+'>Relational cross-store graphFetch plan generation:\n',|''));
@@ -553,6 +588,9 @@ function meta::relational::graphFetch::executionPlan::planCrossRootGraphFetchExe
 
    let parentIdx             = $orderedPaths->indexOf($parentPath);
    let currentIdx            = $orderedPaths->indexOf($rootPath);
+
+   assert($rootTree.propertyMapping->size() == 1, 'Property mappings for path ' + $parentPath + ' tree must be of size 1');
+   assert($rootTree.propertyMapping->toOne()->instanceOf(XStorePropertyMapping), | 'Property mapping should be of type XStore, ensure that your store aliases in mapping are set correctly');
 
    let xStorePropertyMapping = $rootTree.propertyMapping->toOne()->cast(@XStorePropertyMapping);
    let crossExpression       = $xStorePropertyMapping.crossExpression.expressionSequence->evaluateAndDeactivate()->toOne();

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchEmbdded.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchEmbdded.pure
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::relational::metamodel::execute::*;
+import meta::relational::tests::mapping::embedded::model::store::*;
 import meta::relational::tests::model::simple::*;
 import meta::pure::executionPlan::profiles::*;
 import meta::pure::graphFetch::execution::*;
@@ -19,6 +21,15 @@ import meta::pure::graphFetch::execution::*;
 function <<test.BeforePackage>> meta::relational::graphFetch::tests::embedded::setup(): Boolean[1]
 {
    meta::relational::tests::mapping::embedded::setUp();
+
+   let connection = meta::relational::tests::mapping::embedded::model::store::testDataTypeMappingRuntime().connectionByElement(myDB)->cast(@meta::external::store::relational::runtime::TestDatabaseConnection);
+
+   //Insert 2 extra records to test the nullable bewhaviour
+   let s = 'insert into PERSON_FIRM_DENORM (PERSON_ID, PERSON_FIRSTNAME, PERSON_LASTNAME, FIRM_ID, FIRM_LEGALNAME, PERSON_ADDRESS_NAME, PERSON_ADDRESS_TYPE, FIRM_ADDRESS_NAME, FIRM_ADDRESS_TYPE) values ';
+   executeInDb($s + '(7, \'Bob\', \'Brown\', 4, NULL, \'7 Palo Alto\', 2, NULL, NULL);', $connection);
+   executeInDb($s + '(9, \'Anthony\', \'Smith\', 2, \'Firm A\', \'7 Palo Alto\', 2, NULL, NULL);', $connection);
+
+   true;
 }
 
 function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::relational::graphFetch::tests::embedded::testSimpleEmbeddedMapping(): Boolean[1]
@@ -38,7 +49,7 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
    let result = execute($query, $mapping, $runtime, meta::relational::extension::relationalExtensions()).values;
 
    assertJsonStringsEqual(
-      '[{"firstName":"Peter","firm":{"legalName":"Firm X"}},{"firstName":"John","firm":{"legalName":"Firm X"}},{"firstName":"Fabrice","firm":{"legalName":"Firm A"}}]',
+      '[{"firstName":"Peter","firm":{"legalName":"Firm X"}},{"firstName":"John","firm":{"legalName":"Firm X"}},{"firstName":"Fabrice","firm":{"legalName":"Firm A"}},{"firstName":"Bob","firm":null},{"firstName":"Anthony","firm":{"legalName":"Firm A"}}]"',
       $result
    );
 }
@@ -51,7 +62,8 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
          firm {
             legalName,
             address {
-               name
+               name,
+               type
             }
          }
       }
@@ -63,7 +75,11 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
    let result = execute($query, $mapping, $runtime, meta::relational::extension::relationalExtensions()).values;
 
    assertJsonStringsEqual(
-      '[{"firstName":"Peter","firm":{"legalName":"Firm X","address":{"name":"200 west"}}},{"firstName":"John","firm":{"legalName":"Firm X","address":{"name":"200 west"}}},{"firstName":"Fabrice","firm":{"legalName":"Firm A","address":{"name":"3 somewhere"}}}]',
+      '[{"firstName":"Peter","firm":{"legalName":"Firm X","address":{"name":"200 west","type":"CITY"}}},' +
+      '{"firstName":"John","firm":{"legalName":"Firm X","address":{"name":"200 west","type":"CITY"}}},' +
+      '{"firstName":"Fabrice","firm":{"legalName":"Firm A","address":{"name":"3 somewhere","type":"CITY"}}},' +
+      '{"firstName":"Bob","firm":null},' +
+      '{"firstName":"Anthony","firm":{"legalName":"Firm A","address":null}}]',
       $result
    );
 }
@@ -88,7 +104,7 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
    let result = execute($query, $mapping, $runtime, meta::relational::extension::relationalExtensions()).values;
 
    assertJsonStringsEqual(
-      '[{"firstName":"Peter","firm":{"legalName":"Firm X","employees":[{"firstName":"Peter"},{"firstName":"John"}]}},{"firstName":"John","firm":{"legalName":"Firm X","employees":[{"firstName":"Peter"},{"firstName":"John"}]}},{"firstName":"Fabrice","firm":{"legalName":"Firm A","employees":[{"firstName":"Fabrice"}]}}]',
+      '[{"firstName":"Peter","firm":{"legalName":"Firm X","employees":[{"firstName":"Peter"},{"firstName":"John"}]}},{"firstName":"John","firm":{"legalName":"Firm X","employees":[{"firstName":"Peter"},{"firstName":"John"}]}},{"firstName":"Fabrice","firm":{"legalName":"Firm A","employees":[{"firstName":"Fabrice"},{"firstName":"Anthony"}]}},{"firstName":"Bob","firm":null},{"firstName":"Anthony","firm":{"legalName":"Firm A","employees":[{"firstName":"Fabrice"},{"firstName":"Anthony"}]}}]',
       $result
    );
 }
@@ -111,9 +127,11 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
    let result = execute($query, $mapping, $runtime, meta::relational::extension::relationalExtensions()).values;
 
    assertJsonStringsEqual(
-      '[{"firstName":"Peter","firm":{"legalName":"Firm X","nameAndAddress()":"Firm X,200 west"}},' + 
-      '{"firstName":"John","firm":{"legalName":"Firm X","nameAndAddress()":"Firm X,200 west"}},' + 
-      '{"firstName":"Fabrice","firm":{"legalName":"Firm A","nameAndAddress()":"Firm A,3 somewhere"}}]',
+      '[{"firstName":"Peter","firm":{"legalName":"Firm X","nameAndAddress()":"Firm X,200 west"}},' +
+      '{"firstName":"John","firm":{"legalName":"Firm X","nameAndAddress()":"Firm X,200 west"}},' +
+      '{"firstName":"Fabrice","firm":{"legalName":"Firm A","nameAndAddress()":"Firm A,3 somewhere"}},' +
+      '{"firstName":"Bob","firm":null},' +
+      '{"firstName":"Anthony","firm":{"legalName":"Firm A","nameAndAddress()":"Firm A,"}}]',
       $result
    );
 }


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?

For embedded mappings we want to filter out any rows that have no values associated with any of the selected embedded properties. This is to effectively mimic a left outer join which would result in [0] if no join match instead of populating an empty object which could then have false defects.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
