### PR TITLE
IDE Light: make debug version of interpreter a config option

### DIFF
--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDELight_NoExtension.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDELight_NoExtension.java
@@ -86,7 +86,7 @@ public class PureIDELight_NoExtension extends Application<ServerConfiguration>
     {
         environment.jersey().setUrlPattern("/*");
         environment.jersey().register(new SwaggerResource("", configuration.swagger.getSwaggerViewConfiguration(), configuration.swagger.getSwaggerOAuth2Configuration(), configuration.swagger.getContextRoot() + (configuration.swagger.getContextRoot().endsWith("/") ? "" : "/") + "api"));
-        this.pureSession = new PureSession(configuration.sourceLocationConfiguration, this.getRepositories(configuration.sourceLocationConfiguration));
+        this.pureSession = new PureSession(configuration.sourceLocationConfiguration, configuration.debugMode != null && configuration.debugMode, this.getRepositories(configuration.sourceLocationConfiguration));
         environment.jersey().register(new Concept(this.pureSession));
         environment.jersey().register(new RenameConcept(this.pureSession));
         environment.jersey().register(new MovePackageableElements(this.pureSession));

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
@@ -98,7 +98,7 @@ public abstract class PureIDEServer extends Application<ServerConfiguration>
                         (configuration.swagger.getContextRoot().endsWith("/") ? "" : "/") + "api")
         );
 
-        this.pureSession = new PureSession(configuration.sourceLocationConfiguration, this.getRepositories(configuration.sourceLocationConfiguration, configuration.requiredRepositories));
+        this.pureSession = new PureSession(configuration.sourceLocationConfiguration, configuration.debugMode != null && configuration.debugMode, this.getRepositories(configuration.sourceLocationConfiguration, configuration.requiredRepositories));
 
         environment.jersey().register(new Concept(pureSession));
         environment.jersey().register(new RenameConcept(pureSession));

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/ServerConfiguration.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/ServerConfiguration.java
@@ -27,5 +27,6 @@ public class ServerConfiguration extends Configuration
 {
     public SwaggerBundleConfiguration swagger;
     public SourceLocationConfiguration sourceLocationConfiguration;
+    public Boolean debugMode;
     public List<String> requiredRepositories;
 }

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/session/PureSession.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/session/PureSession.java
@@ -72,7 +72,7 @@ public class PureSession
     private final String PURE_OPTION_PREFIX = "pure.option.";
 
 
-    public PureSession(SourceLocationConfiguration sourceLocationConfiguration, MutableList<RepositoryCodeStorage> repos)
+    public PureSession(SourceLocationConfiguration sourceLocationConfiguration, boolean debugMode, MutableList<RepositoryCodeStorage> repos)
     {
         this.sourceLocationConfiguration = sourceLocationConfiguration;
 
@@ -82,7 +82,7 @@ public class PureSession
 
         this.repos = Lists.mutable.withAll(repos).with(new WelcomeCodeStorage(Paths.get(rootPath)));
 
-        this.functionExecution = new FunctionExecutionInterpretedWithDebugSupport();
+        this.functionExecution = debugMode ? new FunctionExecutionInterpretedWithDebugSupport() : new FunctionExecutionInterpreted();
 
         for (String property : System.getProperties().stringPropertyNames())
         {

--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/ideLightConfig.json
@@ -28,6 +28,7 @@
       ]
     }
   },
+  "debugMode" : true,
   "sourceLocationConfiguration": {
     "welcomeFileDirectory": "./"
   }


### PR DESCRIPTION
Make choice of which function interpreter to use in IDE Light configurable at runtime