### PR TITLE
IDE: Ensure parent thread ContextClassLoader is used in debug thread

### DIFF
--- a/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-interpreted-functions/src/main/java/org/finos/legend/engine/pure/ide/interpreted/debug/IDEDebugForkJoinWorkerThreadFactory.java
+++ b/legend-engine-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-interpreted-functions/src/main/java/org/finos/legend/engine/pure/ide/interpreted/debug/IDEDebugForkJoinWorkerThreadFactory.java
@@ -1,0 +1,37 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package org.finos.legend.engine.pure.ide.interpreted.debug;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+
+public class IDEDebugForkJoinWorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory
+{
+    @Override
+    public final ForkJoinWorkerThread newThread(ForkJoinPool pool)
+    {
+        return new IDEDebugForkJoinWorkerThread(pool);
+    }
+
+    private static class IDEDebugForkJoinWorkerThread extends ForkJoinWorkerThread
+    {
+        private IDEDebugForkJoinWorkerThread(final ForkJoinPool pool)
+        {
+            super(pool);
+            setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        }
+    }
+}


### PR DESCRIPTION
nsure parent thread ContextClassLoader is used in debug thread