### PR TITLE
Upgrade legend-pure to 5.31.1

### DIFF
--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-pure/src/test/java/org/finos/legend/engine/code/core/TestCoreFunctionActivatorCompiledStateIntegrity.java
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-pure/src/test/java/org/finos/legend/engine/code/core/TestCoreFunctionActivatorCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.engine.code.core;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestCoreFunctionActivatorCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
@@ -32,14 +31,5 @@ public class TestCoreFunctionActivatorCompiledStateIntegrity extends AbstractCom
     public void testReferenceUsages()
     {
         super.testReferenceUsages();
-    }
-
-    @Test
-    @Ignore
-    @Override
-    public void testPropertyValueTypes()
-    {
-        // TODO This test is failing sporadically: fix it
-        super.testPropertyValueTypes();
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-pure/src/test/java/org/finos/legend/pure/code/core/TestCoreRelationalTrinoCompiledStateIntegrity.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-pure/src/test/java/org/finos/legend/pure/code/core/TestCoreRelationalTrinoCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.code.core;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestCoreRelationalTrinoCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
@@ -32,14 +31,5 @@ public class TestCoreRelationalTrinoCompiledStateIntegrity extends AbstractCompi
     public void testReferenceUsages()
     {
         super.testReferenceUsages();
-    }
-
-    @Test
-    @Ignore
-    @Override
-    public void testPropertyValueTypes()
-    {
-        // TODO This test is failing sporadically: fix it
-        super.testPropertyValueTypes();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>5.30.0</legend.pure.version>
+        <legend.pure.version>5.31.1</legend.pure.version>
         <legend.shared.version>0.25.7</legend.shared.version>
         <legend.web-application.version>13.2.0</legend.web-application.version>
 


### PR DESCRIPTION
#### What type of PR is this?

Dependency upgrade

#### What does this PR do / why is it needed ?

Upgrade legend-pure to 5.31.1. This fixes several bugs, including those causing the sporadic test failures related to [PR 3344](https://github.com/finos/legend-engine/pull/3344).


#### Does this PR introduce a user-facing change?

No