### PR TITLE
Add ability to opt-out of some lineage calculations

### DIFF
--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/src/main/resources/core_analytics_lineage/fullAnalytics.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/src/main/resources/core_analytics_lineage/fullAnalytics.pure
@@ -44,6 +44,14 @@ Class meta::analytics::lineage::FunctionAnalytics
    reportLineage : ReportLineage[1];
 }
 
+Class meta::analytics::lineage::FunctionAnalyticsConfig
+{
+  databaseLineage: Boolean[1];
+  classLineage: Boolean[1];
+  relationTree: Boolean[1];
+  reportLineage: Boolean[1];
+}
+
 Class meta::analytics::lineage::ReportLineage
 {
    columns : ReportColumn[*];
@@ -81,8 +89,18 @@ Class meta::analytics::lineage::PropertyElement
    type : String[0..1];
 }
 
+function meta::analytics::lineage::buildDefaultAnalyticsConfig(): FunctionAnalyticsConfig[1]
+{
+  ^FunctionAnalyticsConfig
+  (
+    databaseLineage = true,
+    classLineage = true,
+    relationTree = true,
+    reportLineage = true
+  )
+}
 
-function meta::analytics::lineage::computeLineage(f:FunctionDefinition<Any>[1], m:Mapping[1], r:Runtime[0..1], extensions:meta::pure::extension::Extension[*]):FunctionAnalytics[1]
+function meta::analytics::lineage::computeLineage(f:FunctionDefinition<Any>[1], m:Mapping[1], r:Runtime[0..1], extensions:meta::pure::extension::Extension[*], config: FunctionAnalyticsConfig[1]):FunctionAnalytics[1]
 {
    let mappings = if($r->isEmpty(), |$m, |$m->concatenate(getMappingsFromRuntime($r->toOne())));
    let modelToModelMappings = $mappings->init();
@@ -99,23 +117,32 @@ function meta::analytics::lineage::computeLineage(f:FunctionDefinition<Any>[1], 
                                 |$updatedFuncBody->map(e|$e->cast(@FunctionExpression)->meta::pure::mapping::modelToModel::chain::allReprocess([], $modelToModelMappings, $extensions, noDebug()).res));
 
    let vars = $f->functionType().parameters->evaluateAndDeactivate()->map(p| pair($p.name, ^List<PlanVarPlaceHolder>(values = ^PlanVarPlaceHolder(name=$p.name, type = $p.genericType.rawType->toOne(), multiplicity=$p.multiplicity))));
-   let relationTree = if($f->functionReturnType().rawType->toOne()->_subTypeOf(TabularDataSet) && $r->isNotEmpty() && $modelToModelMappings->isEmpty(),
-                            | scanRelations(^LambdaFunction<{->Any[*]}>(expressionSequence = $funcBody), $sourceMapping, $r->toOne(), $vars, noDebug(), $extensions),
-                            | scanRelations($combinedTrees->last()->toOne(), $sourceMapping));
    let classLineageMapping = if($modelToModelMappings->isEmpty() && $mappings->size() == 1, | $sourceMapping, | $modelToModelMappings);
    ^FunctionAnalytics
    (
-      databaseLineage = $f->toFlowDatabase($sourceMapping, $combinedTrees, $r)->toGraph(),
-      classLineage = $f->toFlowClass($combinedTrees, $classLineageMapping)->toGraph(),
+      databaseLineage = if($config.databaseLineage, |$f->toFlowDatabase($sourceMapping, $combinedTrees, $r)->toGraph(), |^Graph()),
+      classLineage = if($config.classLineage, |$f->toFlowClass($combinedTrees, $classLineageMapping)->toGraph(), |^Graph()),
       functionTrees = $combinedTrees,
-      relationTree = $relationTree,
-      reportLineage = buildReportLineage($reprocessedFuncBody->last()->toOne(), $sourceMapping,$vars->newMap())
+      relationTree = if($config.relationTree, |if($f->functionReturnType().rawType->toOne()->_subTypeOf(TabularDataSet) && $r->isNotEmpty() && $modelToModelMappings->isEmpty(),
+                                                    | scanRelations(^LambdaFunction<{->Any[*]}>(expressionSequence = $funcBody), $sourceMapping, $r->toOne(), $vars, noDebug(), $extensions),
+                                                    | scanRelations($combinedTrees->last()->toOne(), $sourceMapping)), |^RelationTree()),
+      reportLineage = if($config.reportLineage, |buildReportLineage($reprocessedFuncBody->last()->toOne(), $sourceMapping,$vars->newMap()), |^ReportLineage())
    );
+}
+
+function meta::analytics::lineage::computeLineage(f:FunctionDefinition<Any>[1], m:Mapping[1], extensions:meta::pure::extension::Extension[*], config: FunctionAnalyticsConfig[1]):FunctionAnalytics[1]
+{
+   computeLineage($f, $m, [], $extensions, $config);
+}
+
+function meta::analytics::lineage::computeLineage(f:FunctionDefinition<Any>[1], m:Mapping[1], r:Runtime[0..1], extensions:meta::pure::extension::Extension[*]):FunctionAnalytics[1]
+{
+   computeLineage($f, $m, $r, $extensions, buildDefaultAnalyticsConfig());
 }
 
 function meta::analytics::lineage::computeLineage(f:FunctionDefinition<Any>[1], m:Mapping[1], extensions:meta::pure::extension::Extension[*]):FunctionAnalytics[1]
 {
-   computeLineage($f, $m, [], $extensions);
+   computeLineage($f, $m, [], $extensions, buildDefaultAnalyticsConfig());
 }
 
 function meta::analytics::lineage::buildReportLineage(e:Execute[1]):ReportLineage[1]

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/trans.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/trans.pure
@@ -234,9 +234,15 @@ function meta::analytics::search::transformation::getExtensions(): meta::pure::e
 
 function meta::analytics::search::transformation::service::buildDatabaseColumnDocuments(funcDefinition: FunctionDefinition<Any>[1], mapping: meta::pure::mapping::Mapping[1], runtime: meta::core::runtime::Runtime[1]): meta::analytics::search::metamodel::mapping::DatabaseColumn[*]
 {
-  let lineage = $funcDefinition->meta::analytics::lineage::computeLineage($mapping, $runtime, meta::analytics::search::transformation::getExtensions());
-
-  let columnLineage = $lineage.reportLineage->meta::analytics::lineage::transformColumns();
+  let lineageConfig = ^meta::analytics::lineage::FunctionAnalyticsConfig
+  (
+    databaseLineage = false,
+    classLineage = false,
+    relationTree = false,
+    reportLineage = true
+  );
+  let allLineage = $funcDefinition->meta::analytics::lineage::computeLineage($mapping, $runtime, meta::analytics::search::transformation::getExtensions(), $lineageConfig);
+  let columnLineage = $allLineage.reportLineage->meta::analytics::lineage::transformColumns();
   let tables = $columnLineage->map(l|
     $l.columns->map(c|
       ^meta::analytics::search::metamodel::mapping::DatabaseColumn(


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Adds a configuration for the `computeLineage` function to allow for opting out of some types of calculations.
This allows for computationally expensive calculations to be skipped if only a subset of lineage is required.

Updated the SearchDocumentArtifactGenerationExtension to only calculate `reportLineage` as this is all that is required. This will dramatically speed up calculation for some Service elements.

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

