### PR TITLE
Ignoring 2 slow integrity test classes

### DIFF
--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/test/java/org/finos/legend/pure/code/core/TestCoreServicestoreCompiledStateIntegrity.java
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/src/test/java/org/finos/legend/pure/code/core/TestCoreServicestoreCompiledStateIntegrity.java
@@ -16,8 +16,10 @@ package org.finos.legend.pure.code.core;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class TestCoreServicestoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
     @BeforeClass
@@ -30,7 +32,6 @@ public class TestCoreServicestoreCompiledStateIntegrity extends AbstractCompiled
     @Override
     public void testReferenceUsages()
     {
-        // TODO fix this test
         super.testReferenceUsages();
     }
 }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/test/java/org/finos/legend/engine/code/core/TestCoreExternalQuerySqlCompiledStateIntegrity.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-pure/src/test/java/org/finos/legend/engine/code/core/TestCoreExternalQuerySqlCompiledStateIntegrity.java
@@ -16,8 +16,10 @@ package org.finos.legend.engine.code.core;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class TestCoreExternalQuerySqlCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
     @BeforeClass


### PR DESCRIPTION
#### What type of PR is this?

- Improvement


#### What does this PR do / why is it needed ?
- Ignore integrity tests that are taking longer than 1min while we work on the permanent fix to speed up the slow tests.

#### Which issue(s) this PR fixes:


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
- no user-facing change
