### PR TITLE
External Format Java Gen: generate code for qualified properties

### DIFF
--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/src/main/resources/core_java_platform_binding_external_format/legendJavaPlatformBinding/externalFormat/shared.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/src/main/resources/core_java_platform_binding_external_format/legendJavaPlatformBinding/externalFormat/shared.pure
@@ -330,7 +330,8 @@ function meta::external::format::shared::executionPlan::platformBinding::legendJ
 
    let constraintChecking = if($constraintContext.enableConstraints, | $dataClass->createConstraintCheckingForClass($class, $path, $context, $constraintContext, $debug), | newProject());
    let instanceSizing     = $dataClass->updateImplementationClassWithInstanceSizeMethods($context);
-   mergeProjects(newProject()->concatenate([$constraintChecking, $instanceSizing])->toOneMany());
+   let withQPs            = $dataClass->meta::pure::executionPlan::platformBinding::legendJava::shared::createQualifiedPropertiesForClass($context.typeInfos->allQualifiedProperties($class), $context.conventions, $debug->indent());
+   mergeProjects(newProject()->concatenate([$constraintChecking, $instanceSizing, $withQPs])->toOneMany());
 }
 
 function meta::external::format::shared::executionPlan::platformBinding::legendJava::addIExternalData(javaClass:meta::external::language::java::metamodel::Class[1], class:meta::pure::metamodel::type::Class<Any>[1], context:GenerationContext[1]): meta::external::language::java::metamodel::Class[1]

--- a/legend-engine-xts-xml/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/executionPlan/tests/executionPlanTest.pure
@@ -53,6 +53,7 @@ Class meta::external::format::xml::executionPlan::test::PersonWithFirmConstraint
   dateOfBirth : StrictDate[0..1];
   firm        : Firm[1];
   addresses   : Address[1..*];
+  firmLegalName() { $this.firm.legalName} : String[1];
 }
 
 Class meta::external::format::xml::executionPlan::test::Firm

--- a/legend-engine-xts-xml/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/executionPlan/tests/simple.pure
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-pure/src/main/resources/core_external_format_xml/executionPlan/tests/simple.pure
@@ -141,3 +141,35 @@ function  <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnl
   // TODO [internalize] should only fetch primitive properties
   assertEquals('{"builder":{"_type":"json"},"values":{"defects":[],"source":{"number":1,"record":"<personWithFirmConstraint firstName=\\"John\\" lastName=\\"Doe\\"><age>23</age><dateOfBirth>2000-01-01</dateOfBirth><firm><legalName>FirmName</legalName><firmAddress><street>Mapletree</street></firmAddress><firmAddress><street>Anson</street></firmAddress><active>true</active></firm><addresses><street>Raffles</street></addresses><addresses><street>Link</street></addresses></personWithFirmConstraint>"},"value":{"firstName":"John","lastName":"Doe","age":23,"dateOfBirth":"2000-01-01","firm":{"legalName":"FirmName","firmAddress":[{"street":"Mapletree"},{"street":"Anson"}],"active":true},"addresses":[{"street":"Raffles"},{"street":"Link"}]}}}', $result);
 }
+
+function  <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> meta::external::format::xml::executionPlan::test::testXmlConstraintPassWithQP(): Boolean[0..1]
+{
+  let tree = #{meta::external::format::xml::executionPlan::test::PersonWithFirmConstraint{firstName, lastName, age, dateOfBirth, 'Firm Legal Name' : firmLegalName, firm{legalName, firmAddress{street}, active}, addresses{street}}}#;
+  let binding  = compileLegendGrammar(readFile('/core_external_format_xml/executionPlan/tests/resources/constraint.txt')->toOne())->filter(e | $e->instanceOf(Binding))->cast(@Binding)->toOne();
+  let query   = {data:String[1]| meta::external::format::xml::executionPlan::test::PersonWithFirmConstraint->internalize($binding, $data)->checked()->serialize($tree)};
+  let data = '<personWithFirmConstraint firstName="John" lastName="Doe">\n'+
+    '  <age>23</age>\n'+
+    '  <dateOfBirth>2000-01-01</dateOfBirth>\n'+
+    '  <firm>\n'+
+    '    <legalName>FirmName</legalName>\n'+
+    '    <firmAddress>\n' +
+    '      <street>Mapletree</street>\n'+
+    '    </firmAddress>\n'+
+    '    <firmAddress>\n' +
+    '      <street>Anson</street>\n'+
+    '    </firmAddress>\n'+
+    '    <active>true</active>\n'+
+    '  </firm>\n'+
+    '  <addresses>\n'+
+    '    <street>Raffles</street>\n'+
+    '  </addresses>\n'+
+    '  <addresses>\n'+
+    '    <street>Link</street>\n'+
+    '  </addresses>\n'+
+    '</personWithFirmConstraint>';
+
+  let result  = meta::external::format::xml::executionPlan::test::executeXsdSchemaBindingQuery($query, pair('data', $data));
+
+  // TODO [internalize] should only fetch primitive properties
+  assertEquals('{"builder":{"_type":"json"},"values":{"defects":[],"source":{"number":1,"record":"<personWithFirmConstraint firstName=\\"John\\" lastName=\\"Doe\\"><age>23</age><dateOfBirth>2000-01-01</dateOfBirth><firm><legalName>FirmName</legalName><firmAddress><street>Mapletree</street></firmAddress><firmAddress><street>Anson</street></firmAddress><active>true</active></firm><addresses><street>Raffles</street></addresses><addresses><street>Link</street></addresses></personWithFirmConstraint>"},"value":{"firstName":"John","lastName":"Doe","age":23,"dateOfBirth":"2000-01-01","Firm Legal Name":"FirmName","firm":{"legalName":"FirmName","firmAddress":[{"street":"Mapletree"},{"street":"Anson"}],"active":true},"addresses":[{"street":"Raffles"},{"street":"Link"}]}}}', $result);
+}


### PR DESCRIPTION
Generate Java code for qualified properties in ExternalFormats flow, specifically for data classes representing the model that is used for internalize/externalize