### PR TITLE
Fix parseFloat dyna function for memSQL

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/sqlQueryToString/memSQLExtension.pure
@@ -120,7 +120,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memsq
     dynaFnToSql('monthNumber',               $allStates,            ^ToSql(format='month(%s)')),
     dynaFnToSql('mostRecentDayOfWeek',       $allStates,            ^ToSql(format='adddate(%s, INTERVAL case when %s - dayofweek(%s) > 0 then %s - dayofweek(%s) - 7 else %s - dayofweek(%s) end DAY)', transform={p:String[1..2] | $p->formatMostRecentMemSQL('curdate()')}, parametersWithinWhenClause = [false, false])),
     dynaFnToSql('now',                       $allStates,            ^ToSql(format='now()')),
-    dynaFnToSql('parseFloat',                $allStates,            ^ToSql(format='cast(%s as decimal)')),
+    dynaFnToSql('parseFloat',                $allStates,            ^ToSql(format='%s :> DOUBLE')),
     dynaFnToSql('parseInteger',              $allStates,            ^ToSql(format='cast(%s as signed integer)')),
     dynaFnToSql('position',                  $allStates,            ^ToSql(format='LOCATE(%s, %s)')),
     dynaFnToSql('previousDayOfWeek',         $allStates,            ^ToSql(format='adddate(%s, INTERVAL case when %s - dayofweek(%s) >= 0 then %s - dayofweek(%s) - 7 else %s - dayofweek(%s) end DAY)', transform={p:String[1..2] | $p->formatMostRecentMemSQL('curdate()')}, parametersWithinWhenClause = [false, false])),
@@ -190,8 +190,6 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::memsq
   let msqlDate = $formatpairs->fold( {sub, date|  $date->toOne()->replace($sub.first,$sub.second)},$params->at(2));
   format('TO_CHAR(CONVERT_TZ(%s,\'%s\',%s),%s)',[$params->at(0),$sourceTZ,$params->at(1),$msqlDate]);
 }
-
-
 
 function  <<access.private>> meta::relational::functions::sqlQueryToString::memsql::generateDateDiffExpressionForMemSQL(params:String[*]):String[1]
 {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/src/main/resources/core_relational_memsql/relational/tests/mapping/sqlFunction/testSqlFunctionsInMapping.pure
@@ -51,7 +51,7 @@ function <<test.Test>> meta::relational::memsql::tests::mapping::sqlFunction::st
    let memSql = toSQLString(|SqlFunctionDemo.all()->project([s | $s.string2Float], ['string2Float']),
                          testMapping,
                          meta::relational::runtime::DatabaseType.MemSQL, meta::relational::extension::relationalExtensions());
-   assertEquals('select cast(`root`.string2float as decimal) as `string2Float` from dataTable as `root`',$memSql);
+   assertEquals('select `root`.string2float :> DOUBLE as `string2Float` from dataTable as `root`',$memSql);
 }
 
 function <<test.Test>> meta::relational::memsql::tests::mapping::sqlFunction::toString::testToSQLStringToString_MemSQL():Boolean[1]


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?
Issue - Generated SQL for parseFloat in memSQL truncates floating point numbers to integers
|           | Before Fix                                | After Fix                         |
|-----    | ------                                       | ------                              |
|Query  |   cast('3.14159' as decimal)     |   '3.14159' :> DOUBLE   |
|Result  |     3                                          |      3.14159                    |
