### PR TITLE
Add isolation level support to relational block

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/blockConnection/BlockConnectionContext.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/blockConnection/BlockConnectionContext.java
@@ -20,9 +20,11 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.Conne
 import org.finos.legend.engine.plan.execution.stores.relational.connection.manager.ConnectionManagerSelector;
 import org.finos.legend.engine.plan.execution.stores.relational.plugin.RelationalStoreExecutionState;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseConnection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.TransactionIsolationLevel;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.operational.Assert;
 
+import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
 public class BlockConnectionContext
@@ -82,5 +84,19 @@ public class BlockConnectionContext
     public BlockConnectionContext copy()
     {
         return new BlockConnectionContext(Maps.mutable.ofMap(this.blockConnectionMap));
+    }
+
+    public void setIsolationLevel(TransactionIsolationLevel isolationLevel)
+    {
+        this.blockConnectionMap.values().forEach(conn -> {
+            try
+            {
+                conn.setTransactionIsolation(isolationLevel.getLevel());
+            }
+            catch (SQLException e)
+            {
+                throw new RuntimeException("Failed to set transaction isolation level: " + isolationLevel, e);
+            }
+        });
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/plugin/RelationalExecutionNodeExecutor.java
@@ -192,6 +192,11 @@ public class RelationalExecutionNodeExecutor implements ExecutionNodeVisitor<Res
             ((RelationalStoreExecutionState) connectionAwareState.getStoreExecutionState(StoreType.Relational)).setRetainConnection(true);
             try
             {
+                // Set isolation level if specified
+                if (relationalBlockExecutionNode.isolationLevel != null)
+                {
+                    ((RelationalStoreExecutionState) connectionAwareState.getStoreExecutionState(StoreType.Relational)).getBlockConnectionContext().setIsolationLevel(relationalBlockExecutionNode.isolationLevel);
+                }
                 Result res = new ExecutionNodeExecutor(this.identity, connectionAwareState).visit((SequenceExecutionNode) relationalBlockExecutionNode);
                 ((RelationalStoreExecutionState) connectionAwareState.getStoreExecutionState(StoreType.Relational)).getBlockConnectionContext().unlockAllBlockConnections();
                 return res;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/RelationalBlockIsolationLevelTest.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/RelationalBlockIsolationLevelTest.java
@@ -1,0 +1,59 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.test;
+
+import org.finos.legend.engine.plan.execution.stores.relational.blockConnection.BlockConnection;
+import org.finos.legend.engine.plan.execution.stores.relational.blockConnection.BlockConnectionContext;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.TransactionIsolationLevel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class RelationalBlockIsolationLevelTest
+{
+    @Test
+    public void testSetIsolationLevel() throws SQLException
+    {
+        // Setup
+        Connection mockConnection = Mockito.mock(Connection.class);
+        BlockConnection blockConnection = new BlockConnection(mockConnection);
+        BlockConnectionContext context = new BlockConnectionContext();
+        
+        // Add the block connection to the context using reflection
+        java.lang.reflect.Method setBlockConnectionMethod;
+        try
+        {
+            setBlockConnectionMethod = BlockConnectionContext.class.getDeclaredMethod("setBlockConnection", 
+                org.finos.legend.engine.plan.execution.stores.relational.connection.manager.ConnectionManagerSelector.class,
+                org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseConnection.class,
+                BlockConnection.class);
+            setBlockConnectionMethod.setAccessible(true);
+            setBlockConnectionMethod.invoke(context, null, null, blockConnection);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+        
+        // Test
+        context.setIsolationLevel(TransactionIsolationLevel.SERIALIZABLE);
+        
+        // Verify
+        Mockito.verify(mockConnection).setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/RelationalBlockExecutionNode.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/executionPlan/nodes/RelationalBlockExecutionNode.java
@@ -14,12 +14,15 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.executionPlan.nodes;
 
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.TransactionIsolationLevel;
+
 import java.util.Collections;
 import java.util.List;
 
 public class RelationalBlockExecutionNode extends SequenceExecutionNode
 {
     public List<ExecutionNode> finallyExecutionNodes = Collections.emptyList();
+    public TransactionIsolationLevel isolationLevel;
 
     @Override
     public <T> T accept(ExecutionNodeVisitor<T> executionNodeVisitor)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/TransactionIsolationLevel.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/TransactionIsolationLevel.java
@@ -1,0 +1,57 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection;
+
+import java.sql.Connection;
+
+public enum TransactionIsolationLevel
+{
+    NONE(Connection.TRANSACTION_NONE),
+    READ_UNCOMMITTED(Connection.TRANSACTION_READ_UNCOMMITTED),
+    READ_COMMITTED(Connection.TRANSACTION_READ_COMMITTED),
+    REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ),
+    SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE);
+
+    private final int level;
+
+    TransactionIsolationLevel(int level)
+    {
+        this.level = level;
+    }
+
+    public int getLevel()
+    {
+        return this.level;
+    }
+
+    public static TransactionIsolationLevel fromJdbcLevel(int jdbcLevel)
+    {
+        switch (jdbcLevel)
+        {
+            case Connection.TRANSACTION_NONE:
+                return NONE;
+            case Connection.TRANSACTION_READ_UNCOMMITTED:
+                return READ_UNCOMMITTED;
+            case Connection.TRANSACTION_READ_COMMITTED:
+                return READ_COMMITTED;
+            case Connection.TRANSACTION_REPEATABLE_READ:
+                return REPEATABLE_READ;
+            case Connection.TRANSACTION_SERIALIZABLE:
+                return SERIALIZABLE;
+            default:
+                throw new IllegalArgumentException("Unknown JDBC isolation level: " + jdbcLevel);
+        }
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/executionPlan.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/executionPlan.pure
@@ -121,4 +121,5 @@ Class meta::relational::mapping::CreateAndPopulateTempTableExecutionNode extends
 Class meta::pure::executionPlan::RelationalBlockExecutionNode extends meta::pure::executionPlan::SequenceExecutionNode
 {
   finallyExecutionNodes :  ExecutionNode[*];
+  isolationLevel : String[0..1];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/extension/extension_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/extension/extension_relational.pure
@@ -113,7 +113,8 @@ function meta::protocols::pure::vX_X_X::extension::getRelationalExtension():meta
                      rb:meta::pure::executionPlan::RelationalBlockExecutionNode[1]|
                                ^meta::protocols::pure::vX_X_X::metamodel::executionPlan::RelationalBlockExecutionNode( _type = 'relationalBlock',
                                                                                                                        resultType = $rb.resultType->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::executionPlan::transformResultType($extensions),
-                                                                                                                       finallyExecutionNodes = $rb.finallyExecutionNodes->map(n|$n->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::executionPlan::transformNode($extensions)));,
+                                                                                                                       finallyExecutionNodes = $rb.finallyExecutionNodes->map(n|$n->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::executionPlan::transformNode($extensions)),
+                                                                                                                       isolationLevel = $rb.isolationLevel->map(i| $i->toString()->toOne()->meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::TransactionIsolationLevel));,
                      rel:meta::relational::mapping::SQLExecutionNode[1]|
                         ^meta::protocols::pure::vX_X_X::metamodel::executionPlan::SQLExecutionNode(
                            _type = 'sql',

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/models/executionPlan_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/models/executionPlan_relational.pure
@@ -125,6 +125,7 @@ Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::LoadFromResultSet
 Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::RelationalBlockExecutionNode extends SequenceExecutionNode
 {
   finallyExecutionNodes : ExecutionNode[*];
+  isolationLevel : meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::TransactionIsolationLevel[0..1];
 }
 
 Class meta::protocols::pure::vX_X_X::metamodel::executionPlan::CreateAndPopulateTempTableExecutionNode extends ExecutionNode

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/models/metamodel_transaction.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/vX_X_X/models/metamodel_transaction.pure
@@ -1,0 +1,24 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::*;
+
+Enum meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::TransactionIsolationLevel
+{
+   NONE,
+   READ_UNCOMMITTED,
+   READ_COMMITTED,
+   REPEATABLE_READ,
+   SERIALIZABLE
+}


### PR DESCRIPTION
# Add Isolation Level Support to Relational Block in Legend Engine

This PR adds support for transaction isolation levels in relational blocks by:

1. Creating a new enum `TransactionIsolationLevel` that maps to the standard JDBC isolation levels
2. Adding an `isolationLevel` property to `RelationalBlockExecutionNode`
3. Updating `RelationalExecutionNodeExecutor` to set the isolation level on connections
4. Adding a method to `BlockConnectionContext` to set the isolation level on all connections

The isolation levels supported are:
- NONE (Connection.TRANSACTION_NONE)
- READ_UNCOMMITTED (Connection.TRANSACTION_READ_UNCOMMITTED)
- READ_COMMITTED (Connection.TRANSACTION_READ_COMMITTED)
- REPEATABLE_READ (Connection.TRANSACTION_REPEATABLE_READ)
- SERIALIZABLE (Connection.TRANSACTION_SERIALIZABLE)

## Pure Metamodel Changes

In addition to the Java implementation, this PR also adds isolation level support to the Pure metamodel in the vX_X_X protocol version:

1. Created a new `TransactionIsolationLevel` enum in the Pure metamodel
2. Added an `isolationLevel` property to the `RelationalBlockExecutionNode` class in the Pure metamodel
3. Updated the transformation function to handle the new property

These changes ensure that isolation levels can be properly represented in the Pure model and correctly transformed to the protocol model.

This implementation ensures backward compatibility by making the isolation level property optional. Existing code that doesn't specify an isolation level will continue to work with the default isolation level of the database.

## Link to Devin run
https://app.devin.ai/sessions/e79a769f53b54ed8976bc6696ceb2638

## Requested by
mohammed.ibrahim@gs.com
