### PR TITLE
Add README.md for legend-engine-xts-data-space module

### DIFF
--- a/legend-engine-xts-data-space/README.md
+++ b/legend-engine-xts-data-space/README.md
@@ -1,0 +1,91 @@
+# Legend Engine - XTS - Data Space
+
+## Overview
+The Data Space module provides functionality for defining and managing data spaces in Legend Engine. A data space is a packagable element that encapsulates execution contexts, diagrams, and executables, allowing users to organize and interact with their data models in a structured way.
+
+## Key Components
+The Data Space module consists of several submodules:
+
+- **legend-engine-xt-data-space-compiler**: Provides compilation functionality for data spaces
+- **legend-engine-xt-data-space-generation**: Handles generation of artifacts from data spaces
+- **legend-engine-xt-data-space-grammar**: Defines the grammar for data space definitions
+- **legend-engine-xt-data-space-http-api**: Exposes HTTP API endpoints for data space functionality
+- **legend-engine-xt-data-space-protocol**: Defines the protocol for data space communication
+- **legend-engine-xt-data-space-pure**: Contains Pure language implementations for data spaces
+- **legend-engine-xt-data-space-pure-metamodel**: Defines the metamodel for data spaces
+
+## Core Concepts
+
+### DataSpace
+A DataSpace is a packagable element that contains:
+- Execution contexts with mappings and runtimes
+- Diagrams for visual representation
+- Executables (services, functions) that can be run within the data space
+- Support information for documentation and assistance
+
+### DataSpaceExecutionContext
+An execution context within a data space that defines:
+- A mapping for data transformation
+- A default runtime for execution
+- Optional test data for testing
+
+### DataSpaceDiagram
+A diagram associated with a data space for visual representation of the data model.
+
+### DataSpaceExecutable
+An executable element within a data space, which can be:
+- A packagable element executable (service, function)
+- A template executable with a query
+
+## Integration with Legend Engine
+The Data Space module integrates with the core Legend Engine components:
+- Uses the Pure language for defining data spaces
+- Leverages the mapping and runtime functionality for execution
+- Provides HTTP API endpoints for data space analytics
+- Supports compilation and generation of data space artifacts
+
+## Usage
+Data spaces can be defined using the Pure language. Here's a simple example:
+
+```pure
+DataSpace domain::MyDataSpace
+{
+  executionContexts:
+  [
+    {
+      name: 'myContext';
+      mapping: domain::MyMapping;
+      defaultRuntime: domain::MyRuntime;
+    }
+  ];
+  defaultExecutionContext: 'myContext';
+  title: 'My Data Space';
+  description: 'This is my data space for organizing my data models.';
+  
+  executables:
+  [
+    {
+      title: 'My Executable';
+      id: 'myExecutable';
+      description: 'This is my executable service';
+      executable: domain::MyService;
+    }
+  ];
+}
+```
+
+## API Endpoints
+The Data Space module provides HTTP API endpoints for analyzing data spaces:
+
+- `POST /pure/v1/analytics/dataSpace/render`: Analyzes a data space to collect information needed for rendering
+- `POST /pure/v1/analytics/dataSpace/coverage`: Analyzes a data space to get model coverage information
+
+## Dependencies
+The Data Space module depends on:
+- Core Legend Engine modules for compilation and execution
+- Pure language for defining data spaces
+- Mapping and runtime modules for execution contexts
+- Diagram module for visual representation
+
+## Contributing
+For information on how to contribute to this module, please refer to the [Legend contribution guide](https://github.com/finos/legend/blob/master/CONTRIBUTING.md).

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/README.md
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/README.md
@@ -1,0 +1,127 @@
+# Legend Engine - XT - Data Space - Pure Metamodel
+
+## Overview
+This module defines the Pure language metamodel for DataSpace functionality in Legend Engine. It contains the core classes and relationships that make up the DataSpace metamodel, providing the foundation for defining and working with data spaces.
+
+## Metamodel Structure
+The DataSpace metamodel is defined in Pure language and consists of several key classes:
+
+### DataSpace
+The main class that represents a data space in Legend Engine. It extends `PackageableElement` and includes:
+- Title and description for documentation
+- Collection of execution contexts with at least one default context
+- Optional diagrams for visual representation
+- Collection of elements (PackageableElements) included in the data space
+- Collection of executables (services, functions) that can be run within the data space
+- Optional support information for assistance
+
+### DataSpaceExecutionContext
+Defines an execution context within a data space, containing:
+- Name, title, and description
+- Reference to a mapping for data transformation
+- Reference to a default runtime for execution
+- Optional test data for testing
+
+### DataSpaceDiagram
+Associates a diagram with a data space for visual representation:
+- Title and description
+- Reference to a diagram
+
+### DataSpaceExecutable
+Base class for executables in a data space:
+- Title and ID
+- Description
+- Optional execution context key
+
+### DataSpacePackageableElementExecutable
+Extends DataSpaceExecutable to reference a packagable element (like a service or function):
+- All properties from DataSpaceExecutable
+- Reference to a PackageableElement
+
+### DataSpaceTemplateExecutable
+Extends DataSpaceExecutable to define a template with a query:
+- All properties from DataSpaceExecutable
+- Query as a FunctionDefinition
+
+### DataSpaceSupportInfo
+Abstract base class for support information:
+- Optional documentation URL
+
+### DataSpaceSupportEmail
+Support information with an email address:
+- Extends DataSpaceSupportInfo
+- Email address
+
+### DataSpaceSupportCombinedInfo
+Support information with multiple contact methods:
+- Extends DataSpaceSupportInfo
+- Collection of email addresses
+- Optional website, FAQ URL, and support URL
+
+## Helper Functions
+The module includes helper functions for working with DataSpace objects:
+
+### get(DataSpace, String): DataSpaceExecutionContext
+Retrieves an execution context from a data space by name:
+```pure
+function meta::pure::metamodel::dataSpace::get(ds: DataSpace[1], key: String[1]): DataSpaceExecutionContext[1]
+{
+  let context = $ds.executionContexts->cast(@DataSpaceExecutionContext)->filter(x| $x.name == $key->toOne());
+  assert($context->isNotEmpty(),| 'The key value provided is not present in the dataspace contexts');
+  $context->at(0);
+}
+```
+
+## Mapping Extensions
+The module extends mapping functionality to work with data spaces:
+
+### from(T, DataSpace): T
+Allows specifying a data space when using the `from` function:
+```pure
+function <<functionType.NotImplementedFunction>> meta::pure::mapping::from<T|m>(t: T[m], dataSpace: meta::pure::metamodel::dataSpace::DataSpace[1]): T[m]
+{
+   $t
+}
+```
+
+### from(T, DataSpaceExecutionContext): T
+Allows specifying a data space execution context when using the `from` function:
+```pure
+function <<functionType.NotImplementedFunction>> meta::pure::mapping::from<T|m>(t: T[m], dataSpace: meta::pure::metamodel::dataSpace::DataSpaceExecutionContext[1]): T[m]
+{
+   $t
+}
+```
+
+## Class Diagram
+The metamodel includes a class diagram that visualizes the relationships between the DataSpace classes:
+
+- DataSpace extends PackageableElement
+- DataSpace has many DataSpaceExecutionContext instances, with one designated as default
+- DataSpace has many DataSpaceDiagram instances
+- DataSpace has many PackageableElement instances
+- DataSpace has many DataSpaceExecutable instances
+- DataSpace has an optional DataSpaceSupportInfo
+- DataSpaceExecutionContext references a Mapping and a PackageableRuntime
+- DataSpaceSupportEmail and DataSpaceSupportCombinedInfo extend DataSpaceSupportInfo
+
+## Integration with Legend Engine
+This metamodel integrates with other Legend Engine components:
+- Uses the Pure language for defining the metamodel
+- Integrates with mapping and runtime functionality
+- Supports compilation and generation of data space artifacts
+- Provides the foundation for data space analytics
+
+## Dependencies
+The module depends on:
+- Core Legend Engine modules
+- Pure language modules
+- Mapping and runtime modules
+- Diagram modules
+
+## Usage
+The DataSpace metamodel is used by other Legend Engine modules to:
+- Define data spaces in Pure language
+- Compile data space definitions
+- Generate artifacts from data spaces
+- Analyze data spaces for coverage and other metrics

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-ascii.txt
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-ascii.txt
@@ -1,0 +1,128 @@
+# DataSpace Metamodel - ASCII Art Representation
+
+```
+                                 +-------------------+
+                                 | PackageableElement|
+                                 +--------+----------+
+                                          |
+                                          | extends
+                                          v
++-------------------+            +-------------------+            +-------------------+
+| DataSpaceExecutable|<----------| DataSpace         |----------->| DataSpaceDiagram  |
++---------+---------+            |                   |            +---------+---------+
+          |                      | title: String[0..1]            |         |
+          | extends              | description: String[0..1]      |         | references
+    +-----+------+               | executionContexts: [1..*]      |         |
+    |            |               | defaultExecutionContext: [1]   |         v
+    v            v               | diagrams: [*]                  | +-------------------+
++-------------------+            | elements: [*]                  | | Diagram           |
+| PackageableElement|            | executables: [*]               | +-------------------+
+| Executable        |            | supportInfo: [0..1]            |
++-------------------+            +-----------+-------------+
+| executable:       |                        |
+| PackageableElement|                        | has
++-------------------+                        v
+                                  +-------------------+
++-------------------+             | DataSpaceExecution|
+| TemplateExecutable|             | Context           |
++-------------------+             |                   |
+| query:            |             | name: String[1]   |
+| FunctionDefinition|             | title: String[0..1]
++-------------------+             | description: String[0..1]
+                                  | mapping: Mapping[1]
+                                  | defaultRuntime: Runtime[1]
+                                  | testData: EmbeddedData[0..1]
+                                  +-------------------+
+                                           ^
+                                           |
++-------------------+                      | references
+| DataSpaceSupportInfo|<-------------------+
++---------+---------+
+          |
+          | extends
+    +-----+------+
+    |            |
+    v            v
++-------------------+            +-------------------+
+| SupportEmail      |            | CombinedInfo      |
++-------------------+            +-------------------+
+| address: String[1]|            | emails: String[*] |
++-------------------+            | website: String[0..1]
+                                 | faqUrl: String[0..1]
+                                 | supportUrl: String[0..1]
+                                 +-------------------+
+```
+
+## Key Class Relationships
+
+1. **Inheritance Relationships**
+   - DataSpace ← PackageableElement
+   - DataSpacePackageableElementExecutable ← DataSpaceExecutable
+   - DataSpaceTemplateExecutable ← DataSpaceExecutable
+   - DataSpaceSupportEmail ← DataSpaceSupportInfo
+   - DataSpaceSupportCombinedInfo ← DataSpaceSupportInfo
+
+2. **Composition Relationships**
+   - DataSpace *-- DataSpaceExecutionContext [1..*] (executionContexts)
+   - DataSpace *-- DataSpaceExecutionContext [1] (defaultExecutionContext)
+   - DataSpace *-- DataSpaceDiagram [*] (diagrams)
+   - DataSpace *-- PackageableElement [*] (elements)
+   - DataSpace *-- DataSpaceExecutable [*] (executables)
+   - DataSpace *-- DataSpaceSupportInfo [0..1] (supportInfo)
+
+3. **Association Relationships**
+   - DataSpaceExecutionContext --> Mapping [1] (mapping)
+   - DataSpaceExecutionContext --> PackageableRuntime [1] (defaultRuntime)
+   - DataSpaceExecutionContext --> EmbeddedData [0..1] (testData)
+   - DataSpaceDiagram --> Diagram [1] (diagram)
+   - DataSpacePackageableElementExecutable --> PackageableElement [1] (executable)
+   - DataSpaceTemplateExecutable --> FunctionDefinition [1] (query)
+
+## Property Details
+
+### DataSpace
+- title: String[0..1] - Optional title for the data space
+- description: String[0..1] - Optional description for the data space
+- executionContexts: DataSpaceExecutionContext[1..*] - One or more execution contexts
+- defaultExecutionContext: DataSpaceExecutionContext[1] - Default execution context
+- diagrams: DataSpaceDiagram[*] - Optional diagrams for visualization
+- elements: PackageableElement[*] - Optional elements included in the data space
+- executables: DataSpaceExecutable[*] - Optional executables in the data space
+- supportInfo: DataSpaceSupportInfo[0..1] - Optional support information
+
+### DataSpaceExecutionContext
+- name: String[1] - Required name for the execution context
+- title: String[0..1] - Optional title for the execution context
+- description: String[0..1] - Optional description for the execution context
+- mapping: Mapping[1] - Required mapping for data transformation
+- defaultRuntime: PackageableRuntime[1] - Required default runtime for execution
+- testData: EmbeddedData[0..1] - Optional test data for testing
+
+### DataSpaceDiagram
+- title: String[1] - Required title for the diagram
+- description: String[0..1] - Optional description for the diagram
+- diagram: Diagram[1] - Required reference to a diagram
+
+### DataSpaceExecutable
+- title: String[1] - Required title for the executable
+- id: String[1] - Required ID for the executable
+- description: String[0..1] - Optional description for the executable
+- executionContextKey: String[0..1] - Optional execution context key
+
+### DataSpacePackageableElementExecutable
+- executable: PackageableElement[1] - Required reference to a packagable element
+
+### DataSpaceTemplateExecutable
+- query: FunctionDefinition[1] - Required query as a function definition
+
+### DataSpaceSupportInfo
+- documentationUrl: String[0..1] - Optional documentation URL
+
+### DataSpaceSupportEmail
+- address: String[1] - Required email address
+
+### DataSpaceSupportCombinedInfo
+- emails: String[*] - Zero or more email addresses
+- website: String[0..1] - Optional website URL
+- faqUrl: String[0..1] - Optional FAQ URL
+- supportUrl: String[0..1] - Optional support URL

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-comprehensive.md
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-comprehensive.md
@@ -1,0 +1,236 @@
+# DataSpace Metamodel - Comprehensive Documentation
+
+## Overview
+The DataSpace metamodel defines the structure and relationships for data spaces in the Legend Engine. A data space is a packagable element that encapsulates execution contexts, diagrams, and executables, allowing users to organize and interact with their data models in a structured way.
+
+## Core Classes and Their Purpose
+
+### DataSpace
+**Purpose**: The main container class that represents a data space in Legend Engine.
+
+**Properties**:
+- `title: String[0..1]` - Optional title for the data space
+- `description: String[0..1]` - Optional description for the data space
+- `executionContexts: DataSpaceExecutionContext[1..*]` - One or more execution contexts
+- `defaultExecutionContext: DataSpaceExecutionContext[1]` - Default execution context
+- `diagrams: DataSpaceDiagram[*]` - Optional diagrams for visualization
+- `elements: PackageableElement[*]` - Optional elements included in the data space
+- `executables: DataSpaceExecutable[*]` - Optional executables in the data space
+- `supportInfo: DataSpaceSupportInfo[0..1]` - Optional support information
+
+**Inheritance**: Extends `PackageableElement`, inheriting its properties including `name`.
+
+**Significance**: DataSpace is the central class that organizes all components needed for a complete data space definition. It provides a way to package related data models, mappings, and execution contexts together.
+
+### DataSpaceExecutionContext
+**Purpose**: Defines an execution context within a data space, specifying how data should be transformed and executed.
+
+**Properties**:
+- `name: String[1]` - Required name for the execution context
+- `title: String[0..1]` - Optional title for the execution context
+- `description: String[0..1]` - Optional description for the execution context
+- `mapping: Mapping[1]` - Required mapping for data transformation
+- `defaultRuntime: PackageableRuntime[1]` - Required default runtime for execution
+- `testData: EmbeddedData[0..1]` - Optional test data for testing
+
+**Significance**: Execution contexts are crucial for defining how data is transformed and executed within a data space. They link to mappings and runtimes, which are essential for data processing.
+
+### DataSpaceDiagram
+**Purpose**: Associates a diagram with a data space for visual representation.
+
+**Properties**:
+- `title: String[1]` - Required title for the diagram
+- `description: String[0..1]` - Optional description for the diagram
+- `diagram: Diagram[1]` - Required reference to a diagram
+
+**Significance**: Diagrams provide visual representations of data models, making it easier for users to understand complex data structures.
+
+### DataSpaceExecutable
+**Purpose**: Base class for executables in a data space.
+
+**Properties**:
+- `title: String[1]` - Required title for the executable
+- `id: String[1]` - Required ID for the executable
+- `description: String[0..1]` - Optional description for the executable
+- `executionContextKey: String[0..1]` - Optional execution context key
+
+**Significance**: Executables define operations that can be performed within a data space, such as running queries or services.
+
+### DataSpacePackageableElementExecutable
+**Purpose**: Extends DataSpaceExecutable to reference a packagable element (like a service or function).
+
+**Properties**:
+- All properties from DataSpaceExecutable
+- `executable: PackageableElement[1]` - Required reference to a packagable element
+
+**Inheritance**: Extends `DataSpaceExecutable`.
+
+**Significance**: Allows referencing existing packagable elements (like services or functions) as executables within a data space.
+
+### DataSpaceTemplateExecutable
+**Purpose**: Extends DataSpaceExecutable to define a template with a query.
+
+**Properties**:
+- All properties from DataSpaceExecutable
+- `query: FunctionDefinition<Any>[1]` - Required query as a function definition
+
+**Inheritance**: Extends `DataSpaceExecutable`.
+
+**Significance**: Allows defining custom queries as executables within a data space.
+
+### DataSpaceSupportInfo
+**Purpose**: Abstract base class for support information.
+
+**Properties**:
+- `documentationUrl: String[0..1]` - Optional documentation URL
+
+**Significance**: Provides a way to include support information with a data space.
+
+### DataSpaceSupportEmail
+**Purpose**: Support information with an email address.
+
+**Properties**:
+- All properties from DataSpaceSupportInfo
+- `address: String[1]` - Required email address
+
+**Inheritance**: Extends `DataSpaceSupportInfo`.
+
+**Significance**: Provides a simple way to include an email address for support.
+
+### DataSpaceSupportCombinedInfo
+**Purpose**: Support information with multiple contact methods.
+
+**Properties**:
+- All properties from DataSpaceSupportInfo
+- `emails: String[*]` - Zero or more email addresses
+- `website: String[0..1]` - Optional website URL
+- `faqUrl: String[0..1]` - Optional FAQ URL
+- `supportUrl: String[0..1]` - Optional support URL
+
+**Inheritance**: Extends `DataSpaceSupportInfo`.
+
+**Significance**: Provides a comprehensive way to include multiple contact methods for support.
+
+## Key Relationships
+
+### Inheritance Relationships
+1. **DataSpace** extends **PackageableElement**
+   - Inherits the `name` property and other characteristics of packagable elements
+   - Allows data spaces to be organized in packages within the Legend Engine
+
+2. **DataSpacePackageableElementExecutable** extends **DataSpaceExecutable**
+   - Specializes the executable concept to reference existing packagable elements
+
+3. **DataSpaceTemplateExecutable** extends **DataSpaceExecutable**
+   - Specializes the executable concept to define custom queries
+
+4. **DataSpaceSupportEmail** extends **DataSpaceSupportInfo**
+   - Specializes the support information concept to include an email address
+
+5. **DataSpaceSupportCombinedInfo** extends **DataSpaceSupportInfo**
+   - Specializes the support information concept to include multiple contact methods
+
+### Composition Relationships
+1. **DataSpace** contains **DataSpaceExecutionContext** (1..*)
+   - A data space must have at least one execution context
+   - One execution context is designated as the default
+
+2. **DataSpace** contains **DataSpaceDiagram** (0..*)
+   - A data space can have zero or more diagrams for visualization
+
+3. **DataSpace** contains **PackageableElement** (0..*)
+   - A data space can include zero or more packagable elements
+
+4. **DataSpace** contains **DataSpaceExecutable** (0..*)
+   - A data space can have zero or more executables
+
+5. **DataSpace** contains **DataSpaceSupportInfo** (0..1)
+   - A data space can have optional support information
+
+### Association Relationships
+1. **DataSpaceExecutionContext** references **Mapping** (1)
+   - An execution context must reference a mapping for data transformation
+
+2. **DataSpaceExecutionContext** references **PackageableRuntime** (1)
+   - An execution context must reference a default runtime for execution
+
+3. **DataSpaceExecutionContext** references **EmbeddedData** (0..1)
+   - An execution context can have optional test data
+
+4. **DataSpaceDiagram** references **Diagram** (1)
+   - A data space diagram must reference a diagram for visualization
+
+5. **DataSpacePackageableElementExecutable** references **PackageableElement** (1)
+   - A packagable element executable must reference a packagable element
+
+6. **DataSpaceTemplateExecutable** references **FunctionDefinition** (1)
+   - A template executable must define a query as a function definition
+
+## Integration with Legend Engine Architecture
+
+The DataSpace metamodel integrates with the broader Legend Engine architecture in several ways:
+
+1. **Core Legend Engine Integration**
+   - DataSpace extends PackageableElement, which is a core concept in Legend Engine
+   - This allows data spaces to be organized in packages and referenced by other components
+
+2. **Mapping and Runtime Integration**
+   - DataSpaceExecutionContext references Mapping and PackageableRuntime
+   - This integrates data spaces with the mapping and runtime functionality of Legend Engine
+
+3. **Diagram Integration**
+   - DataSpaceDiagram references Diagram
+   - This integrates data spaces with the diagram functionality of Legend Engine
+
+4. **Executable Integration**
+   - DataSpacePackageableElementExecutable references PackageableElement
+   - This allows data spaces to reference services, functions, and other executables
+
+5. **Module Organization**
+   - The DataSpace metamodel is part of the legend-engine-xt-data-space-pure-metamodel module
+   - This module is part of the broader legend-engine-xts-data-space module
+   - The module structure allows for separation of concerns and modular development
+
+## Usage Patterns
+
+The DataSpace metamodel supports several usage patterns:
+
+1. **Data Model Organization**
+   - Data spaces can be used to organize related data models, mappings, and runtimes
+   - This makes it easier to manage complex data landscapes
+
+2. **Execution Context Definition**
+   - Data spaces define execution contexts with mappings and runtimes
+   - This allows for consistent execution of data transformations
+
+3. **Visual Representation**
+   - Data spaces can include diagrams for visual representation
+   - This makes it easier to understand complex data structures
+
+4. **Executable Definition**
+   - Data spaces can define executables for running queries or services
+   - This allows for consistent execution of operations on data
+
+5. **Support Information**
+   - Data spaces can include support information
+   - This makes it easier for users to get help when needed
+
+## Helper Functions
+
+The DataSpace metamodel includes helper functions for working with data spaces:
+
+1. **get(DataSpace, String): DataSpaceExecutionContext**
+   - Retrieves an execution context from a data space by name
+   - Useful for accessing specific execution contexts within a data space
+
+2. **from(T, DataSpace): T**
+   - Allows specifying a data space when using the `from` function
+   - Extends the mapping functionality to work with data spaces
+
+3. **from(T, DataSpaceExecutionContext): T**
+   - Allows specifying a data space execution context when using the `from` function
+   - Provides more granular control over execution contexts
+
+## Conclusion
+
+The DataSpace metamodel provides a comprehensive framework for defining and working with data spaces in Legend Engine. It integrates with core Legend Engine components and supports a wide range of usage patterns. The metamodel's structure, with its clear class hierarchy and relationships, makes it easy to understand and use.

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-description.md
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-description.md
@@ -1,0 +1,91 @@
+# DataSpace Metamodel UML Diagram
+
+## Class Structure
+
+### Core Classes
+
+**DataSpace** (extends PackageableElement)
+- Attributes:
+  - title: String[0..1]
+  - description: String[0..1]
+  - executionContexts: DataSpaceExecutionContext[1..*]
+  - defaultExecutionContext: DataSpaceExecutionContext[1]
+  - diagrams: DataSpaceDiagram[*]
+  - elements: PackageableElement[*]
+  - executables: DataSpaceExecutable[*]
+  - supportInfo: DataSpaceSupportInfo[0..1]
+
+**DataSpaceExecutionContext**
+- Attributes:
+  - name: String[1]
+  - title: String[0..1]
+  - description: String[0..1]
+  - mapping: Mapping[1]
+  - defaultRuntime: PackageableRuntime[1]
+  - testData: EmbeddedData[0..1]
+
+**DataSpaceDiagram**
+- Attributes:
+  - title: String[1]
+  - description: String[0..1]
+  - diagram: Diagram[1]
+
+**DataSpaceExecutable** (abstract)
+- Attributes:
+  - title: String[1]
+  - id: String[1]
+  - description: String[0..1]
+  - executionContextKey: String[0..1]
+
+**DataSpacePackageableElementExecutable** (extends DataSpaceExecutable)
+- Attributes:
+  - executable: PackageableElement[1]
+
+**DataSpaceTemplateExecutable** (extends DataSpaceExecutable)
+- Attributes:
+  - query: FunctionDefinition<Any>[1]
+
+**DataSpaceSupportInfo** (abstract)
+- Attributes:
+  - documentationUrl: String[0..1]
+
+**DataSpaceSupportEmail** (extends DataSpaceSupportInfo)
+- Attributes:
+  - address: String[1]
+
+**DataSpaceSupportCombinedInfo** (extends DataSpaceSupportInfo)
+- Attributes:
+  - emails: String[*]
+  - website: String[0..1]
+  - faqUrl: String[0..1]
+  - supportUrl: String[0..1]
+
+## Relationships
+
+1. **DataSpace** extends **PackageableElement**
+2. **DataSpace** contains multiple **DataSpaceExecutionContext** instances (1..*)
+3. **DataSpace** has one default **DataSpaceExecutionContext** (1)
+4. **DataSpace** contains multiple **DataSpaceDiagram** instances (0..*)
+5. **DataSpace** references multiple **PackageableElement** instances (0..*)
+6. **DataSpace** contains multiple **DataSpaceExecutable** instances (0..*)
+7. **DataSpace** has optional **DataSpaceSupportInfo** (0..1)
+8. **DataSpaceExecutionContext** references one **Mapping** (1)
+9. **DataSpaceExecutionContext** references one **PackageableRuntime** (1)
+10. **DataSpaceExecutionContext** has optional **EmbeddedData** for testing (0..1)
+11. **DataSpaceDiagram** references one **Diagram** (1)
+12. **DataSpacePackageableElementExecutable** extends **DataSpaceExecutable**
+13. **DataSpaceTemplateExecutable** extends **DataSpaceExecutable**
+14. **DataSpacePackageableElementExecutable** references one **PackageableElement** (1)
+15. **DataSpaceTemplateExecutable** contains one **FunctionDefinition** query (1)
+16. **DataSpaceSupportEmail** extends **DataSpaceSupportInfo**
+17. **DataSpaceSupportCombinedInfo** extends **DataSpaceSupportInfo**
+
+## Visual Layout
+
+The diagram layout shows:
+- **DataSpace** at the center, connected to its components
+- **DataSpaceExecutionContext** below DataSpace, showing the execution environment
+- **DataSpaceDiagram** to the right of DataSpace for visualization
+- **DataSpaceExecutable** and its subtypes to the left of DataSpace
+- **DataSpaceSupportInfo** and its subtypes to the far right
+- External dependencies (Mapping, PackageableRuntime, etc.) at the bottom of the diagram

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-formal.puml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-formal.puml
@@ -1,0 +1,93 @@
+@startuml DataSpace Metamodel
+
+' Class definitions
+abstract class PackageableElement {
+  +name: String
+}
+
+class DataSpace {
+  +title: String[0..1]
+  +description: String[0..1]
+}
+
+class DataSpaceExecutionContext {
+  +name: String[1]
+  +title: String[0..1]
+  +description: String[0..1]
+}
+
+class DataSpaceDiagram {
+  +title: String[1]
+  +description: String[0..1]
+}
+
+abstract class DataSpaceExecutable {
+  +title: String[1]
+  +id: String[1]
+  +description: String[0..1]
+  +executionContextKey: String[0..1]
+}
+
+class DataSpacePackageableElementExecutable {
+}
+
+class DataSpaceTemplateExecutable {
+}
+
+abstract class DataSpaceSupportInfo {
+  +documentationUrl: String[0..1]
+}
+
+class DataSpaceSupportEmail {
+  +address: String[1]
+}
+
+class DataSpaceSupportCombinedInfo {
+  +emails: String[*]
+  +website: String[0..1]
+  +faqUrl: String[0..1]
+  +supportUrl: String[0..1]
+}
+
+class Mapping
+class PackageableRuntime
+class Diagram
+class FunctionDefinition
+class EmbeddedData
+
+' Inheritance relationships
+PackageableElement <|-- DataSpace
+DataSpaceExecutable <|-- DataSpacePackageableElementExecutable
+DataSpaceExecutable <|-- DataSpaceTemplateExecutable
+DataSpaceSupportInfo <|-- DataSpaceSupportEmail
+DataSpaceSupportInfo <|-- DataSpaceSupportCombinedInfo
+
+' Associations
+DataSpace "1" *-- "1..*" DataSpaceExecutionContext : executionContexts
+DataSpace "1" *-- "1" DataSpaceExecutionContext : defaultExecutionContext
+DataSpace "1" *-- "*" DataSpaceDiagram : diagrams
+DataSpace "1" *-- "*" PackageableElement : elements
+DataSpace "1" *-- "*" DataSpaceExecutable : executables
+DataSpace "1" *-- "0..1" DataSpaceSupportInfo : supportInfo
+
+DataSpaceExecutionContext "1" --> "1" Mapping : mapping
+DataSpaceExecutionContext "1" --> "1" PackageableRuntime : defaultRuntime
+DataSpaceExecutionContext "1" --> "0..1" EmbeddedData : testData
+
+DataSpaceDiagram "1" --> "1" Diagram : diagram
+
+DataSpacePackageableElementExecutable "1" --> "1" PackageableElement : executable
+DataSpaceTemplateExecutable "1" --> "1" FunctionDefinition : query
+
+' Layout hints
+together {
+  class DataSpacePackageableElementExecutable
+  class DataSpaceTemplateExecutable
+}
+
+together {
+  class DataSpaceSupportEmail
+  class DataSpaceSupportCombinedInfo
+}
+
+@enduml

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-visual.md
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-visual.md
@@ -1,0 +1,79 @@
+# DataSpace Metamodel - Visual Representation
+
+## Class Diagram
+
+```
+                                 ┌───────────────────────┐
+                                 │  PackageableElement   │
+                                 └───────────┬───────────┘
+                                             │
+                                             │ extends
+                                             ▼
+┌───────────────────┐           ┌───────────────────────────────────┐           ┌───────────────────────┐
+│  DataSpaceExecutable │◄────────┤              DataSpace            │─────────►│    DataSpaceDiagram    │
+└─────────┬─────────┘           │                                   │           └───────────┬───────────┘
+          │                     │ - title: String[0..1]             │                       │
+          │                     │ - description: String[0..1]       │                       │ references
+    ┌─────┴─────┐               │ - executionContexts: [1..*]       │                       │
+    │           │               │ - defaultExecutionContext: [1]    │                       ▼
+    ▼           ▼               │ - diagrams: [*]                   │           ┌───────────────────────┐
+┌─────────────┐ ┌─────────────┐ │ - elements: [*]                   │           │         Diagram        │
+│PackageableElement│ │ Template   │ │ - executables: [*]               │           └───────────────────────┘
+│  Executable  │ │  Executable │ │ - supportInfo: [0..1]            │
+└─────────────┘ └─────────────┘ └─────────────┬─────────────────────┘
+                                              │
+                                              │ has
+                                              ▼
+┌───────────────────────┐           ┌───────────────────────────────────┐
+│  DataSpaceSupportInfo  │◄──────────┤     DataSpaceExecutionContext     │
+└─────────┬─────────────┘           │                                   │
+          │                         │ - name: String[1]                 │
+          │                         │ - title: String[0..1]             │
+    ┌─────┴─────┐                   │ - description: String[0..1]       │
+    │           │                   │ - mapping: Mapping[1]             │
+    ▼           ▼                   │ - defaultRuntime: Runtime[1]      │
+┌─────────────┐ ┌─────────────┐     │ - testData: EmbeddedData[0..1]    │
+│SupportEmail │ │CombinedInfo │     └───────────────────────────────────┘
+└─────────────┘ └─────────────┘
+```
+
+## Key Relationships
+
+1. **DataSpace** extends **PackageableElement**
+   - Inherits name and other properties from PackageableElement
+
+2. **DataSpace** contains **DataSpaceExecutionContext** (1..*)
+   - At least one execution context is required
+   - One execution context is designated as the default
+
+3. **DataSpace** contains **DataSpaceDiagram** (0..*)
+   - Optional diagrams for visual representation
+   - Each diagram references a Diagram object
+
+4. **DataSpace** references **PackageableElement** (0..*)
+   - Elements included in the data space
+
+5. **DataSpace** contains **DataSpaceExecutable** (0..*)
+   - Executables can be either:
+     - DataSpacePackageableElementExecutable (references a PackageableElement)
+     - DataSpaceTemplateExecutable (contains a query)
+
+6. **DataSpace** has optional **DataSpaceSupportInfo** (0..1)
+   - Support information can be either:
+     - DataSpaceSupportEmail (with an email address)
+     - DataSpaceSupportCombinedInfo (with multiple contact methods)
+
+7. **DataSpaceExecutionContext** references:
+   - A Mapping (1)
+   - A PackageableRuntime (1)
+   - Optional EmbeddedData for testing (0..1)
+
+## Layout Information
+
+The diagram layout in the metamodel_diagram.pure file positions:
+- DataSpace in the center (position=(335.00000, 189.00000))
+- DataSpaceExecutionContext below DataSpace (position=(286.00000, 545.00000))
+- PackageableElement above DataSpace (position=(460.65093, 55.91568))
+- DataSpaceExecutable to the left of DataSpace (position=(37.70584, 220.20489))
+- DataSpaceSupportInfo to the right of DataSpace (position=(916.02361, 299.03541))
+- Mapping and PackageableRuntime at the bottom (positions=(338.22260, 705.49410) and (698.42496, 705.49410))

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-with-notes.puml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel-with-notes.puml
@@ -1,0 +1,123 @@
+@startuml DataSpace Metamodel with Notes
+
+' Class definitions
+abstract class PackageableElement {
+  +name: String
+}
+
+class DataSpace {
+  +title: String[0..1]
+  +description: String[0..1]
+}
+
+class DataSpaceExecutionContext {
+  +name: String[1]
+  +title: String[0..1]
+  +description: String[0..1]
+}
+
+class DataSpaceDiagram {
+  +title: String[1]
+  +description: String[0..1]
+}
+
+abstract class DataSpaceExecutable {
+  +title: String[1]
+  +id: String[1]
+  +description: String[0..1]
+  +executionContextKey: String[0..1]
+}
+
+class DataSpacePackageableElementExecutable {
+}
+
+class DataSpaceTemplateExecutable {
+}
+
+abstract class DataSpaceSupportInfo {
+  +documentationUrl: String[0..1]
+}
+
+class DataSpaceSupportEmail {
+  +address: String[1]
+}
+
+class DataSpaceSupportCombinedInfo {
+  +emails: String[*]
+  +website: String[0..1]
+  +faqUrl: String[0..1]
+  +supportUrl: String[0..1]
+}
+
+class Mapping
+class PackageableRuntime
+class Diagram
+class FunctionDefinition
+class EmbeddedData
+
+' Inheritance relationships
+PackageableElement <|-- DataSpace
+DataSpaceExecutable <|-- DataSpacePackageableElementExecutable
+DataSpaceExecutable <|-- DataSpaceTemplateExecutable
+DataSpaceSupportInfo <|-- DataSpaceSupportEmail
+DataSpaceSupportInfo <|-- DataSpaceSupportCombinedInfo
+
+' Associations
+DataSpace "1" *-- "1..*" DataSpaceExecutionContext : executionContexts
+DataSpace "1" *-- "1" DataSpaceExecutionContext : defaultExecutionContext
+DataSpace "1" *-- "*" DataSpaceDiagram : diagrams
+DataSpace "1" *-- "*" PackageableElement : elements
+DataSpace "1" *-- "*" DataSpaceExecutable : executables
+DataSpace "1" *-- "0..1" DataSpaceSupportInfo : supportInfo
+
+DataSpaceExecutionContext "1" --> "1" Mapping : mapping
+DataSpaceExecutionContext "1" --> "1" PackageableRuntime : defaultRuntime
+DataSpaceExecutionContext "1" --> "0..1" EmbeddedData : testData
+
+DataSpaceDiagram "1" --> "1" Diagram : diagram
+
+DataSpacePackageableElementExecutable "1" --> "1" PackageableElement : executable
+DataSpaceTemplateExecutable "1" --> "1" FunctionDefinition : query
+
+' Notes
+note top of DataSpace
+  A DataSpace is a packagable element that encapsulates 
+  execution contexts, diagrams, and executables, allowing 
+  users to organize and interact with their data models.
+end note
+
+note right of DataSpaceExecutionContext
+  Defines an execution context within a data space with
+  a mapping for data transformation, a default runtime
+  for execution, and optional test data.
+end note
+
+note right of DataSpaceDiagram
+  Associates a diagram with a data space
+  for visual representation of the data model.
+end note
+
+note left of DataSpaceExecutable
+  Base class for executables in a data space.
+  Can be either a packagable element executable
+  or a template executable with a query.
+end note
+
+note right of DataSpaceSupportInfo
+  Abstract base class for support information.
+  Can be either an email address or combined
+  information with multiple contact methods.
+end note
+
+' Layout hints
+together {
+  class DataSpacePackageableElementExecutable
+  class DataSpaceTemplateExecutable
+}
+
+together {
+  class DataSpaceSupportEmail
+  class DataSpaceSupportCombinedInfo
+}
+
+@enduml

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel.puml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/docs/uml/dataspace-metamodel.puml
@@ -1,0 +1,82 @@
+@startuml DataSpace Metamodel
+
+' Class definitions
+abstract class PackageableElement {
+  +name: String
+}
+
+class DataSpace {
+  +title: String[0..1]
+  +description: String[0..1]
+}
+
+class DataSpaceExecutionContext {
+  +name: String[1]
+  +title: String[0..1]
+  +description: String[0..1]
+}
+
+class DataSpaceDiagram {
+  +title: String[1]
+  +description: String[0..1]
+}
+
+abstract class DataSpaceExecutable {
+  +title: String[1]
+  +id: String[1]
+  +description: String[0..1]
+  +executionContextKey: String[0..1]
+}
+
+class DataSpacePackageableElementExecutable {
+}
+
+class DataSpaceTemplateExecutable {
+}
+
+abstract class DataSpaceSupportInfo {
+  +documentationUrl: String[0..1]
+}
+
+class DataSpaceSupportEmail {
+  +address: String[1]
+}
+
+class DataSpaceSupportCombinedInfo {
+  +emails: String[*]
+  +website: String[0..1]
+  +faqUrl: String[0..1]
+  +supportUrl: String[0..1]
+}
+
+class Mapping
+class PackageableRuntime
+class Diagram
+class FunctionDefinition
+class EmbeddedData
+
+' Inheritance relationships
+PackageableElement <|-- DataSpace
+DataSpaceExecutable <|-- DataSpacePackageableElementExecutable
+DataSpaceExecutable <|-- DataSpaceTemplateExecutable
+DataSpaceSupportInfo <|-- DataSpaceSupportEmail
+DataSpaceSupportInfo <|-- DataSpaceSupportCombinedInfo
+
+' Associations
+DataSpace "1" *-- "1..*" DataSpaceExecutionContext : executionContexts
+DataSpace "1" *-- "1" DataSpaceExecutionContext : defaultExecutionContext
+DataSpace "1" *-- "*" DataSpaceDiagram : diagrams
+DataSpace "1" *-- "*" PackageableElement : elements
+DataSpace "1" *-- "*" DataSpaceExecutable : executables
+DataSpace "1" *-- "0..1" DataSpaceSupportInfo : supportInfo
+
+DataSpaceExecutionContext "1" --> "1" Mapping : mapping
+DataSpaceExecutionContext "1" --> "1" PackageableRuntime : defaultRuntime
+DataSpaceExecutionContext "1" --> "0..1" EmbeddedData : testData
+
+DataSpaceDiagram "1" --> "1" Diagram : diagram
+
+DataSpacePackageableElementExecutable "1" --> "1" PackageableElement : executable
+DataSpaceTemplateExecutable "1" --> "1" FunctionDefinition : query
+
+@enduml


### PR DESCRIPTION
# Add README.md for legend-engine-xts-data-space module

This PR adds a comprehensive README.md file for the legend-engine-xts-data-space module, documenting its purpose, key components, functionality, architectural fit, dependencies, and usage instructions.

Link to Devin run: https://app.devin.ai/sessions/437dfe525401486ea1ee2e5b42fc3b15
