### PR TITLE
Implement CONTAINS function for DuckDB

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -184,6 +184,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
     dynaFnToSql('joinStrings',            $allStates,            ^ToSql(format='string_agg(%s,%s)')),
     dynaFnToSql('last',                   $allStates,            ^ToSql(format='last(%s)')),
     dynaFnToSql('length',                 $allStates,            ^ToSql(format='length(%s)')),
+    dynaFnToSql('contains',               $allStates,            ^ToSql(format='contains(%s, %s)', transform={p:String[2]|$p})),
     dynaFnToSql('lpad',                   $allStates,            ^ToSql(format='lpad(%s,%s,%s)', transform=processPaddingParams_String_MANY__String_MANY_)),
     dynaFnToSql('matches',                $allStates,            ^ToSql(format= 'regexp_matches(%s,%s)', transform={p:String[2]|$p})),
     dynaFnToSql('md5',                    $allStates,            ^ToSql(format='md5(%s)')),


### PR DESCRIPTION
# Implement CONTAINS function for DuckDB

This PR implements the CONTAINS function for DuckDB in the legend-engine repository. The implementation leverages the native DuckDB CONTAINS function which returns true if a search_string is found within a string.

## Implementation Details
- Added a new dynaFnToSql entry in the getDynaFunctionToSqlForDuckDB function:
```pure
dynaFnToSql('contains', $allStates, ^ToSql(format='contains(%s, %s)', transform={p:String[2]|$p}))
```

- The implementation follows the same pattern as other string functions in the DuckDB extension
- This approach is more efficient than using LIKE patterns with wildcards as it directly uses the database's native function

## Documentation
The CONTAINS function in DuckDB returns true if the first string contains the second string.
For example: `contains('abc', 'a')` returns `true`

Link to Devin run: https://app.devin.ai/sessions/2c3220b9df8c476f93d6fe5c376f0c3f

Requested by: rajiv.dudhia@gs.com
