### PR TITLE
Changes for DataQualityValidation constraints to check additional "from" functions

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -26,7 +26,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "###DataQualityValidation\n" +
                 "DataQualityValidation meta::dataquality::Person\n" + // duplicated the validation name, same name as the class
                 "{\n" +
-                "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    context: fromMappingAndRuntime(meta::dataquality::dataquality::Mapping, meta::dataquality::DataQualityRuntime);\n" +
                 "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
                 "    validationTree: $[\n" +
                 "      meta::dataquality::Person<mustBeOfLegalAge>{\n" +
@@ -49,7 +49,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "###DataQualityValidation\n" +
                 "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
                 "{\n" +
-                "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    context: fromMappingAndRuntime(meta::dataquality::dataquality::Mapping, meta::dataquality::DataQualityRuntime);\n" +
                 "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
                 "    validationTree: $[\n" +
                 "      meta::dataquality::Person<mustBeOfLegalAge>{\n" +
@@ -83,7 +83,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "###DataQualityValidation\n" +
                 "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
                 "{\n" +
-                "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    context: fromMappingAndRuntime(meta::dataquality::dataquality::Mapping, meta::dataquality::DataQualityRuntime);\n" +
                 "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
                 "    validationTree: $[\n" +
                 "      meta::dataquality::Person{\n" +
@@ -100,7 +100,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "###DataQualityValidation\n" +
                 "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
                 "{\n" +
-                "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    context: fromMappingAndRuntime(meta::dataquality::dataquality::Mapping, meta::dataquality::DataQualityRuntime);\n" +
                 "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
                 "    validationTree: $[\n" +
                 "      meta::dataquality::Person<mustBeOfLegalAge>{\n" +
@@ -116,7 +116,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "###DataQualityValidation\n" +
                 "DataQualityValidation meta::dataquality::PersonDataQualityValidation\n" +
                 "{\n" +
-                "    context: fromMappingAndRuntime(meta::dataquality::dataqualitymappings, meta::dataquality::DataQualityRuntime);\n" +
+                "    context: fromMappingAndRuntime(meta::dataquality::dataquality::Mapping, meta::dataquality::DataQualityRuntime);\n" +
                 "    filter: p:meta::dataquality::Person[1] | $p.name=='John';\n" +
                 "    validationTree: $[\n" +
                 "      meta::dataquality::Person{\n" +
@@ -139,6 +139,25 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "         name: 'validFirstName';\n" +
                 "         description: 'First name cannot be empty';\n" +
                 "         assertion: row|$row.FIRSTNAME->isNotEmpty();\n" +
+                "      }\n" +
+                "    ];\n" +
+                "}");
+    }
+
+    @Test
+    public void testRelationValidation_forClass_fromMappingRuntime()
+    {
+        TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite.test(COMPILATION_PREREQUISITE_CODE +
+                "###DataQualityValidation\n" +
+                "DataQualityRelationValidation meta::external::dataquality::testvalidation\n" +
+                "{\n" +
+                "    query: meta::dataquality::Person.all()->project(~[theName: x|$x.name])" +
+                "       ->from(meta::dataquality::dataquality::Mapping, meta::dataquality::DataQualityRuntime);\n" +
+                "    validations: [\n" +
+                "      {\n" +
+                "         name: 'validTheName';\n" +
+                "         description: 'theName cannot be empty';\n" +
+                "         assertion: row|$row.theName->isNotEmpty();\n" +
                 "      }\n" +
                 "    ];\n" +
                 "}");
@@ -226,7 +245,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
             "\n" +
             "\n" +
             "###Mapping\n" +
-            "Mapping meta::dataquality::dataqualitymappings\n" +
+            "Mapping meta::dataquality::dataquality::Mapping\n" +
             "(\n" +
             "\n" +
             "   meta::dataquality::Person : Relational\n" +
@@ -254,7 +273,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
             "{\n" +
             "  mappings:\n" +
             "  [\n" +
-            "    meta::dataquality::dataqualitymappings\n" +
+            "    meta::dataquality::dataquality::Mapping\n" +
             "  ];\n" +
             "  connections:\n" +
             "  [\n" +
@@ -297,7 +316,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
             "  [\n" +
             "    {\n" +
             "      name: 'default';\n" +
-            "      mapping: meta::dataquality::dataqualitymappings;\n" +
+            "      mapping: meta::dataquality::dataquality::Mapping;\n" +
             "      defaultRuntime: meta::dataquality::DataQualityRuntime;\n" +
             "    }\n" +
             "  ];\n" +

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -249,3 +249,25 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           {|{rel|$rel->meta::external::dataquality::relationNotEmpty();}->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));}
     )
 }
+
+function <<test.Test>> meta::external::dataquality::tests::testFromFunctionListIsComplete():Boolean[1]
+{
+  let funcs = meta::external::dataquality::fromFunctions();
+
+  let actualFromFuncs = meta::pure::mapping.children->map(pe|$pe->match([
+    f:Function<Any>[1]|if($f.functionName == 'from', | $f, | []), 
+    a:Any[*]|[]
+    ]));
+     
+  let missingFuncs = $actualFromFuncs
+    ->removeAll($funcs)
+    //TODO: Need to review for if these should be ignored, or if this module 
+    //needs a depdenecy to the core_service module to be able to reference them 
+
+    ->filter(pe|[
+      'meta::pure::mapping::from_T_m__SingleExecutionParameters_1__T_m_', 
+      'meta::pure::mapping::from_T_m__ExecutionEnvironmentInstance_1__T_m_'
+      ]->contains($pe->elementToPath()) == false);
+
+  assertEmpty($missingFuncs->map(pe|$pe->elementToPath()));
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -613,6 +613,28 @@ function meta::external::dataquality::buildFromRuntimeExpression(f: FunctionExpr
 
 function meta::external::dataquality::isFromFunctionPresent(func: FunctionDefinition<Any>[1]):Boolean[1]
 {
-  let getExprList = $func->findExpressionsForFunctionInFunctionDefinition([meta::pure::mapping::from_T_m__Runtime_1__T_m_, meta::pure::mapping::from_T_m__PackageableRuntime_1__T_m_]);
+  let getExprList = $func->findExpressionsForFunctionInFunctionDefinition(
+    meta::external::dataquality::fromFunctions()
+    );
   !$getExprList->isEmpty();
+}
+
+function <<access.protected>> meta::external::dataquality::fromFunctions():Function<Any>[*]
+{
+  [
+    meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__Runtime_1__T_m_,
+    meta::pure::mapping::from_FunctionDefinition_1__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_FunctionDefinition_1__Runtime_1__T_m_,
+    meta::pure::mapping::from_T_m__DataSpaceExecutionContext_1__T_m_,
+    meta::pure::mapping::from_T_m__DataSpace_1__T_m_,
+    meta::pure::mapping::from_T_m__Mapping_1__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_T_m__Mapping_1__Runtime_1__T_m_,
+    meta::pure::mapping::from_T_m__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_T_m__Runtime_1__T_m_,
+    meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__ExecutionContext_1__TabularDataSet_1_,
+    meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__TabularDataSet_1_,
+    meta::pure::mapping::from_TabularDataSet_1__Mapping_1__Runtime_1__ExecutionContext_1__TabularDataSet_1_,
+    meta::pure::mapping::from_TabularDataSet_1__Mapping_1__Runtime_1__TabularDataSet_1_
+    ] 
 }


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?

Resolved incorrect "Constraint :[mustHaveOneRuntime] violated in the Class DataQualityRelationValidation" failures when other overloads of the "from" method

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No breaking change expected. 
