### PR TITLE
BugFix: Ensure expressions that end on let statements dont generate allocation nodes.

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
@@ -95,11 +95,10 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx:
     pair($l->cast(@FunctionDefinition<Any>), $f->openVariableValues())
   );
 
-  let vs      = $expressions->last()->toOne();
-  let varName = $vs->extractLetVariableName();
-  let vars    = if($varName->isNotEmpty(),
-                   | $initStatements.second->put($varName->toOne(), createPlanVarPlaceHolderInScopeVar($varName->toOne(), $vs->cast(@FunctionExpression).parametersValues->evaluateAndDeactivate()->at(1))), // Since its a let function, use ->at(1) parameter
-                   | $initStatements.second);
+  let lastExpression      = $expressions->last()->toOne();
+  // preeval should do this, but until we enable preeval, remove last statement lets
+  let vs = if($lastExpression->isLetFunction(), |$lastExpression->cast(@FunctionExpression).parametersValues->evaluateAndDeactivate()->at(1), |$lastExpression);
+  let vars    = $initStatements.second;
   let newF    = ^$l(expressionSequence    = $vs,
                     openVariables         = $vars->keys(),
                     classifierGenericType = ^GenericType(rawType=LambdaFunction, typeArguments=^GenericType(rawType=$f->functionType())));
@@ -135,9 +134,15 @@ function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], routing
 
    let valueSpecifications = $f.expressionSequence->evaluateAndDeactivate();
 
+   let valueSpecificationsInit = $valueSpecifications->init();
+   let valueSpecificationsLast = $valueSpecifications->last()->toOne();
+
+   // preeval should do this, but until we enable preeval, remove last statement lets
+   let valueSpecificationsLastWithoutLet = if($valueSpecificationsLast->isLetFunction(), |$valueSpecificationsLast->cast(@FunctionExpression).parametersValues->evaluateAndDeactivate()->at(1), |$valueSpecificationsLast);
+
    // Enriching Function Expressions with relevant info (mapping / binding / platform)
    print(if($debug.debug,|'\n'+$debug.space+'Enriching Function Expressions with relevant info (mapping / binding / platform) and assigning routing strategy:\n',|''));
-   let enrichedExpressions = enrichFunctionExpressions($valueSpecifications, $routingStrategy, $exeCtx, $openVariables, $graphFetchFlow, $extensions, $debug);   
+   let enrichedExpressions = enrichFunctionExpressions($valueSpecificationsInit->concatenate($valueSpecificationsLastWithoutLet), $routingStrategy, $exeCtx, $openVariables, $graphFetchFlow, $extensions, $debug);   
 
    // Enriching Function Expressions with more information based on type of expression (subTypes of ExtendedRoutedValueSpecification)
    print(if($debug.debug,|'\n'+$debug.space+'Enriching Function Expressions with strategy based info (mapping / binding / platform):\n',|''));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -2753,3 +2753,29 @@ function <<test.Test>> meta::pure::executionPlan::tests::testGraphFetchH2TempTab
   assertEquals('INSERT INTO "temp_table_node_0" SELECT * FROM CSVREAD(\'${csv_file_location}\');', $tempTableStrategy.loadTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
   assertEquals('Drop table if exists "temp_table_node_0";', $tempTableStrategy.dropTempTableNode.executionNodes->at(0)->cast(@SQLExecutionNode).sqlQuery);
 }
+
+function <<test.Test>> meta::pure::executionPlan::tests::testTdsLastExpressionAssingesToVariable_withFrom():Boolean[1]
+{
+   let result = meta::pure::executionPlan::executionPlan(|let a = Person.all()->project(p|$p.firstName, 'firstName')->from(simpleRelationalMapping, meta::external::store::relational::tests::testRuntime()), meta::relational::extension::relationalExtensions())->planToString( meta::relational::extension::relationalExtensions());
+   // no allocation node
+   assertEquals('Relational\n' +
+  '(\n' +
+  '  type = TDS[(firstName, String, VARCHAR(200), "")]\n' +
+  '  resultColumns = [("firstName", VARCHAR(200))]\n' +
+  '  sql = select "root".FIRSTNAME as "firstName" from personTable as "root"\n' +
+  '  connection = TestDatabaseConnection(type = "H2")\n' +
+  ')\n', $result);
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::testTdsLastExpressionAssingesToVariable_DeprecatedFlow():Boolean[1]
+{
+   let result = meta::pure::executionPlan::executionPlan(|let a = Person.all()->project(p|$p.firstName, 'firstName'), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions())->planToString( meta::relational::extension::relationalExtensions());
+   // no allocation node
+   assertEquals('Relational\n' +
+  '(\n' +
+  '  type = TDS[(firstName, String, VARCHAR(200), "")]\n' +
+  '  resultColumns = [("firstName", VARCHAR(200))]\n' +
+  '  sql = select "root".FIRSTNAME as "firstName" from personTable as "root"\n' +
+  '  connection = TestDatabaseConnection(type = "H2")\n' +
+  ')\n', $result);
+}


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

When a TDs is the last statement, it end on an allocation node.  Recent changes made relational results lazy/deferred when they are inside allocation nodes.

This broke when the result need to be returned / consumed.

This fix remove allocation nodes all together as they are redundant, fixing the bug, while making the exec plan simpler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
