### PR TITLE
fix runtime field in dq relation validation composer

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/DataQualityGrammarComposerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/DataQualityGrammarComposerExtension.java
@@ -88,6 +88,7 @@ public class DataQualityGrammarComposerExtension implements PureGrammarComposerE
         return "DataQualityRelationValidation " + renderAnnotations(dataqualityRelationValidation.stereotypes, dataqualityRelationValidation.taggedValues) + packageName + "\n" +
                 "{\n" +
                 "   query: " + renderRelationQuery(dataqualityRelationValidation, context) +
+                renderRuntime(dataqualityRelationValidation, context) +
                 "   validations: " + renderValidations(dataqualityRelationValidation.validations, context) +
                 "}";
     }
@@ -99,6 +100,15 @@ public class DataQualityGrammarComposerExtension implements PureGrammarComposerE
             return "";
         }
         return "   filter: " + dataQuality.filter.accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance(context).build()) + ";\n";
+    }
+
+    private static String renderRuntime(DataqualityRelationValidation dataqualityRelationValidation, PureGrammarComposerContext context)
+    {
+        if (Objects.isNull(dataqualityRelationValidation.runtime))
+        {
+            return "";
+        }
+        return "   runtime: " + dataqualityRelationValidation.runtime.path + ";\n";
     }
 
     private static String getContextFunc(DataQuality dataQuality)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/from/TestDataQualityParsing.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/from/TestDataQualityParsing.java
@@ -304,5 +304,23 @@ public class TestDataQualityParsing extends TestGrammarParser.TestGrammarParserT
                 "}", "PARSER error at [2:1-10:1]: Field 'assertion' is required");
     }
 
+    @Test
+    public void testParserForValidRelationValidationGrammar_separateRuntime()
+    {
+        test("###DataQualityValidation\n" +
+                "DataQualityRelationValidation meta::external::dataquality::testvalidation\n" +
+                "{\n" +
+                "    query: #>{my::Store.myTable}#->filter(c|$c.name == 'ok');\n" +
+                "    runtime: test::TestRuntime;\n" +
+                "    validations: [\n" +
+                "      {\n" +
+                "         name: 'testValidation';\n" +
+                "         description: 'test validation';\n" +
+                "         assertion: row|$row.name != 'error';\n" +
+                "      }\n" +
+                "    ];\n" +
+                "}");
+
+    }
 
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/to/TestDataQualityRoundtrip.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/test/java/org/finos/legend/engine/language/dataquality/grammar/to/TestDataQualityRoundtrip.java
@@ -151,4 +151,23 @@ public class TestDataQualityRoundtrip extends TestGrammarRoundtrip.TestGrammarRo
                 "}\n");
     }
 
+    @Test
+    public void testRelationalValidation_separateRuntime()
+    {
+        test("###DataQualityValidation\n" +
+                "DataQualityRelationValidation meta::external::dataquality::testvalidation\n" +
+                "{\n" +
+                "   query: |#>{my::Store.myTable}#->filter(c|$c.name == 'ok');\n" +
+                "   runtime: test::test;\n" +
+                "   validations: [\n" +
+                "   {\n" +
+                "     name: 'testValidation';\n" +
+                "     description: 'test validation';\n" +
+                "     assertion: row|$row.name != 'error';\n" +
+                "     type: ROW_LEVEL;\n" +
+                "    }\n" +
+                "   ];\n" +
+                "}\n");
+    }
+
 }


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
Runtime field was not added to the composer in the dataquality relation validation specification which this merge request fixes.

#### Which issue(s) this PR fixes:

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
