### PR TITLE
update PCT testcases assertions to make result in sorted order

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/pom.xml
@@ -76,6 +76,11 @@
                         <artifactId>legend-pure-m2-dsl-tds-grammar</artifactId>
                         <version>${legend.pure.version}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
                 </dependencies>
             </plugin>
             <plugin>
@@ -99,6 +104,11 @@
                         <artifactId>legend-pure-m2-dsl-tds-grammar</artifactId>
                         <version>${legend.pure.version}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
                 </dependencies>
             </plugin>
         </plugins>
@@ -112,6 +122,12 @@
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-tds-grammar</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation.definition.json
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation.definition.json
@@ -3,6 +3,7 @@
   "pattern": "(meta::pure::functions::relation)(::.*)?",
   "dependencies": [
     "platform",
-    "platform_dsl_tds"
+    "platform_dsl_tds",
+    "core_functions_unclassified"
   ]
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/graph/project.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/graph/project.pure
@@ -151,7 +151,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::project::testSimpl
                 '   one,two,three\n'+
                 '   ok,no,null\n'+
                 '   ok,other,null\n'+
-                '#', $res->toString());
+                '#', $res->sort([~one->ascending(), ~two->ascending(), ~three->ascending()])->toString());
 }
 
 
@@ -177,7 +177,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::project::testSimpl
                   '   a1\n'+
                   '   ewe3\n'+
                   '   qw4\n'+
-                  '   wwe5\n'+
                   '   weq6\n'+
-                  '#', $res->toString());
+                  '   wwe5\n'+
+                  '#', $res->sort([~name->ascending()])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/filter.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/filter.pure
@@ -34,7 +34,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::filter::testSimple
                   '   val\n'+
                   '   3\n'+
                   '   4\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::filter::testSimpleFilter_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -57,5 +57,5 @@ function <<PCT.test>> meta::pure::functions::relation::tests::filter::testSimple
     assertEquals( '#TDS\n'+
                   '   val\n'+
                   '   5\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/drop.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/drop.pure
@@ -27,7 +27,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::drop::testSimpleDr
                 4, qw
                 5, wwe
                 6, weq
-                #->drop(3)
+                #->sort(~val->ascending())->drop(3)
               };
 
     let res =  $f->eval($expr);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/limit.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/limit.pure
@@ -27,7 +27,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::limit::testSimpleL
                   4, qw
                   5, wwe
                   6, weq
-                #->limit(3)
+                #->sort(~val->ascending())->limit(3)
                };
 
     let res =  $f->eval($expr);
@@ -37,7 +37,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::limit::testSimpleL
                   '   1,a\n'+
                   '   3,ewe\n'+
                   '   4,qw\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::limit::testSimpleLimit_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -51,7 +51,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::limit::testSimpleL
                   5, wwe
                   6, weq
                 #;
-                $t->limit(3);                
+                $t->sort(~val->ascending())->limit(3);                
                };
 
     let res =  $f->eval($expr);
@@ -61,5 +61,5 @@ function <<PCT.test>> meta::pure::functions::relation::tests::limit::testSimpleL
                   '   1,a\n'+
                   '   3,ewe\n'+
                   '   4,qw\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/slice.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/slice.pure
@@ -27,7 +27,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::slice::testSimpleS
                   4, qw
                   5, wwe
                   6, weq
-                #->slice(1,3);
+                #->sort(~val->ascending())->slice(1,3);
               };
 
     let res =  $f->eval($expr);
@@ -36,7 +36,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::slice::testSimpleS
                   '   val,str\n'+
                   '   3,ewe\n'+
                   '   4,qw\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::slice::testSimpleSlice_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/concatenate.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/concatenate.pure
@@ -46,7 +46,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::concatenate::testS
                   '   5,qwea\n'+
                   '   6,eeewe\n'+
                   '   7,qqwew\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::concatenate::testSimpleConcatenate_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -77,10 +77,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::concatenate::testS
                   '   3,ewe\n'+
                   '   4,qw\n'+
                   '   5,qwea\n'+
-                  '   6,eeewe\n'+
-                  '   7,qqwew\n'+
                   '   5,qwea\n'+
                   '   6,eeewe\n'+
+                  '   6,eeewe\n'+
                   '   7,qqwew\n'+
-                  '#', $res->toString());
+                  '   7,qqwew\n'+
+                  '#', $res->sort([~val->ascending(), ~str->ascending()])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/extend.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/extend.pure
@@ -50,7 +50,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,qw,qw4\n'+
                   '   5,wwe,wwe5\n'+
                   '   6,weq,weq6\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimpleExtendStr_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -76,7 +76,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,qw,qw4\n'+
                   '   5,wwe,wwe5\n'+
                   '   6,weq,weq6\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimpleExtendInt<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -101,7 +101,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,qw,5\n'+
                   '   5,wwe,6\n'+
                   '   6,weq,7\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimpleExtendInt_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -127,7 +127,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,qw,5\n'+
                   '   5,wwe,6\n'+
                   '   6,weq,7\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimpleExtendFloat<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -152,7 +152,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,4.2,5.2\n'+
                   '   5,4.2,5.2\n'+
                   '   6,4.5,5.5\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimpleExtendFloat_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -178,7 +178,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,4.2,5.2\n'+
                   '   5,4.2,5.2\n'+
                   '   6,4.5,5.5\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimpleMultipleColumns<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -203,7 +203,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,qw,5,qw_ext\n'+
                   '   5,wwe,6,wwe_ext\n'+
                   '   6,weq,7,weq_ext\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimpleMultipleColumns_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -229,7 +229,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::extend::testSimple
                   '   4,qw,5,qw_ext\n'+
                   '   5,wwe,6,wwe_ext\n'+
                   '   6,weq,7,weq_ext\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::extend::testOLAPAggNoWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
@@ -42,16 +42,17 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                };
 
     let res =  $f->eval($expr);
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
 
     assertEquals( '#TDS\n'+
-                  '   grp,newCol\n'+
+                  '   grp,newColSorted\n'+
                   '   0,J\n'+
                   '   1,BFH\n'+
                   '   2,AE\n'+
                   '   3,CG\n'+
                   '   4,D\n'+
                   '   5,I\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '#', $resSorted->sort(~grp->ascending())->select(~[grp, newColSorted])->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleSingle_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -74,16 +75,17 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                };
 
     let res =  $f->eval($expr);
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
 
     assertEquals( '#TDS\n'+
-                  '   grp,newCol\n'+
+                  '   grp,newColSorted\n'+
                   '   0,J\n'+
                   '   1,BFH\n'+
                   '   2,AE\n'+
                   '   3,CG\n'+
                   '   4,D\n'+
                   '   5,I\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '#', $resSorted->sort(~grp->ascending())->select(~[grp, newColSorted])->toString());
 }
 
 
@@ -105,16 +107,17 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                };
 
     let res =  $f->eval($expr);
-
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
+    
     assertEquals( '#TDS\n'+
-                  '   grp,newCol\n'+
+                  '   grp,newColSorted\n'+
                   '   0,J\n'+
                   '   1,BFH\n'+
                   '   2,AE\n'+
                   '   3,CG\n'+
                   '   4,D\n'+
                   '   5,I\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '#',  $resSorted->sort(~grp->ascending())->select(~[grp, newColSorted])->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleSingle_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -137,16 +140,17 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                };
 
     let res =  $f->eval($expr);
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
 
     assertEquals( '#TDS\n'+
-                  '   grp,newCol\n'+
+                  '   grp,newColSorted\n'+
                   '   0,J\n'+
                   '   1,BFH\n'+
                   '   2,AE\n'+
                   '   3,CG\n'+
                   '   4,D\n'+
                   '   5,I\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '#', $resSorted->sort(~grp->ascending())->select(~[grp, newColSorted])->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleMultiple<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -168,16 +172,17 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                };
 
     let res =  $f->eval($expr);
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
 
     assertEquals( '#TDS\n'+
-                  '   grp,newCol,YoCol\n'+
-                  '   0,J,10\n'+
-                  '   1,BFH,16\n'+
-                  '   2,AE,6\n'+
-                  '   3,CG,10\n'+
-                  '   4,D,4\n'+
-                  '   5,I,9\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '   grp,YoCol,newColSorted\n'+
+                  '   0,10,J\n'+
+                  '   1,16,BFH\n'+
+                  '   2,6,AE\n'+
+                  '   3,10,CG\n'+
+                  '   4,4,D\n'+
+                  '   5,9,I\n'+
+                  '#', $resSorted->sort(~grp->ascending())->select(~[grp, YoCol, newColSorted])->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleMultiple_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -200,20 +205,21 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                };
 
     let res =  $f->eval($expr);
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
 
     assertEquals( '#TDS\n'+
-                  '   grp,newCol,YoCol\n'+
-                  '   0,J,10\n'+
-                  '   1,BFH,16\n'+
-                  '   2,AE,6\n'+
-                  '   3,CG,10\n'+
-                  '   4,D,4\n'+
-                  '   5,I,9\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '   grp,YoCol,newColSorted\n'+
+                  '   0,10,J\n'+
+                  '   1,16,BFH\n'+
+                  '   2,6,AE\n'+
+                  '   3,10,CG\n'+
+                  '   4,4,D\n'+
+                  '   5,9,I\n'+
+                  '#', $resSorted->sort(~grp->ascending())->select(~[grp, YoCol, newColSorted])->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleMultiple<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
-{
+{ 
     let expr = {
                 |#TDS
                   id, grp, name
@@ -227,20 +233,21 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                   8, 1, H
                   9, 5, I
                   10, 0, J
-                #->groupBy(~[grp], ~[newCol : x | $x.name : y | $y->joinStrings(''), YoCol : x | $x.id : y | $y->plus()])
+                #->sort([ascending(~name)])->groupBy(~[grp], ~[newCol : x | $x.name : y | $y->joinStrings(''), YoCol : x | $x.id : y | $y->plus()])
                };
 
     let res =  $f->eval($expr);
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
 
     assertEquals( '#TDS\n'+
-                  '   grp,newCol,YoCol\n'+
-                  '   0,J,10\n'+
-                  '   1,BFH,16\n'+
-                  '   2,AE,6\n'+
-                  '   3,CG,10\n'+
-                  '   4,D,4\n'+
-                  '   5,I,9\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '   grp,YoCol,newColSorted\n'+
+                  '   0,10,J\n'+
+                  '   1,16,BFH\n'+
+                  '   2,6,AE\n'+
+                  '   3,10,CG\n'+
+                  '   4,4,D\n'+
+                  '   5,9,I\n'+
+                  '#', $resSorted->sort(~grp->ascending())->select(~[grp, YoCol, newColSorted])->toString());
 }
 
 
@@ -264,14 +271,16 @@ function <<PCT.test>> meta::pure::functions::relation::tests::groupBy::testSimpl
                };
 
     let res =  $f->eval($expr);
+    let resSorted = $res->extend(~newColSorted : c | $c.newCol->toOne()->chunk(1)->sort()->joinStrings(''););
 
     assertEquals( '#TDS\n'+
-                  '   grp,newCol,YoCol\n'+
-                  '   0,J,10\n'+
-                  '   1,BFH,16\n'+
-                  '   2,AE,6\n'+
-                  '   3,CG,10\n'+
-                  '   4,D,4\n'+
-                  '   5,I,9\n'+
-                  '#', $res->sort(~grp->ascending())->toString());
+                  '   grp,YoCol,newColSorted\n'+
+                  '   0,10,J\n'+
+                  '   1,16,BFH\n'+
+                  '   2,6,AE\n'+
+                  '   3,10,CG\n'+
+                  '   4,4,D\n'+
+                  '   5,9,I\n'+
+                  '#', $resSorted->sort(~grp->ascending())->select(~[grp, YoCol, newColSorted])->toString()
+);
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/rename.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/rename.pure
@@ -39,7 +39,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::rename::testSimple
                   '   4,qw\n'+
                   '   5,wwe\n'+
                   '   6,weq\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::rename::testSimpleRename_MultipleExpressions<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -65,5 +65,5 @@ function <<PCT.test>> meta::pure::functions::relation::tests::rename::testSimple
                   '   4,qw\n'+
                   '   5,wwe\n'+
                   '   6,weq\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/select.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/select.pure
@@ -45,7 +45,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testMultiC
                   '   4,c\n'+
                   '   5,d\n'+
                   '   6,e\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testMultiColsSelect_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -72,7 +72,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testMultiC
                   '   4,c\n'+
                   '   5,d\n'+
                   '   6,e\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingleColSelectShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -95,9 +95,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingle
                   '   a\n'+
                   '   ewe\n'+
                   '   qw\n'+
-                  '   wwe\n'+
                   '   weq\n'+
-                  '#', $res->toString());
+                  '   wwe\n'+
+                  '#', $res->sort(~str->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingleColSelect_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -122,9 +122,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingle
                   '   a\n'+
                   '   ewe\n'+
                   '   qw\n'+
-                  '   wwe\n'+
                   '   weq\n'+
-                  '#', $res->toString());
+                  '   wwe\n'+
+                  '#', $res->sort(~str->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingleSelectWithQuotedColumn<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -149,7 +149,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingle
                   '   c\n'+
                   '   d\n'+
                   '   e\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~'other kind'->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingleSelectWithQuotedColumn_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -176,7 +176,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testSingle
                   '   c\n'+
                   '   d\n'+
                   '   e\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~'other kind'->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testSelectAll<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -201,7 +201,7 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testSelect
                   '   4,qw,c\n'+
                   '   5,wwe,d\n'+
                   '   6,weq,e\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testSelectAll_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
@@ -228,5 +228,5 @@ function <<PCT.test>> meta::pure::functions::relation::tests::select::testSelect
                   '   4,qw,c\n'+
                   '   5,wwe,d\n'+
                   '   6,weq,e\n'+
-                  '#', $res->toString());
+                  '#', $res->sort(~val->ascending())->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
@@ -84,11 +84,11 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testF
 
         assertEquals( '#TDS\n' +
                       '   legalName,firstName\n' +
-                      '   Firm X,Peter\n' +
-                      '   Firm X,John\n' +
-                      '   Firm X,John\n' +
                       '   Firm X,Anthony\n' +
-                      '#', $res->toString());
+                      '   Firm X,John\n' +
+                      '   Firm X,John\n' +
+                      '   Firm X,Peter\n' +
+                      '#', $res->sort(~firstName->ascending())->toString());
 }
 
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/pom.xml
@@ -69,6 +69,17 @@
                         <artifactId>legend-engine-pure-functions-relation-pure</artifactId>
                         <version>${project.version}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+                        <version>${project.version}</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-unclassified</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
                 </dependencies>
             </plugin>
             <plugin>
@@ -104,6 +115,26 @@
                     <dependency>
                         <groupId>org.finos.legend.engine</groupId>
                         <artifactId>legend-engine-pure-platform-dsl-tds-java</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-unclassified</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-unclassified</artifactId>
                         <version>${project.version}</version>
                     </dependency>
                 </dependencies>
@@ -151,6 +182,17 @@
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-tds-pure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-unclassified</artifactId>
         </dependency>
 
         <dependency>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/test/java/org/finos/legend/pure/runtime/java/extension/relation/compiled/pure/TestPCTReport.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/test/java/org/finos/legend/pure/runtime/java/extension/relation/compiled/pure/TestPCTReport.java
@@ -24,6 +24,6 @@ public class TestPCTReport
     public void canFindPCTReport()
     {
         Assert.assertEquals("Native", PCTReportProviderLoader.gatherReports().collect(c -> c.adapterKey.adapter.name).distinct().sortThis().makeString(", "));
-        Assert.assertEquals(3, PCTReportProviderLoader.gatherReports().size());
+        Assert.assertEquals(4, PCTReportProviderLoader.gatherReports().size());
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/pom.xml
@@ -56,6 +56,21 @@
                         <artifactId>legend-engine-pure-functions-relation-pure</artifactId>
                         <version>${project.version}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.finos.legend.engine</groupId>
+                        <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-unclassified</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
                 </dependencies>
             </plugin>
         </plugins>
@@ -69,6 +84,21 @@
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-unclassified</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!--        <dependency>-->

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/test/java/org/finos/legend/pure/runtime/java/extension/relation/interpreted/pure/TestPCTReport.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/test/java/org/finos/legend/pure/runtime/java/extension/relation/interpreted/pure/TestPCTReport.java
@@ -24,6 +24,6 @@ public class TestPCTReport
     public void canFindPCTReport()
     {
         Assert.assertEquals("Native", PCTReportProviderLoader.gatherReports().collect(c -> c.adapterKey.adapter.name).distinct().sortThis().makeString(", "));
-        Assert.assertEquals(3, PCTReportProviderLoader.gatherReports().size());
+        Assert.assertEquals(4, PCTReportProviderLoader.gatherReports().size());
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/pom.xml
@@ -58,5 +58,10 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-functions-unclassified-pure</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/percentile.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/percentile.pure
@@ -126,5 +126,5 @@ function <<PCT.test>> meta::pure::functions::math::tests::percentile::testPercen
                   '   3,1.0,1.7\n'+
                   '   3,1.5,1.7\n'+
                   '   3,2.0,1.7\n'+
-                  '#', $res->sort(~id->ascending())->toString());
+                  '#', $res->sort([~id->ascending(), ~val->ascending()])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
@@ -71,5 +71,5 @@ function <<PCT.test>> meta::pure::functions::math::tests::stdDev::testSimpleWind
                   '   1,2,0.5\n'+
                   '   2,2,1.0\n'+
                   '   2,4,1.0\n'+
-                  '#', $res->sort(~id->ascending())->toString());
+                  '#', $res->sort([~id->ascending(), ~val->ascending()])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
@@ -108,5 +108,5 @@ function <<PCT.test>> meta::pure::functions::math::tests::stdDev::testSimpleWind
                   '   3,1.0,0.5\n'+
                   '   3,1.5,0.5\n'+
                   '   3,2.0,0.5\n'+
-                  '#', $res->sort(~id->ascending())->toString());
+                  '#', $res->sort([~id->ascending(), ~val->ascending()])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/variancePopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/variancePopulation.pure
@@ -67,5 +67,5 @@ function <<PCT.test>> meta::pure::functions::math::tests::variance::testSimpleWi
                   '   1,2,0.25\n'+
                   '   2,2,1.0\n'+
                   '   2,4,1.0\n'+
-                  '#', $res->sort(~id->ascending())->toString());
+                  '#', $res->sort([~id->ascending(), ~val->ascending()])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/varianceSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/varianceSample.pure
@@ -72,5 +72,5 @@ function <<PCT.test>> meta::pure::functions::math::tests::variance::testSimpleWi
                   '   2,2.0,4.0\n'+
                   '   2,4.0,4.0\n'+
                   '   2,6.0,4.0\n'+
-                  '#', $res->sort(~id->ascending())->toString());
+                  '#', $res->sort([~id->ascending(), ~val->ascending()])->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/test/java/org/finos/legend/pure/code/core/tests/TestPCTReport.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/test/java/org/finos/legend/pure/code/core/tests/TestPCTReport.java
@@ -23,8 +23,8 @@ public class TestPCTReport
     @Test
     public void canFindPCTReport()
     {
-        Assert.assertEquals(4, PCTReportProviderLoader.gatherFunctions().size());
-        Assert.assertEquals("essential, grammar, relation, standard", PCTReportProviderLoader.gatherFunctions().collect(c -> c.reportScope.module).distinct().sortThis().makeString(", "));
+        Assert.assertEquals(5, PCTReportProviderLoader.gatherFunctions().size());
+        Assert.assertEquals("essential, grammar, relation, standard, unclassified", PCTReportProviderLoader.gatherFunctions().collect(c -> c.reportScope.module).distinct().sortThis().makeString(", "));
         Assert.assertEquals(0, PCTReportProviderLoader.gatherReports().size());
         Assert.assertEquals("", PCTReportProviderLoader.gatherReports().collect(c -> c.adapterKey.adapter.name).distinct().sortThis().makeString(", "));
     }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-compiled-functions-standard/src/test/java/org/finos/legend/pure/runtime/java/extension/functions/standard/compiled/TestPCTReport.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-compiled-functions-standard/src/test/java/org/finos/legend/pure/runtime/java/extension/functions/standard/compiled/TestPCTReport.java
@@ -26,7 +26,7 @@ public class TestPCTReport
     public void canFindPCTReport()
     {
         Assert.assertEquals("Native", PCTReportProviderLoader.gatherReports().collect(c -> c.adapterKey.adapter.name).distinct().sortThis().makeString(", "));
-        ImmutableSet<String> expectedReports = Sets.immutable.of("essential", "grammar", "relation", "standard");
+        ImmutableSet<String> expectedReports = Sets.immutable.of("essential", "grammar", "relation", "standard", "unclassified");
         Assert.assertEquals(expectedReports, PCTReportProviderLoader.gatherReports().collect(c -> c.reportScope.module).toSet());
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-interpreted-functions-standard/src/test/java/org/finos/legend/pure/runtime/java/extension/functions/standard/interpreted/TestPCTReport.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-interpreted-functions-standard/src/test/java/org/finos/legend/pure/runtime/java/extension/functions/standard/interpreted/TestPCTReport.java
@@ -27,7 +27,7 @@ public class TestPCTReport
     {
         Assert.assertEquals("Native", PCTReportProviderLoader.gatherReports().collect(c -> c.adapterKey.adapter.name).distinct().sortThis().makeString(", "));
         System.out.println(PCTReportProviderLoader.gatherReports().collect(c -> c.reportScope.module));
-        ImmutableSet expectedReports = Sets.immutable.of("essential", "grammar", "relation", "standard");
+        ImmutableSet expectedReports = Sets.immutable.of("essential", "grammar", "unclassified", "relation", "standard");
         Assert.assertEquals(expectedReports, PCTReportProviderLoader.gatherReports().collect(c -> c.reportScope.module).toSet());
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/memsql/pct/TestPCRReport.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/memsql/pct/TestPCRReport.java
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.pure.code.core.tests;
+package org.finos.legend.engine.plan.execution.stores.relational.test.memsql.pct;
 
 import org.finos.legend.pure.m3.pct.shared.provider.PCTReportProviderLoader;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestPCTReport
+public class TestPCRReport
 {
     @Test
     public void canFindPCTReport()
     {
-        Assert.assertEquals(4, PCTReportProviderLoader.gatherFunctions().size());
-        Assert.assertEquals("essential, grammar, relation, unclassified", PCTReportProviderLoader.gatherFunctions().collect(c -> c.reportScope.module).distinct().sortThis().makeString(", "));
-        Assert.assertEquals(0, PCTReportProviderLoader.gatherReports().size());
-        Assert.assertEquals("", PCTReportProviderLoader.gatherReports().collect(c -> c.adapterKey.adapter).distinct().sortThis().makeString(", "));
+        Assert.assertEquals("MemSQL, Native", PCTReportProviderLoader.gatherReports().collect(c -> c.adapterKey.adapter.name).distinct().sortThis().makeString(", "));
+        Assert.assertEquals(9, PCTReportProviderLoader.gatherReports().size());
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/spanner/pct/Test_Relational_Spanner_RelationFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/spanner/pct/Test_Relational_Spanner_RelationFunctions_PCT.java
@@ -46,7 +46,6 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
 
             //composition
             one("meta::pure::functions::relation::tests::composition::testExtendFilter_Function_1__Boolean_1_", "\"[unsupported-api] The function 'toString' (state: [Where, false]) is not supported yet\""),
-            one("meta::pure::functions::relation::tests::composition::testFilterPostProject_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   legalName,firstName\n   Firm X,Peter\n   Firm X,John\n   Firm X,John\n   Firm X,Anthony\n#'\nactual:   '#TDS\n   legalName,firstName\n   Firm X,Anthony\n   Firm X,John\n   Firm X,John\n   Firm X,Peter\n#'\""),
             one("meta::pure::functions::relation::tests::composition::testWindowFunctionsAfterProject_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),
             one("meta::pure::functions::relation::tests::composition::test_Distinct_GroupBy_Filter_Function_1__Boolean_1_", "Error while executing: insert into"),
             one("meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_ComplexGroupBy_Pivot_Function_1__Boolean_1_", "Error while executing: insert into"),
@@ -56,7 +55,6 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::relation::tests::composition::test_Pivot_Filter_Function_1__Boolean_1_", "Error while executing: insert into"),
 
             //concatenate
-            one("meta::pure::functions::relation::tests::concatenate::testSimpleConcatenateShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,str\n   1,a\n   3,ewe\n   4,qw\n   5,qwea\n   6,eeewe\n   7,qqwew\n#'\nactual:   '#TDS\n   val,str\n   1,a\n   6,eeewe\n   7,qqwew\n   3,ewe\n   4,qw\n   5,qwea\n#'\""),
             one("meta::pure::functions::relation::tests::concatenate::testSimpleConcatenate_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //cumulativeDistribution
@@ -74,7 +72,6 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::relation::tests::distinct::testDistinctSingle_MultipleExpressions_Function_1__Boolean_1_", "Error while executing: insert into"),
 
             //drop
-            one("meta::pure::functions::relation::tests::drop::testSimpleDropShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,str\n   5,wwe\n   6,weq\n#'\nactual:   '#TDS\n   val,str\n   6,weq\n   4,qw\n#'\""),
             one("meta::pure::functions::relation::tests::drop::testSimpleDrop_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //extend
@@ -102,9 +99,7 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndMultipleOrderWindowMultipleColumns_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),
             one("meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndOrderWindowMultipleColumns_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),
             one("meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndOrderWindowMultipleColumns_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
-            one("meta::pure::functions::relation::tests::extend::testSimpleExtendFloat_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,doub,name\n   1,1.2,2.2\n   3,2.3,3.3\n   4,4.2,5.2\n   5,4.2,5.2\n   6,4.5,5.5\n#'\nactual:   '#TDS\n   val,doub,name\n   5,4.2,5.2\n   4,4.2,5.2\n   3,2.3,3.3\n   1,1.2,2.2\n   6,4.5,5.5\n#'\""),
             one("meta::pure::functions::relation::tests::extend::testSimpleExtendFloat_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
-            one("meta::pure::functions::relation::tests::extend::testSimpleExtendInt_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,str,name\n   1,a,2\n   3,ewe,4\n   4,qw,5\n   5,wwe,6\n   6,weq,7\n#'\nactual:   '#TDS\n   val,str,name\n   5,wwe,6\n   4,qw,5\n   3,ewe,4\n   1,a,2\n   6,weq,7\n#'\""),
             one("meta::pure::functions::relation::tests::extend::testSimpleExtendInt_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
             one("meta::pure::functions::relation::tests::extend::testSimpleExtendStrShared_Function_1__Boolean_1_", "\"[unsupported-api] The function 'toString' (state: [Select, false]) is not supported yet\""),
             one("meta::pure::functions::relation::tests::extend::testSimpleExtendStr_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
@@ -112,7 +107,6 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::relation::tests::extend::testSimpleMultipleColumns_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //filter
-            one("meta::pure::functions::relation::tests::filter::testSimpleFilterShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val\n   3\n   4\n#'\nactual:   '#TDS\n   val\n   4\n   3\n#'\""),
             one("meta::pure::functions::relation::tests::filter::testSimpleFilter_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //first
@@ -137,7 +131,6 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::relation::tests::lead::testOLAPWithPartitionAndOrderWindow_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),
 
             //limit
-            one("meta::pure::functions::relation::tests::limit::testSimpleLimitShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,str\n   1,a\n   3,ewe\n   4,qw\n#'\nactual:   '#TDS\n   val,str\n   5,wwe\n   3,ewe\n   1,a\n#'\""),
             one("meta::pure::functions::relation::tests::limit::testSimpleLimit_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //nth
@@ -161,25 +154,20 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::relation::tests::pivot::testPivot_SingleSingle_MultipleExpressions_Function_1__Boolean_1_", "Error while executing: insert into"),
 
             //project
-            one("meta::pure::functions::relation::tests::project::testSimpleProjectWithEmpty_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   one,two,three\n   ok,no,null\n   ok,other,null\n#'\nactual:   '#TDS\n   one,two,three\n   ok,other,null\n   ok,no,null\n#'\""),
             one("meta::pure::functions::relation::tests::project::testSimpleRelationProject_Function_1__Boolean_1_", "\"[unsupported-api] The function 'toString' (state: [Select, false]) is not supported yet\""),
 
             //rank
             one("meta::pure::functions::relation::tests::rank::testOLAPWithPartitionAndOrderRank_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),
 
             //rename
-            one("meta::pure::functions::relation::tests::rename::testSimpleRenameShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,newStr\n   1,a\n   3,ewe\n   4,qw\n   5,wwe\n   6,weq\n#'\nactual:   '#TDS\n   val,newStr\n   3,ewe\n   5,wwe\n   1,a\n   4,qw\n   6,weq\n#'\""),
             one("meta::pure::functions::relation::tests::rename::testSimpleRename_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //rowNumber
             one("meta::pure::functions::relation::tests::rowNumber::testOLAPWithPartitionAndRowNumber_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),
 
             //select
-            one("meta::pure::functions::relation::tests::select::testMultiColsSelectShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,other\n   1,a\n   3,b\n   4,c\n   5,d\n   6,e\n#'\nactual:   '#TDS\n   val,other\n   3,b\n   5,d\n   1,a\n   4,c\n   6,e\n#'\""),
             one("meta::pure::functions::relation::tests::select::testMultiColsSelect_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
-            one("meta::pure::functions::relation::tests::select::testSelectAll_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,str,other\n   1,a,a\n   3,ewe,b\n   4,qw,c\n   5,wwe,d\n   6,weq,e\n#'\nactual:   '#TDS\n   val,str,other\n   3,ewe,b\n   5,wwe,d\n   1,a,a\n   4,qw,c\n   6,weq,e\n#'\""),
             one("meta::pure::functions::relation::tests::select::testSelectAll_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
-            one("meta::pure::functions::relation::tests::select::testSingleColSelectShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   str\n   a\n   ewe\n   qw\n   wwe\n   weq\n#'\nactual:   '#TDS\n   str\n   ewe\n   wwe\n   a\n   qw\n   weq\n#'\""),
             one("meta::pure::functions::relation::tests::select::testSingleColSelect_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
             one("meta::pure::functions::relation::tests::select::testSingleSelectWithQuotedColumn_Function_1__Boolean_1_", "Error while executing: Create Table"),
             one("meta::pure::functions::relation::tests::select::testSingleSelectWithQuotedColumn_MultipleExpressions_Function_1__Boolean_1_", "Error while executing: Create Table"),
@@ -191,7 +179,6 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::relation::tests::size::testSize_Relation_Window_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),
 
             //slice
-            one("meta::pure::functions::relation::tests::slice::testSimpleSliceShared_Function_1__Boolean_1_", "\"\nexpected: '#TDS\n   val,str\n   3,ewe\n   4,qw\n#'\nactual:   '#TDS\n   val,str\n   1,a\n   5,wwe\n#'\""),
             one("meta::pure::functions::relation::tests::slice::testSimpleSlice_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //sort


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?
Update assertion in PCT tests that contains unordered tds. Allow the tds being unsorted during testing
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--Fix testcases accuracy
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
