### PR TITLE
Fix usage of double quotes in Schema. Remove ambiguity with precise primitive type names.

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
@@ -2403,14 +2403,14 @@ public class Handlers
         map.put("cov_String", Sets.mutable.with("String", "Varchar", "Nil"));
         map.put("cov_function_LambdaFunction", Sets.mutable.with("LambdaFunction", "Nil"));
         map.put("cov_type_Unit", Sets.mutable.with("Unit", "Nil"));
-        map.put("cov_Number", Sets.mutable.with("Number", "Integer", "Float", "Decimal", "TinyInt", "UTinyInt", "SmallInt", "USmallInt", "Int", "UInt", "BigInt", "UBigInt", "Float4", "Double", "Decimal", "Nil"));
+        map.put("cov_Number", Sets.mutable.with("Number", "Integer", "Float", "Decimal", "TinyInt", "UTinyInt", "SmallInt", "USmallInt", "Int", "UInt", "BigInt", "UBigInt", "Float4", "Double", "Numeric", "Nil"));
         map.put("cov_Boolean", Sets.mutable.with("Boolean", "Nil"));
         map.put("cov_type_Type", Sets.mutable.with("Type", "Class", "FunctionType", "DataType", "RelationType", "ClassProjection", "MappingClass", "Unit", "Enumeration", "PrimitiveType", "Measure", "Mass", "Gram", "Kilogram", "Pound", "Nil"));
         map.put("cov_Integer", Sets.mutable.with("Integer", "TinyInt", "UTinyInt", "SmallInt", "USmallInt", "Int", "UInt", "BigInt", "UBigInt", "Nil"));
-        map.put("cov_Date", Sets.mutable.with("Date", "StrictDate", "DateTime", "LatestDate", "Date", "Timestamp", "Nil"));
+        map.put("cov_Date", Sets.mutable.with("Date", "StrictDate", "DateTime", "LatestDate", "Timestamp", "Nil"));
         map.put("cov_function_FunctionDefinition", Sets.mutable.with("FunctionDefinition", "NewPropertyRouteNodeFunctionDefinition", "LambdaFunction", "QualifiedProperty", "ConcreteFunctionDefinition", "Nil"));
         map.put("cov_graphFetch_RootGraphFetchTree", Sets.mutable.with("RootGraphFetchTree", "ExtendedRootGraphFetchTree", "RoutedRootGraphFetchTree", "DataQualityRootGraphFetchTree", "SerializeTopRootGraphFetchTree", "Nil"));
-        map.put("cov_StrictDate", Sets.mutable.with("StrictDate", "Date", "Nil"));
+        map.put("cov_StrictDate", Sets.mutable.with("StrictDate", "Nil"));
         map.put("cov_date_Duration", Sets.mutable.with("Duration", "Nil"));
         map.put("cov_date_DurationUnit", Sets.mutable.with("DurationUnit", "Nil"));
         map.put("cov_DateTime", Sets.mutable.with("DateTime", "Timestamp", "Nil"));
@@ -2418,7 +2418,7 @@ public class Handlers
         map.put("cov_hash_HashType", Sets.mutable.with("HashType", "Nil"));
         map.put("cov_function_KeyExpression", Sets.mutable.with("KeyExpression", "Nil"));
         map.put("cov_Float", Sets.mutable.with("Float", "Float4", "Double", "Nil"));
-        map.put("cov_Decimal", Sets.mutable.with("Decimal", "Decimal", "Nil"));
+        map.put("cov_Decimal", Sets.mutable.with("Decimal", "Numeric", "Nil"));
         map.put("cov_wavgUtility_WavgRowMapper", Sets.mutable.with("WavgRowMapper", "Nil"));
         map.put("cov_relation_Relation", Sets.mutable.with("Relation", "RelationElementAccessor", "TDS", "RelationStoreAccessor", "TDSRelationAccessor", "Nil"));
         map.put("cov_relation_ColSpec", Sets.mutable.with("ColSpec", "Nil"));

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestCompilationFromGrammar.java
@@ -1065,6 +1065,17 @@ public class TestCompilationFromGrammar
         );
     }
 
+    @Test
+    public void testDateFunctionTypeInference()
+    {
+        TestCompilationFromGrammarTestSuite.test(
+                "###Pure\n" +
+                        "function x::func(param1: Date[1], param2:Date[1]):Any[*]" +
+                        "{" +
+                        "   max([$param1, $param2])->toString()" +
+                        "}","COMPILATION error at [2:86-93]: Can't find a match for function 'toString(Date[0..1])'"
+        );
+    }
 
     @Test
     public void testTypeVariables()

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
@@ -149,7 +149,7 @@ function meta::relational::tests::pct::testAdapterForRelationalExecution<X|o>(f:
                                                                                           $type == 'meta::pure::precisePrimitives::Varchar', |'null'),
                                                                                     pair(|$type == 'DateTime' ||
                                                                                           $type == 'meta::pure::precisePrimitives::Timestamp' ||
-                                                                                          $type == 'meta::pure::precisePrimitives::Date', |'')
+                                                                                          $type == 'StrictDate', |'')
                                                                                   ],
                                                                                   |fail($type->toOne()+' is not managed yet!');0;
                                                                               );,

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
@@ -58,7 +58,7 @@ taggedValue:                                    qualifiedName DOT identifier EQU
 
 // -------------------------------------- SCHEMA & TABLE --------------------------------------
 
-schema:                                     SCHEMA stereotypes? taggedValues? relationalIdentifier
+schema:                                     SCHEMA stereotypes? taggedValues? schemaIdentifier
                                                 PAREN_OPEN
                                                     (
                                                         table
@@ -331,4 +331,7 @@ scopeInfo:                                  relationalIdentifier (DOT relational
 databasePointer:                            BRACKET_OPEN qualifiedName BRACKET_CLOSE
 ;
 relationalIdentifier:                       unquotedIdentifier | QUOTED_STRING
+;
+// Should be the same as relationalIdentifier, but it currently breaks some projects
+schemaIdentifier:                           identifier | QUOTED_STRING
 ;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
@@ -843,7 +843,7 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
 
     private GenericType convertTypes(String type, RichIterable<? extends ValueSpecification> typeVariableValues, CompileContext compileContext)
     {
-        return compileContext.newGenericType((PrimitiveType) compileContext.resolvePackageableElement("meta::pure::precisePrimitives::" + type, null))
+        return compileContext.newGenericType((PrimitiveType) compileContext.resolvePackageableElement(type, null))
                 ._typeVariableValues(typeVariableValues);
     }
 
@@ -851,15 +851,15 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
     {
         if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Integer)
         {
-            return convertTypes("Int", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::Int", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Float)
         {
-            return convertTypes("Float4", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::Float4", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Varchar)
         {
-            return convertTypes("Varchar",
+            return convertTypes("meta::pure::precisePrimitives::Varchar",
                     Lists.mutable.with(new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, compileContext.pureModel.getClass(M3Paths.InstanceValue))
                             ._genericType(compileContext.pureModel.getGenericType("Integer"))
                             ._multiplicity(compileContext.pureModel.getMultiplicity("One"))
@@ -868,7 +868,7 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Char)
         {
-            return convertTypes("Varchar",
+            return convertTypes("meta::pure::precisePrimitives::Varchar",
                     Lists.mutable.with(new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, compileContext.pureModel.getClass(M3Paths.InstanceValue))
                             ._genericType(compileContext.pureModel.getGenericType("Integer"))
                             ._multiplicity(compileContext.pureModel.getMultiplicity("One"))
@@ -878,7 +878,7 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Decimal)
         {
-            return convertTypes("Decimal",
+            return convertTypes("meta::pure::precisePrimitives::Numeric",
                     Lists.mutable.with(
                             new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, compileContext.pureModel.getClass(M3Paths.InstanceValue))
                                     ._genericType(compileContext.pureModel.getGenericType("Integer"))
@@ -892,31 +892,31 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Timestamp)
         {
-            return convertTypes("Timestamp", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::Timestamp", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Date)
         {
-            return convertTypes("Date", compileContext);
+            return convertTypes("StrictDate", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.BigInt)
         {
-            return convertTypes("BigInt", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::BigInt", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.SmallInt)
         {
-            return convertTypes("SmallInt", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::SmallInt", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.TinyInt)
         {
-            return convertTypes("TinyInt", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::TinyInt", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Double)
         {
-            return convertTypes("Double", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::Double", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Numeric)
         {
-            return convertTypes("Decimal",
+            return convertTypes("meta::pure::precisePrimitives::Numeric",
                     Lists.mutable.with(
                             new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, compileContext.pureModel.getClass(M3Paths.InstanceValue))
                                     ._genericType(compileContext.pureModel.getGenericType("Integer"))
@@ -930,11 +930,11 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Bit)
         {
-            return convertTypes("TinyInt", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::TinyInt", compileContext);
         }
         else if (c instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.Real)
         {
-            return convertTypes("Double", compileContext);
+            return convertTypes("meta::pure::precisePrimitives::Double", compileContext);
         }
         // Fallback to platform function if precise primitive not available
         return (GenericType) compileContext.pureModel.getExecutionSupport().getProcessorSupport().type_wrapGenericType(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -195,9 +195,9 @@ public class RelationalParseTreeWalker
     {
         Schema schema = new Schema();
         schema.sourceInformation = this.walkerSourceInformation.getSourceInformation(ctx);
-        schema.name = ctx.relationalIdentifier().QUOTED_STRING() == null ? ctx.relationalIdentifier().unquotedIdentifier().getText() : ctx.relationalIdentifier().QUOTED_STRING().getText();
+        schema.name = ctx.schemaIdentifier().QUOTED_STRING() == null ? ctx.schemaIdentifier().identifier().getText() : ctx.schemaIdentifier().QUOTED_STRING().getText();
         schema.tables = ListIterate.collect(ctx.table(), this::visitTable);
-        schema.views = ListIterate.collect(ctx.view(), viewCtx -> this.visitView(viewCtx, ScopeInfo.Builder.newInstance(scopeInfo).withSchemaToken(ctx.relationalIdentifier().getStart()).build()));
+        schema.views = ListIterate.collect(ctx.view(), viewCtx -> this.visitView(viewCtx, ScopeInfo.Builder.newInstance(scopeInfo).withSchemaToken(ctx.schemaIdentifier().getStart()).build()));
         schema.tabularFunctions = ListIterate.collect(ctx.tabularFunction(), funcCtx -> this.visitTabularFunc(funcCtx));
         if (ctx.stereotypes() != null)
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
@@ -266,7 +266,7 @@ public class HelperRelationalGrammarComposer
         StringBuilder builder = new StringBuilder();
         builder.append(getTabString(baseIndentation)).append("Schema ");
         builder.append(HelperDomainGrammarComposer.renderAnnotations(schema.stereotypes, schema.taggedValues));
-        builder.append(PureGrammarComposerUtility.convertIdentifier(schema.name)).append("\n");
+        builder.append(schema.name).append("\n");
         builder.append(getTabString(baseIndentation)).append("(\n");
         boolean nonEmpty = false;
         if (!schema.tables.isEmpty())

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -3182,4 +3182,49 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
                 ")", null, Arrays.asList("COMPILATION error at [21:3-52]: Found filters with duplicate names: FirmFilter", "COMPILATION error at [22:3-44]: Found filters with duplicate names: FirmFilter"));
     }
 
+
+    @Test
+    public void testRelationalSchema()
+    {
+        test("###Relational\n" +
+                        "Database model::relational::tests::dbInc\n" +
+                        "(\n" +
+                        "   Schema test" +
+                        "   (" +
+                        "    Table personTable (ID INT PRIMARY KEY, FIRMID INT)\n" +
+                        "    Table firmTable(ID INT PRIMARY KEY)\n" +
+                        "   )" +
+                        "\n" +
+                        ")");
+    }
+
+    @Test
+    public void testRelationalSchemaDoubleQuoted()
+    {
+        test("###Relational\n" +
+                "Database model::relational::tests::dbInc\n" +
+                "(\n" +
+                "   Schema \"test\"" +
+                "   (" +
+                "    Table personTable (ID INT PRIMARY KEY, FIRMID INT)\n" +
+                "    Table firmTable(ID INT PRIMARY KEY)\n" +
+                "   )" +
+                "\n" +
+                ")");
+    }
+
+    @Test
+    public void testRelationalSchemaSingleAndDoubleQuoted()
+    {
+        test("###Relational\n" +
+                "Database model::relational::tests::dbInc\n" +
+                "(\n" +
+                "   Schema '\"test\"'" +
+                "   (" +
+                "    Table personTable (ID INT PRIMARY KEY, FIRMID INT)\n" +
+                "    Table firmTable(ID INT PRIMARY KEY)\n" +
+                "   )" +
+                "\n" +
+                ")");
+    }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
@@ -169,7 +169,43 @@ public class TestRelationalGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
                 "  }\n" +
                 ")\n");
     }
-    
+
+    @Test
+    public void testRelationalSchemaDoubleQuote()
+    {
+        test("###Relational\n" +
+                "Database simple::dbInc\n" +
+                "(\n" +
+                "  Schema \"productSchema\"\n" +
+                "  (\n" +
+                "    Table \"productTable\"\n" +
+                "    (\n" +
+                "      ID INTEGER PRIMARY KEY,\n" +
+                "      NAME VARCHAR(200)\n" +
+                "    )\n" +
+                "  )\n" +
+                ")\n"
+        );
+    }
+
+    @Test
+    public void testRelationalSchemaSingleDoubleQuote()
+    {
+        test("###Relational\n" +
+                "Database simple::dbInc\n" +
+                "(\n" +
+                "  Schema '\"productSchema\"'\n" +
+                "  (\n" +
+                "    Table \"productTable\"\n" +
+                "    (\n" +
+                "      \"ID\" INTEGER PRIMARY KEY,\n" +
+                "      NAME VARCHAR(200)\n" +
+                "    )\n" +
+                "  )\n" +
+                ")\n"
+        );
+    }
+
     @Test
     public void testRelationalSimpleFullInPretty()
     {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/transform/fromPure/pureToRelational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/transform/fromPure/pureToRelational.pure
@@ -49,10 +49,9 @@ function meta::relational::transform::fromPure::pureTypeToDataTypeMap():Map<Type
       pair(meta::pure::precisePrimitives::UBigInt, ^meta::relational::metamodel::datatype::BigInt()),
       pair(meta::pure::precisePrimitives::Varchar, ^meta::relational::metamodel::datatype::Varchar(size = 1024)),
       pair(meta::pure::precisePrimitives::Time, ^meta::relational::metamodel::datatype::Timestamp()),
-      pair(meta::pure::precisePrimitives::Date, ^meta::relational::metamodel::datatype::Date()),
       pair(meta::pure::precisePrimitives::Timestamp, ^meta::relational::metamodel::datatype::Timestamp()),
       pair(meta::pure::precisePrimitives::Float4, ^meta::relational::metamodel::datatype::Float()),
       pair(meta::pure::precisePrimitives::Double, ^meta::relational::metamodel::datatype::Double()),
-      pair(meta::pure::precisePrimitives::Decimal, ^meta::relational::metamodel::datatype::Decimal(scale=10, precision=10))
+      pair(meta::pure::precisePrimitives::Numeric, ^meta::relational::metamodel::datatype::Decimal(scale=10, precision=10))
    ]);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>5.41.1</legend.pure.version>
+        <legend.pure.version>5.42.0</legend.pure.version>
         <legend.shared.version>0.25.7</legend.shared.version>
         <legend.web-application.version>13.2.0</legend.web-application.version>
 


### PR DESCRIPTION
Fix usage of double quotes in Schema. Remove ambiguity with precise primitive type names.