### PR TITLE
fix relation mapping routing bug, better error messages

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/cluster.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/cluster.pure
@@ -503,9 +503,10 @@ function meta::pure::router::clustering::getClusterVSFromSets(r:StoreMappingRout
 function meta::pure::router::clustering::storeContractForSetImplementation(setImpl:SetImplementation[1], mapping:Mapping[1], extensions:meta::pure::extension::Extension[*]):Pair<StoreContract, Store>[1]
 {
   $setImpl->match([
-      t:RelationFunctionInstanceSetImplementation[1]| let vs = $t.relationFunction.expressionSequence->evaluateAndDeactivate()->at(0);
-                                                      assert($vs->instanceOf(StoreClusteredValueSpecification), 'Relation mapping does not support cross store queries yet.');
-                                                      let store = $vs->cast(@StoreClusteredValueSpecification).store;
+      t:RelationFunctionInstanceSetImplementation[1]| let vs = $t.relationFunction.expressionSequence->evaluateAndDeactivate();
+                                                      assert($vs->size() == 1, 'Function used in Relation function class mapping can only have a single expression!');
+                                                      assert($vs->at(0)->instanceOf(StoreClusteredValueSpecification), 'Relation function for set \'' + $setImpl.id + '\' in mapping \'' + $mapping->elementToPath() + '\' may not have been routed correctly. Found a ' + $vs->type().name->toOne() + ' instead of a StoreClusteredValueSpecification.');
+                                                      let store = $vs->at(0)->cast(@StoreClusteredValueSpecification).store;
                                                       pair(meta::pure::extension::storeContractFromStore($extensions, $store), $store);,
       i: InstanceSetImplementation[1]|
          let storeContract = $extensions->meta::pure::extension::storeContractForSetImplementation($i->toOne());
@@ -513,6 +514,7 @@ function meta::pure::router::clustering::storeContractForSetImplementation(setIm
          pair($storeContract, $mapping->resolveStore($store));,
       o: meta::pure::mapping::OperationSetImplementation[1]|
          let roots = $o->resolveInstanceSetImplementations();
+         assert($roots->forAll(r|!$r->instanceOf(RelationFunctionInstanceSetImplementation)), 'Relation function class mapping not supported in union operations yet!');
          let storeContract = $roots->map(r|$extensions->meta::pure::extension::storeContractForSetImplementation($r))->removeDuplicatesBy(x|$x.id)->toOne();
          let store = $roots->map(r|$mapping->resolveStore($storeContract.resolveStoreFromSetImplementation->toOne()->eval($r)))->removeDuplicatesBy(x|$x->elementToPath())->toOne();
          pair($storeContract, $mapping->resolveStore($store));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
@@ -114,11 +114,10 @@ function meta::pure::router::store::routing::routeRelationFunctionSetImplementat
 
 function meta::pure::router::store::routing::routeRelationFunctionSetImplementation(s:SetImplementation[1], mapping:Mapping[1], runtime:Runtime[1], extensions: Extension[*]):SetImplementation[1]
 {
-   $s->match([
-              t:RelationFunctionInstanceSetImplementation[1]|^$t(relationFunction=$t->routeRelationFunction($mapping, $runtime, $extensions)),
-              s:InstanceSetImplementation[1]|$s,
-              o:OperationSetImplementation[1]|^$o(parameters = $o.parameters->map(i| ^$i(setImplementation=$mapping->classMappingById($i.id)->toOne()->routeRelationFunctionSetImplementation($mapping, $runtime, $extensions))))
-            ]);
+  $s->match([
+    r:RelationFunctionInstanceSetImplementation[1]| ^$r(relationFunction = $r->routeRelationFunction($mapping, $runtime, $extensions)),
+    s:SetImplementation[1]| $s
+  ]);
 }
 
 function meta::pure::router::store::routing::routeRelationFunction(r:RelationFunctionInstanceSetImplementation[1], mapping:Mapping[1], runtime:Runtime[1], extensions: Extension[*]):FunctionDefinition<{->Relation<Any>[1]}>[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/relationMappingSetup.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/relationMappingSetup.pure
@@ -69,7 +69,7 @@ Association meta::relational::tests::mapping::relation::Person_Firm
 
 ###Mapping
 import meta::relational::tests::mapping::relation::*;
-Mapping meta::relational::tests::mapping::relation::simpleMapping
+Mapping meta::relational::tests::mapping::relation::SimpleMapping
 (
   *Person[person]: Relation
   {
@@ -93,7 +93,7 @@ Mapping meta::relational::tests::mapping::relation::simpleMapping
   }
 )
 
-Mapping meta::relational::tests::mapping::relation::mixedMapping
+Mapping meta::relational::tests::mapping::relation::MixedMapping
 (
   *Person[person]: Relation
   {
@@ -105,15 +105,15 @@ Mapping meta::relational::tests::mapping::relation::mixedMapping
 
   *PersonWithFirmId: Relational 
   {
-    firstName: [meta::relational::tests::mapping::relation::testDB]personTable."FIRST NAME",
-    age: [meta::relational::tests::mapping::relation::testDB]personTable.AGE,
-    firmId: [meta::relational::tests::mapping::relation::testDB]personTable.FIRMID
+    firstName: [testDB]personTable."FIRST NAME",
+    age: [testDB]personTable.AGE,
+    firmId: [testDB]personTable.FIRMID
   }
 
   *Firm[firm]: Relational 
   {
-    +id: Integer[1]: [meta::relational::tests::mapping::relation::testDB]firmTable.ID,
-    legalName: [meta::relational::tests::mapping::relation::testDB]firmTable.legalName
+    +id: Integer[1]: [testDB]firmTable.ID,
+    legalName: [testDB]firmTable.legalName
   }
 
   Person_Firm: XStore
@@ -123,15 +123,47 @@ Mapping meta::relational::tests::mapping::relation::mixedMapping
   }
 )
 
-Mapping meta::relational::tests::mapping::relation::complexMapping
+Mapping meta::relational::tests::mapping::relation::WindowFunctionMapping
 (
   *ExtendedPerson[person]: Relation
   {
-    ~func meta::relational::tests::mapping::relation::complexPersonFunction__Relation_1_
+    ~func meta::relational::tests::mapping::relation::personFunctionWithWindowColumn__Relation_1_
     firstName: 'FIRST NAME',
     groupName: GROUPNAME,
     age: AGE,
     rank: RANK
+  }
+)
+
+Mapping meta::relational::tests::mapping::relation::UnionMapping
+(
+  *Person[person] : Operation
+  {
+    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(person1, person2)
+  }
+
+  Person[person1]: Relation
+  {
+    ~func meta::relational::tests::mapping::relation::personFunction__Relation_1_
+    firstName: 'FIRST NAME',
+    age: AGE
+  }
+
+  Person[person2]: Relation
+  {
+    ~func meta::relational::tests::mapping::relation::personFunctionWithProject__Relation_1_
+    firstName: 'FIRST NAME',
+    age: AGE
+  }
+)
+
+Mapping meta::relational::tests::mapping::relation::MultiExprFunctionMapping
+(
+  *Person[person1]: Relation
+  {
+    ~func meta::relational::tests::mapping::relation::personFunctionMultiExpr__Relation_1_
+    firstName: 'FIRST NAME',
+    age: AGE
   }
 )
 
@@ -148,6 +180,14 @@ function meta::relational::tests::mapping::relation::personFunction(): Relation<
   #>{meta::relational::tests::mapping::relation::testDB.personTable}#
     ->filter(x | $x.AGE > 25)
     ->limit(5)
+}
+
+function meta::relational::tests::mapping::relation::personFunctionMultiExpr(): Relation<Any>[1]
+{
+  let age = 25;
+  #>{meta::relational::tests::mapping::relation::testDB.personTable}#
+    ->filter(x | $x.AGE > $age)
+    ->limit(5);
 }
 
 function meta::relational::tests::mapping::relation::personFunctionWithProject(): Relation<Any>[1]
@@ -171,7 +211,7 @@ function meta::relational::tests::mapping::relation::firmFunction(): Relation<An
     ->select(~[ID, legalName])
 }
 
-function meta::relational::tests::mapping::relation::complexPersonFunction(): Relation<Any>[1]
+function meta::relational::tests::mapping::relation::personFunctionWithWindowColumn(): Relation<Any>[1]
 {
   #>{meta::relational::tests::mapping::relation::testDB.personTable}#
     ->join(#>{meta::relational::tests::mapping::relation::testDB.groupMembershipTable}#, JoinKind.INNER, {x,y| $x.ID == $y.PERSONID})

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/tests.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/tests.pure
@@ -27,87 +27,87 @@ function <<test.BeforePackage>> meta::relational::tests::mapping::relation::setU
 
 function meta::relational::tests::mapping::relation::createTablesAndFillDb():Boolean[1]
 {
-   let connection = meta::external::store::relational::tests::testRuntime(testDB).connectionByElement(testDB)->cast(@meta::external::store::relational::runtime::TestDatabaseConnection);
-   
-   executeInDb('Drop table if exists PersonTable;', $connection);
-   executeInDb('Create Table PersonTable(id INT, "FIRST NAME" VARCHAR(200), age INT, firmId INT, birthdate DATE, salary DOUBLE, isMale BIT);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (1, \'Peter\',   23,  1, \'2000-11-01\', 14.34, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (2, \'John\',    30,  1, \'1994-11-01\', 72.40, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (3, \'Jane\',    23,  2, \'2000-11-01\', 48.00, 0);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (4, \'Anthony\', 19,  3, \'2005-11-01\', 64.90, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (5, \'Fabrice\', 45,  4, \'1979-11-01\', 19.29, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (6, \'Oliver\',  26,  4, \'1998-11-01\', 42.34, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (7, \'David\',   52,  5, \'1972-11-01\', 88.88, 1);', $connection);
+  let connection = meta::external::store::relational::tests::testRuntime(testDB).connectionByElement(testDB)->cast(@meta::external::store::relational::runtime::TestDatabaseConnection);
+  
+  executeInDb('Drop table if exists PersonTable;', $connection);
+  executeInDb('Create Table PersonTable(id INT, "FIRST NAME" VARCHAR(200), age INT, firmId INT, birthdate DATE, salary DOUBLE, isMale BIT);', $connection);
+  executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (1, \'Peter\',   23,  1, \'2000-11-01\', 14.34, 1);', $connection);
+  executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (2, \'John\',    30,  1, \'1994-11-01\', 72.40, 1);', $connection);
+  executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (3, \'Jane\',    23,  2, \'2000-11-01\', 48.00, 0);', $connection);
+  executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (4, \'Anthony\', 19,  3, \'2005-11-01\', 64.90, 1);', $connection);
+  executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (5, \'Fabrice\', 45,  4, \'1979-11-01\', 19.29, 1);', $connection);
+  executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (6, \'Oliver\',  26,  4, \'1998-11-01\', 42.34, 1);', $connection);
+  executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (7, \'David\',   52,  5, \'1972-11-01\', 88.88, 1);', $connection);
 
-   executeInDb('Drop table if exists FirmTable;', $connection);
-   executeInDb('Create Table FirmTable(id INT, legalName VARCHAR(200), addressId INT, ceoId INT);', $connection);
-   executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (1, \'Firm X\', 8, 1);', $connection);
-   executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (2, \'Firm A\', 9, 5);', $connection);
-   executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (3, \'Firm B\', 10, 3);', $connection);
-   executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (4, \'Firm C\', 11, 7);', $connection);
-   executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (5, \'Firm D\', 11, 2);', $connection);
+  executeInDb('Drop table if exists FirmTable;', $connection);
+  executeInDb('Create Table FirmTable(id INT, legalName VARCHAR(200), addressId INT, ceoId INT);', $connection);
+  executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (1, \'Firm X\', 8, 1);', $connection);
+  executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (2, \'Firm A\', 9, 5);', $connection);
+  executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (3, \'Firm B\', 10, 3);', $connection);
+  executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (4, \'Firm C\', 11, 7);', $connection);
+  executeInDb('insert into FirmTable (id, legalName, addressId, ceoId) values (5, \'Firm D\', 11, 2);', $connection);
 
-   executeInDb('Drop table if exists GroupMembershipTable;', $connection);
-   executeInDb('Create Table GroupMembershipTable(groupid INT, personid INT, groupname VARCHAR(30));', $connection);
-   executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (1, 1, \'Group A\');', $connection);
-   executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (1, 2, \'Group A\');', $connection);
-   executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (2, 3, \'Group B\');', $connection);
-   executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (3, 4, \'Group C\');', $connection);
-   executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (3, 5, \'Group C\');', $connection);
-   executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (3, 6, \'Group C\');', $connection);
-   executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (4, 7, \'Group D\');', $connection);
+  executeInDb('Drop table if exists GroupMembershipTable;', $connection);
+  executeInDb('Create Table GroupMembershipTable(groupid INT, personid INT, groupname VARCHAR(30));', $connection);
+  executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (1, 1, \'Group A\');', $connection);
+  executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (1, 2, \'Group A\');', $connection);
+  executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (2, 3, \'Group B\');', $connection);
+  executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (3, 4, \'Group C\');', $connection);
+  executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (3, 5, \'Group C\');', $connection);
+  executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (3, 6, \'Group C\');', $connection);
+  executeInDb('insert into GroupMembershipTable (groupid, personid, groupname) values (4, 7, \'Group D\');', $connection);
 
   true;
 }
 
 function <<access.private>> meta::relational::tests::mapping::relation::testTds(func: FunctionDefinition<{->TabularDataSet[1]}>[1], mapping: Mapping[1], expectedRows:String[*]):Boolean[1]
 {
-   let result = execute($func, 
+  let result = execute($func, 
                         $mapping, 
-                        meta::external::store::relational::tests::testRuntime(meta::relational::tests::mapping::relation::testDB), 
+                        meta::external::store::relational::tests::testRuntime(testDB), 
                         meta::relational::extension::relationalExtensions()
                       ).values->at(0);
 
-   assertSameElements($expectedRows, $result.rows->map(r|$r.values->makeString(' | ')));
+  assertSameElements($expectedRows, $result.rows->map(r|$r.values->makeString(' | ')));
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testSimpleRelationMapping():Boolean[1]
 {
-   testTds(|Person.all()->project([x|$x.firstName, x|$x.age], ['name', 'age']), 
-            meta::relational::tests::mapping::relation::simpleMapping, 
+  testTds(|Person.all()->project([x|$x.firstName, x|$x.age], ['name', 'age']), 
+            SimpleMapping, 
             ['David | 52', 'Fabrice | 45', 'John | 30', 'Oliver | 26']
           );
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testSimpleRelationMappingWithAssociation():Boolean[1]
 {
-   testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.legalName], ['name', 'firmName']),
-            meta::relational::tests::mapping::relation::simpleMapping, 
+  testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.legalName], ['name', 'firmName']),
+            SimpleMapping, 
             ['David | Firm D', 'Fabrice | Firm C', 'John | Firm X', 'Oliver | Firm C']
           );
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testSimpleRelationMappingWithFilter():Boolean[1]
 {
-   testTds(|Firm.all()->filter(x|$x.legalName != 'Firm X')->project([x|$x.legalName, x|$x.employees.firstName], ['firmName', 'name']), 
-            meta::relational::tests::mapping::relation::simpleMapping, 
+  testTds(|Firm.all()->filter(x|$x.legalName != 'Firm X')->project([x|$x.legalName, x|$x.employees.firstName], ['firmName', 'name']), 
+            SimpleMapping, 
             ['Firm A | TDSNull', 'Firm B | TDSNull', 'Firm C | Fabrice', 'Firm C | Oliver', 'Firm D | David']
           );
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testSimpleRelationMappingWithSubFilter():Boolean[1]
 {
-   testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.employees->filter(e|$e.age < 35).firstName], ['name', 'firmName']), 
-            meta::relational::tests::mapping::relation::simpleMapping, 
+  testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.employees->filter(e|$e.age < 35).firstName], ['name', 'firmName']), 
+            SimpleMapping, 
             ['David | TDSNull', 'Fabrice | TDSNull', 'John | John', 'Oliver | Fabrice', 'Oliver | Oliver']
           );
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testSimpleRelationMappingWithGroupByAndProject():Boolean[1]
 {
-   testTds(|Person.all()->groupBy([p|$p.firm.legalName], [agg(p|$p.age, y | $y->average())], ['name', 'averageAge'])
+  testTds(|Person.all()->groupBy([p|$p.firm.legalName], [agg(p|$p.age, y | $y->average())], ['name', 'averageAge'])
                         ->project([col(r:TDSRow[1]|$r.getString('name'), 'name'), col(r:TDSRow[1]|$r.getString('averageAge'), 'averageAge')]),
-            meta::relational::tests::mapping::relation::simpleMapping,
+            SimpleMapping,
             ['Firm C | 35.5', 'Firm D | 52.0', 'Firm X | 30.0']
           );
 }
@@ -115,23 +115,23 @@ function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::r
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testMixedMapping():Boolean[1]
 {
   testTds(|Person.all()->project([x|$x.firstName, x|$x.age], ['name', 'age']), 
-            meta::relational::tests::mapping::relation::mixedMapping, 
+            MixedMapping, 
             ['David | 52', 'Fabrice | 45', 'John | 30', 'Oliver | 26']
           );
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testMixedMappingWithAssociation():Boolean[1]
 {
-   testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.legalName], ['name', 'firmName']), 
-            meta::relational::tests::mapping::relation::mixedMapping, 
+  testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.legalName], ['name', 'firmName']), 
+            MixedMapping, 
             ['David | Firm D', 'Fabrice | Firm C', 'John | Firm X', 'Oliver | Firm C']
           );
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testMixedMappingWithFilter():Boolean[1]
 {
-   testTds(|Firm.all()->filter(x|$x.legalName != 'Firm X')->project([x|$x.legalName, x|$x.employees.firstName], ['firmName', 'name']), 
-            meta::relational::tests::mapping::relation::mixedMapping, 
+  testTds(|Firm.all()->filter(x|$x.legalName != 'Firm X')->project([x|$x.legalName, x|$x.employees.firstName], ['firmName', 'name']), 
+            MixedMapping, 
             ['Firm A | TDSNull', 'Firm B | TDSNull', 'Firm C | Fabrice', 'Firm C | Oliver', 'Firm D | David']
           );
 }
@@ -139,26 +139,45 @@ function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::r
 // SQL Gen fails during isolation when adding a self join, need to investigate further
 function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.ToFix>> meta::relational::tests::mapping::relation::testMixedMappingWithSubFilter():Boolean[1]
 {
-   testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.employees->filter(e|$e.age < 35).firstName], ['name', 'firmName']), 
-            meta::relational::tests::mapping::relation::mixedMapping, 
+  testTds(|Person.all()->project([x|$x.firstName, x|$x.firm.employees->filter(e|$e.age < 35).firstName], ['name', 'firmName']), 
+            MixedMapping, 
             ['David | TDSNull', 'Fabrice | TDSNull', 'John | John', 'Oliver | Fabrice', 'Oliver | Oliver']
           );
 }
 
 function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testMixedMappingWithGroupByAndProject():Boolean[1]
 {
-   testTds(|Person.all()->groupBy([p|$p.firm.legalName], [agg(p|$p.age, y | $y->average())], ['name', 'averageAge'])
+  testTds(|Person.all()->groupBy([p|$p.firm.legalName], [agg(p|$p.age, y | $y->average())], ['name', 'averageAge'])
                         ->project([col(r:TDSRow[1]|$r.getString('name'), 'name'), col(r:TDSRow[1]|$r.getString('averageAge'), 'averageAge')]),
-            meta::relational::tests::mapping::relation::mixedMapping,
+            MixedMapping,
             ['Firm C | 35.5', 'Firm D | 52.0', 'Firm X | 30.0']
           );
 }
 
-function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testComplexRelationMapping():Boolean[1]
+function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testRelationMappingWithWindowFunction():Boolean[1]
 {
-   testTds(|ExtendedPerson.all()->filter(x|$x.age > 25)->project([x|$x.firstName, x|$x.groupName, x|$x.rank], ['name', 'groupName', 'rank']), 
-            meta::relational::tests::mapping::relation::complexMapping, 
+  testTds(|ExtendedPerson.all()->filter(x|$x.age > 25)->project([x|$x.firstName, x|$x.groupName, x|$x.rank], ['name', 'groupName', 'rank']), 
+            meta::relational::tests::mapping::relation::WindowFunctionMapping, 
             ['David | Group D | 1', 'Fabrice | Group C | 1', 'John | Group A | 2', 'Oliver | Group C | 2']
           );
 }
 
+function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testUnionRelationMappingShouldFail():Boolean[1]
+{
+  let execQuery = {|execute(| Person.all()->project([x|$x.firstName], ['name']), 
+                    UnionMapping, 
+                    meta::external::store::relational::tests::testRuntime(testDB), 
+                    meta::relational::extension::relationalExtensions()
+                  )};
+  assertError($execQuery, 'Relation function class mapping not supported in union operations yet!');
+}
+
+function <<meta::pure::profiles::test.Test>> meta::relational::tests::mapping::relation::testRelationMappingFunctionWithMultipleExpressionsShouldFail():Boolean[1]
+{
+  let execQuery = {|execute(| Person.all()->project([x|$x.firstName], ['name']), 
+                    MultiExprFunctionMapping, 
+                    meta::external::store::relational::tests::testRuntime(testDB), 
+                    meta::relational::extension::relationalExtensions()
+                  )};
+  assertError($execQuery, 'Function used in Relation function class mapping can only have a single expression!');
+}


### PR DESCRIPTION
fix relation mapping routing bug, better error messages

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
Bug Fix

#### What does this PR do / why is it needed ?
Fix niche bug when handling union operations during relation function mapping routing. This is a temporary fix, dropping union handling altogether (unions with relation mapping isn't supported anyway). Strategic fix would be to only route set impls when actually used in the expression being routed rather than routing all sets in scope.
Also, add user-friendly error messages about unsupported functionality.

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
