### PR TITLE
FlatData: option for FixedWidth final column to read to EoL

### DIFF
--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/src/test/java/org/finos/legend/engine/external/format/flatdata/grammar/driver/TestFixedWidth.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/src/test/java/org/finos/legend/engine/external/format/flatdata/grammar/driver/TestFixedWidth.java
@@ -115,6 +115,97 @@ public class TestFixedWidth extends AbstractDriverTest
         Assert.assertEquals("MD", p3.TITLE);
     }
 
+
+    @Test
+    public void canReadErrorFreeDynamicSizeFinalColumn()
+    {
+        FlatData flatData = parseFlatData("section default: FixedWidth\n" +
+                "{\n" +
+                "  scope.untilEof;\n" +
+                "\n" +
+                "  Record\n" +
+                "  {\n" +
+                "    FIRM          {1:2} : STRING;\n" +
+                "    AGE           {3:4} : INTEGER;\n" +
+                "    MASTER        {5:5} : INTEGER(optional);\n" +
+                "    WEIGHT        {6:8} : STRING(optional);\n" +
+                "    NAME          {9:12} : STRING;\n" +
+                "    EMPLOYED_DATE {13:22} : DATE(format='yyyy-MM-dd');\n" +
+                "    TITLE         {23} : STRING;\n" +
+                "  }\n" +
+                "}\n");
+
+        String data = data("\r\n",
+                "GS2511.1Alex2013-08-13Mrs",
+                "GG2601.2Brad2003-01-01Mr",
+                "FB2711.3Karl2011-11-26Master"
+        );
+
+        List<IChecked<Person>> records = deserialize(Person.class, flatData, data);
+        records.forEach(this::assertNoDefects);
+
+        List<ExpectedRecordValue> expectedRecordValues1 = Arrays.asList(
+                AbstractDriverTest.rValue("1:2", "GS"),
+                AbstractDriverTest.rValue("3:4", "25"),
+                AbstractDriverTest.rValue("5:5", "1"),
+                AbstractDriverTest.rValue("6:8", "1.1"),
+                AbstractDriverTest.rValue("9:12", "Alex"),
+                AbstractDriverTest.rValue("13:22", "2013-08-13"),
+                AbstractDriverTest.rValue("23", "Mrs")
+        );
+
+        List<ExpectedRecordValue> expectedRecordValues2 = Arrays.asList(
+                AbstractDriverTest.rValue("1:2", "GG"),
+                AbstractDriverTest.rValue("3:4", "26"),
+                AbstractDriverTest.rValue("5:5", "0"),
+                AbstractDriverTest.rValue("6:8", "1.2"),
+                AbstractDriverTest.rValue("9:12", "Brad"),
+                AbstractDriverTest.rValue("13:22", "2003-01-01"),
+                AbstractDriverTest.rValue("23", "Mr")
+        );
+
+        List<AbstractDriverTest.ExpectedRecordValue> expectedRecordValues3 = Arrays.asList(
+                AbstractDriverTest.rValue("1:2", "FB"),
+                AbstractDriverTest.rValue("3:4", "27"),
+                AbstractDriverTest.rValue("5:5", "1"),
+                AbstractDriverTest.rValue("6:8", "1.3"),
+                AbstractDriverTest.rValue("9:12", "Karl"),
+                AbstractDriverTest.rValue("13:22", "2011-11-26"),
+                AbstractDriverTest.rValue("23", "Master")
+        );
+
+        assertSource(1, 1, "GS2511.1Alex2013-08-13Mrs", expectedRecordValues1, records.get(0));
+        Person p1 = records.get(0).getValue();
+        Assert.assertEquals("GS", p1.FIRM);
+        Assert.assertEquals(25L, p1.AGE);
+        Assert.assertEquals(1, p1.MASTER);
+        Assert.assertEquals("1.1", p1.WEIGHT);
+        Assert.assertEquals("Alex", p1.NAME);
+        Assert.assertEquals(LocalDate.parse("2013-08-13"), p1.EMPLOYED_DATE);
+        Assert.assertEquals("Mrs", p1.TITLE);
+
+        assertSource(2, 2, "GG2601.2Brad2003-01-01Mr", expectedRecordValues2, records.get(1));
+        Person p2 = records.get(1).getValue();
+        Assert.assertEquals("GG", p2.FIRM);
+        Assert.assertEquals(26L, p2.AGE);
+        Assert.assertEquals(0, p2.MASTER);
+        Assert.assertEquals("1.2", p2.WEIGHT);
+        Assert.assertEquals("Brad", p2.NAME);
+        Assert.assertEquals(LocalDate.parse("2003-01-01"), p2.EMPLOYED_DATE);
+        Assert.assertEquals("Mr", p2.TITLE);
+
+
+        assertSource(3, 3, "FB2711.3Karl2011-11-26Master", expectedRecordValues3, records.get(2));
+        Person p3 = records.get(2).getValue();
+        Assert.assertEquals("FB", p3.FIRM);
+        Assert.assertEquals(27L, p3.AGE);
+        Assert.assertEquals(1, p3.MASTER);
+        Assert.assertEquals("1.3", p3.WEIGHT);
+        Assert.assertEquals("Karl", p3.NAME);
+        Assert.assertEquals(LocalDate.parse("2011-11-26"), p3.EMPLOYED_DATE);
+        Assert.assertEquals("Master", p3.TITLE);
+    }
+
     @SuppressWarnings("WeakerAccess")  // Required for reflective access
     public static class Person
     {

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/src/test/java/org/finos/legend/engine/external/format/flatdata/grammar/driver/TestFixedWidth.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/src/test/java/org/finos/legend/engine/external/format/flatdata/grammar/driver/TestFixedWidth.java
@@ -178,7 +178,7 @@ public class TestFixedWidth extends AbstractDriverTest
                 AbstractDriverTest.rValue("23:EOL", "Master")
         );
 
-        assert(new FixedWidthDriverDescription().validate(flatData, flatData.sections.get(0)).isEmpty());
+        Assert.assertTrue(new FixedWidthDriverDescription().validate(flatData, flatData.sections.get(0)).isEmpty());
         assertSource(1, 1, "GS2511.1Alex2013-08-13Mrs", expectedRecordValues1, records.get(0));
         Person p1 = records.get(0).getValue();
         Assert.assertEquals("GS", p1.FIRM);

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/src/test/java/org/finos/legend/engine/external/format/flatdata/grammar/driver/TestFixedWidth.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/src/test/java/org/finos/legend/engine/external/format/flatdata/grammar/driver/TestFixedWidth.java
@@ -236,6 +236,31 @@ public class TestFixedWidth extends AbstractDriverTest
         Assert.assertEquals("Invalid address for 'TITLE' (Expected start:end column numbers or EOL for final column end index) in section 'default'", defects.get(0).toString());
     }
 
+    @Test
+    public void checkValidationErrorEOLNonFinalColumn()
+    {
+        FlatData flatData = parseFlatData("section default: FixedWidth\n" +
+                "{\n" +
+                "  scope.untilEof;\n" +
+                "\n" +
+                "  Record\n" +
+                "  {\n" +
+                "    FIRM          {1:2} : STRING;\n" +
+                "    AGE           {3:4} : INTEGER;\n" +
+                "    MASTER        {5:5} : INTEGER(optional);\n" +
+                "    WEIGHT        {6:EOL} : STRING(optional);\n" +
+                "    NAME          {9:12} : STRING;\n" +
+                "    EMPLOYED_DATE {13:22} : DATE(format='yyyy-MM-dd');\n" +
+                "    TITLE         {23:EOL} : STRING;\n" +
+                "  }\n" +
+                "}\n");
+
+        FixedWidthDriverDescription fdd = new FixedWidthDriverDescription();
+        List<FlatDataDefect> defects = fdd.validate(flatData, flatData.sections.get(0));
+        Assert.assertEquals(1, defects.size());
+        Assert.assertEquals("Invalid address for 'WEIGHT' (Expected start:end column numbers) in section 'default'", defects.get(0).toString());
+    }
+
     @SuppressWarnings("WeakerAccess")  // Required for reflective access
     public static class Person
     {

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthDriverDescription.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthDriverDescription.java
@@ -67,10 +67,9 @@ public class FixedWidthDriverDescription extends StreamingDriverDescription impl
             }
             else
             {
-                if (field.address == null || field.address != null && !(field.address.matches("^\\d+:\\d+$") || field.address.matches("^\\d+$")))
+                if (field.address == null || field.address != null && !(field.address.matches("^\\d+:(\\d+|EOL)$")))
                 {
-                   //TODO better error message
-                    defects.add(new FlatDataDefect(store, section, "Invalid address for '" + field.label + "' (Expected start:end column numbers or for final column start column number)"));
+                    defects.add(new FlatDataDefect(store, section, "Invalid address for '" + field.label + "' (Expected start:end column numbers or EOL for final column end index)"));
                 }
             }
         }

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthDriverDescription.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthDriverDescription.java
@@ -14,11 +14,13 @@
 
 package org.finos.legend.engine.external.format.flatdata.driver.core;
 
+import java.util.Iterator;
 import org.finos.legend.engine.external.format.flatdata.driver.core.connection.InputStreamConnection;
 import org.finos.legend.engine.external.format.flatdata.driver.spi.FlatDataProcessingContext;
 import org.finos.legend.engine.external.format.flatdata.driver.spi.FlatDataReadDriver;
 import org.finos.legend.engine.external.format.flatdata.driver.spi.RecordTypeMultiplicity;
 import org.finos.legend.engine.external.format.flatdata.metamodel.FlatData;
+import org.finos.legend.engine.external.format.flatdata.metamodel.FlatDataRecordField;
 import org.finos.legend.engine.external.format.flatdata.metamodel.FlatDataSection;
 import org.finos.legend.engine.external.format.flatdata.validation.FlatDataDefect;
 import org.finos.legend.engine.external.format.flatdata.validation.FlatDataValidator;
@@ -51,13 +53,27 @@ public class FixedWidthDriverDescription extends StreamingDriverDescription impl
     public List<FlatDataDefect> validate(FlatData store, FlatDataSection section)
     {
         List<FlatDataDefect> defects = new ArrayList<>();
-        section.recordType.fields.forEach(field ->
+        Iterator<FlatDataRecordField> fieldIterator = section.recordType.fields.iterator();
+
+        while (fieldIterator.hasNext())
         {
-            if (field.address == null || field.address != null && !field.address.matches("^\\d+:\\d+$"))
+            FlatDataRecordField field = fieldIterator.next();
+            if (fieldIterator.hasNext())
             {
-                defects.add(new FlatDataDefect(store, section, "Invalid address for '" + field.label + "' (Expected start:end column numbers)"));
+                if (field.address == null || field.address != null && !field.address.matches("^\\d+:\\d+$"))
+                {
+                    defects.add(new FlatDataDefect(store, section, "Invalid address for '" + field.label + "' (Expected start:end column numbers)"));
+                }
             }
-        });
+            else
+            {
+                if (field.address == null || field.address != null && !(field.address.matches("^\\d+:\\d+$") || field.address.matches("^\\d+$")))
+                {
+                   //TODO better error message
+                    defects.add(new FlatDataDefect(store, section, "Invalid address for '" + field.label + "' (Expected start:end column numbers or for final column start column number)"));
+                }
+            }
+        }
         return defects;
     }
 

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthReadDriver.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthReadDriver.java
@@ -52,8 +52,26 @@ public class FixedWidthReadDriver<T> extends StreamingReadDriver<T>
         for (int i = 0; i < addresses.length; i++)
         {
             String address = section.recordType.fields.get(i).address;
-            int start = Integer.parseInt(address.split(":")[0]) - 1;
-            int end = Integer.parseInt(address.split(":")[1]);
+            int start;
+            int end;
+            if (i == addresses.length - 1)
+            {
+                if (address.contains(":"))
+                {
+                    start = Integer.parseInt(address.split(":")[0]) - 1;
+                    end = Integer.parseInt(address.split(":")[1]);
+                }
+                else
+                {
+                    start = Integer.parseInt(address) - 1;
+                    end = -1;
+                }
+            }
+            else
+            {
+                start = Integer.parseInt(address.split(":")[0]) - 1;
+                end = Integer.parseInt(address.split(":")[1]);
+            }
 
             this.addresses[i] = address;
             this.starts[i] = start;
@@ -99,9 +117,16 @@ public class FixedWidthReadDriver<T> extends StreamingReadDriver<T>
             String text = line.getText();
             for (int i = 0; i < addresses.length; i++)
             {
-                values[i] = ends[i] <= text.length()
-                        ? text.substring(starts[i], ends[i]).trim()
-                        : "";
+                if (i == addresses.length - 1 && ends[i] == -1)
+                {
+                    values[i] = text.substring(starts[i]).trim();
+                }
+                else
+                {
+                    values[i] = ends[i] <= text.length()
+                            ? text.substring(starts[i], ends[i]).trim()
+                            : "";
+                }
             }
             RawFlatData rawFlatData = dataFactory.createRawFlatData(++recordNumber, line, values);
             return Optional.of(BasicChecked.newChecked(rawFlatData, null));

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthReadDriver.java
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/src/main/java/org/finos/legend/engine/external/format/flatdata/driver/core/FixedWidthReadDriver.java
@@ -56,16 +56,9 @@ public class FixedWidthReadDriver<T> extends StreamingReadDriver<T>
             int end;
             if (i == addresses.length - 1)
             {
-                if (address.contains(":"))
-                {
-                    start = Integer.parseInt(address.split(":")[0]) - 1;
-                    end = Integer.parseInt(address.split(":")[1]);
-                }
-                else
-                {
-                    start = Integer.parseInt(address) - 1;
-                    end = -1;
-                }
+                String[] indices = address.split(":");
+                start = Integer.parseInt(indices[0]) - 1;
+                end = indices[1].equals("EOL") ? -1 : Integer.parseInt(indices[1]);
             }
             else
             {


### PR DESCRIPTION
FlatData: option for FixedWidth final column to read to EoL

Allow column specification for final column to accept EOL to tell driver to read the rest of the line. 
EOL only accepted for final column to handle files with variable lengths on final field. 

Example schema, where the final column will read from index 3 upto the EoL (in this case the default EoL character since no new line character is specified in the schema definition)
```
section default: FixedWidth
{
  scope.untilEof;
  
  Record 
  {
     Title {1:2} : STRING;
     Surname: {3:EOL} : STRING;
  }
}
```
