### PR TITLE
Trigger preprocessFunction prior to plan generation

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
@@ -130,7 +130,8 @@ Class meta::pure::executionPlan::PlanSetPlaceHolder
 
 function meta::pure::executionPlan::preprocessFunction(f:FunctionDefinition<Any>[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*]):FunctionDefinition<Any>[1]
 {
-  let fromExpr = $f->findExpressionsForFunctionInFunctionDefinition([from_T_m__PackageableRuntime_1__T_m_, 
+  let fromExpr = $f->findExpressionsForFunctionInFunctionDefinition([from_T_m__Runtime_1__T_m_,
+                                                                     from_T_m__PackageableRuntime_1__T_m_,
                                                                      from_FunctionDefinition_1__Runtime_1__T_m_]);
   if(!$fromExpr->isEmpty(),
         | let runtime = $fromExpr->evaluateAndDeactivate()->map(exp | $exp.parametersValues->tail()->evaluateAndDeactivate()->filter(p | $p->instanceOf(InstanceValue))->cast(@InstanceValue).values)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
@@ -128,10 +128,25 @@ Class meta::pure::executionPlan::PlanSetPlaceHolder
     tdsColumns: TDSColumn[*];
 }
 
+function meta::pure::executionPlan::preprocessFunction(f:FunctionDefinition<Any>[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*]):FunctionDefinition<Any>[1]
+{
+  let fromExpr = $f->findExpressionsForFunctionInFunctionDefinition([from_T_m__PackageableRuntime_1__T_m_, 
+                                                                     from_FunctionDefinition_1__Runtime_1__T_m_]);
+  if(!$fromExpr->isEmpty(),
+        | let runtime = $fromExpr->evaluateAndDeactivate()->map(exp | $exp.parametersValues->tail()->evaluateAndDeactivate()->filter(p | $p->instanceOf(InstanceValue))->cast(@InstanceValue).values)
+                        ->map(v | $v->match([ runtime:Runtime[1] | $runtime,
+                                              packageableRuntime:meta::pure::runtime::PackageableRuntime[1] | $packageableRuntime.runtimeValue,
+                                              any:Any[1] | []
+                                            ]));
+          if($runtime.preprocessFunction->isEmpty(), | $f, | $runtime.preprocessFunction->toOne()->eval($f, $runtime));,
+        | $f);
+}
+
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionPlan[1]
 {
-   let routed = $f->routeFunction($context, $extensions, $debugContext);
-   meta::pure::executionPlan::executionPlan($routed, $f, ^Mapping(package=meta::pure::executionPlan, name='dummy'), ^meta::core::runtime::Runtime(), $context, $extensions, $debugContext);
+   let preProcessedFunction = meta::pure::executionPlan::preprocessFunction($f, $context, $extensions);
+   let routed = $preProcessedFunction->routeFunction($context, $extensions, $debugContext);
+   meta::pure::executionPlan::executionPlan($routed, $preProcessedFunction, ^Mapping(package=meta::pure::executionPlan, name='dummy'), ^meta::core::runtime::Runtime(), $context, $extensions, $debugContext);
 }
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], m:Mapping[1], runtime:meta::core::runtime::Runtime[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionPlan[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::pure::mapping::modelToModel::chain::*;
+import meta::relational::metamodel::*;
 import meta::relational::graphFetch::executionPlan::*;
 import meta::relational::functions::sqlQueryToString::h2::*;
 import meta::pure::alloy::connections::alloy::authentication::*;
@@ -1660,6 +1662,72 @@ function <<test.Test>> meta::pure::executionPlan::tests::withPlatform():Boolean[
                 '    )\n' +
                 '  )\n' +
                 ')\n',$result->planToString(meta::relational::extension::relationalExtensions()));
+}
+
+function meta::pure::executionPlan::tests::addLimit(f:FunctionDefinition<Any>[1], runtime:meta::core::runtime::Runtime[1]):FunctionDefinition<Any>[1]
+{
+  $f->rewriteFunction()->toOne()->cast(@FunctionDefinition<Any>)
+}
+
+function meta::pure::executionPlan::tests::rewriteFunction(vs:Any[1]):Any[*]
+{
+  $vs->match(
+    [
+      s : SimpleFunctionExpression[1] | if($s.func.name == 'select_Relation_1__ColSpecArray_1__Relation_1_',
+                                            |  
+                                              ^SimpleFunctionExpression(func = limit_T_MANY__Integer_1__T_MANY_,
+                                                                        functionName = 'limit',
+                                                                        importGroup = system::imports::coreImport,
+                                                                        genericType = $s.genericType,
+                                                                        multiplicity = $s.multiplicity,
+                                                                        parametersValues = [$s, createInstanceValue(10)]
+                                              ),
+                                            | ^$s(parametersValues = $s.parametersValues->evaluateAndDeactivate()->map(x|$x->rewriteFunction())->cast(@ValueSpecification)););,
+      l : FunctionDefinition<Any>[1] | ^$l(expressionSequence = $l.expressionSequence->evaluateAndDeactivate()->map(x|$x->rewriteFunction())->cast(@ValueSpecification)->toOneMany());,
+      z : Any[*] | $z;
+    ]
+  );
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::testPreprocessFunctionOnRuntime():Boolean[1]
+{
+  let lambda = {|#>{meta::relational::tests::dbInc.personTable}#->select(~[FIRSTNAME])};
+  let con = ^meta::external::store::relational::runtime::TestDatabaseConnection(type = DatabaseType.H2);
+  let runtime = ^meta::pure::runtime::PackageableRuntime
+                (
+                  runtimeValue = ^meta::core::runtime::EngineRuntime
+                  (
+                    preprocessFunction = addLimit_FunctionDefinition_1__Runtime_1__FunctionDefinition_1_,
+                    connectionStores=^ConnectionStore
+                                      (
+                                        connection=$con,
+                                        element = ^Database(name = 'dummyDatabase')
+                                      )
+                  )
+                );
+
+  let returnGenericType = $lambda->functionReturnType();
+  let returnMultiplicity = $lambda->functionReturnMultiplicity();
+  let withFrom = ^SimpleFunctionExpression
+  (
+    importGroup=system::imports::coreImport,
+    func = from_T_m__PackageableRuntime_1__T_m_,
+    functionName = 'from',
+    genericType = $returnGenericType,
+    multiplicity = $returnMultiplicity,
+    parametersValues =  $lambda.expressionSequence
+                        ->concatenate(^InstanceValue
+                                       (
+                                          genericType = ^GenericType(rawType=meta::pure::runtime::PackageableRuntime),
+                                          multiplicity = PureOne,
+                                          values = $runtime
+                                       )),
+    resolvedMultiplicityParameters = $returnMultiplicity,
+    resolvedTypeParameters = $returnGenericType
+  );
+  let final = ^FunctionDefinition<{->Any[1]}>(expressionSequence = $withFrom);
+  let rawPlan = meta::pure::executionPlan::executionPlan($final, ^meta::pure::runtime::ExecutionContext(), meta::relational::extension::relationalExtensions());
+  assertEquals('select top 10 "persontable_0".FIRSTNAME as "FIRSTNAME" from personTable as "persontable_0"', $rawPlan.rootExecutionNode.executionNodes->cast(@SQLExecutionNode).sqlQuery);
 }
 
 function <<test.Test>> meta::pure::executionPlan::tests::testDatabaseConnectionSQLPopulationLegacy():Boolean[1]

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>5.47.0</legend.pure.version>
+        <legend.pure.version>5.48.0</legend.pure.version>
         <legend.shared.version>0.26.0</legend.shared.version>
         <legend.web-application.version>13.2.0</legend.web-application.version>
 


### PR DESCRIPTION
#### What type of PR is this?
- Improvement

#### What does this PR do / why is it needed ?
Trigger preprocessFunction configured on runtime to be able to rewrite a function expression before preval and routing if needed (prior to plan generation)