### PR TITLE
Option to Pure grammar composer to not quote enum values

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DEPRECATED_PureGrammarComposerCore.java
@@ -138,6 +138,11 @@ public final class DEPRECATED_PureGrammarComposerCore implements
      */
     private final boolean isValueSpecificationExternalParameter;
     /**
+     * This flag will notify the transformer that elements should be parsed as Pure Grammar.
+     * E.g. no quotes shall be added to enum starting with digits (310_ACT would not get converted to '310_ACT')
+     */
+    private final boolean isPureGrammar;
+    /**
      * This flag will notify the transformer that the variable being processed is in the signature of the function,
      * hence omitting the `$` symbol preceding the variable.
      */
@@ -154,6 +159,7 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         this.isVariableInFunctionSignature = builder.isVariableInFunctionSignature;
         this.isValueSpecificationExternalParameter = builder.isValueSpecificationExternalParameter;
         this.isPropertyBracketExpressionModeEnabled = builder.isPropertyBracketExpressionModeEnabled;
+        this.isPureGrammar = builder.isPureGrammar;
     }
 
     public int getBaseTabLevel()
@@ -174,6 +180,11 @@ public final class DEPRECATED_PureGrammarComposerCore implements
     public boolean isValueSpecificationExternalParameter()
     {
         return isValueSpecificationExternalParameter;
+    }
+
+    public boolean isPureGrammar()
+    {
+        return isPureGrammar;
     }
 
     public RenderStyle getRenderStyle()
@@ -198,6 +209,7 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         private boolean isValueSpecificationExternalParameter = false;
         private boolean isVariableInFunctionSignature = false;
         private boolean isPropertyBracketExpressionModeEnabled = false;
+        private boolean isPureGrammar = false;
 
         private Builder()
         {
@@ -212,6 +224,7 @@ public final class DEPRECATED_PureGrammarComposerCore implements
             builder.isVariableInFunctionSignature = grammarTransformer.isVariableInFunctionSignature;
             builder.isValueSpecificationExternalParameter = grammarTransformer.isValueSpecificationExternalParameter;
             builder.isPropertyBracketExpressionModeEnabled = grammarTransformer.isPropertyBracketExpressionModeEnabled;
+            builder.isPureGrammar = grammarTransformer.isPureGrammar;
             return builder;
         }
 
@@ -223,6 +236,7 @@ public final class DEPRECATED_PureGrammarComposerCore implements
             builder.isVariableInFunctionSignature = context.isVariableInFunctionSignature();
             builder.isValueSpecificationExternalParameter = context.isValueSpecificationExternalParameter();
             builder.isPropertyBracketExpressionModeEnabled = context.isPropertyBracketExpressionModeEnabled();
+            builder.isPureGrammar = context.isPureGrammar();
             return builder;
         }
 
@@ -246,6 +260,12 @@ public final class DEPRECATED_PureGrammarComposerCore implements
         public Builder withVariableInFunctionSignature()
         {
             this.isVariableInFunctionSignature = true;
+            return this;
+        }
+
+        public Builder withPureGrammar()
+        {
+            this.isPureGrammar = true;
             return this;
         }
 
@@ -337,9 +357,10 @@ public final class DEPRECATED_PureGrammarComposerCore implements
     @Override
     public String visit(Enumeration _enum)
     {
-        return "Enum " + HelperDomainGrammarComposer.renderAnnotations(_enum.stereotypes, _enum.taggedValues) + PureGrammarComposerUtility.convertPath(_enum.getPath()) +
+        return "Enum " + HelperDomainGrammarComposer.renderAnnotations(_enum.stereotypes, _enum.taggedValues) +
+                PureGrammarComposerUtility.convertPath(_enum.getPath(), this.isPureGrammar) +
                 "\n{\n" +
-                LazyIterate.collect(_enum.values, enumValue -> getTabString() + HelperDomainGrammarComposer.renderEnumValue(enumValue)).makeString(",\n") + (_enum.values.isEmpty() ? "" : "\n") +
+                LazyIterate.collect(_enum.values, enumValue -> getTabString() + HelperDomainGrammarComposer.renderEnumValue(enumValue, this.isPureGrammar)).makeString(",\n") + (_enum.values.isEmpty() ? "" : "\n") +
                 "}";
     }
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperDomainGrammarComposer.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperDomainGrammarComposer.java
@@ -73,7 +73,13 @@ public class HelperDomainGrammarComposer
 
     public static String renderEnumValue(EnumValue enumValue)
     {
-        return renderAnnotations(enumValue.stereotypes, enumValue.taggedValues) + PureGrammarComposerUtility.convertIdentifier(enumValue.value);
+        return renderEnumValue(enumValue, false);
+    }
+
+    public static String renderEnumValue(EnumValue enumValue, boolean isPureGrammar)
+    {
+        return renderAnnotations(enumValue.stereotypes, enumValue.taggedValues) +
+                PureGrammarComposerUtility.convertIdentifier(enumValue.value, false, isPureGrammar);
     }
 
     public static String renderUnit(Unit unit, DEPRECATED_PureGrammarComposerCore transformer)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerContext.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerContext.java
@@ -48,6 +48,11 @@ public class PureGrammarComposerContext
      */
     private final boolean isValueSpecificationExternalParameter;
     /**
+     * This flag will notify the transformer that elements should be parsed as Pure Grammar.
+     * E.g. no quotes shall be added to enum starting with digits (310_ACT would not get converted to '310_ACT')
+     */
+    private final boolean isPureGrammar;
+    /**
      * This flag will notify the transformer that the variable being processed is in the signature of the function,
      * hence omitting the `$` symbol preceding the variable.
      */
@@ -73,6 +78,7 @@ public class PureGrammarComposerContext
         this.isVariableInFunctionSignature = builder.isVariableInFunctionSignature;
         this.isValueSpecificationExternalParameter = builder.isValueSpecificationExternalParameter;
         this.isPropertyBracketExpressionModeEnabled = builder.isPropertyBracketExpressionModeEnabled;
+        this.isPureGrammar = builder.isPureGrammar;
         // extensions
         this.extensions = PureGrammarComposerExtensionLoader.extensions();
         this.extraSectionComposers = ListIterate.flatCollect(this.extensions, PureGrammarComposerExtension::getExtraSectionComposers);
@@ -98,6 +104,11 @@ public class PureGrammarComposerContext
         return isValueSpecificationExternalParameter;
     }
 
+    public boolean isPureGrammar()
+    {
+        return isPureGrammar;
+    }
+
     public RenderStyle getRenderStyle()
     {
         return renderStyle;
@@ -120,6 +131,7 @@ public class PureGrammarComposerContext
         private boolean isValueSpecificationExternalParameter = false;
         private boolean isVariableInFunctionSignature = false;
         private boolean isPropertyBracketExpressionModeEnabled = false;
+        private boolean isPureGrammar = false;
 
         private Builder()
         {
@@ -134,6 +146,7 @@ public class PureGrammarComposerContext
             builder.isVariableInFunctionSignature = composerContext.isVariableInFunctionSignature;
             builder.isValueSpecificationExternalParameter = composerContext.isValueSpecificationExternalParameter;
             builder.isPropertyBracketExpressionModeEnabled = composerContext.isPropertyBracketExpressionModeEnabled;
+            builder.isPureGrammar = composerContext.isPureGrammar;
             return builder;
         }
 
@@ -146,6 +159,7 @@ public class PureGrammarComposerContext
             builder.isVariableInFunctionSignature = DEPRECATED_context.isVariableInFunctionSignature();
             builder.isValueSpecificationExternalParameter = DEPRECATED_context.isValueSpecificationExternalParameter();
             builder.isPropertyBracketExpressionModeEnabled = DEPRECATED_context.isPropertyBracketExpressionModeEnabled();
+            builder.isPureGrammar = DEPRECATED_context.isPureGrammar();
             return builder;
         }
 
@@ -174,6 +188,12 @@ public class PureGrammarComposerContext
         public Builder withVariableInFunctionSignature()
         {
             this.isVariableInFunctionSignature = true;
+            return this;
+        }
+
+        public Builder withPureGrammar()
+        {
+            this.isPureGrammar = true;
             return this;
         }
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerUtility.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/PureGrammarComposerUtility.java
@@ -133,8 +133,13 @@ public class PureGrammarComposerUtility
 
     public static String convertPath(String val)
     {
+        return convertPath(val, false);
+    }
+
+    public static String convertPath(String val, boolean isPureGrammar)
+    {
         return Arrays.stream(val.split(PACKAGE_SEPARATOR))
-                .map(PureGrammarComposerUtility::convertIdentifier)
+                .map(v -> convertIdentifier(v, false, isPureGrammar))
                 .collect(Collectors.joining(PACKAGE_SEPARATOR));
     }
 
@@ -145,9 +150,19 @@ public class PureGrammarComposerUtility
 
     public static String convertIdentifier(String val, boolean doubleQuotes)
     {
+        return convertIdentifier(val, doubleQuotes, false);
+    }
+
+    public static String convertIdentifier(String val, boolean doubleQuotes, boolean isPureGrammar)
+    {
         if (val == null || val.isEmpty())
         {
             return "";
+        }
+
+        if (isPureGrammar)
+        {
+            return val;
         }
         else
         {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestGrammarRoundtrip.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestGrammarRoundtrip.java
@@ -98,7 +98,17 @@ public class TestGrammarRoundtrip
             test(code, null, true);
         }
 
+        public static void testSectionWithPureGrammar(String code, boolean isPureGrammar)
+        {
+            test(code, null, false, RenderStyle.STANDARD, isPureGrammar);
+        }
+
         private static void test(String code, String message, boolean keepSectionIndex, RenderStyle renderStyle)
+        {
+            test(code, message, keepSectionIndex, renderStyle, false);
+        }
+
+        private static void test(String code, String message, boolean keepSectionIndex, RenderStyle renderStyle, boolean isPureGrammar)
         {
             PureModelContextData modelData = null;
             try
@@ -112,7 +122,9 @@ public class TestGrammarRoundtrip
             {
                 throw new RuntimeException(e);
             }
-            PureGrammarComposer grammarTransformer = PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(renderStyle).build());
+            PureGrammarComposer grammarTransformer = isPureGrammar ?
+                    PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withPureGrammar().withRenderStyle(renderStyle).build())
+            : PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(renderStyle).build());
             Assert.assertEquals(message, code, grammarTransformer.renderPureModelContextData(modelData));
 
             if (keepSectionIndex)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -18,6 +18,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.finos.legend.engine.language.pure.grammar.test.TestGrammarRoundtrip;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammarRoundtripTestSuite
 {
     @Test
@@ -93,6 +96,53 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
                 "  var1: Float[1];\n" +
                 "  var2: Float[1];\n" +
                 "}\n");
+    }
+
+    @Test
+    public void testEnumsWithPureGrammar()
+    {
+        testSectionWithPureGrammar(("Enum my::Test\n" +
+                "{\n" +
+                "  TEST,\n" +
+                "  HELLO,\n" +
+                "  360_ACT\n" +
+                "}\n"), true);
+    }
+
+    @Test
+    public void testEnumsWithSingleQuotes()
+    {
+        testSectionWithPureGrammar(("Enum my::Test\n" +
+                "{\n" +
+                "  TEST,\n" +
+                "  HELLO,\n" +
+                "  '360_ACT'\n" +
+                "}\n"), false);
+    }
+
+
+    @Test
+    public void testEnumsWithOutPureGrammar()
+    {
+        AssertionError failed_assert = assertThrows(AssertionError.class, () -> test(("Enum my::Test\n" +
+                "{\n" +
+                "  TEST,\n" +
+                "  HELLO,\n" +
+                "  360_ACT\n" +
+                "}\n")));
+
+        assertEquals("expected:<...\n" +
+                "  TEST,\n" +
+                "  HELLO,\n" +
+                "  [360_ACT]\n" +
+                "}\n" +
+                "> but was:<...\n" +
+                "  TEST,\n" +
+                "  HELLO,\n" +
+                "  ['360_ACT']\n" +
+                "}\n" +
+                ">", failed_assert.getMessage());
+
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
Add option to legend grammar composer to generate enum values without single quotes for legend-pure compatibility
