### PR TITLE
Resolve only user-defined packageable elements

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
@@ -178,6 +178,12 @@ public class CompileContext
             return this;
         }
 
+        public Builder withoutMetaImports()
+        {
+            this.imports = this.imports.newWithoutAll(META_IMPORTS);
+            return this;
+        }
+
         public CompileContext build()
         {
             return new CompileContext(this);

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/CompileContext.java
@@ -178,12 +178,6 @@ public class CompileContext
             return this;
         }
 
-        public Builder withoutMetaImports()
-        {
-            this.imports = this.imports.newWithoutAll(META_IMPORTS);
-            return this;
-        }
-
         public CompileContext build()
         {
             return new CompileContext(this);
@@ -293,9 +287,9 @@ public class CompileContext
         return this.resolve(fullPath, sourceInformation, path -> this.pureModel.getPackageableElement(path, sourceInformation));
     }
 
-    public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement resolvePackageableElement_safe(String fullPath, SourceInformation sourceInformation)
+    public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement resolveUserDefinedPackageableElement_safe(String fullPath, SourceInformation sourceInformation)
     {
-        return this.resolve(fullPath, sourceInformation, this.pureModel::getPackageableElement_safe);
+        return this.resolve(fullPath, sourceInformation, this.pureModel::getUserDefinedPackageableElement_safe);
     }
 
     public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type resolveType(String fullPath)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PureModel.java
@@ -320,7 +320,7 @@ public class PureModel implements IPureModel
                     this.maybeParallel(allElementsInDisjointDependencyGraph).forEach(element ->
                     {
                         String elementFullPath = buildPackageString(element._package, element.name);
-                        CompileContext context = getContext(element);
+                        CompileContext context = new CompileContext.Builder(this).withElement(element).withoutMetaImports().build();
                         Set<PackageableElementPointer> packageableElementPointers = processPrerequisiteElementsPass(element);
                         MutableSet<String> prerequisiteElementFullPaths = Sets.mutable.empty();
                         for (PackageableElementPointer packageableElementPointer : packageableElementPointers)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestCompilationFromGrammar.java
@@ -207,7 +207,7 @@ public class TestCompilationFromGrammar
         }
         long timeAfter = System.currentTimeMillis();
         long timeTaken = timeAfter - timeBefore;
-        Assert.assertTrue("With caching in the compiler, it is expected to take no longer than 1500ms, but took: " + timeTaken, timeTaken < 1500);
+        Assert.assertTrue("With caching in the compiler, it is expected to take no longer than 3000ms, but took: " + timeTaken, timeTaken < 3000);
     }
 
     @Test


### PR DESCRIPTION
- Resolve only user-defined packageable elements
- Assign null sentinel value to be of type Class, so that it can be used for both types and packageable elements
- Increase the timeout for caching search imports test case