### PR TITLE
Fix bug with relational join when no rows match join for in memory execution

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/join.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/join.pure
@@ -117,3 +117,26 @@ function <<PCT.test>> meta::pure::functions::relation::tests::join::testSimpleJo
                 '   4,David,4,More David,1\n'+
                 '#', $res2->sort([~id->ascending(),~col->ascending()])->toString());
 }
+
+function <<PCT.test>> meta::pure::functions::relation::tests::join::testJoin_forFailedJoinWhenNoRowsMatchJoinCondition<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+  let expr = {|
+    let t1 = #TDS
+              id, col, other
+              1, More Test 1, 1
+              2, More Test 2, 2
+            #;
+    let t2 = #TDS
+              id2, name
+              3, Pierre
+            #;
+    $t1->join($t2, JoinKind.LEFT, {x,y| $x.id == $y.id2});
+  };
+  let res =  $f->eval($expr);
+
+  assertEquals( '#TDS\n'+
+                '   id,col,other,id2,name\n'+
+                '   1,More Test 1,1,null,null\n'+
+                '   2,More Test 2,2,null,null\n'+
+                '#', $res->sort([~id->ascending(),~col->ascending()])->toString());             
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/TestTDS.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/TestTDS.java
@@ -765,6 +765,10 @@ public abstract class TestTDS
 
     private void sort(TestTDS copy, ListIterable<SortInfo> sortInfos, int start, int end, MutableList<Pair<Integer, Integer>> ranges)
     {
+        if (copy.rowCount == 0)
+        {
+            return;
+        }
         SortInfo currentSort = sortInfos.getFirst();
         this.sortOneLevel(copy, currentSort, start, end);
         if (!sortInfos.isEmpty())
@@ -1138,7 +1142,7 @@ public abstract class TestTDS
         MutableList<Integer> missings = Lists.mutable.empty();
         while (rowLeftCurs < leftS.rowCount)
         {
-            if (!leftS.fullMatch(cols, resS, rowLeftCurs, rowResCurs))
+            if (resS.rowCount == 0 || !leftS.fullMatch(cols, resS, rowLeftCurs, rowResCurs))
             {
                 missings.add(rowLeftCurs);
                 rowLeftCurs++;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/Test_Relational_Databricks_RelationFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/Test_Relational_Databricks_RelationFunctions_PCT.java
@@ -95,6 +95,7 @@ public class Test_Relational_Databricks_RelationFunctions_PCT extends PCTReportC
 
             //join
             one("meta::pure::functions::relation::tests::join::testSimpleJoin_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Databricks\""),
+            one("meta::pure::functions::relation::tests::join::testJoin_forFailedJoinWhenNoRowsMatchJoinCondition_Function_1__Boolean_1_", "\"Common table expression not supported on DB Databricks\""),
 
             //limit
             one("meta::pure::functions::relation::tests::limit::testSimpleLimit_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Databricks\""),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/memsql/pct/Test_Relational_MemSQL_RelationFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/memsql/pct/Test_Relational_MemSQL_RelationFunctions_PCT.java
@@ -95,6 +95,7 @@ public class Test_Relational_MemSQL_RelationFunctions_PCT extends PCTReportConfi
 
             //join
             one("meta::pure::functions::relation::tests::join::testSimpleJoin_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB MemSQL\""),
+            one("meta::pure::functions::relation::tests::join::testJoin_forFailedJoinWhenNoRowsMatchJoinCondition_Function_1__Boolean_1_", "\"Common table expression not supported on DB MemSQL\""),
 
             //limit
             one("meta::pure::functions::relation::tests::limit::testSimpleLimit_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB MemSQL\""),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/spanner/pct/Test_Relational_Spanner_RelationFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/spanner/pct/Test_Relational_Spanner_RelationFunctions_PCT.java
@@ -120,6 +120,7 @@ public class Test_Relational_Spanner_RelationFunctions_PCT extends PCTReportConf
 
             //join
             one("meta::pure::functions::relation::tests::join::testSimpleJoin_MultipleExpressions_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
+            one("meta::pure::functions::relation::tests::join::testJoin_forFailedJoinWhenNoRowsMatchJoinCondition_Function_1__Boolean_1_", "\"Common table expression not supported on DB Spanner\""),
 
             //lag
             one("meta::pure::functions::relation::tests::lag::testOLAPWithPartitionAndOrderWindowUsingLag_Function_1__Boolean_1_", "\"[unsupported-api] Window Columns not supported for Database Type: Spanner\""),


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

There is a bug in the "in-memory" execution for relational join when no rows match the join condition. An index out of bound exception is thrown as we are trying to access the first element of an empty relational.

#### Does this PR introduce a user-facing change?

No
