### PR TITLE
Switch to using H2 inmemory for some tests

### DIFF
--- a/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/test/java/TestArrowNodeExecutor.java
+++ b/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/test/java/TestArrowNodeExecutor.java
@@ -56,7 +56,7 @@ public class TestArrowNodeExecutor
 
         mockExecutionNode.connection = mockDatabaseConnection;
         Mockito.when(mockDatabaseConnection.accept(any())).thenReturn(false);
-        try (Connection conn = DriverManager.getConnection("jdbc:h2:~/test;TIME ZONE=America/New_York", "sa", "");
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test;TIME ZONE=America/New_York", "sa", "");
              ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             //setup table
@@ -96,7 +96,7 @@ public class TestArrowNodeExecutor
 
         mockExecutionNode.connection = mockDatabaseConnection;
         Mockito.when(mockDatabaseConnection.accept(any())).thenReturn(false);
-        try (Connection conn = DriverManager.getConnection("jdbc:h2:~/test;TIME ZONE=America/New_York", "sa", "");
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test;TIME ZONE=America/New_York", "sa", "");
         )
 
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-execution-2.1.214/src/test/java/org/h2/legendTests/TestH2Abstract.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-execution-2.1.214/src/test/java/org/h2/legendTests/TestH2Abstract.java
@@ -31,7 +31,7 @@ public abstract class TestH2Abstract
     {
         Class.forName("org.h2.Driver"); // Driver name
         String defaultH2Properties = ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR;MODE=LEGACY";
-        String url = "jdbc:h2:~/test" + defaultH2Properties;
+        String url = "jdbc:h2:mem:test_h2" + defaultH2Properties;
         h2Conn = DriverManager.getConnection(url, "sa", "");
         System.out.println("H2 Connection Acquired....");
         h2ConnStatement = h2Conn.createStatement();


### PR DESCRIPTION
Switch some tests to in memory to avoid using the same DB file (~/test) for different tests. This isolates test data from different modules and avoid potential issues due to shared data 