### PR TITLE
Bugfix: Support for case-insensitive metadata handling for Snowflake persistence

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/partitioning/PartitioningAbstract.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/src/main/java/org/finos/legend/engine/persistence/components/ingestmode/partitioning/PartitioningAbstract.java
@@ -117,7 +117,7 @@ public interface PartitioningAbstract extends PartitioningStrategy
             {
                 for (String partitionKey : partitionSpec.keySet())
                 {
-                    if (!partitionFields().contains(partitionKey))
+                    if (partitionFields().stream().noneMatch(partitionKey::equalsIgnoreCase))
                     {
                         throw new IllegalStateException(String.format("Can not build Partitioning, partitionKey: [%s] not specified in partitionSpec", partitionKey));
                     }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/utils/IngestionUtils.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/src/main/java/org/finos/legend/engine/persistence/components/relational/api/utils/IngestionUtils.java
@@ -108,13 +108,15 @@ public class IngestionUtils
             List<Map<String, Object>> metadataResults = tabularDataList.get(0).data();
             for (Map<String, Object> metadata: metadataResults)
             {
-                Timestamp ingestionTimestampUTC = (Timestamp) metadata.get(metadataDataset.batchStartTimeField());
-                Timestamp ingestionEndTimestampUTC = (Timestamp) metadata.get(metadataDataset.batchEndTimeField());
-                String batchStatus = String.valueOf(metadata.get(metadataDataset.batchStatusField()));
+                Map<String, Object> caseInsensitiveMetadata = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                caseInsensitiveMetadata.putAll(metadata);
+                Timestamp ingestionTimestampUTC = (Timestamp) caseInsensitiveMetadata.get(metadataDataset.batchStartTimeField());
+                Timestamp ingestionEndTimestampUTC = (Timestamp) caseInsensitiveMetadata.get(metadataDataset.batchEndTimeField());
+                String batchStatus = String.valueOf(caseInsensitiveMetadata.get(metadataDataset.batchStatusField()));
                 batchStatus = batchStatus.equalsIgnoreCase(batchSuccessStatusValue)  ? IngestStatus.SUCCEEDED.name() : batchStatus;
                 IngestorResult ingestorResult = IngestorResult.builder()
-                    .batchId(retrieveValueAsLong(metadata.get(metadataDataset.tableBatchIdField())).orElseThrow(IllegalStateException::new).intValue())
-                    .putAllStatisticByName(readValueAsMap(String.valueOf(metadata.get(metadataDataset.batchStatisticsField()))))
+                    .batchId(retrieveValueAsLong(caseInsensitiveMetadata.get(metadataDataset.tableBatchIdField())).orElseThrow(IllegalStateException::new).intValue())
+                    .putAllStatisticByName(readValueAsMap(String.valueOf(caseInsensitiveMetadata.get(metadataDataset.batchStatisticsField()))))
                     .status(IngestStatus.valueOf(batchStatus))
                     .updatedDatasets(enrichedDatasets)
                     .schemaEvolutionSql(schemaEvolutionResult.schemaEvolutionSql())
@@ -542,11 +544,13 @@ public class IngestionUtils
 
         for (Map<String, Object> dataError: dataErrors)
         {
+            Map<String, Object> caseInsensitiveDataError = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            caseInsensitiveDataError.putAll(dataError);
             dataErrorList.add(DataError.builder()
                     .errorMessage(errorCategory.getDefaultErrorMessage())
                     .errorCategory(errorCategory)
-                    .errorRecord(buildErrorRecord(allFields, dataError))
-                    .putAllErrorDetails(buildErrorDetails(dataError, caseCorrectedErrorField, errorDetailsKey))
+                    .errorRecord(buildErrorRecord(allFields, caseInsensitiveDataError))
+                    .putAllErrorDetails(buildErrorDetails(caseInsensitiveDataError, caseCorrectedErrorField, errorDetailsKey))
                     .build());
         }
         return dataErrorList;

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/SnowflakeSink.java
@@ -113,18 +113,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Queue;
-import java.util.Set;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.finos.legend.engine.persistence.components.relational.api.utils.IngestionUtils.BATCH_ID_PATTERN;
@@ -621,10 +610,12 @@ public class SnowflakeSink extends AnsiSqlSink
                 List<Map<String, Object>> queryOperatorStatsResults = queryOperatorStats.get(0).data();
                 queryOperatorStatsResults.forEach(queryStats ->
                 {
-                    switch ((String) queryStats.get(QueryStatsLogicalPlanUtils.OPERATOR_TYPE_ALIAS))
+                    Map<String, Object> caseInsensitiveQueryStats = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                    caseInsensitiveQueryStats.putAll(queryStats);
+                    switch ((String) caseInsensitiveQueryStats.get(QueryStatsLogicalPlanUtils.OPERATOR_TYPE_ALIAS))
                     {
                         case QueryStatsLogicalPlanUtils.EXTERNAL_SCAN_STAGE:
-                            Object externalScan = queryStats.get(QueryStatsLogicalPlanUtils.EXTERNAL_BYTES_SCANNED_ALIAS);
+                            Object externalScan = caseInsensitiveQueryStats.get(QueryStatsLogicalPlanUtils.EXTERNAL_BYTES_SCANNED_ALIAS);
                             if (externalScan != null && !String.valueOf(externalScan).isEmpty())
                             {
                                 stats.put(StatisticName.INPUT_FILES_BYTES_SCANNED, Long.parseLong(String.valueOf(externalScan)));
@@ -635,7 +626,7 @@ public class SnowflakeSink extends AnsiSqlSink
                             }
                             break;
                         case QueryStatsLogicalPlanUtils.INSERT_STAGE:
-                            Object insert = queryStats.get(QueryStatsLogicalPlanUtils.INPUT_ROWS_ALIAS);
+                            Object insert = caseInsensitiveQueryStats.get(QueryStatsLogicalPlanUtils.INPUT_ROWS_ALIAS);
                             if (insert != null && !String.valueOf(insert).isEmpty())
                             {
                                 stats.put(StatisticName.INCOMING_RECORD_COUNT, Long.parseLong(String.valueOf(insert)));


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
When using case-insensitive metadata on Snowflake, some parts of logic of persistence module break to understand the changes. Like idempotency check or partition column validation. This is because existing code expects exact case to be pulled from Snowflake, but when QUOTED_IDENTIFIER_IGNORE_CASE session parameter is set on Snowflake then it Snowflake keeps all column/table metadata in upper case. And this results in failure in finding right metadata.

This PR changes the breaking few places to ignore the case for metadata.

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No