### PR TITLE
Relation function always quote columns as these are case sensitive

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/helperFunctions/helperFunctions.pure
@@ -430,7 +430,7 @@ function meta::relational::mapping::transformRelationPropertyMappingsToRelationa
 {
   $propertyMappings->map(r| let relationColumnType = $r.column.classifierGenericType.typeArguments->at(1).rawType->toOne();
                             let relOpElement = ^TableAliasColumn(alias=^TableAlias(name=$classMapping.id, relationalElement=^RelationFunction(owner=$classMapping)),
-                                                                 column=^RelationFunctionColumn(column=$r.column, name=$r.column.name->toOne(), type=pureTypeToRelationalTypeMap()->get($relationColumnType)->toOne())
+                                                                 column=^RelationFunctionColumn(column=$r.column, name=addQuotesIfNecessary($r.column.name->toOne()), type=pureTypeToRelationalTypeMap()->get($relationColumnType)->toOne())
                                                                 );
                             ^RelationalPropertyMapping(
                               owner = $r.owner,

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelationsTests.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelationsTests.pure
@@ -913,7 +913,7 @@ function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations:
 
    let expectedTree = 'root\n'+
                       '  ------> (t) personTable [ID]\n'+
-                      '    ------> (t) firmTable(equal_"joinleft_"_d"eID"_"joinright_"_d"ID") [ADDRESSID, CEOID, ID, LEGALNAME]\n';
+                      '    ------> (t) firmTable(equal_"joinleft_"_deID_"joinright_"_dID) [ADDRESSID, CEOID, ID, LEGALNAME]\n';
    assertEquals($expectedTree, $relationTree-> relationTreeAsString());
 }
 
@@ -969,7 +969,7 @@ function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations:
 
    let expectedTree = 'root\n'+
                       '  ------> (t) personTable [ID]\n'+
-                      '    ------> (t) personTable(equal_"joinleft_"_d"personID"_"joinright_"_d"ID") [ADDRESSID, AGE, FIRMID, FIRSTNAME, ID, LASTNAME, MANAGERID]\n';
+                      '    ------> (t) personTable(equal_"joinleft_"_dpersonID_"joinright_"_dID) [ADDRESSID, AGE, FIRMID, FIRSTNAME, ID, LASTNAME, MANAGERID]\n';
    assertEquals($expectedTree, $relationTree-> relationTreeAsString());
 }
 
@@ -987,7 +987,7 @@ function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations:
 
    let expectedTree = 'root\n'+
                       '  ------> (t) personTable [ADDRESSID, AGE, FIRMID, FIRSTNAME, ID, LASTNAME, MANAGERID]\n' +
-                      '    ------> (t) firmTable(equal_"joinleft_"_d#3"ID"_"joinright_"_d#3"firmID") [CEOID, ID]\n';
+                      '    ------> (t) firmTable(equal_"joinleft_"_d#3ID_"joinright_"_d#3firmID) [CEOID, ID]\n';
 
    assertEquals($expectedTree, $relationTree-> relationTreeAsString());
 }
@@ -1045,12 +1045,12 @@ function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations:
   let relationTree = meta::pure::lineage::scanRelations::scanRelations($query, $mapping, $runtime, relationalExtensions());
   let expectedTree = 'root\n'+
                       '  ------> (t) personTable [AGE, FIRSTNAME]\n'+
-                      '    ------> (t) personTable(equal_"joinleft_"_d"First_1"_"joinright_"_d"fName") [AGE, FIRSTNAME]\n'+
-                      '    ------> (t) personTable(equal_"joinleft_"_d_d0_d#3"First_2"_"joinright_"_d_d0_d#3"First_3") [AGE, FIRSTNAME]\n'+
-                      '    ------> (t) personTable(equal_"joinleft_"_d_d0_d#3_d0_d"First_1"_"joinright_"_d_d0_d#3_d0_d"First_2") [AGE, FIRSTNAME]\n'+
+                      '    ------> (t) personTable(equal_"joinleft_"_dFirst_1_"joinright_"_dfName) [AGE, FIRSTNAME]\n'+
+                      '    ------> (t) personTable(equal_"joinleft_"_d_d0_d#3First_2_"joinright_"_d_d0_d#3First_3) [AGE, FIRSTNAME]\n'+
+                      '    ------> (t) personTable(equal_"joinleft_"_d_d0_d#3_d0_dFirst_1_"joinright_"_d_d0_d#3_d0_dFirst_2) [AGE, FIRSTNAME]\n'+
                       '  ------> (t) personTable [AGE, FIRSTNAME]\n'+
-                      '    ------> (t) personTable(equal_"joinleft_"_d"First_1"_"joinright_"_d"fName") [AGE, FIRSTNAME]\n'+
-                      '    ------> (t) personTable(equal_"joinleft_"_d_d0_d#2"First_1"_"joinright_"_d_d0_d#2"First_2") [AGE, FIRSTNAME]\n';
+                      '    ------> (t) personTable(equal_"joinleft_"_dFirst_1_"joinright_"_dfName) [AGE, FIRSTNAME]\n'+
+                      '    ------> (t) personTable(equal_"joinleft_"_d_d0_d#2First_1_"joinright_"_d_d0_d#2First_2) [AGE, FIRSTNAME]\n';
 
    assertEquals($expectedTree, $relationTree-> relationTreeAsString());
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -1127,7 +1127,7 @@ function meta::relational::functions::pureToSqlQuery::buildCorrelatedSubQuery(se
 
    let nestedColumns = $extraColumns->map(a|^$a(alias = $aliasForExtractedColumns->toOne()))
                                     ->concatenate($allColumnsInScope)
-                                    ->removeDuplicates({u,v|$u.alias.name == $v.alias.name && $u.column.name == $v.column.name})
+                                    ->removeDuplicatesBy(u | $u->buildUniqueName(true, $extensions))
                                     ->map(c|^Alias(name = $c.column.name, relationalElement = $c));
 
    let allNestedColumns = $nestedColumns->concatenate($nestedSelect.columns->cast(@Alias));
@@ -1158,9 +1158,9 @@ function meta::relational::functions::pureToSqlQuery::buildCorrelatedSubQuery(se
                                                      // We need to rewrite the filter so that it can be applied within the SQL Query
                                                      // In order to do so we find the internal TableAliasColumn by using the SQL Query columns
                                                      let remap = $filtersPartition.first->extractTableAliasColumns()->concatenate($child->children()->extractTableAliasColumns())
-                                                                                        ->filter(e|$e.alias.name == $targetAlias.name)//extra cols are added to SelectSqlQuery, relationalElements are not reprocessed
-                                                                                        ->distinct()
-                                                                                        ->map(c|pair($c, $nestedSelect.columns->cast(@Alias)->filter(a|$a.name == $c.column.name)->toOne().relationalElement->cast(@TableAliasColumn)));
+                                                                                        ->filter(e|quoteSafeEqual($e.alias.name, $targetAlias.name))//extra cols are added to SelectSqlQuery, relationalElements are not reprocessed
+                                                                                        ->removeDuplicatesBy(x | $x->buildUniqueName(true, $extensions))
+                                                                                        ->map(c|pair($c, $nestedSelect.columns->cast(@Alias)->filter(a|quoteSafeEqual($a.name, $c.column.name))->toOne('Column not found \'%s\' among [%s]'->format([$c.column.name, $nestedSelect.columns->cast(@Alias).name->joinStrings(',')])).relationalElement->cast(@TableAliasColumn)));
 
                                                      let data = $nestedSelect.data->toOne();
                                                      let newData=$child->children()->fold({c,root|let join = $c.join;
@@ -6470,7 +6470,7 @@ function meta::relational::functions::pureToSqlQuery::processProject(ids:String[
          ^$operation(
                      select = ^TdsSelectSqlQuery(
                         distinct = $merge.distinct,
-                        columns = $nonOlap->concatenate($importDataFlowCols)->cast(@Alias)->removeDuplicatesBy(a|$a.name)->concatenate($olapCols),
+                        columns = $nonOlap->concatenate($importDataFlowCols)->cast(@Alias)->removeDuplicatesBy(a|$a->buildUniqueName(true, $extensions))->concatenate($olapCols),
                         data = $possiblePKsWithUpdatedData.second,
                         savedFilteringOperation = $merge.savedFilteringOperation,
                         filteringOperation = $merge.filteringOperation,
@@ -6946,11 +6946,11 @@ function meta::relational::functions::pureToSqlQuery::buildUniqueName(elements:R
          u:UnaryOperation[1]| $u->type()->toOne().name->toOne() + $u.nested->buildUniqueName($alias, $selectColumns, $extensions),
          i:BinaryOperation[1]|$i->type()->toOne().name->toOne() + '_' + $i.left->buildUniqueName($alias, $selectColumns, $extensions) + '_' + $i.right->buildUniqueName($alias, $selectColumns, $extensions),
          a:Alias[1]|if($alias,|$a.name,|$a.relationalElement->buildUniqueName($alias, $selectColumns, $extensions)),
-         c:ColumnName[1]|$c.name,
+         c:ColumnName[1]|stripMatchingQuotes($c.name),
          n:NamedRelation[1]|$n.name,
          u:Union[1]|$u.queries->map(q|$q->buildUniqueName($alias, $selectColumns, $extensions))->joinStrings(),
-         c:TableAliasColumnName[1]|$c.alias->buildUniqueName($alias, $selectColumns, $extensions)+$c.columnName;,
-         c:TableAliasColumn[1]|$c.alias->buildUniqueName($alias, $selectColumns, $extensions)+$c.column.name;,
+         c:TableAliasColumnName[1]|$c.alias->buildUniqueName($alias, $selectColumns, $extensions)+stripMatchingQuotes($c.columnName);,
+         c:TableAliasColumn[1]|$c.alias->buildUniqueName($alias, $selectColumns, $extensions)+stripMatchingQuotes($c.column.name);,
          sc:CommonTableExpressionReference[1]|$sc.name,
          l:Literal[1]|if($l.value->instanceOf(VarPlaceHolder),|$l.value->cast(@VarPlaceHolder).name,|$l.value->toString()),
          l:LiteralList[1]|  $l.values->map(l|$l->buildUniqueName($alias, $selectColumns, $extensions))->joinStrings(),
@@ -7029,7 +7029,7 @@ function meta::relational::functions::pureToSqlQuery::moveSelectQueryToSubSelect
                                               relationalElement=^$select(
                                                  data = $newData,
                                                  filteringOperation = $reprocessedFilteringOperation,
-                                                 columns = $reprocessedColumns.second->cast(@Alias)->removeDuplicatesBy(a|$a.name),
+                                                 columns = $reprocessedColumns.second->cast(@Alias)->removeDuplicatesBy(a|$a->buildUniqueName(true, $extensions)),
                                                  preIsolationCurrentTreeNode = $currentTreeNode,
                                                  groupBy = $reprocessedGroupBys->filter(c|$c->instanceOf(TableAliasColumn)),
                                                  leftSideOfFilter = $newLeftSideOfFilter
@@ -7863,10 +7863,10 @@ function meta::relational::functions::pureToSqlQuery::addExtraJoinColumns(tableA
                                                                                               //join alias is vs select, not safe to use the same alias within the select's join tree nodes, since it will likely match with the root (CorrelatedSubQuery), but the subselect could have many nodes
                                                                                               let allNodes = $s.data->toOne()->getAllNodes()->cast(@RelationalTreeNode);
                                                                                               let nodeAliasNameToRelation = $allNodes->map(n|pair($n.alias.name, $n.alias.relation))->newMap();
-                                                                                              let colsToAdd = $joinTableAliasColumns->filter(c|!$existingCols->contains($c.column.name))->map(c|if($nodeAliasNameToRelation->get($c.alias.name).columns->contains($c.column),| $c
-                                                                                                                                                                                                                                                                       ,| let aliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->match([s:ViewSelectSQLQuery[1]|$s.view,r:Relation[1]|$r])->cast(@Relation).columns->contains($c.column));
+                                                                                              let colsToAdd = $joinTableAliasColumns->filter(c|!$existingCols->contains($c.column.name->stripMatchingQuotes()))->map(c|if($nodeAliasNameToRelation->get($c.alias.name).columns->contains($c.column),| $c
+                                                                                                                                                                                                                                                                       ,| let aliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->match([s:ViewSelectSQLQuery[1]|$s.view,r:Relation[1]|$r])->cast(@Relation).columns->filter(col | quoteSafeEqual($col->extractColumnName(), $c.column.name))->isNotEmpty());
                                                                                                                                                                                                                                                                           // checking sub-select for handling class mapping inner join filters
-                                                                                                                                                                                                                                                                          let subSelectAliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->instanceOf(SelectSQLQuery) && $a.relation.columns->filter(col | $col->extractColumnName() == $c.column.name)->extractTableAliasColumns().column->contains($c.column));
+                                                                                                                                                                                                                                                                          let subSelectAliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->instanceOf(SelectSQLQuery) && $a.relation.columns->filter(col | quoteSafeEqual($col->extractColumnName(), $c.column.name))->extractTableAliasColumns().column->contains($c.column));
                                                                                                                                                                                                                                                                           if($aliasWithMatchingColumn->size()==1,
                                                                                                                                                                                                                                                                              |^Alias(name=$c.column.name, relationalElement=^$c(alias=$aliasWithMatchingColumn->toOne())),
                                                                                                                                                                                                                                                                              | if($subSelectAliasWithMatchingColumn->size() == 1,

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -607,11 +607,6 @@ function meta::relational::functions::pureToSqlQuery::findColumn(relation:Relati
   $relation.columns->filter(c|$c->extractColumnName()->quoteSafeEqual($name))->first();
 }
 
-function meta::relational::functions::pureToSqlQuery::hasColumn(relation:Relation[1], name:String[1]):Boolean[1]
-{
-  $relation->findColumn($name)->isNotEmpty();
-}
-
 function meta::relational::functions::pureToSqlQuery::processPropertyFunctionExpression(fe:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):OperationWithParentPropertyMapping[1]
 {
    let propertyOwner = $fe.parametersValues->at(0)->map(p|$p->byPassRouterInfo());
@@ -2165,7 +2160,7 @@ function meta::relational::functions::pureToSqlQuery::processFunctionExpressionF
                   );
                   let cteReference = ^CommonTableExpressionReference(name = $varName, columns = $cteColumns);
                   let cteAlias = ^TableAlias(name = 'root', relationalElement = $cteReference);
-                  
+
                   let cteReferenceSelect = ^TdsSelectSqlQuery
                   (
                     columns = $cteColumns->map(c | ^TableAliasColumn(columnName = $c.name, column = $c, alias = $cteAlias)),
@@ -3091,8 +3086,8 @@ function meta::relational::functions::pureToSqlQuery::processTdsWindowColumn(
    assert(!$mainSelect.columns->map(col | $col->extractColumnName())->contains($newColumnName), | 'Attempting to reuse the same column name: '+ $newColumnName);
 
    let windowElement = $partitionKeys->map(columnName|findAliasOrFail($columnName, $mainSelect).relationalElement);
-   let sortElements = $sortInfo->map(si|^SortByInfo(sortByElement=findAliasOrFail($si.column, $mainSelect).relationalElement, 
-                                                    sortDirection = if($si.direction.name == meta::pure::tds::SortDirection.DESC.name,| meta::relational::metamodel::SortDirection.DESC,| meta::relational::metamodel::SortDirection.ASC)));                                
+   let sortElements = $sortInfo->map(si|^SortByInfo(sortByElement=findAliasOrFail($si.column, $mainSelect).relationalElement,
+                                                    sortDirection = if($si.direction.name == meta::pure::tds::SortDirection.DESC.name,| meta::relational::metamodel::SortDirection.DESC,| meta::relational::metamodel::SortDirection.ASC)));
    let window = ^meta::relational::metamodel::WindowColumn(
       columnName = $newColumnName,
       func=^DynaFunction(name='PLACEHOLDER'),
@@ -3764,7 +3759,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::newDyna
    let unwrapped = $params->map(p | $p->match([
     a: Alias[1] | $a.relationalElement,
     roe: RelationalOperationElement[1] | $roe
-   ])); 
+   ]));
    if($name->in(['and','or']),
                | newAndOrDynaFunctionWrappedInGroup($name, $unwrapped),
                | ^DynaFunction(name = $name, parameters = $unwrapped)
@@ -5100,7 +5095,7 @@ function meta::relational::functions::pureToSqlQuery::processPivot(expression:Fu
                                           );
 
   if ($pivotColumnExtendQueryAndAggPairs->size() == 1,
-      | 
+      |
         let pivotColumnExtendQuery = $pivotColumnExtendQueryAndAggPairs->toOne().first;
         let pivotColumnExtendSelect = $pivotColumnExtendQuery.select->cast(@TdsSelectSqlQuery);
         ^TdsSelectSqlQuery(
@@ -5114,7 +5109,7 @@ function meta::relational::functions::pureToSqlQuery::processPivot(expression:Fu
           ),
           paths = $pathInfos
         )->isolateNonTerminalGroupByQueryWithEmptyGroupingColumns($pivotColumnExtendQuery, $state, $extensions);,
-      | 
+      |
         let aggregateColumnAliasName = 'aggregate_column';
         let originalAggColumnNames = $newAggColumns->extractTableAliasColumns()->map(tac | $tac.column.name);
         let originalAggColumns = $originalAggColumnNames->map(n | $allInputColumns->filter(c | $c.column.name->quoteSafeEqual($n))->toOne('Could not find the original aggregate column: ' + $n));
@@ -5143,7 +5138,7 @@ function meta::relational::functions::pureToSqlQuery::processPivot(expression:Fu
                                                                                             groupBy = $groupByAliases,
                                                                                             paths = $pathInfos
                                                                         )->isolateNonTerminalGroupByQueryWithEmptyGroupingColumns($p.first, $state, $extensions);
-        
+
         );
         let rootTable = ^TableAlias(
           name = 'union',
@@ -6980,8 +6975,8 @@ function meta::relational::functions::pureToSqlQuery::buildUniqueName(elements:R
 
 function meta::relational::functions::pureToSqlQuery::incrementAliasRecursively(head:Alias[1], tail:Alias[*]):Pair<Alias,Alias>[*]
 {
-  if ($tail->isEmpty(), 
-    | pair($head, $head), 
+  if ($tail->isEmpty(),
+    | pair($head, $head),
     | let headName =  if($head.name->contains('"'),
                         | ($head.name->stripMatchingQuotes() + '_' + $tail->size()->toString())->addQuotesIfNecessary(),
                         | $head.name + '_' + $tail->size()->toString()
@@ -7863,34 +7858,24 @@ function meta::relational::functions::pureToSqlQuery::mergeSQLQueryData(preQuery
 
 function meta::relational::functions::pureToSqlQuery::addExtraJoinColumns(tableAlias: TableAlias[1], j:Join[1]):TableAlias[1]
 {
-  let joinTableAliasColumns = $j.operation->extractTableAliasColumns()->filter(c|$c.alias==$tableAlias)->removeDuplicates();
-  let updatedRelationalElement = $tableAlias.relationalElement->match(
-    [
-      s:SelectSQLQuery[1] |
-        //join alias is vs select, not safe to use the same alias within the select's join tree nodes, since it will likely match with the root (CorrelatedSubQuery), but the subselect could have many nodes
-        let allNodes = $s.data->toOne()->getAllNodes()->cast(@RelationalTreeNode);
-        let nodeAliasNameToRelation = $allNodes->map(n | pair($n.alias.name, $n.alias.relation))->newMap();
-        let colsToAdd = $joinTableAliasColumns->filter(c | !$s->hasColumn($c.column.name))
-                          ->map(c|let relation = $nodeAliasNameToRelation->get($c.alias.name);
-                                  if($relation->isNotEmpty() && $relation->toOne()->hasColumn($c.column.name),
-                                    | $c,
-                                    | let aliasWithMatchingColumn = $allNodes.alias->filter(a | $a.relation->match([s:ViewSelectSQLQuery[1] | $s.view, r:Relation[1] | $r])->cast(@Relation)->hasColumn($c.column.name));
-                                      // checking sub-select for handling class mapping inner join filters
-                                      let subSelectAliasWithMatchingColumn = $allNodes.alias->filter(a | $a.relation->instanceOf(SelectSQLQuery) && $a.relation->hasColumn($c.column.name));
-                                      if($aliasWithMatchingColumn->size()==1,
-                                        | ^Alias(name = $c.column.name, relationalElement = ^$c(alias = $aliasWithMatchingColumn->toOne())),
-                                        | if($subSelectAliasWithMatchingColumn->size() == 1,
-                                            | ^Alias(name = $c.column.name, relationalElement = ^$c(alias=$subSelectAliasWithMatchingColumn->toOne())),
-                                            | assert(false, | 'Unable to determine the select node alias to use for the extra column:'+$c.column.name->toOne()+if($aliasWithMatchingColumn->size() > 1,|' ,found matching aliases: '+$aliasWithMatchingColumn->map(a|$a.name)->makeString('[',',',']'),|' ,no valid aliases found'));^Alias(relationalElement = ^RelationalOperationElement(), name='fakeAlias');
-                                          )
-                                      );
-                                  );
-                          );
-        ^$s(columns += $colsToAdd);,
-      r:RelationalOperationElement[1] | $r;
-    ]
-  );
-  ^$tableAlias(relationalElement=$updatedRelationalElement);
+   let joinTableAliasColumns = $j.operation->extractTableAliasColumns()->filter(c|$c.alias==$tableAlias)->removeDuplicates();
+   let updatedRelationalElement = $tableAlias.relationalElement->match([s:SelectSQLQuery[1] | let existingCols = $s.columns->map(col| $col->extractColumnName()->stripMatchingQuotes());
+                                                                                              //join alias is vs select, not safe to use the same alias within the select's join tree nodes, since it will likely match with the root (CorrelatedSubQuery), but the subselect could have many nodes
+                                                                                              let allNodes = $s.data->toOne()->getAllNodes()->cast(@RelationalTreeNode);
+                                                                                              let nodeAliasNameToRelation = $allNodes->map(n|pair($n.alias.name, $n.alias.relation))->newMap();
+                                                                                              let colsToAdd = $joinTableAliasColumns->filter(c|!$existingCols->contains($c.column.name))->map(c|if($nodeAliasNameToRelation->get($c.alias.name).columns->contains($c.column),| $c
+                                                                                                                                                                                                                                                                       ,| let aliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->match([s:ViewSelectSQLQuery[1]|$s.view,r:Relation[1]|$r])->cast(@Relation).columns->contains($c.column));
+                                                                                                                                                                                                                                                                          // checking sub-select for handling class mapping inner join filters
+                                                                                                                                                                                                                                                                          let subSelectAliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->instanceOf(SelectSQLQuery) && $a.relation.columns->filter(col | $col->extractColumnName() == $c.column.name)->extractTableAliasColumns().column->contains($c.column));
+                                                                                                                                                                                                                                                                          if($aliasWithMatchingColumn->size()==1,
+                                                                                                                                                                                                                                                                             |^Alias(name=$c.column.name, relationalElement=^$c(alias=$aliasWithMatchingColumn->toOne())),
+                                                                                                                                                                                                                                                                             | if($subSelectAliasWithMatchingColumn->size() == 1,
+                                                                                                                                                                                                                                                                                  |^Alias(name=$c.column.name, relationalElement=^$c(alias=$subSelectAliasWithMatchingColumn->toOne())),
+                                                                                                                                                                                                                                                                                  |assert(false, | 'Unable to determine the select node alias to use for the extra column:'+$c.column.name->toOne()+if($aliasWithMatchingColumn->size() > 1,|' ,found matching aliases: '+$aliasWithMatchingColumn->map(a|$a.name)->makeString('[',',',']'),|' ,no valid aliases found'));^Alias(relationalElement = ^RelationalOperationElement(), name='fakeAlias');));
+                                                                                                                                                                                              ));
+                                                                                              ^$s(columns+=$colsToAdd);,
+                                                                       r:RelationalOperationElement[1] | $r; ]);
+   ^$tableAlias(relationalElement=$updatedRelationalElement);
 }
 
 Class meta::relational::functions::pureToSqlQuery::ApplyJoinInTreeState{
@@ -7906,6 +7891,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::applyJo
 
    let explodeInCurrentNode = explodeInCurrentJoinOperation($joinTreeNode.join.operation);
    let appliedJoinTreeNode = if($explodeInCurrentNode, | applyJoinWithExplodeInCondition($position, $joinTreeNode, $nodeId, $jt, $reprocess, $state, $milestoningContext, $context, $extensions), | applyOneJoin($position, $joinTreeNode, $nodeId, $jt, $reprocess, $state, $milestoningContext, $context, $extensions));
+
    let positionAliasWithExtraJoinCols = $position.alias->addExtraJoinColumns($appliedJoinTreeNode.join); //subselect may not have all cols required for join (prev isolation if applied may take care of this)
    let uniqueAppliedJoinTreeNode =  if($position.childrenData->filter(c|$c->cast(@JoinTreeNode).joinName==$appliedJoinTreeNode.joinName)->isEmpty()
                                       ,|^$appliedJoinTreeNode(join = reprocessJoin($appliedJoinTreeNode.join, [^OldAliasToNewAlias(first = $position.alias.name, second = $positionAliasWithExtraJoinCols)], []))
@@ -8163,44 +8149,28 @@ function meta::relational::functions::pureToSqlQuery::findTarget(join:Join[1], s
 
 function meta::relational::functions::pureToSqlQuery::applyOneJoin(currentNode:RelationalTreeNode[1], joinTree:JoinTreeNode[1], nodeId:String[1], joinType:JoinType[1], reprocess:Boolean[1], state:State[1], milestoningContext: TemporalMilestoningContext[0..1], context:DebugContext[1], extensions:Extension[*]):JoinTreeNode[1]
 {
-  let join = $joinTree.join;
-  let targetAliasInJoin = findTarget($join, $currentNode, $extensions);
-  let sourceAliasInJoin = $join->otherTableFromAlias($targetAliasInJoin)->toOne();
+   let join = $joinTree.join;
+   let targetAliasInJoin = findTarget($join, $currentNode, $extensions);
+   let sourceAliasInJoin = $join->otherTableFromAlias($targetAliasInJoin)->toOne();
 
-  let newTargetAlias = createJoinTableAlias($targetAliasInJoin, $joinType, $nodeId, $state, $milestoningContext, $context, $extensions);
+   let newTargetAlias = createJoinTableAlias($targetAliasInJoin, $joinType, $nodeId, $state, $milestoningContext, $context, $extensions);
 
-  // Column could be quoted in built query, replace in JoinTreeNode accordingly
-  let colsInJoinOp = $join.operation->extractTableAliasColumns();
-  let oldToNewColumnMap = $colsInJoinOp->map(c|
-    let col = $c.column;
-    let alias = if($c.alias.name->toOne() == $sourceAliasInJoin.name->toOne(),
-      | $currentNode.alias.relation,
-      | $newTargetAlias.relation
-    );
-    let foundCol = $alias->findColumn($c.column.name)->map(c|$c->match(
-      [
-        t:TableAliasColumn[1]| $t.column,
-        r:RelationalOperationElement[1]| ^$col(name = $r->extractColumnName())
-      ]
-    ));
-    if($foundCol->isNotEmpty(),
-      | pair($c.column, $foundCol->toOne());,
-      | []
-    );
-  )->newMap();
-
-  let reprocessedJoin = if($reprocess,
-    | reprocessJoin(
-        $join,
-        [
-          ^OldAliasToNewAlias(first=$sourceAliasInJoin.name->toOne(), second=$currentNode.alias),
-          ^OldAliasToNewAlias(first=$targetAliasInJoin.name->toOne(), second=$newTargetAlias)
-        ], 
-        $oldToNewColumnMap
-      ),
-    | $join
-  );
-  ^$joinTree(alias = $newTargetAlias, join = $reprocessedJoin, joinType = $joinType, childrenData = []);
+   print(if(!$context.debug, |'', | $context.space+'>Apply Join: '+$joinTree.join.operation->meta::relational::functions::sqlQueryToString::processOperation(DatabaseType.DebugPrint, [], [], $extensions) + '\n'));
+   let res = ^$joinTree(
+                 alias=$newTargetAlias,
+                 join=if($reprocess,
+                       |reprocessJoin(
+                                          $join,
+                                          [
+                                            ^OldAliasToNewAlias(first=$sourceAliasInJoin.name->toOne(), second=$currentNode.alias),
+                                            ^OldAliasToNewAlias(first=$targetAliasInJoin.name->toOne(), second=$newTargetAlias)
+                                          ], []
+                                     ),
+                       |$join
+                     ),
+                 joinType = $joinType,
+                 childrenData = []
+             );
 }
 
 function meta::relational::functions::pureToSqlQuery::createJoinTableAlias(targetAliasInJoin:TableAlias[1], joinType:JoinType[1], nodeId:String[1], state:State[1], milestoningContext: TemporalMilestoningContext[0..1], context:DebugContext[1], extensions:Extension[*]):TableAlias[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -607,6 +607,11 @@ function meta::relational::functions::pureToSqlQuery::findColumn(relation:Relati
   $relation.columns->filter(c|$c->extractColumnName()->quoteSafeEqual($name))->first();
 }
 
+function meta::relational::functions::pureToSqlQuery::hasColumn(relation:Relation[1], name:String[1]):Boolean[1]
+{
+  $relation->findColumn($name)->isNotEmpty();
+}
+
 function meta::relational::functions::pureToSqlQuery::processPropertyFunctionExpression(fe:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):OperationWithParentPropertyMapping[1]
 {
    let propertyOwner = $fe.parametersValues->at(0)->map(p|$p->byPassRouterInfo());
@@ -7858,24 +7863,34 @@ function meta::relational::functions::pureToSqlQuery::mergeSQLQueryData(preQuery
 
 function meta::relational::functions::pureToSqlQuery::addExtraJoinColumns(tableAlias: TableAlias[1], j:Join[1]):TableAlias[1]
 {
-   let joinTableAliasColumns = $j.operation->extractTableAliasColumns()->filter(c|$c.alias==$tableAlias)->removeDuplicates();
-   let updatedRelationalElement = $tableAlias.relationalElement->match([s:SelectSQLQuery[1] | let existingCols = $s.columns->map(col| $col->extractColumnName()->stripMatchingQuotes());
-                                                                                              //join alias is vs select, not safe to use the same alias within the select's join tree nodes, since it will likely match with the root (CorrelatedSubQuery), but the subselect could have many nodes
-                                                                                              let allNodes = $s.data->toOne()->getAllNodes()->cast(@RelationalTreeNode);
-                                                                                              let nodeAliasNameToRelation = $allNodes->map(n|pair($n.alias.name, $n.alias.relation))->newMap();
-                                                                                              let colsToAdd = $joinTableAliasColumns->filter(c|!$existingCols->contains($c.column.name))->map(c|if($nodeAliasNameToRelation->get($c.alias.name).columns->contains($c.column),| $c
-                                                                                                                                                                                                                                                                       ,| let aliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->match([s:ViewSelectSQLQuery[1]|$s.view,r:Relation[1]|$r])->cast(@Relation).columns->contains($c.column));
-                                                                                                                                                                                                                                                                          // checking sub-select for handling class mapping inner join filters
-                                                                                                                                                                                                                                                                          let subSelectAliasWithMatchingColumn = $allNodes.alias->filter(a|$a.relation->instanceOf(SelectSQLQuery) && $a.relation.columns->filter(col | $col->extractColumnName() == $c.column.name)->extractTableAliasColumns().column->contains($c.column));
-                                                                                                                                                                                                                                                                          if($aliasWithMatchingColumn->size()==1,
-                                                                                                                                                                                                                                                                             |^Alias(name=$c.column.name, relationalElement=^$c(alias=$aliasWithMatchingColumn->toOne())),
-                                                                                                                                                                                                                                                                             | if($subSelectAliasWithMatchingColumn->size() == 1,
-                                                                                                                                                                                                                                                                                  |^Alias(name=$c.column.name, relationalElement=^$c(alias=$subSelectAliasWithMatchingColumn->toOne())),
-                                                                                                                                                                                                                                                                                  |assert(false, | 'Unable to determine the select node alias to use for the extra column:'+$c.column.name->toOne()+if($aliasWithMatchingColumn->size() > 1,|' ,found matching aliases: '+$aliasWithMatchingColumn->map(a|$a.name)->makeString('[',',',']'),|' ,no valid aliases found'));^Alias(relationalElement = ^RelationalOperationElement(), name='fakeAlias');));
-                                                                                                                                                                                              ));
-                                                                                              ^$s(columns+=$colsToAdd);,
-                                                                       r:RelationalOperationElement[1] | $r; ]);
-   ^$tableAlias(relationalElement=$updatedRelationalElement);
+  let joinTableAliasColumns = $j.operation->extractTableAliasColumns()->filter(c|$c.alias==$tableAlias)->removeDuplicates();
+  let updatedRelationalElement = $tableAlias.relationalElement->match(
+    [
+      s:SelectSQLQuery[1] |
+        //join alias is vs select, not safe to use the same alias within the select's join tree nodes, since it will likely match with the root (CorrelatedSubQuery), but the subselect could have many nodes
+        let allNodes = $s.data->toOne()->getAllNodes()->cast(@RelationalTreeNode);
+        let nodeAliasNameToRelation = $allNodes->map(n | pair($n.alias.name, $n.alias.relation))->newMap();
+        let colsToAdd = $joinTableAliasColumns->filter(c | !$s->hasColumn($c.column.name))
+                          ->map(c|let relation = $nodeAliasNameToRelation->get($c.alias.name);
+                                  if($relation->isNotEmpty() && $relation->toOne()->hasColumn($c.column.name),
+                                    | $c,
+                                    | let aliasWithMatchingColumn = $allNodes.alias->filter(a | $a.relation->match([s:ViewSelectSQLQuery[1] | $s.view, r:Relation[1] | $r])->cast(@Relation)->hasColumn($c.column.name));
+                                      // checking sub-select for handling class mapping inner join filters
+                                      let subSelectAliasWithMatchingColumn = $allNodes.alias->filter(a | $a.relation->instanceOf(SelectSQLQuery) && $a.relation->hasColumn($c.column.name));
+                                      if($aliasWithMatchingColumn->size()==1,
+                                        | ^Alias(name = $c.column.name, relationalElement = ^$c(alias = $aliasWithMatchingColumn->toOne())),
+                                        | if($subSelectAliasWithMatchingColumn->size() == 1,
+                                            | ^Alias(name = $c.column.name, relationalElement = ^$c(alias=$subSelectAliasWithMatchingColumn->toOne())),
+                                            | assert(false, | 'Unable to determine the select node alias to use for the extra column:'+$c.column.name->toOne()+if($aliasWithMatchingColumn->size() > 1,|' ,found matching aliases: '+$aliasWithMatchingColumn->map(a|$a.name)->makeString('[',',',']'),|' ,no valid aliases found'));^Alias(relationalElement = ^RelationalOperationElement(), name='fakeAlias');
+                                          )
+                                      );
+                                  );
+                          );
+        ^$s(columns += $colsToAdd);,
+      r:RelationalOperationElement[1] | $r;
+    ]
+  );
+  ^$tableAlias(relationalElement=$updatedRelationalElement);
 }
 
 Class meta::relational::functions::pureToSqlQuery::ApplyJoinInTreeState{
@@ -7891,7 +7906,6 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::applyJo
 
    let explodeInCurrentNode = explodeInCurrentJoinOperation($joinTreeNode.join.operation);
    let appliedJoinTreeNode = if($explodeInCurrentNode, | applyJoinWithExplodeInCondition($position, $joinTreeNode, $nodeId, $jt, $reprocess, $state, $milestoningContext, $context, $extensions), | applyOneJoin($position, $joinTreeNode, $nodeId, $jt, $reprocess, $state, $milestoningContext, $context, $extensions));
-
    let positionAliasWithExtraJoinCols = $position.alias->addExtraJoinColumns($appliedJoinTreeNode.join); //subselect may not have all cols required for join (prev isolation if applied may take care of this)
    let uniqueAppliedJoinTreeNode =  if($position.childrenData->filter(c|$c->cast(@JoinTreeNode).joinName==$appliedJoinTreeNode.joinName)->isEmpty()
                                       ,|^$appliedJoinTreeNode(join = reprocessJoin($appliedJoinTreeNode.join, [^OldAliasToNewAlias(first = $position.alias.name, second = $positionAliasWithExtraJoinCols)], []))
@@ -8149,27 +8163,44 @@ function meta::relational::functions::pureToSqlQuery::findTarget(join:Join[1], s
 
 function meta::relational::functions::pureToSqlQuery::applyOneJoin(currentNode:RelationalTreeNode[1], joinTree:JoinTreeNode[1], nodeId:String[1], joinType:JoinType[1], reprocess:Boolean[1], state:State[1], milestoningContext: TemporalMilestoningContext[0..1], context:DebugContext[1], extensions:Extension[*]):JoinTreeNode[1]
 {
-   let join = $joinTree.join;
-   let targetAliasInJoin = findTarget($join, $currentNode, $extensions);
-   let sourceAliasInJoin = $join->otherTableFromAlias($targetAliasInJoin)->toOne();
+  let join = $joinTree.join;
+  let targetAliasInJoin = findTarget($join, $currentNode, $extensions);
+  let sourceAliasInJoin = $join->otherTableFromAlias($targetAliasInJoin)->toOne();
 
-   let newTargetAlias = createJoinTableAlias($targetAliasInJoin, $joinType, $nodeId, $state, $milestoningContext, $context, $extensions);
+  let newTargetAlias = createJoinTableAlias($targetAliasInJoin, $joinType, $nodeId, $state, $milestoningContext, $context, $extensions);
 
-   let res = ^$joinTree(
-                 alias=$newTargetAlias,
-                 join=if($reprocess,
-                       |reprocessJoin(
-                                          $join,
-                                          [
-                                            ^OldAliasToNewAlias(first=$sourceAliasInJoin.name->toOne(), second=$currentNode.alias),
-                                            ^OldAliasToNewAlias(first=$targetAliasInJoin.name->toOne(), second=$newTargetAlias)
-                                          ], []
-                                     ),
-                       |$join
-                     ),
-                 joinType = $joinType,
-                 childrenData = []
-             );
+  // Column could be quoted in built query, replace in JoinTreeNode accordingly
+  let colsInJoinOp = $join.operation->extractTableAliasColumns();
+  let oldToNewColumnMap = $colsInJoinOp->map(c|
+    let col = $c.column;
+    let alias = if($c.alias.name->toOne() == $sourceAliasInJoin.name->toOne(),
+      | $currentNode.alias.relation,
+      | $newTargetAlias.relation
+    );
+    let foundCol = $alias->findColumn($c.column.name)->map(c|$c->match(
+      [
+        t:TableAliasColumn[1]| $t.column,
+        r:RelationalOperationElement[1]| ^$col(name = $r->extractColumnName())
+      ]
+    ));
+    if($foundCol->isNotEmpty(),
+      | pair($c.column, $foundCol->toOne());,
+      | []
+    );
+  )->newMap();
+
+  let reprocessedJoin = if($reprocess,
+    | reprocessJoin(
+        $join,
+        [
+          ^OldAliasToNewAlias(first=$sourceAliasInJoin.name->toOne(), second=$currentNode.alias),
+          ^OldAliasToNewAlias(first=$targetAliasInJoin.name->toOne(), second=$newTargetAlias)
+        ], 
+        $oldToNewColumnMap
+      ),
+    | $join
+  );
+  ^$joinTree(alias = $newTargetAlias, join = $reprocessedJoin, joinType = $joinType, childrenData = []);
 }
 
 function meta::relational::functions::pureToSqlQuery::createJoinTableAlias(targetAliasInJoin:TableAlias[1], joinType:JoinType[1], nodeId:String[1], state:State[1], milestoningContext: TemporalMilestoningContext[0..1], context:DebugContext[1], extensions:Extension[*]):TableAlias[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -416,8 +416,7 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
                                           s:ViewSelectSQLQuery[1]|'('+$s.selectSQLQuery->processOperation($dbConfig, $format, $generationState, $config, $extensions)+')',
                                           t:Table[1]|$t->tableToString($dbConfig),
                                           tf:TabularFunction[1]|$tf->tabularFunctionToString($dbConfig),
-                                          js:JoinStrings[1] | $dbConfig.joinStringsProcessor($js, ^$sgc(config=^Config())),
-                                          c: RelationFunctionColumn[1] | processColumnName('"' + $c.name->toOne() + '"', $dbConfig), // columns from Relation are case sensitive
+                                          js:JoinStrings[1] | $dbConfig.joinStringsProcessor($js, ^$sgc(config=^Config())),                                          
                                           c: Column[1] | processColumnName($c.name->toOne(), $dbConfig),
                                           alias:Alias[1]|
                                                 let innerTerm = $alias.relationalElement->match([

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -417,6 +417,8 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
                                           t:Table[1]|$t->tableToString($dbConfig),
                                           tf:TabularFunction[1]|$tf->tabularFunctionToString($dbConfig),
                                           js:JoinStrings[1] | $dbConfig.joinStringsProcessor($js, ^$sgc(config=^Config())),
+                                          c: RelationFunctionColumn[1] | processColumnName('"' + $c.name->toOne() + '"', $dbConfig), // columns from Relation are case sensitive
+                                          c: Column[1] | processColumnName($c.name->toOne(), $dbConfig),
                                           alias:Alias[1]|
                                                 let innerTerm = $alias.relationalElement->match([
                                                    c : CommonTableExpressionReference[1]| $c->cast(@CommonTableExpressionReference).name->toString(),
@@ -439,7 +441,7 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
                                           x:TableAliasColumnName[1] | processTableAlias($x.alias, $dbConfig, $config) + processColumnName($x.columnName, $dbConfig),                                                                
                                           c:TableAliasColumn[1]| if($config.useUnqualifiedColumnNameInPivot == true,
                                             | '',
-                                            | processTableAlias($c.alias, $dbConfig, $config)) + processColumnName($c.column.name->toOne(), $dbConfig)
+                                            | processTableAlias($c.alias, $dbConfig, $config)) + $c.column->processOperation($dbConfig, $format, $generationState, $config, $extensions)
                                           ,                                                                
                                           l:Literal[1]| processLiteral($l, $dbConfig),
                                           ll:LiteralList[1] | $ll.values->map(e | $e->processOperation($dbConfig, $format, $generationState, $config, $extensions))->joinStrings('(', ', ', ')'),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/relationMappingSetup.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/relationMappingSetup.pure
@@ -150,7 +150,7 @@ function meta::relational::tests::mapping::relation::personFunction(): Relation<
     ->limit(5)
 }
 
-function meta::relational::tests::mapping::relation::personFunctionWithProject(): Relation<Any>[1]
+function meta::relational::tests::mapping::relation::personFunctionWithProject(): Relation<('FIRST NAME':String, AGE:Integer, 'FirmId':Integer)>[1]
 {
   PersonWithFirmId.all()
     ->filter(x|$x.age > 25)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/relationMappingSetup.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/relationMappingSetup.pure
@@ -20,7 +20,7 @@ Database meta::relational::tests::mapping::relation::testDB
     ID INTEGER PRIMARY KEY,
     "FIRST NAME" VARCHAR(100),
     AGE INTEGER,
-    FIRMID INTEGER,
+    "FirmId" INTEGER,
     SALARY FLOAT
   )
 
@@ -76,7 +76,7 @@ Mapping meta::relational::tests::mapping::relation::simpleMapping
     ~func meta::relational::tests::mapping::relation::personFunction__Relation_1_
     firstName: 'FIRST NAME',
     age: AGE,
-    +firmId: Integer[1]: FIRMID
+    +firmId: Integer[1]: 'FirmId'
   }
 
   *Firm[firm]: Relation 
@@ -100,14 +100,14 @@ Mapping meta::relational::tests::mapping::relation::mixedMapping
     ~func meta::relational::tests::mapping::relation::personFunctionWithProject__Relation_1_
     firstName: 'FIRST NAME',
     age: AGE,
-    +firmId: Integer[1]: FIRMID
+    +firmId: Integer[1]: 'FirmId'
   }
 
   *PersonWithFirmId: Relational 
   {
     firstName: [meta::relational::tests::mapping::relation::testDB]personTable."FIRST NAME",
     age: [meta::relational::tests::mapping::relation::testDB]personTable.AGE,
-    firmId: [meta::relational::tests::mapping::relation::testDB]personTable.FIRMID
+    firmId: [meta::relational::tests::mapping::relation::testDB]personTable."FirmId"
   }
 
   *Firm[firm]: Relational 
@@ -158,10 +158,10 @@ function meta::relational::tests::mapping::relation::personFunctionWithProject()
       ~[
         'FIRST NAME':x|$x.firstName,
         AGE:x|$x.age,
-        FIRMID:x|$x.firmId
+        'FirmId':x|$x.firmId
       ]
     )
-    ->select(~['FIRST NAME', AGE, FIRMID])
+    ->select(~['FIRST NAME', AGE, 'FirmId'])
 }
 
 function meta::relational::tests::mapping::relation::firmFunction(): Relation<Any>[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/tests.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/relation/tests.pure
@@ -30,14 +30,14 @@ function meta::relational::tests::mapping::relation::createTablesAndFillDb():Boo
    let connection = meta::external::store::relational::tests::testRuntime(testDB).connectionByElement(testDB)->cast(@meta::external::store::relational::runtime::TestDatabaseConnection);
    
    executeInDb('Drop table if exists PersonTable;', $connection);
-   executeInDb('Create Table PersonTable(id INT, "FIRST NAME" VARCHAR(200), age INT, firmId INT, birthdate DATE, salary DOUBLE, isMale BIT);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (1, \'Peter\',   23,  1, \'2000-11-01\', 14.34, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (2, \'John\',    30,  1, \'1994-11-01\', 72.40, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (3, \'Jane\',    23,  2, \'2000-11-01\', 48.00, 0);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (4, \'Anthony\', 19,  3, \'2005-11-01\', 64.90, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (5, \'Fabrice\', 45,  4, \'1979-11-01\', 19.29, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (6, \'Oliver\',  26,  4, \'1998-11-01\', 42.34, 1);', $connection);
-   executeInDb('insert into PersonTable (id, "FIRST NAME", age, firmId, birthDate, salary, isMale) values (7, \'David\',   52,  5, \'1972-11-01\', 88.88, 1);', $connection);
+   executeInDb('Create Table PersonTable(id INT, "FIRST NAME" VARCHAR(200), age INT, "FirmId" INT, birthdate DATE, salary DOUBLE, isMale BIT);', $connection);
+   executeInDb('insert into PersonTable (id, "FIRST NAME", age, "FirmId", birthDate, salary, isMale) values (1, \'Peter\',   23,  1, \'2000-11-01\', 14.34, 1);', $connection);
+   executeInDb('insert into PersonTable (id, "FIRST NAME", age, "FirmId", birthDate, salary, isMale) values (2, \'John\',    30,  1, \'1994-11-01\', 72.40, 1);', $connection);
+   executeInDb('insert into PersonTable (id, "FIRST NAME", age, "FirmId", birthDate, salary, isMale) values (3, \'Jane\',    23,  2, \'2000-11-01\', 48.00, 0);', $connection);
+   executeInDb('insert into PersonTable (id, "FIRST NAME", age, "FirmId", birthDate, salary, isMale) values (4, \'Anthony\', 19,  3, \'2005-11-01\', 64.90, 1);', $connection);
+   executeInDb('insert into PersonTable (id, "FIRST NAME", age, "FirmId", birthDate, salary, isMale) values (5, \'Fabrice\', 45,  4, \'1979-11-01\', 19.29, 1);', $connection);
+   executeInDb('insert into PersonTable (id, "FIRST NAME", age, "FirmId", birthDate, salary, isMale) values (6, \'Oliver\',  26,  4, \'1998-11-01\', 42.34, 1);', $connection);
+   executeInDb('insert into PersonTable (id, "FIRST NAME", age, "FirmId", birthDate, salary, isMale) values (7, \'David\',   52,  5, \'1972-11-01\', 88.88, 1);', $connection);
 
    executeInDb('Drop table if exists FirmTable;', $connection);
    executeInDb('Create Table FirmTable(id INT, legalName VARCHAR(200), addressId INT, ceoId INT);', $connection);


### PR DESCRIPTION
From respective to mapping from a relation function, this forces the alias name of a relation column mapped to a property to be quoted.  This is consistent with how we handle alias of relational table accessors, and when casting to a relation.

To ensure this works, this also aims to fix places where column and column names are compared, to ensure the quotes dont interfere.  