### PR TITLE
Move to default waitUntil config for central-maven-publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,6 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                      <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
                     <waitMaxTime>3600</waitMaxTime> 
                 </configuration>
             </plugin>


### PR DESCRIPTION
Move to default waitUntil config for central-maven-publishing