### PR TITLE
Fix column type issue when using col(i.e:~) in select and other funcs

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -508,7 +508,12 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
                 gt = this.context.newGenericType(colSpec.genericType);
                 gt.setSourceInformation(SourceInformationHelper.toM3SourceInformation(colSpec.sourceInformation));
             }
-            return Handlers.wrapInstanceValue(Handlers.buildColSpec(colSpec.name, gt, (Multiplicity) org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.newMultiplicity(0, 1, processorSupport), this.context.pureModel, this.context.pureModel.getExecutionSupport().getProcessorSupport()), this.context.pureModel);
+            Multiplicity multiplicity = null;
+            if (colSpec.multiplicity != null)
+            {
+                multiplicity = this.context.pureModel.getMultiplicity(colSpec.multiplicity);
+            }
+            return Handlers.wrapInstanceValue(Handlers.buildColSpec(colSpec.name, gt, multiplicity, this.context.pureModel, this.context.pureModel.getExecutionSupport().getProcessorSupport()), this.context.pureModel);
         }
         else if (colSpec.function2 == null)
         {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
@@ -474,6 +474,7 @@ public class Handlers
         {
             Column<?, ?> found = findColumn(type, c, valueSpecificationBuilder.getContext().pureModel.getExecutionSupport().getProcessorSupport());
             c.genericType = CompileContext.convertGenericType(_Column.getColumnType(found));
+            c.multiplicity = CompileContext.convertMultiplicity(_Column.getColumnMultiplicity(found));
         });
 
         return Lists.mutable.with(
@@ -561,6 +562,7 @@ public class Handlers
             ColSpec column = (ColSpec) ((ClassInstance) ((AppliedFunction) parameter).parameters.get(0)).value;
             Column<?, ?> foundColumn = findColumn(type, column, processorSupport);
             column.genericType = CompileContext.convertGenericType(_Column.getColumnType(foundColumn));
+            column.multiplicity = CompileContext.convertMultiplicity(_Column.getColumnMultiplicity(foundColumn));
         }
         else if (parameter instanceof Collection)
         {
@@ -594,6 +596,7 @@ public class Handlers
             ColSpec column = (ColSpec) ((ClassInstance) af.parameters.get(0)).value;
             org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.Column<?, ?> foundColumn = findColumn(type, column, processorSupport);
             column.genericType = CompileContext.convertGenericType(_Column.getColumnType(foundColumn));
+            column.multiplicity = CompileContext.convertMultiplicity(_Column.getColumnMultiplicity(foundColumn));
         }
         else
         {
@@ -802,6 +805,7 @@ public class Handlers
             {
                 Column<?, ?> found = findColumn(relationType, c, cc.pureModel.getExecutionSupport().getProcessorSupport());
                 c.genericType = CompileContext.convertGenericType(_Column.getColumnType(found));
+                c.multiplicity = CompileContext.convertMultiplicity(_Column.getColumnMultiplicity(found));
             });
         }
     }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/m3/valuespecification/constant/classInstance/relation/ColSpec.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/m3/valuespecification/constant/classInstance/relation/ColSpec.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.finos.legend.engine.protocol.pure.m3.multiplicity.Multiplicity;
 import org.finos.legend.engine.protocol.pure.m3.type.generics.GenericType;
 import org.finos.legend.engine.protocol.pure.m3.valuespecification.constant.PackageableType;
 import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
@@ -35,6 +36,7 @@ public class ColSpec
     public SourceInformation sourceInformation;
     public String name;
     public GenericType genericType;
+    public Multiplicity multiplicity;
     public LambdaFunction function1;
     public LambdaFunction function2;
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
@@ -59,6 +59,157 @@ public class TestRelationFunctions extends TestCompilationFromGrammar.TestCompil
     }
 
     @Test
+    public void lambdaColumnsMultiplicityAfterSelect() throws Exception
+    {
+        Pair<PureModelContextData, PureModel> pureModelPair = test(
+                "###Relational\n" +
+                        "Database a::A (Table tb(id Integer, other Integer NOT NULL))\n"
+        );
+
+        LambdaFunction lambda = PureGrammarParser.newInstance().parseLambda("|#>{a::A.tb}#->select(~id)");
+        GenericType genericType = Compiler.getLambdaReturnGenericType(lambda, pureModelPair.getTwo());
+        String actualValue = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().writeValueAsString(genericType);
+        JsonAssert.assertJsonEquals(
+                "{\n" +
+                        "  \"multiplicityArguments\": [],\n" +
+                        "  \"rawType\": {\n" +
+                        "    \"_type\": \"packageableType\",\n" +
+                        "    \"fullPath\": \"meta::pure::metamodel::relation::Relation\"\n" +
+                        "  },\n" +
+                        "  \"typeArguments\": [\n" +
+                        "    {\n" +
+                        "      \"multiplicityArguments\": [],\n" +
+                        "      \"rawType\": {\n" +
+                        "        \"_type\": \"relationType\",\n" +
+                        "        \"columns\": [\n" +
+                        "          {\n" +
+                        "            \"genericType\": {\n" +
+                        "              \"multiplicityArguments\": [],\n" +
+                        "              \"rawType\": {\n" +
+                        "                \"_type\": \"packageableType\",\n" +
+                        "                \"fullPath\": \"meta::pure::precisePrimitives::Int\"\n" +
+                        "              },\n" +
+                        "              \"typeArguments\": [],\n" +
+                        "              \"typeVariableValues\": []\n" +
+                        "            },\n" +
+                        "            \"multiplicity\": {\n" +
+                        "              \"lowerBound\": 0,\n" +
+                        "              \"upperBound\": 1\n" +
+                        "            },\n" +
+                        "            \"name\": \"id\"\n" +
+                        "          }\n" +
+                        "        ]\n" +
+                        "      },\n" +
+                        "      \"typeArguments\": [],\n" +
+                        "      \"typeVariableValues\": []\n" +
+                        "    }\n" +
+                        "  ],\n" +
+                        "  \"typeVariableValues\": []\n" +
+                        "}",
+                actualValue);
+
+        LambdaFunction lambda2 = PureGrammarParser.newInstance().parseLambda("|#>{a::A.tb}#->select(~other)");
+        GenericType genericType2 = Compiler.getLambdaReturnGenericType(lambda2, pureModelPair.getTwo());
+        String actualValue2 = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().writeValueAsString(genericType2);
+        JsonAssert.assertJsonEquals(
+                "{\n" +
+                        "  \"multiplicityArguments\": [],\n" +
+                        "  \"rawType\": {\n" +
+                        "    \"_type\": \"packageableType\",\n" +
+                        "    \"fullPath\": \"meta::pure::metamodel::relation::Relation\"\n" +
+                        "  },\n" +
+                        "  \"typeArguments\": [\n" +
+                        "    {\n" +
+                        "      \"multiplicityArguments\": [],\n" +
+                        "      \"rawType\": {\n" +
+                        "        \"_type\": \"relationType\",\n" +
+                        "        \"columns\": [\n" +
+                        "          {\n" +
+                        "            \"genericType\": {\n" +
+                        "              \"multiplicityArguments\": [],\n" +
+                        "              \"rawType\": {\n" +
+                        "                \"_type\": \"packageableType\",\n" +
+                        "                \"fullPath\": \"meta::pure::precisePrimitives::Int\"\n" +
+                        "              },\n" +
+                        "              \"typeArguments\": [],\n" +
+                        "              \"typeVariableValues\": []\n" +
+                        "            },\n" +
+                        "            \"multiplicity\": {\n" +
+                        "              \"lowerBound\": 1,\n" +
+                        "              \"upperBound\": 1\n" +
+                        "            },\n" +
+                        "            \"name\": \"other\"\n" +
+                        "          }\n" +
+                        "        ]\n" +
+                        "      },\n" +
+                        "      \"typeArguments\": [],\n" +
+                        "      \"typeVariableValues\": []\n" +
+                        "    }\n" +
+                        "  ],\n" +
+                        "  \"typeVariableValues\": []\n" +
+                        "}",
+                actualValue2);
+
+        LambdaFunction lambda3 = PureGrammarParser.newInstance().parseLambda("|#>{a::A.tb}#->select(~[id, other])");
+        GenericType genericType3 = Compiler.getLambdaReturnGenericType(lambda3, pureModelPair.getTwo());
+        String actualValue3 = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().writeValueAsString(genericType3);
+        JsonAssert.assertJsonEquals(
+                "{\n" +
+                        "  \"multiplicityArguments\": [],\n" +
+                        "  \"rawType\": {\n" +
+                        "    \"_type\": \"packageableType\",\n" +
+                        "    \"fullPath\": \"meta::pure::metamodel::relation::Relation\"\n" +
+                        "  },\n" +
+                        "  \"typeArguments\": [\n" +
+                        "    {\n" +
+                        "      \"multiplicityArguments\": [],\n" +
+                        "      \"rawType\": {\n" +
+                        "        \"_type\": \"relationType\",\n" +
+                        "        \"columns\": [\n" +
+                        "          {\n" +
+                        "            \"genericType\": {\n" +
+                        "              \"multiplicityArguments\": [],\n" +
+                        "              \"rawType\": {\n" +
+                        "                \"_type\": \"packageableType\",\n" +
+                        "                \"fullPath\": \"meta::pure::precisePrimitives::Int\"\n" +
+                        "              },\n" +
+                        "              \"typeArguments\": [],\n" +
+                        "              \"typeVariableValues\": []\n" +
+                        "            },\n" +
+                        "            \"multiplicity\": {\n" +
+                        "              \"lowerBound\": 0,\n" +
+                        "              \"upperBound\": 1\n" +
+                        "            },\n" +
+                        "            \"name\": \"id\"\n" +
+                        "          },\n" +
+                        "          {\n" +
+                        "            \"genericType\": {\n" +
+                        "              \"multiplicityArguments\": [],\n" +
+                        "              \"rawType\": {\n" +
+                        "                \"_type\": \"packageableType\",\n" +
+                        "                \"fullPath\": \"meta::pure::precisePrimitives::Int\"\n" +
+                        "              },\n" +
+                        "              \"typeArguments\": [],\n" +
+                        "              \"typeVariableValues\": []\n" +
+                        "            },\n" +
+                        "            \"multiplicity\": {\n" +
+                        "              \"lowerBound\": 1,\n" +
+                        "              \"upperBound\": 1\n" +
+                        "            },\n" +
+                        "            \"name\": \"other\"\n" +
+                        "          }\n" +
+                        "        ]\n" +
+                        "      },\n" +
+                        "      \"typeArguments\": [],\n" +
+                        "      \"typeVariableValues\": []\n" +
+                        "    }\n" +
+                        "  ],\n" +
+                        "  \"typeVariableValues\": []\n" +
+                        "}",
+                actualValue3);
+    }
+
+    @Test
     public void testFilterError()
     {
         test(
@@ -564,7 +715,7 @@ public class TestRelationFunctions extends TestCompilationFromGrammar.TestCompil
                         "{\n" +
                         "   #>{a::A.tb}#->sort(~id2)\n" +
                         "}",
-                "COMPILATION error at [7:18-21]: Can't find a match for function 'sort(RelationStoreAccessor<(id:Int)>[1],ColSpec<(id2:NULL)>[1])"
+                "COMPILATION error at [7:18-21]: Can't find a match for function 'sort(RelationStoreAccessor<(id:Int)>[1],ColSpec<(id2:NULL[NULL])>[1])'"
         );
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>5.52.1</legend.pure.version>
+        <legend.pure.version>5.52.2</legend.pure.version>
         <legend.shared.version>0.27.0</legend.shared.version>
         <legend.web-application.version>13.2.0</legend.web-application.version>
 


### PR DESCRIPTION
Fix column type issue when using col(i.e:~) in select and other funcs