### PR TITLE
Handle schema evolution for iceberg tables

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
@@ -110,5 +110,11 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/SnowflakeIcebergDataTypeToDefaultSizeMapping.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/sql/SnowflakeIcebergDataTypeToDefaultSizeMapping.java
@@ -1,0 +1,107 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.persistence.components.relational.snowflake.sql;
+
+import org.finos.legend.engine.persistence.components.logicalplan.datasets.DataType;
+import org.finos.legend.engine.persistence.components.relational.sql.DataTypeToDefaultSizeMapping;
+
+import java.util.Optional;
+
+public class SnowflakeIcebergDataTypeToDefaultSizeMapping implements DataTypeToDefaultSizeMapping
+{
+    @Override
+    public Optional<Integer> getDefaultLength(DataType type)
+    {
+        switch (type)
+        {
+            case INT:
+            case INTEGER:
+            case BIGINT:
+            case TINYINT:
+            case SMALLINT:
+            case REAL:
+            case FLOAT:
+            case DOUBLE:
+            case BOOLEAN:
+            case DATE:
+            case JSON:
+            case VARIANT:
+            case ARRAY:
+            case MAP:
+                return Optional.empty();
+            case NUMERIC:
+            case DECIMAL:
+                return Optional.of(38);
+            case CHAR:
+                return Optional.of(1);
+            case VARCHAR:
+            case STRING:
+            case TEXT:
+                return Optional.empty();
+            case BINARY:
+            case VARBINARY:
+                return Optional.of(8388608);
+            case TIME:
+            case DATETIME:
+            case TIMESTAMP:
+            case TIMESTAMP_NTZ:
+            case TIMESTAMP_TZ:
+            case TIMESTAMP_LTZ:
+                return Optional.of(6);
+            default:
+                throw new IllegalArgumentException("Unexpected value: " + type);
+        }
+    }
+
+    @Override
+    public Optional<Integer> getDefaultScale(DataType type)
+    {
+        switch (type)
+        {
+            case INT:
+            case INTEGER:
+            case BIGINT:
+            case TINYINT:
+            case SMALLINT:
+            case REAL:
+            case FLOAT:
+            case DOUBLE:
+            case CHAR:
+            case VARCHAR:
+            case STRING:
+            case TEXT:
+            case BINARY:
+            case VARBINARY:
+            case BOOLEAN:
+            case DATE:
+            case TIME:
+            case DATETIME:
+            case TIMESTAMP:
+            case TIMESTAMP_NTZ:
+            case TIMESTAMP_TZ:
+            case TIMESTAMP_LTZ:
+            case JSON:
+            case VARIANT:
+            case ARRAY:
+            case MAP:
+                return Optional.empty();
+            case NUMERIC:
+            case DECIMAL:
+                return Optional.of(0);
+            default:
+                throw new IllegalArgumentException("Unexpected value: " + type);
+        }
+    }
+}

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <immutable.version>2.8.2</immutable.version>
-        <junit-jupiter.version>5.4.0</junit-jupiter.version>
+        <junit-jupiter.version>5.11.0</junit-jupiter.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <joda.time.version>2.10.6</joda.time.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonunit.version>2.17.0</jsonunit.version>
-        <junit-jupiter.version>5.4.0</junit-jupiter.version>
+        <junit-jupiter.version>5.11.0</junit-jupiter.version>
         <junit.version>4.13.1</junit.version>
         <reload4j.version>1.2.19</reload4j.version>
         <logback-contrib.version>0.1.5</logback-contrib.version>


### PR DESCRIPTION
Improvement

Handling schema evolution for varchar columns in iceberg tables in Snowflake, as their default max_len is increasing gradually
Command that would get executed:
ALTER ICEBERG TABLE <table_name>ALTER COLUMN <col_name> varchar

Not specifying any length in schema evolution evolves the column to the max length supported by the engine