### PR TITLE
Add support for groupby with no cols to allow aggregations at table level

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
@@ -15,6 +15,10 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
+
+native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
+
 native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
 native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
@@ -283,4 +287,65 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '   5,9,I\n'+
                   '#', $resSorted->sort(~grp->ascending())->select(~[grp, YoCol, newColSorted])->toString()
 );
+}
+
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_NoGroupByCols_AggColSpec<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                |#TDS
+                  id, grp, name
+                  1, 2, A
+                  2, 1, B
+                  3, 3, C
+                #->groupBy(~idSum : x | $x.id : y | $y->plus());
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   idSum\n'+
+                  '   6\n'+
+                  '#', $res->toString());
+}
+
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_NoGroupByCols_AggColSpecArray<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                |#TDS
+                  id, grp, code
+                  1, 2, A
+                  2, 1, A
+                  3, 3, A
+                #->groupBy(~[idSum : x | $x.id : y | $y->plus(), codes : x | $x.code : y | $y->joinStrings(':')]);
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   idSum,codes\n'+
+                  '   6,A:A:A\n'+
+                  '#', $res->toString());
+}
+
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_NoGroupByCols_WithFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    /*
+      NOTE:- this works because it currently produces a WHERE on a sub query (if it produced WHERE directly on main query it would fail as we can't query by aggregated fields)
+      however ideally this should be generating HAVING instead of WHERE. TODO - look into fixing this
+    */
+    let expr = {
+                |#TDS
+                  id, grp, name
+                  1, 2, A
+                  2, 1, B
+                  3, 3, C
+                #->groupBy(~idSum : x | $x.id : y | $y->plus())->filter(r | $r.idSum == 6);
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   idSum\n'+
+                  '   6\n'+
+                  '#', $res->toString());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
@@ -15,17 +15,41 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
-native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
+native function <<PCT.function>> 
+{
+    doc.doc='Groups the entire given relation and adds new column where its value is aggregated using the reduce (second) function using the values collected from the map (first) function'
+}
+meta::pure::functions::relation::groupBy<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
 
-native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
+native function <<PCT.function>>
+{
+    doc.doc='Groups the entire given relation and adds new column(s) where their values are aggregated using the reduce (second) function using the values collected from the map (first) function'
+}
+meta::pure::functions::relation::groupBy<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
 
-native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
+native function <<PCT.function>>
+{
+    doc.doc='Groups the given relation with the given columns and adds new column where its value is aggregated using the reduce (second) function using the values collected from the map (first) function'
+}
+meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
-native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
+native function <<PCT.function>>
+{
+    doc.doc='Groups the given relation with the given column and adds new column where its value is aggregated using the reduce (second) function using the values collected from the map (first) function'
+}
+meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
-native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
+native function <<PCT.function>>
+{
+    doc.doc='Groups the given relation with the given columns and adds new column(s) where their values are aggregated using the reduce (second) function using the values collected from the map (first) function'
+}
+meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
-native function <<PCT.function>> meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
+native function <<PCT.function>>
+{
+    doc.doc='Groups the given relation with the given column and adds new column(s) where their values are aggregated using the reduce (second) function using the values collected from the map (first) function'
+}
+meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleSingle<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationNativeImplementation.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationNativeImplementation.java
@@ -463,6 +463,11 @@ public class RelationNativeImplementation
         }
     }
 
+    public static <T> Relation<? extends Object> groupBy(Relation<? extends T> rel, MutableList<AggColSpecTrans1> aggColSpecTrans, ExecutionSupport es)
+    {
+        return groupBy(rel, Lists.mutable.empty(), aggColSpecTrans, es);
+    }
+
     public static <T> Relation<? extends Object> groupBy(Relation<? extends T> rel, ColSpec<?> cols, MutableList<AggColSpecTrans1> aggColSpecTrans, ExecutionSupport es)
     {
         return groupBy(rel, Lists.mutable.with(cols._name()), aggColSpecTrans, es);
@@ -478,7 +483,7 @@ public class RelationNativeImplementation
         ProcessorSupport ps = ((CompiledExecutionSupport) es).getProcessorSupport();
         TestTDSCompiled tds = RelationNativeImplementation.getTDS(rel, es);
 
-        Pair<TestTDS, MutableList<Pair<Integer, Integer>>> sortRes = tds.sort(cols.collect(name -> new SortInfo(name, SortDirection.ASC)).toList());
+        Pair<TestTDS, MutableList<Pair<Integer, Integer>>> sortRes = cols.isEmpty() ? tds.wrapFullTDS() : tds.sort(cols.collect(name -> new SortInfo(name, SortDirection.ASC)).toList());
 
         MutableSet<String> columnsToRemove = tds.getColumnNames().clone().toSet();
         columnsToRemove.removeAll(cols.toSet());

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/GroupBy.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/GroupBy.java
@@ -24,19 +24,24 @@ public class GroupBy extends AbstractNative implements Native
 {
     public GroupBy()
     {
-        super("groupBy_Relation_1__ColSpec_1__AggColSpec_1__Relation_1_", "groupBy_Relation_1__ColSpecArray_1__AggColSpec_1__Relation_1_");
+        super("groupBy_Relation_1__ColSpec_1__AggColSpec_1__Relation_1_", "groupBy_Relation_1__ColSpecArray_1__AggColSpec_1__Relation_1_", "groupBy_Relation_1__AggColSpec_1__Relation_1_");
     }
 
     @Override
     public String build(CoreInstance topLevelElement, CoreInstance functionExpression, ListIterable<String> transformedParams, ProcessorContext processorContext)
     {
+        boolean containsGroupByCols = transformedParams.size() == 3;
+        int aggSpecParamIndex = containsGroupByCols ? 2 : 1;
         StringBuilder result = new StringBuilder("org.finos.legend.pure.runtime.java.extension.external.relation.compiled.RelationNativeImplementation.groupBy");
         result.append('(');
         result.append(transformedParams.get(0));
         result.append(", ");
-        result.append(transformedParams.get(1));
-        result.append(", ");
-        result.append("Lists.mutable.with(" + transformedParams.get(2) + ")");
+        if (containsGroupByCols)
+        {
+            result.append(transformedParams.get(1));
+            result.append(", ");
+        }
+        result.append("Lists.mutable.with(" + transformedParams.get(aggSpecParamIndex) + ")");
 
         processAggColSpec(result, false);
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/GroupByArray.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/GroupByArray.java
@@ -25,19 +25,24 @@ public class GroupByArray extends AbstractNative implements Native
 {
     public GroupByArray()
     {
-        super("groupBy_Relation_1__ColSpec_1__AggColSpecArray_1__Relation_1_", "groupBy_Relation_1__ColSpecArray_1__AggColSpecArray_1__Relation_1_");
+        super("groupBy_Relation_1__ColSpec_1__AggColSpecArray_1__Relation_1_", "groupBy_Relation_1__ColSpecArray_1__AggColSpecArray_1__Relation_1_", "groupBy_Relation_1__AggColSpecArray_1__Relation_1_");
     }
 
     @Override
     public String build(CoreInstance topLevelElement, CoreInstance functionExpression, ListIterable<String> transformedParams, ProcessorContext processorContext)
     {
+        boolean containsGroupByCols = transformedParams.size() == 3;
+        int aggSpecParamIndex = containsGroupByCols ? 2 : 1;
         StringBuilder result = new StringBuilder("org.finos.legend.pure.runtime.java.extension.external.relation.compiled.RelationNativeImplementation.groupBy");
         result.append('(');
         result.append(transformedParams.get(0));
         result.append(", ");
-        result.append(transformedParams.get(1));
-        result.append(", ");
-        result.append("Lists.mutable.withAll(" + transformedParams.get(2) + "._aggSpecs())");
+        if (containsGroupByCols)
+        {
+            result.append(transformedParams.get(1));
+            result.append(", ");
+        }
+        result.append("Lists.mutable.withAll(" + transformedParams.get(aggSpecParamIndex) + "._aggSpecs())");
         processAggColSpec(result, false);
         result.append(", es)");
         return result.toString();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/RelationExtensionInterpreted.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/RelationExtensionInterpreted.java
@@ -104,6 +104,8 @@ public class RelationExtensionInterpreted extends BaseInterpretedExtension
                 Tuples.pair("groupBy_Relation_1__ColSpec_1__AggColSpec_1__Relation_1_", GroupBy::new),
                 Tuples.pair("groupBy_Relation_1__ColSpec_1__AggColSpecArray_1__Relation_1_", GroupBy::new),
                 Tuples.pair("groupBy_Relation_1__ColSpecArray_1__AggColSpecArray_1__Relation_1_", GroupBy::new),
+                Tuples.pair("groupBy_Relation_1__AggColSpec_1__Relation_1_", GroupBy::new),
+                Tuples.pair("groupBy_Relation_1__AggColSpecArray_1__Relation_1_", GroupBy::new),
                 Tuples.pair("pivot_Relation_1__ColSpecArray_1__AggColSpecArray_1__Relation_1_", Pivot::new),
                 Tuples.pair("pivot_Relation_1__ColSpecArray_1__AggColSpec_1__Relation_1_", Pivot::new),
                 Tuples.pair("pivot_Relation_1__ColSpec_1__AggColSpecArray_1__Relation_1_", Pivot::new),

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -319,7 +319,8 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '      }',
           'nonEmptyDataset',
           {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
-                    $rel->extend(~DQ_COUNT: row | $rel->size())->select(~DQ_COUNT)->rename(~DQ_COUNT,~COUNT)->filter(row|$row.COUNT == 0)->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.COUNT->isEmpty(), | '', |$row.COUNT->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
+                    $rel->groupBy(~COUNT : x | 1 : y | $y->count())->filter(row|$row.COUNT == 0)
+                        ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.COUNT->isEmpty(), | '', |$row.COUNT->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
                         ->extend(~DQ_DEFECT_ID: row | generateGuid())
                         ->extend(~DQ_RULE_NAME: row | 'nonEmptyDataset')
             }
@@ -461,7 +462,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '      }',
           'nonEmptyDataset',
           {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
-                    $rel->extend(~DQ_COUNT: row | $rel->size())->select(~DQ_COUNT)->rename(~DQ_COUNT,~COUNT)->filter(row|$row.COUNT == 0)
+                    $rel->groupBy(~COUNT : x | 1 : y | $y->count())->filter(row|$row.COUNT == 0)
             }
             ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));},
             'meta::external::dataquality::tests::domain::DataQualityRuntime'        

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -624,54 +624,77 @@ function meta::external::dataquality::buildSelectExpression(inputRel: ValueSpeci
 //we need to create an expression that will produce 1 row with the count if the relation is empty otherwise return no rows.
 function meta::external::dataquality::buildOneRowIfEmptyExpression(inputRel: ValueSpecification[1]):FunctionExpression[1]
 {
-  //get the row count as DQ_COUNT column
+  //get COUNT of relation
   let inputRelType = $inputRel.genericType.typeArguments.rawType->toOne()->cast(@meta::pure::metamodel::relation::RelationType<Any>);
-  let dqCountColSpec = ^InstanceValue(values=^ColSpec<Integer>(name='DQ_COUNT'), genericType=^GenericType(rawType=ColSpec, typeArguments = ^GenericType(rawType=Integer)), multiplicity=PureOne)->evaluateAndDeactivate();
-  let newRelTypeWithDqCount = $inputRelType->addColumns(~[DQ_COUNT: Integer[1]])->evaluateAndDeactivate();
-  let withDqCount = buildDqCountExpression($inputRel, $inputRelType, $newRelTypeWithDqCount);
-
-  //select only the DQ_COUNT column
-  let newRelTypeWithOnlyDqCount = ^meta::pure::metamodel::relation::RelationType<Nil>(columns = $newRelTypeWithDqCount.columns->filter(col | 'DQ_COUNT' == ($col.name->toOne())));
-  let withOnlyCount = buildSelectExpression($withDqCount, $dqCountColSpec);
-
-  //rename the DQ_COUNT column to COUNT (this is needed as we can't directly use aggregate functions like count(*) in the WHERE clause of a query)
-  let relTypeWithRenamedCount = $newRelTypeWithOnlyDqCount->addColumns(~[COUNT: Integer[1]])->evaluateAndDeactivate();
-  let newRelTypeWithCount = ^meta::pure::metamodel::relation::RelationType<Nil>(columns = $relTypeWithRenamedCount.columns->filter(col | 'COUNT' == ($col.name->toOne())));
-  let withRenameCount = buildRenameDqCountExpression($withOnlyCount, $dqCountColSpec, $newRelTypeWithCount);
+  let newRelTypeWithCount = $inputRelType->addColumns(~[COUNT: Integer[1]])->evaluateAndDeactivate();
+  let newRelTypeWithOnlyCount = ^meta::pure::metamodel::relation::RelationType<Nil>(columns = $newRelTypeWithCount.columns->filter(col | 'COUNT' == ($col.name->toOne())));
+  let withCount = buildGetRowCountExpression($inputRel, $inputRelType, $newRelTypeWithOnlyCount);
 
   //filter where COUNT == 0
-  buildFilterOnEmptyCountExpression($withRenameCount, $newRelTypeWithCount);
+  buildFilterOnEmptyCountExpression($withCount, $newRelTypeWithOnlyCount);
 }
 
-function meta::external::dataquality::buildDqCountExpression(rel: ValueSpecification[1], relType: meta::pure::metamodel::relation::RelationType<Any>[1], newRelType: meta::pure::metamodel::relation::RelationType<Any>[1]):FunctionExpression[1]
-{
-  let rowCountFunction = ^SimpleFunctionExpression
-  (
-      func = size_Relation_1__Integer_1_,
-      multiplicity = PureOne,
-      genericType  = ^GenericType(rawType=Integer),
-      importGroup  = system::imports::coreImport,
-      parametersValues = [
-        ^VariableExpression(name='rel', genericType=^GenericType(rawType=$relType), multiplicity=PureOne)->evaluateAndDeactivate()
-      ]
-  )->evaluateAndDeactivate();
-
-  $rel->buildExtendExpression('DQ_COUNT', $rowCountFunction, 'row', $relType, $newRelType, Integer);
-}
-
-function meta::external::dataquality::buildRenameDqCountExpression(rel: ValueSpecification[1], columnToRename: InstanceValue[1], newRelType: meta::pure::metamodel::relation::RelationType<Any>[1]):FunctionExpression[1]
+function meta::external::dataquality::buildGetRowCountExpression(rel: ValueSpecification[1], relType: meta::pure::metamodel::relation::RelationType<Any>[1], newRelType: meta::pure::metamodel::relation::RelationType<Any>[1]):FunctionExpression[1]
 {
   ^SimpleFunctionExpression
   (
-      func = rename_Relation_1__ColSpec_1__ColSpec_1__Relation_1_,
+      func = groupBy_Relation_1__AggColSpec_1__Relation_1_,
       multiplicity = PureOne,
-      genericType  = ^GenericType(rawType=Relation, typeArguments = ^GenericType(rawType=$newRelType)),
+      genericType  = ^GenericType(rawType=$newRelType),
       importGroup  = system::imports::coreImport,
       parametersValues = [
         $rel,
-        $columnToRename,
-        ^InstanceValue(values=^ColSpec<Integer>(name='COUNT'), genericType=^GenericType(rawType=ColSpec, typeArguments = ^GenericType(rawType=Integer)), multiplicity=PureOne)->evaluateAndDeactivate()
+        buildAggColSpecCountExpression($rel, $relType, $newRelType)
       ]
+  )->evaluateAndDeactivate();
+}
+
+function meta::external::dataquality::buildAggColSpecCountExpression(rel: ValueSpecification[1], relType: meta::pure::metamodel::relation::RelationType<Any>[1], newRelType: meta::pure::metamodel::relation::RelationType<Any>[1]):FunctionExpression[1]
+{
+  let param1 = buildAggColSpecCountFirstParam($relType);
+  let param2 = buildAggColSpecCountSecondParam();
+  ^SimpleFunctionExpression
+  (
+      func = aggColSpec_Function_1__Function_1__String_1__T_1__AggColSpec_1_,
+      multiplicity = PureOne,
+      genericType  = ^GenericType(rawType = AggColSpec, typeArguments = [$param1.genericType, $param2.genericType, ^GenericType(rawType=$newRelType)]),
+      importGroup  = system::imports::coreImport,
+      parametersValues = [
+        $param1,
+        $param2,
+        ^InstanceValue(genericType = ^GenericType(rawType = String), multiplicity = PureOne, values = 'COUNT')->evaluateAndDeactivate(),
+        ^InstanceValue(genericType = ^GenericType(rawType = $newRelType), multiplicity = PureOne)->evaluateAndDeactivate()
+      ]
+  )->evaluateAndDeactivate();
+}
+
+function meta::external::dataquality::buildAggColSpecCountFirstParam(relType: meta::pure::metamodel::relation::RelationType<Any>[1]):InstanceValue[1]
+{
+  let expression = ^VariableExpression(name = 'x', genericType = ^GenericType(rawType = $relType), multiplicity = PureOne);
+  ^InstanceValue(
+      genericType = ^GenericType(rawType = LambdaFunction, typeArguments = ^GenericType(rawType = ^FunctionType(parameters = $expression, returnMultiplicity = PureOne, returnType = ^GenericType(rawType = Integer)))),
+      multiplicity = PureOne,
+      values = meta::external::dataquality::lambda(^FunctionType(returnMultiplicity = PureOne, returnType = ^GenericType(rawType = Integer), parameters = $expression), ^InstanceValue(genericType = ^GenericType(rawType = Integer), multiplicity = PureOne, values = 1))
+  )->evaluateAndDeactivate();
+}
+
+function meta::external::dataquality::buildAggColSpecCountSecondParam():InstanceValue[1]
+{
+  let countExpression = ^SimpleFunctionExpression
+  (
+      func = count_Any_MANY__Integer_1_,
+      multiplicity = PureOne,
+      genericType  = ^GenericType(rawType = Integer),
+      importGroup  = system::imports::coreImport,
+      parametersValues = [
+        ^VariableExpression(name = 'y', genericType = ^GenericType(rawType = Integer), multiplicity = ZeroMany)
+      ]
+  )->evaluateAndDeactivate();
+  let expression = ^VariableExpression(name = 'y', genericType = ^GenericType(rawType = Integer), multiplicity = ZeroMany);
+  ^InstanceValue(
+      genericType = ^GenericType(rawType = LambdaFunction, typeArguments = ^GenericType(rawType = ^FunctionType(parameters = $expression, returnMultiplicity = PureOne, returnType = ^GenericType(rawType = Integer)))),
+      multiplicity = PureOne,
+      values = meta::external::dataquality::lambda(^FunctionType(returnMultiplicity = PureOne, returnType = ^GenericType(rawType = Integer), parameters = $expression), $countExpression)
   )->evaluateAndDeactivate();
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
@@ -825,6 +825,23 @@ public class TestRelationFunctions extends TestCompilationFromGrammar.TestCompil
     }
 
     @Test
+    public void testGroupByNoGroupingCols()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A (" +
+                        "   Table tb(id Integer, other VARCHAR(200))" +
+                        ")\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->groupBy(~new : x|$x.id : y|$y->sum())\n" +
+                        "}"
+        );
+    }
+
+    @Test
     public void testGroupByErrorCol()
     {
         test(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -5282,13 +5282,18 @@ function meta::relational::functions::pureToSqlQuery::processTDSMapReduce(a:AggC
 
 function meta::relational::functions::pureToSqlQuery::processGroupBy(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
+   let containsGroupByCols = $expression.parametersValues->size() > 2;
    let nestedQuery = processValueSpecification($expression.parametersValues->at(0), [], $operation, $vars, $state, JoinType.LEFT_OUTER, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
    let select = $nestedQuery.select->pushExtraFilteringOperation($extensions)->cast(@TdsSelectSqlQuery);
-   let groupByColumns = findAliasOrFail($expression, $select,  $vars, $state);
+   let groupByColumns = if ($containsGroupByCols,
+    | let cols = findAliasOrFail($expression, $select,  $vars, $state);
+      $cols->map(gc| assert(!$gc.relationalElement->instanceOf(WindowColumn),'Group by columns cannot include window columns'););
+      $cols;,
+    | []);
    let noSubSelect = $select.groupBy->isEmpty() && $select.pivot->isEmpty() && ($select.distinct->isEmpty() || !$select.distinct->toOne()) && $select.orderBy.column->removeAll($groupByColumns)->isEmpty();
    let subSelectAliasName = 'aggreg';
-   $groupByColumns->map(gc| assert(!$gc.relationalElement->instanceOf(WindowColumn),'Group by columns cannot include window columns'););
-   let aggVS = $expression.parametersValues->at(2)->reprocessVS()->reactivate($state.inScopeVars)->evaluateAndDeactivate()->match([
+   let aggIndex = if ($containsGroupByCols, | 2, | 1);
+   let aggVS = $expression.parametersValues->at($aggIndex)->reprocessVS()->reactivate($state.inScopeVars)->evaluateAndDeactivate()->match([
                       avs:meta::pure::tds::AggregateValue<Any,Any>[*]|$avs->map(a|^AggContainer(name=$a.name,map=$a.mapFn,reduce=$a.aggregateFn));,
                       x:meta::pure::metamodel::relation::AggColSpec<Any,Any,Any>[1]|^AggContainer(name=$x.name,map=$x.map,reduce=$x.reduce);,
                       z:meta::pure::metamodel::relation::AggColSpecArray<Any,Any,Any>[1]|$z.aggSpecs->map(x|^AggContainer(name=$x.name,map=$x.map,reduce=$x.reduce));
@@ -5296,15 +5301,17 @@ function meta::relational::functions::pureToSqlQuery::processGroupBy(expression:
 
    let newColumns= $aggVS->map(a|^Alias(name=$a.name->addQuotesIfNecessary(), relationalElement=processTDSMapReduce($a, $select, $noSubSelect, $subSelectAliasName, $currentPropertyMapping, $vars, $state, $context)));
    let existingPaths = $select.paths;
-   let pathInfos = $expression->instanceValuesAtParameter(1, $vars, $state.inScopeVars)->match(
-                                                                                          [
-                                                                                            s:String[*]|$s,
-                                                                                            x:meta::pure::metamodel::relation::ColSpecArray<Any>[1]|$x.names,
-                                                                                            z:meta::pure::metamodel::relation::ColSpec<Any>[1]|$z.name
-                                                                                          ]
-                                                                                        )->map(n|$existingPaths->filter(p|$p.first == $n))
+   let pathInfos = if ($containsGroupByCols,
+    | $expression->instanceValuesAtParameter(1, $vars, $state.inScopeVars)->match(
+                                                                                  [
+                                                                                    s:String[*]|$s,
+                                                                                    x:meta::pure::metamodel::relation::ColSpecArray<Any>[1]|$x.names,
+                                                                                    z:meta::pure::metamodel::relation::ColSpec<Any>[1]|$z.name
+                                                                                  ]
+                                                                                )->map(n|$existingPaths->filter(p|$p.first == $n))
                    ->concatenate($aggVS->map(a|  let pureType = $a.reduce->toOne()->functionReturnType().rawType->toOne();
-                                                 pair($a.name, ^PathInformation(type=$pureType, relationalType= meta::relational::transform::fromPure::pureTypeToDataTypeMap()->get($pureType)));));
+                                                 pair($a.name, ^PathInformation(type=$pureType, relationalType= meta::relational::transform::fromPure::pureTypeToDataTypeMap()->get($pureType)));)),
+    | []);                                                 
 
    if($noSubSelect
       ,|^$select(columns = $groupByColumns->concatenate($newColumns),
@@ -9369,6 +9376,8 @@ function meta::relational::functions::pureToSqlQuery::getSupportedFunctions():Ma
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::groupBy_Relation_1__ColSpecArray_1__AggColSpecArray_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processGroupBy_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::groupBy_Relation_1__ColSpec_1__AggColSpec_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processGroupBy_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::groupBy_Relation_1__ColSpec_1__AggColSpecArray_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processGroupBy_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::groupBy_Relation_1__AggColSpec_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processGroupBy_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::groupBy_Relation_1__AggColSpecArray_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processGroupBy_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::join_Relation_1__Relation_1__JoinKind_1__Function_1__Relation_1_,second=meta::relational::functions::pureToSqlQuery::processTdsJoin_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::limit_Relation_1__Integer_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processTake_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::rename_Relation_1__ColSpec_1__ColSpec_1__Relation_1_,second=meta::relational::functions::pureToSqlQuery::processTdsRenameColumns_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

- This is required so can do aggregate operations at the table level, for example to get row count of table (select count(*) from table)
- Changing the data quality generated queries to use this new functionality to get row count instead of doing it with an extend using size operator which was not correct as this was producing an aggregated level operation at row level

#### Other notes for reviewers:

- Adding a new function for group by instead of making colspec parameter as optional in existing one as this was failing in pure compiler as the generic type of the optional param was used as part of the return type (Z+R) and the complier was complaining that "can't resolve some type parameters in: X". Can look into investigating this later but for now added these as separate functions which reuse existing method implementations
