### PR TITLE
Rename evalcol.pure to eval.pure to match pct function name

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/eval.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/eval.pure
@@ -20,7 +20,7 @@ function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::fu
   $col->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,Z|*>)->eval($row);
 }
 
-function <<PCT.test>> meta::pure::functions::relation::tests::evalColumn::testSimpleEvalColumn<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+function <<PCT.test>> meta::pure::functions::relation::tests::eval::testSimpleEval<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
               | #TDS

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_RelationFunction_PCT.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_RelationFunction_PCT.java
@@ -65,7 +65,7 @@ public class Test_JAVA_RelationFunction_PCT extends PCTReportConfiguration
             one("meta::pure::functions::relation::tests::composition::testWindowFunctionsAfterProject_Function_1__Boolean_1_", "\"meta::pure::functions::relation::sort_Relation_1__SortInfo_MANY__Relation_1_ is not supported yet!\"", AdapterQualifier.unsupportedFeature),
             pack("meta::pure::functions::relation::tests::write", "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\"", AdapterQualifier.needsInvestigation),
             pack("meta::pure::functions::relation::tests::over", "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\"", AdapterQualifier.needsInvestigation),
-            pack("meta::pure::functions::relation::tests::evalColumn", "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\"", AdapterQualifier.needsInvestigation)
+            pack("meta::pure::functions::relation::tests::eval", "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\"", AdapterQualifier.needsInvestigation)
     );
 
     public static Test suite()


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

- Rename evalcol.pure to eval.pure to match pct function name to be consistent with the conventions
