### PR TITLE
datqaquality metamodel - deprecate mustEndWithRuntime constraint

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -181,7 +181,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "         type: ROW_LEVEL;\n" +
                 "      }\n" +
                 "    ];\n" +
-                "}", " at [104:1-115:1]: Error in 'meta::external::dataquality::Validation': Execution error at (resource: lines:104c1-115c1), \"Constraint :[mustEndWithRuntime] violated in the Class DataQualityRelationValidation\"");
+                "}");
     }
 
     @Test

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
@@ -51,9 +51,6 @@ Class meta::external::dataquality::DataQualityRule
 }
 
 Class meta::external::dataquality::DataQualityRelationValidation extends PackageableElement
-[
-  mustEndWithRuntime: $this.query->meta::external::dataquality::isEndingWithFromFunction()
-]
 {
   query: LambdaFunction<Any>[1];                                         // should return a relation - enforced in compiler
   validations: meta::external::dataquality::RelationValidation[*];


### PR DESCRIPTION
#### What type of PR is this?
- Improvement

#### What does this PR do / why is it needed ?
removes the mustEndWithRuntime constraint to relax the primary query on which validations are being written. For executable queries users must mention the runtime using the `from` function, however this is not mandated by spec 

#### Which issue(s) this PR fixes:
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No