### PR TITLE
enable xstore without reference to mapping ids

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/pom.xml
@@ -257,6 +257,11 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/resources/localCrossStoreJoins.pure
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/resources/localCrossStoreJoins.pure
@@ -1,0 +1,69 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class test::Person
+{
+  fullName: String[1];
+  firmName : String[0..1];
+  addressName : String[0..1];
+}
+
+Class test::Firm
+{
+  name: String[1];
+  addressName : String[0..1];
+}
+
+Class test::Address
+{
+  name: String[1];
+  streetName: String[0..1];
+}
+
+Class test::Street
+{
+  streetId: String[1];
+}
+
+Association test::Firm_Person
+{
+  employees: test::Person[*];
+  employer: test::Firm[0..1];
+}
+
+Association test::Person_Address
+{
+  persons: test::Person[*];
+  address: test::Address[0..1];
+}
+
+Association test::Firm_Address
+{
+  firms: test::Firm[*];
+  address: test::Address[0..1];
+}
+
+Association test::Address_Street
+{
+  addresses: test::Address[*];
+  street: test::Street[0..1];
+}
+
+###Mapping
+Mapping test::crossPropertyMappingWithLocalProperties
+(
+  %s
+)
+

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/resources/localCrossStoreJoinsWMilestoning.pure
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/resources/localCrossStoreJoinsWMilestoning.pure
@@ -1,0 +1,63 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class %s test::Person
+{
+  fullName: String[1];
+  firmName : String[0..1];
+  addressName : String[0..1];
+}
+
+Class %s test::Firm
+{
+  name: String[1];
+  addressName : String[0..1];
+}
+
+Class %s test::Address
+{
+  name: String[1];
+  streetName: String[0..1];
+}
+
+Class %s test::Street
+{
+  streetId: String[1];
+}
+
+Association test::Firm_Person
+{
+  employees: test::Person[*];
+  employer: test::Firm[0..1];
+}
+
+Association test::Person_Address
+{
+  persons: test::Person[*];
+  address: test::Address[0..1];
+}
+
+Association test::Firm_Address
+{
+  firms: test::Firm[*];
+  address: test::Address[0..1];
+}
+
+Association test::Address_Street
+{
+  addresses: test::Address[*];
+  street: test::Street[0..1];
+}
+

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestFunctionDefinitionModify.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestFunctionDefinitionModify.java
@@ -1,0 +1,47 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function;
+
+import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m3.tests.function.AbstractTestFunctionDefinitionModify;
+import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
+import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestFunctionDefinitionModify extends AbstractTestFunctionDefinitionModify
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), AbstractTestFunctionDefinitionModify.getCodeStorage(), JavaModelFactoryRegistryLoader.loader());
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionCompiledBuilder().build();
+    }
+
+    @Test
+    @Ignore(value = "Further fixes needed for clone as source information is copied over currently")
+    @Override
+    public void testConcreteFunctionDefinitionModifyWithCopyConstructor()
+    {
+        super.testConcreteFunctionDefinitionModifyWithCopyConstructor();
+    }
+
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestFunctionDefinitionModify.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestFunctionDefinitionModify.java
@@ -1,0 +1,34 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.interpreted.function;
+
+import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.tests.function.AbstractTestFunctionDefinitionModify;
+import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
+import org.junit.BeforeClass;
+
+public class TestFunctionDefinitionModify extends AbstractTestFunctionDefinitionModify
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
Improvement - enable xstore without reference to mapping ids

#### What does this PR do / why is it needed ?
enable xstore without reference to mapping ids - so we can define XStore without any reference to physical data

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
yes - new feature