### PR TITLE
Optimisation for ability to run all DQ validations at once

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
@@ -68,7 +68,7 @@ public class DataQualityLambdaGenerator
         {
             return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) packageableElement._query();
         }
-        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataqualityRelationValidationLambda_DataQualityRelationValidation_1__String_1__Integer_$0_1$__Boolean_1__LambdaFunction_1_(packageableElement, validationName, Objects.isNull(resultLimit) ? null : resultLimit.longValue(), enrichDQColumns, pureModel.getExecutionSupport());
+        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataqualityRelationValidationLambda_DataQualityRelationValidation_1__String_$0_1$__Integer_$0_1$__Boolean_1__LambdaFunction_1_(packageableElement, validationName, Objects.isNull(resultLimit) ? null : resultLimit.longValue(), enrichDQColumns, pureModel.getExecutionSupport());
     }
 
     public static LambdaFunction transformLambda(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> lambda, PureModel pureModel, Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> extensions)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -299,6 +299,38 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     'meta::external::dataquality::tests::domain::DataQualityRuntime'
     )
 }
+
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_relationValidation_row_level_all_validations():Boolean[1]
+{
+  doRelationTestWithoutDQColumns(
+    '###DataQualityValidation' +
+    '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
+    '      {' +
+    '        query: #>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->toOne(), $x.LASTNAME->toOne()]->joinStrings())->from(meta::external::dataquality::tests::domain::DataQualityRuntime);' +
+    '        validations: [' +
+    '          {' +
+    '             name: \'validFirstName\';' +
+    '             description: \'first name should not be empty\';' +
+    '             assertion: row2|$row2.FIRSTNAME->isNotEmpty();' +
+    '             type: ROW_LEVEL;' +
+    '          },' +
+    '          {' +
+    '             name: \'validLastName\';' +
+    '             description: \'last name should not be empty\';' +
+    '             assertion: row2|$row2.LASTNAME->isNotEmpty();' +
+    '             type: ROW_LEVEL;' +
+    '          }' +    
+    '         ];' +
+    '      }',
+    [],
+    {|#>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
+                                                    ->filter(row2|$row2.LASTNAME->meta::pure::functions::collection::isNotEmpty()->meta::pure::functions::boolean::not())->concatenate(
+      #>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
+                                                    ->filter(row2|$row2.FIRSTNAME->meta::pure::functions::collection::isNotEmpty()->meta::pure::functions::boolean::not()))
+                                                    },
+    'meta::external::dataquality::tests::domain::DataQualityRuntime'
+    )
+}
 // --------------------------------------   row level tests for backward compatibility end ------------------------------------------------------------------------------------------------
 
 
@@ -457,7 +489,12 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '             name: \'nonEmptyDataset\';' +
     '             description: \'dataset should not be empty\';' +
     '             assertion: rel|$rel->meta::external::dataquality::assertRelationNotEmpty();' +
-    '          }' +
+    '          },' +
+    '          {' +
+    '             name: \'nameNotEmpty\';' +
+    '             description: \'dataset should have name\';' +
+    '             assertion: rel|$rel->meta::external::dataquality::assertRelationEmpty(~[FIRSTNAME,LASTNAME]);' +
+    '          }' +    
     '         ];' +
     '      }',
           'nonEmptyDataset',
@@ -492,6 +529,57 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
             ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->filter(row|$row.AGE >= $age)->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));},
           'meta::external::dataquality::tests::domain::DataQualityRuntime'        
     );
+}
+
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_relationValidation_all_validations():Boolean[1]
+{
+  doRelationTest(
+    '###DataQualityValidation' +
+    '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
+    '      {' +
+    '        query: #>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->from(meta::external::dataquality::tests::domain::DataQualityRuntime);' +
+    '        validations: [' +
+    '          {' +
+    '             name: \'notEmpty\';' +
+    '             description: \'data is not empty\';' +
+    '             assertion: rel|$rel->meta::external::dataquality::assertRelationNotEmpty();' +
+    '          },' +
+    '          {' +
+    '             name: \'invalidFirstName\';' +
+    '             description: \'first name is not valid\';' +
+    '             assertion: rel|$rel->filter(row|$row.FIRSTNAME == \'invalid\')->meta::external::dataquality::assertRelationEmpty(~[FIRSTNAME]);' +
+    '          },' +
+    '          {' +
+    '             name: \'invalidLastName\';' +
+    '             description: \'last name is not valid\';' +
+    '             assertion: rel|$rel->filter(row|$row.LASTNAME == \'invalid\')->meta::external::dataquality::assertRelationEmpty(~[FIRSTNAME,LASTNAME]);' +
+    '             type: AGGREGATE;' +
+    '          }' +        
+    '         ];' +
+    '      }',
+          [],
+          {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200),LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+                $rel->filter(row|$row.LASTNAME == 'invalid')
+                    ->select(~[FIRSTNAME,LASTNAME])
+                    ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()) + if($row.LASTNAME->isEmpty(), | '', |$row.LASTNAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
+                    ->extend(~DQ_DEFECT_ID: row | generateGuid())
+                    ->extend(~DQ_RULE_NAME: row | 'invalidLastName')}
+                ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]))->concatenate(
+            {rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200),LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+                $rel->filter(row|$row.FIRSTNAME == 'invalid')
+                    ->select(~[FIRSTNAME])
+                    ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
+                    ->extend(~DQ_DEFECT_ID: row | generateGuid())
+                    ->extend(~DQ_RULE_NAME: row | 'invalidFirstName')}
+                ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]))->concatenate(
+            {rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200),LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+                $rel->aggregate(~COUNT : x | 1 : y | $y->count())->filter(row|$row.COUNT == 0)
+                    ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.COUNT->isEmpty(), | '', |$row.COUNT->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
+                    ->extend(~DQ_DEFECT_ID: row | generateGuid())
+                    ->extend(~DQ_RULE_NAME: row | 'notEmpty')}
+                ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]))));},
+          'meta::external::dataquality::tests::domain::DataQualityRuntime'        
+    )
 }
 
 function <<test.Test>> meta::external::dataquality::tests::testFromFunctionListIsComplete():Boolean[1]

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_utils.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_utils.pure
@@ -56,11 +56,11 @@ function meta::external::dataquality::tests::doTest(tree:String[1], expected:Fun
   if ($assertJson, | assertLambdaJSONEquals($expected, $actual), | true);
 }
 
-function meta::external::dataquality::tests::doRelationTest(dq:String[1], validationName:String[1], expected:FunctionDefinition<Any>[1], packageableRuntimeAsString: String[1]):Boolean[1]
+function meta::external::dataquality::tests::doRelationTest(dq:String[1], validationName:String[0..1], expected:FunctionDefinition<Any>[1], packageableRuntimeAsString: String[1]):Boolean[1]
 {
   let dataqualityRelationValidation = $dq->loadDataQualityRelationValidation();
 
-  let actual = $dataqualityRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationName, []);
+  let actual = $dataqualityRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationName, [], true);
 
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), $packageableRuntimeAsString);
 }
@@ -83,7 +83,7 @@ function meta::external::dataquality::tests::doRelationTestWithLimit(dq:String[1
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), $packageableRuntimeAsString);
 }
 
-function meta::external::dataquality::tests::doRelationTestWithoutDQColumns(dq:String[1], validationName:String[1], expected:FunctionDefinition<Any>[1], packageableRuntimeAsString: String[1]):Boolean[1]
+function meta::external::dataquality::tests::doRelationTestWithoutDQColumns(dq:String[1], validationName:String[0..1], expected:FunctionDefinition<Any>[1], packageableRuntimeAsString: String[1]):Boolean[1]
 {
   let dataqualityRelationValidation = $dq->loadDataQualityRelationValidation();
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -506,10 +506,25 @@ function meta::external::dataquality::generateDataqualityRelationValidationLambd
   $dqRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationName, $defectsLimit, true)
 }
 
-function meta::external::dataquality::generateDataqualityRelationValidationLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], validationName: String[1], defectsLimit:Integer[0..1], enrichDQColumns:Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::generateDataqualityRelationValidationLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], validationName: String[0..1], defectsLimit:Integer[0..1], enrichDQColumns:Boolean[1]): LambdaFunction<Any>[1]
 {
-  let selectedValidation = $dqRelationValidation.validations->filter(val| $val.name == $validationName)->toOne();
+  let lambda = $dqRelationValidation.query;
+  //if validation name provided only generate query for that validation else generate query for all validations
+  let selectedValidations = if ($validationName->isEmpty(),
+    | $dqRelationValidation.validations,
+    | $dqRelationValidation.validations->filter(val| $val.name == $validationName)->toOne()
+  );
+  if ($selectedValidations->isEmpty(),
+    | fail('Expect at least one validation to exist on data quality validation');
+      $lambda;,
+    | let validationSubQueries = $selectedValidations->map(val | $dqRelationValidation->generateDataqualityRelationValidationLambda($val, $defectsLimit, $enrichDQColumns));
+      let validationsUnion = $validationSubQueries->tail()->fold({val1, val2 | buildUnionExpression($val1->evaluateAndDeactivate(), $val2->evaluateAndDeactivate())}, $validationSubQueries->head()->toOne()->evaluateAndDeactivate());
+      ^$lambda(expressionSequence=$validationsUnion);
+  );
+}
 
+function meta::external::dataquality::generateDataqualityRelationValidationLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], selectedValidation: RelationValidation[1], defectsLimit:Integer[0..1], enrichDQColumns:Boolean[1]): FunctionExpression[1]
+{
   if($selectedValidation.type->isNotEmpty() && $selectedValidation.type == 'ROW_LEVEL',
      | $dqRelationValidation->generateDataqualityRelationValidationLambda_RowLevel($selectedValidation, $defectsLimit, $enrichDQColumns), // for backward compatibility
      | $dqRelationValidation->generateDataqualityRelationValidationLambda_Aggregate($selectedValidation, $defectsLimit, $enrichDQColumns));
@@ -517,26 +532,23 @@ function meta::external::dataquality::generateDataqualityRelationValidationLambd
 
 
 // row level validation for backward compatibility
-function meta::external::dataquality::generateDataqualityRelationValidationLambda_RowLevel(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], selectedValidation: RelationValidation[1], defectsLimit:Integer[0..1], enrichDQColumns:Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::generateDataqualityRelationValidationLambda_RowLevel(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], selectedValidation: RelationValidation[1], defectsLimit:Integer[0..1], enrichDQColumns:Boolean[1]): FunctionExpression[1]
 {
-  let lambda = $dqRelationValidation.query;
   let inputRelType = $dqRelationValidation.query->evaluateAndDeactivate()->functionReturnType().typeArguments.rawType->cast(@meta::pure::metamodel::relation::RelationType<Any>)->toOne();
   let withValidationFilterExpression = $dqRelationValidation.query.expressionSequence->toOne()->evaluateAndDeactivate()->buildRelationFilterExpressionForRowLevelVal($selectedValidation, $inputRelType);
 
   // assertion - enrich DQ columns
-  let withDQColumnsAndNewRelationType = if($enrichDQColumns, | $withValidationFilterExpression->enrichDQColumns($inputRelType, $selectedValidation), | ^Pair<ValueSpecification, meta::pure::metamodel::relation::RelationType<Any>>(first=$withValidationFilterExpression, second=$inputRelType););
+  let withDQColumnsAndNewRelationType = if($enrichDQColumns, | $withValidationFilterExpression->enrichDQColumns($inputRelType, $selectedValidation), | ^Pair<FunctionExpression, meta::pure::metamodel::relation::RelationType<Any>>(first=$withValidationFilterExpression, second=$inputRelType););
 
-  let withLimitExpression = if($defectsLimit->isEmpty(),
-                                | $withDQColumnsAndNewRelationType.first,
-                                | $withDQColumnsAndNewRelationType.first->buildLimitFilterExpression($defectsLimit->toOne(), ^GenericType(rawType=Relation, typeArguments = ^GenericType(rawType=$withDQColumnsAndNewRelationType.second)))
-                            );
-
-  ^$lambda(expressionSequence=$withLimitExpression);
+  if($defectsLimit->isEmpty(),
+    | $withDQColumnsAndNewRelationType.first,
+    | $withDQColumnsAndNewRelationType.first->buildLimitFilterExpression($defectsLimit->toOne(), ^GenericType(rawType=Relation, typeArguments = ^GenericType(rawType=$withDQColumnsAndNewRelationType.second)))
+  );
 }
 
-function meta::external::dataquality::generateDataqualityRelationValidationLambda_Aggregate(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], selectedValidation: RelationValidation[1], resultLimit:Integer[0..1], enrichDQcolumns:Boolean[0..1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::generateDataqualityRelationValidationLambda_Aggregate(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], selectedValidation: RelationValidation[1], resultLimit:Integer[0..1], enrichDQcolumns:Boolean[0..1]): FunctionExpression[1]
 {
-  // assertion transformation - 
+  // assertion transformation
   let poppedAssertion = $selectedValidation->popAssertionForProjection()->evaluateAndDeactivate();
 
   // assertion - columns transformation
@@ -545,19 +557,38 @@ function meta::external::dataquality::generateDataqualityRelationValidationLambd
   // assertion - enrich DQ columns by default
   let withDQColumnsAndNewRelationType = if($enrichDQcolumns->isEmpty() || $enrichDQcolumns->toOne(), | $poppedAssertion->enrichDQColumns($inputRelType, $selectedValidation), | ^Pair<ValueSpecification, meta::pure::metamodel::relation::RelationType<Any>>(first=$poppedAssertion, second=$inputRelType););
 
-  // main dataset query transformation -
+  // main dataset query transformation
   let queryWithLimitExpression = if($resultLimit->isEmpty(),
                                      | $dqRelationValidation.query.expressionSequence->toOne()->evaluateAndDeactivate(),
                                      | $dqRelationValidation.query.expressionSequence->toOne()->evaluateAndDeactivate()->buildRelationLimitFilterExpression($resultLimit->toOne(), $dqRelationValidation.query->genericType())
                                   );
 
   // compose above transformed query and assertion
-  let evalExpression = $withDQColumnsAndNewRelationType.first->buildEvalExpression($queryWithLimitExpression->cast(@ValueSpecification), $selectedValidation, getRelationType($selectedValidation), $withDQColumnsAndNewRelationType.second);
-  let lambda = $dqRelationValidation.query;
-  ^$lambda(expressionSequence=$evalExpression);
+  $withDQColumnsAndNewRelationType.first->buildEvalExpression($queryWithLimitExpression->cast(@ValueSpecification), $selectedValidation, getRelationType($selectedValidation), $withDQColumnsAndNewRelationType.second);
 }
 
-function meta::external::dataquality::enrichDQColumns(f:ValueSpecification[1], inputRelType:meta::pure::metamodel::relation::RelationType<Any>[1], selectedValidation: RelationValidation[1]): Pair<ValueSpecification, meta::pure::metamodel::relation::RelationType<Any>>[1]
+function meta::external::dataquality::buildUnionExpression(param1: FunctionExpression[1], param2: FunctionExpression[1]): FunctionExpression[1]
+{
+  let inputRelType1 = $param1.genericType.typeArguments.rawType->toOne()->cast(@meta::pure::metamodel::relation::RelationType<Any>);
+  let inputRelType2 = $param2.genericType.typeArguments.rawType->toOne()->cast(@meta::pure::metamodel::relation::RelationType<Any>);
+  let colsToAdd = $inputRelType2.columns->filter(col | !$inputRelType1.columns.name->contains($col.name->toOne()));
+  let allCols = $inputRelType1.columns->concatenate($colsToAdd);
+  let newRelTypeWithAllCols = ^meta::pure::metamodel::relation::RelationType<Nil>(columns = $allCols);
+
+  let concatFunction = ^SimpleFunctionExpression
+  (
+      func = concatenate_Relation_1__Relation_1__Relation_1_,
+      multiplicity = PureOne,
+      genericType  = ^GenericType(rawType=Relation, typeArguments = ^GenericType(rawType=$newRelTypeWithAllCols)),
+      importGroup  = system::imports::coreImport,
+      parametersValues = [
+        $param1,
+        $param2
+      ]
+  )->evaluateAndDeactivate();
+}
+
+function meta::external::dataquality::enrichDQColumns(f:ValueSpecification[1], inputRelType:meta::pure::metamodel::relation::RelationType<Any>[1], selectedValidation: RelationValidation[1]): Pair<FunctionExpression, meta::pure::metamodel::relation::RelationType<Any>>[1]
 {
   let relParamName = 'row';
 
@@ -570,7 +601,7 @@ function meta::external::dataquality::enrichDQColumns(f:ValueSpecification[1], i
   let newRelTypeWithRuleId = $newRelTypeWithDefectId->addColumns(~[DQ_RULE_NAME: String[1]])->evaluateAndDeactivate();
   let withRuleId = $withDefectId->buildExtendExpression('DQ_RULE_NAME', ^InstanceValue(values=$selectedValidation.name, genericType=^GenericType(rawType=String), multiplicity=PureOne), $relParamName, $newRelTypeWithDefectId, $newRelTypeWithRuleId, String);
   
-  ^Pair<ValueSpecification, meta::pure::metamodel::relation::RelationType<Any>>(first=$withRuleId, second=$newRelTypeWithRuleId);
+  ^Pair<FunctionExpression, meta::pure::metamodel::relation::RelationType<Any>>(first=$withRuleId, second=$newRelTypeWithRuleId);
 }
 
 function meta::external::dataquality::getRelationType(selectedValidation: RelationValidation[1]):meta::pure::metamodel::relation::RelationType<Any>[1]


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

At the moment you can only run one validation/rule within a data quality validation at once. This change provides the ability to run all rules within a data quality validation at once to improve the performance and reduce the number of queries required on the underlying db. Changes:

- Union all sub queries together (for each dq rule in the validation)
- Normalize schema so that output is union of all columns of sub queries
