### PR TITLE
Add data quality dependency to make available in SDLC server

### DIFF
--- a/legend-engine-config/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-config/legend-engine-extensions-collection-generation/pom.xml
@@ -486,6 +486,21 @@
         </dependency>
         <!-- Peristence -->
 
+        <!-- DataQuality -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-dataquality-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-dataquality-grammar</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-dataquality-protocol</artifactId>
+        </dependency>
+        <!-- DataQuality -->
+
         <!-- Dataspace -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-config/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
+++ b/legend-engine-config/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
@@ -36,6 +36,8 @@ import org.finos.legend.engine.generation.SearchDocumentArtifactGenerationExtens
 import org.finos.legend.engine.language.bigqueryFunction.compiler.toPureGraph.BigQueryFunctionCompilerExtension;
 import org.finos.legend.engine.language.bigqueryFunction.grammar.from.BigQueryFunctionGrammarParserExtension;
 import org.finos.legend.engine.language.bigqueryFunction.grammar.to.BigQueryFunctionGrammarComposer;
+import org.finos.legend.engine.language.dataquality.grammar.from.DataQualityGrammarParserExtension;
+import org.finos.legend.engine.language.dataquality.grammar.to.DataQualityGrammarComposerExtension;
 import org.finos.legend.engine.language.deephaven.from.DeephavenGrammarParserExtension;
 import org.finos.legend.engine.language.deephaven.to.DeephavenGrammarComposerExtension;
 import org.finos.legend.engine.language.functionActivator.grammar.postDeployment.to.PostDeploymentActionGrammarComposer;
@@ -341,6 +343,7 @@ public class TestExtensions
                 .with(org.finos.legend.engine.protocol.pure.v1.PersistenceProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.PersistenceCloudProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.PersistenceRelationalProtocolExtension.class)
+                .with(org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.RelationalProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.BigQueryProtocolExtension.class)
                 .with(org.finos.legend.engine.protocol.pure.v1.SpannerProtocolExtension.class)
@@ -389,6 +392,7 @@ public class TestExtensions
                 .with(PersistenceParserExtension.class)
                 .with(PersistenceCloudParserExtension.class)
                 .with(PersistenceRelationalParserExtension.class)
+                .with(DataQualityGrammarParserExtension.class)
                 .with(RelationalGrammarParserExtension.class)
                 .with(ServiceParserExtension.class)
                 .with(AuthenticationGrammarParserExtension.class)
@@ -420,6 +424,7 @@ public class TestExtensions
                 .with(PersistenceComposerExtension.class)
                 .with(PersistenceCloudComposerExtension.class)
                 .with(PersistenceRelationalComposerExtension.class)
+                .with(DataQualityGrammarComposerExtension.class)
                 .with(RelationalGrammarComposerExtension.class)
                 .with(BigQueryGrammarComposerExtension.class)
                 .with(SpannerGrammarComposerExtension.class)
@@ -469,6 +474,7 @@ public class TestExtensions
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.compiler.toPureGraph.PersistenceCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.cloud.compiler.toPureGraph.PersistenceCloudCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.dsl.persistence.relational.compiler.toPureGraph.PersistenceRelationalCompilerExtension.class)
+                .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.DataQualityCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.RelationalCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.BigQueryCompilerExtension.class)
                 .with(org.finos.legend.engine.language.pure.compiler.toPureGraph.SpannerCompilerExtension.class)
@@ -607,6 +613,7 @@ public class TestExtensions
                 .with("core_persistence")
                 .with("core_persistence_cloud")
                 .with("core_persistence_relational")
+                .with("core_dataquality")
                 .with("core_relational")
                 .with("core_relational_bigquery")
                 .with("core_relational_spanner")

--- a/legend-engine-config/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
+++ b/legend-engine-config/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
@@ -33,7 +33,6 @@ import org.finos.legend.engine.generation.DataSpaceAnalyticsArtifactGenerationEx
 import org.finos.legend.engine.generation.OpenApiArtifactGenerationExtension;
 import org.finos.legend.engine.generation.PowerBIArtifactGenerationExtension;
 import org.finos.legend.engine.generation.SearchDocumentArtifactGenerationExtension;
-import org.finos.legend.engine.generation.dataquality.DataQualityValidationArtifactGenerationExtension;
 import org.finos.legend.engine.language.bigqueryFunction.compiler.toPureGraph.BigQueryFunctionCompilerExtension;
 import org.finos.legend.engine.language.bigqueryFunction.grammar.from.BigQueryFunctionGrammarParserExtension;
 import org.finos.legend.engine.language.bigqueryFunction.grammar.to.BigQueryFunctionGrammarComposer;
@@ -556,7 +555,6 @@ public class TestExtensions
         // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
         return Lists.mutable.<Class<? extends ArtifactGenerationExtension>>empty()
                 .with(DataSpaceAnalyticsArtifactGenerationExtension.class)
-                .with(DataQualityValidationArtifactGenerationExtension.class)
                 .with(SearchDocumentArtifactGenerationExtension.class)
                 .with(OpenApiArtifactGenerationExtension.class)
                 .with(SnowflakeAppArtifactGenerationExtension.class)

--- a/legend-engine-config/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
+++ b/legend-engine-config/legend-engine-extensions-collection-generation/src/test/java/org/finos/legend/engine/extensions/collection/generation/TestExtensions.java
@@ -33,6 +33,7 @@ import org.finos.legend.engine.generation.DataSpaceAnalyticsArtifactGenerationEx
 import org.finos.legend.engine.generation.OpenApiArtifactGenerationExtension;
 import org.finos.legend.engine.generation.PowerBIArtifactGenerationExtension;
 import org.finos.legend.engine.generation.SearchDocumentArtifactGenerationExtension;
+import org.finos.legend.engine.generation.dataquality.DataQualityValidationArtifactGenerationExtension;
 import org.finos.legend.engine.language.bigqueryFunction.compiler.toPureGraph.BigQueryFunctionCompilerExtension;
 import org.finos.legend.engine.language.bigqueryFunction.grammar.from.BigQueryFunctionGrammarParserExtension;
 import org.finos.legend.engine.language.bigqueryFunction.grammar.to.BigQueryFunctionGrammarComposer;
@@ -555,6 +556,7 @@ public class TestExtensions
         // DO NOT DELETE ITEMS FROM THIS LIST (except when replacing them with something equivalent)
         return Lists.mutable.<Class<? extends ArtifactGenerationExtension>>empty()
                 .with(DataSpaceAnalyticsArtifactGenerationExtension.class)
+                .with(DataQualityValidationArtifactGenerationExtension.class)
                 .with(SearchDocumentArtifactGenerationExtension.class)
                 .with(OpenApiArtifactGenerationExtension.class)
                 .with(SnowflakeAppArtifactGenerationExtension.class)
@@ -604,6 +606,7 @@ public class TestExtensions
                 .with("core_external_store_relational_postgres_sql_model")
                 .with("core_external_store_relational_postgres_sql_model_extensions")
                 .with("core_external_compiler")
+                .with("core_external_execution")
                 .with("core_external_language_daml")
                 .with("core_external_language_haskell")
                 .with("core_function_activator")

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/pom.xml
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/pom.xml
@@ -446,7 +446,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-dataquality-protocol</artifactId>
-            <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
         <!--        DataQuality     -->

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/pom.xml
@@ -127,7 +127,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-dataquality-protocol</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-dataquality-protocol</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-dataquality-protocol</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/pom.xml
@@ -123,7 +123,6 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-dataquality-protocol</artifactId>
-            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <!-- TEST -->

--- a/pom.xml
+++ b/pom.xml
@@ -2653,6 +2653,11 @@
             </dependency>
             <dependency>
                 <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-dataquality-protocol</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
                 <artifactId>legend-engine-xt-dataquality-compiler</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

SDLC server did not have the data quality composer available in the class path so it was not able to serialise the data quality elements to .pure files and instead would commit the files as .json. 

