### PR TITLE
Ability to run a subset of the DQ validations at once

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/pom.xml
@@ -226,6 +226,13 @@
         </dependency>
         <!-- LOG -->
 
+        <!-- APACHE -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <!-- APACHE -->
+
         <!-- TEST -->
         <dependency>
             <groupId>junit</groupId>

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
@@ -255,7 +255,7 @@ public class DataQualityExecute
         {
             return DataQualityLambdaGenerator.generateRelationValidationMainQueryRowCount(pureModel, dataQualityExecuteInput.packagePath);
         }
-        return DataQualityLambdaGenerator.generateLambda(pureModel, dataQualityExecuteInput.packagePath, dataQualityExecuteInput.validationName, dataQualityExecuteInput.runQuery, dataQualityExecuteInput.defectsLimit, dataQualityExecuteInput.enrichDQColumns);
+        return DataQualityLambdaGenerator.generateLambda(pureModel, dataQualityExecuteInput.packagePath, dataQualityExecuteInput.getValidationNames(), dataQualityExecuteInput.runQuery, dataQualityExecuteInput.defectsLimit, dataQualityExecuteInput.enrichDQColumns);
     }
 
     @POST
@@ -269,7 +269,7 @@ public class DataQualityExecute
         // 1. load pure model from PureModelContext
         PureModel pureModel = this.modelManager.loadModel(dataQualityExecuteInput.model, dataQualityExecuteInput.clientVersion, identity, null);
         // 2. call DQ PURE func to generate lambda
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction dqLambdaFunction = DataQualityLambdaGenerator.generateLambda(pureModel, dataQualityExecuteInput.packagePath, dataQualityExecuteInput.validationName, dataQualityExecuteInput.runQuery, dataQualityExecuteInput.defectsLimit, dataQualityExecuteInput.enrichDQColumns);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction dqLambdaFunction = DataQualityLambdaGenerator.generateLambda(pureModel, dataQualityExecuteInput.packagePath, dataQualityExecuteInput.getValidationNames(), dataQualityExecuteInput.runQuery, dataQualityExecuteInput.defectsLimit, dataQualityExecuteInput.enrichDQColumns);
         LambdaFunction lambda = DataQualityLambdaGenerator.transformLambda(dqLambdaFunction, pureModel, this.extensions);
         return ManageConstantResult.manageResult(identity.getName(), lambda, objectMapper);
     }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecuteTrialInput.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecuteTrialInput.java
@@ -16,10 +16,14 @@ package org.finos.legend.engine.language.dataquality.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContext;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 
 import java.util.List;
+import java.util.Set;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DataQualityExecuteTrialInput
@@ -31,7 +35,20 @@ public class DataQualityExecuteTrialInput
     public String packagePath;
     public Integer defectsLimit;
     public List<ParameterValue> lambdaParameterValues;
-    public String validationName;
+    @Deprecated
+    public String validationName; //this should be replaced by validationNames - remove once all usages migrated
+    public Set<String> validationNames = Sets.mutable.empty();
     public Boolean runQuery;
     public boolean enrichDQColumns = true;
+
+    //todo - this method can be removed once all usages of validationName migrated to validationNames
+    public Set<String> getValidationNames()
+    {
+        Set<String> validations = this.validationNames;
+        if (isNotBlank(this.validationName))
+        {
+            validations.add(this.validationName);
+        }
+        return validations;
+    }
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/test/java/org/finos/legend/engine/language/dataquality/api/TestDataQualityExecuteTrialInput.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/test/java/org/finos/legend/engine/language/dataquality/api/TestDataQualityExecuteTrialInput.java
@@ -1,0 +1,47 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.dataquality.api;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.junit.Test;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestDataQualityExecuteTrialInput
+{
+    @Test
+    public void testGetValidationNamesWhenNull()
+    {
+        DataQualityExecuteTrialInput input = new DataQualityExecuteTrialInput();
+
+        Set<String> validationNames = input.getValidationNames();
+
+        assertTrue(validationNames.isEmpty());
+    }
+
+    @Test
+    public void testGetValidationNamesWhenNotNull()
+    {
+        DataQualityExecuteTrialInput input = new DataQualityExecuteTrialInput();
+        input.validationNames = Sets.mutable.of("name1", "name2");
+        input.validationName = "name3";
+
+        Set<String> validationNames = input.getValidationNames();
+
+        assertEquals(Sets.mutable.of("name1", "name2", "name3"), validationNames);
+    }
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.generation.dataquality;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.PureClientVersions;
 import org.finos.legend.engine.protocol.pure.m3.function.LambdaFunction;
@@ -34,17 +35,18 @@ import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
+import java.util.Set;
 
 public class DataQualityLambdaGenerator
 {
 
-    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, String qualifiedPath, String validationName, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns)
+    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, String qualifiedPath, Set<String> validationNames, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns)
     {
         PackageableElement packageableElement = pureModel.getPackageableElement(qualifiedPath);
-        return generateLambda(pureModel, packageableElement, validationName, runQuery, resultLimit, enrichDQColumns);
+        return generateLambda(pureModel, packageableElement, validationNames, runQuery, resultLimit, enrichDQColumns);
     }
 
-    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, PackageableElement packageableElement, String validationName, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns)
+    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, PackageableElement packageableElement, Set<String> validationNames, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns)
     {
         if (packageableElement instanceof Root_meta_external_dataquality_DataQuality)
         {
@@ -52,7 +54,7 @@ public class DataQualityLambdaGenerator
         }
         else if (packageableElement instanceof Root_meta_external_dataquality_DataQualityRelationValidation)
         {
-            return generateRelationValidationLambda(pureModel, (Root_meta_external_dataquality_DataQualityRelationValidation) packageableElement, validationName, runQuery, resultLimit, enrichDQColumns);
+            return generateRelationValidationLambda(pureModel, (Root_meta_external_dataquality_DataQualityRelationValidation) packageableElement, validationNames, runQuery, resultLimit, enrichDQColumns);
         }
         throw new EngineException("Unsupported Dataquality element! " + packageableElement.getClass().getSimpleName(), ExceptionCategory.USER_EXECUTION_ERROR);
     }
@@ -62,13 +64,13 @@ public class DataQualityLambdaGenerator
         return core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataQualityQuery_DataQuality_1__Integer_$0_1$__LambdaFunction_1_(packageableElement, Objects.isNull(queryLimit) ? null : queryLimit.longValue(), pureModel.getExecutionSupport());
     }
 
-    private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateRelationValidationLambda(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationValidation packageableElement, String validationName, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns)
+    private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateRelationValidationLambda(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationValidation packageableElement, Set<String> validationNames, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns)
     {
         if (Boolean.TRUE.equals(runQuery))
         {
             return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) packageableElement._query();
         }
-        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataqualityRelationValidationLambda_DataQualityRelationValidation_1__String_$0_1$__Integer_$0_1$__Boolean_1__LambdaFunction_1_(packageableElement, validationName, Objects.isNull(resultLimit) ? null : resultLimit.longValue(), enrichDQColumns, pureModel.getExecutionSupport());
+        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataqualityRelationValidationLambda_DataQualityRelationValidation_1__String_MANY__Integer_$0_1$__Boolean_1__LambdaFunction_1_(packageableElement, Sets.immutable.ofAll(validationNames), Objects.isNull(resultLimit) ? null : resultLimit.longValue(), enrichDQColumns, pureModel.getExecutionSupport());
     }
 
     public static LambdaFunction transformLambda(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> lambda, PureModel pureModel, Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> extensions)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/test/java/org/finos/legend/engine/generation/dataquality/TestDataQualityLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/test/java/org/finos/legend/engine/generation/dataquality/TestDataQualityLambdaGenerator.java
@@ -18,6 +18,7 @@ import net.javacrumbs.jsonunit.JsonAssert;
 import net.javacrumbs.jsonunit.core.Option;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -153,7 +154,7 @@ public class TestDataQualityLambdaGenerator
         PureModelContextData modelData = loadWithModel(modelString);
         PureModel model = Compiler.compile(modelData, DeploymentMode.TEST_IGNORE_FUNCTION_MATCH, Identity.getAnonymousIdentity().getName());
         Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> routerExtensions = extensions();
-        LambdaFunction<?> lambdaFunction = DataQualityLambdaGenerator.generateLambda(model, "meta::dataquality::Validation", validationName, false, null, true);
+        LambdaFunction<?> lambdaFunction = DataQualityLambdaGenerator.generateLambda(model, "meta::dataquality::Validation", Sets.mutable.of(validationName), false, null, true);
         return DataQualityLambdaGenerator.transformLambdaAsJson(lambdaFunction, model, routerExtensions);
     }
 
@@ -161,7 +162,7 @@ public class TestDataQualityLambdaGenerator
     {
         PureModelContextData modelData = loadWithModel(modelString);
         PureModel model = Compiler.compile(modelData, DeploymentMode.TEST_IGNORE_FUNCTION_MATCH, Identity.getAnonymousIdentity().getName());
-        return DataQualityLambdaGenerator.generateLambda(model, "meta::dataquality::Validation", validationName, false, null, true);
+        return DataQualityLambdaGenerator.generateLambda(model, "meta::dataquality::Validation", Sets.mutable.of(validationName), false, null, true);
     }
 
     private static PureModelContextData loadWithModel(String code)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -531,6 +531,50 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     );
 }
 
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_relationValidation_some_validations():Boolean[1]
+{
+  doRelationTest(
+    '###DataQualityValidation' +
+    '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
+    '      {' +
+    '        query: #>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->from(meta::external::dataquality::tests::domain::DataQualityRuntime);' +
+    '        validations: [' +
+    '          {' +
+    '             name: \'notEmpty\';' +
+    '             description: \'data is not empty\';' +
+    '             assertion: rel|$rel->meta::external::dataquality::assertRelationNotEmpty();' +
+    '          },' +
+    '          {' +
+    '             name: \'invalidFirstName\';' +
+    '             description: \'first name is not valid\';' +
+    '             assertion: rel|$rel->filter(row|$row.FIRSTNAME == \'invalid\')->meta::external::dataquality::assertRelationEmpty(~[FIRSTNAME]);' +
+    '          },' +
+    '          {' +
+    '             name: \'invalidLastName\';' +
+    '             description: \'last name is not valid\';' +
+    '             assertion: rel|$rel->filter(row|$row.LASTNAME == \'invalid\')->meta::external::dataquality::assertRelationEmpty(~[FIRSTNAME,LASTNAME]);' +
+    '             type: AGGREGATE;' +
+    '          }' +        
+    '         ];' +
+    '      }',
+          ['notEmpty', 'invalidFirstName'],
+          {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200),LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+                $rel->filter(row|$row.FIRSTNAME == 'invalid')
+                    ->select(~[FIRSTNAME])
+                    ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
+                    ->extend(~DQ_DEFECT_ID: row | generateGuid())
+                    ->extend(~DQ_RULE_NAME: row | 'invalidFirstName')}
+                ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]))->concatenate(
+            {rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200),LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+                $rel->aggregate(~COUNT : x | 1 : y | $y->count())->filter(row|$row.COUNT == 0)
+                    ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.COUNT->isEmpty(), | '', |$row.COUNT->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
+                    ->extend(~DQ_DEFECT_ID: row | generateGuid())
+                    ->extend(~DQ_RULE_NAME: row | 'notEmpty')}
+                ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME])));},
+          'meta::external::dataquality::tests::domain::DataQualityRuntime'        
+    )
+}
+
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_relationValidation_all_validations():Boolean[1]
 {
   doRelationTest(

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_utils.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_utils.pure
@@ -56,11 +56,11 @@ function meta::external::dataquality::tests::doTest(tree:String[1], expected:Fun
   if ($assertJson, | assertLambdaJSONEquals($expected, $actual), | true);
 }
 
-function meta::external::dataquality::tests::doRelationTest(dq:String[1], validationName:String[0..1], expected:FunctionDefinition<Any>[1], packageableRuntimeAsString: String[1]):Boolean[1]
+function meta::external::dataquality::tests::doRelationTest(dq:String[1], validationNames:String[*], expected:FunctionDefinition<Any>[1], packageableRuntimeAsString: String[1]):Boolean[1]
 {
   let dataqualityRelationValidation = $dq->loadDataQualityRelationValidation();
 
-  let actual = $dataqualityRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationName, [], true);
+  let actual = $dataqualityRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationNames, [], true);
 
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), $packageableRuntimeAsString);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -506,13 +506,13 @@ function meta::external::dataquality::generateDataqualityRelationValidationLambd
   $dqRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationName, $defectsLimit, true)
 }
 
-function meta::external::dataquality::generateDataqualityRelationValidationLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], validationName: String[0..1], defectsLimit:Integer[0..1], enrichDQColumns:Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::generateDataqualityRelationValidationLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], validationNames: String[*], defectsLimit:Integer[0..1], enrichDQColumns:Boolean[1]): LambdaFunction<Any>[1]
 {
   let lambda = $dqRelationValidation.query;
   //if validation name provided only generate query for that validation else generate query for all validations
-  let selectedValidations = if ($validationName->isEmpty(),
+  let selectedValidations = if ($validationNames->isEmpty(),
     | $dqRelationValidation.validations,
-    | $dqRelationValidation.validations->filter(val| $val.name == $validationName)->toOne()
+    | $dqRelationValidation.validations->filter(val| $validationNames->contains($val.name))
   );
   if ($selectedValidations->isEmpty(),
     | fail('Expect at least one validation to exist on data quality validation');


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

At the moment we can only run either one or all DQ validations at a time. This PR extends this ability so that we can also run a subset of the DQ validations at once.

