### PR TITLE
Duplicate View Column Warning Message

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -423,7 +423,8 @@ public class HelperRelationalBuilder
 
         if (!duplicateColumns.isEmpty())
         {
-            context.pureModel.addWarnings(org.eclipse.collections.impl.factory.Lists.mutable.with(new Warning(databaseTable.sourceInformation, "Duplicate column definitions " + duplicateColumns + " in table: " + table._name())));
+            MutableList<String> duplicateList = duplicateColumns.toSortedList();
+            context.pureModel.addWarnings(org.eclipse.collections.impl.factory.Lists.mutable.with(new Warning(databaseTable.sourceInformation, "Duplicate column definitions " + duplicateList + " in table: " + table._name())));
         }
         RichIterable<Column> pk = ListIterate.collect(databaseTable.primaryKey, s -> columns.select(column -> s.equals(column._name())).getFirst());
         RichIterable<org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.Milestoning> milestoning = ListIterate.collect(databaseTable.milestoning, m -> processMilestoning(m, context, columns.groupBy(ColumnAccessor::_name)));
@@ -442,7 +443,34 @@ public class HelperRelationalBuilder
         View view = new Root_meta_relational_metamodel_relation_View_Impl(srcView.name, SourceInformationHelper.toM3SourceInformation(srcView.sourceInformation), context.pureModel.getClass("meta::relational::metamodel::relation::View"))._name(srcView.name);
         view._stereotypes(srcView.stereotypes == null ? Lists.fixedSize.empty() : ListIterate.collect(srcView.stereotypes, stereotypePointer -> context.resolveStereotype(stereotypePointer.profile, stereotypePointer.value, stereotypePointer.profileSourceInformation, stereotypePointer.sourceInformation)));
         view._taggedValues(srcView.taggedValues == null ? Lists.fixedSize.empty() : ListIterate.collect(srcView.taggedValues, taggedValue -> new Root_meta_pure_metamodel_extension_TaggedValue_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::extension::TaggedValue"))._tag(context.resolveTag(taggedValue.tag.profile, taggedValue.tag.value, taggedValue.tag.profileSourceInformation, taggedValue.tag.sourceInformation))._value(taggedValue.value)));
-        MutableList<Column> columns = ListIterate.collect(srcView.columnMappings, columnMapping -> new Root_meta_relational_metamodel_Column_Impl(columnMapping.name, SourceInformationHelper.toM3SourceInformation(columnMapping.sourceInformation), context.pureModel.getClass("meta::relational::metamodel::Column"))._name(columnMapping.name)._type(new Root_meta_relational_metamodel_datatype_Varchar_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Varchar")))._owner(view));
+        MutableList<Column> columns = Lists.mutable.empty();
+        MutableSet<String> validColumnNames = Sets.mutable.empty();
+        MutableSet<String> duplicateColumns = Sets.mutable.empty();
+
+        for (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.ColumnMapping columnMapping : srcView.columnMappings)
+        {
+            if (validColumnNames.contains(columnMapping.name))
+            {
+                duplicateColumns.add(columnMapping.name);
+            }
+            else
+            {
+                validColumnNames.add(columnMapping.name);
+                Column col = new Root_meta_relational_metamodel_Column_Impl(columnMapping.name, SourceInformationHelper.toM3SourceInformation(columnMapping.sourceInformation), context.pureModel.getClass("meta::relational::metamodel::Column"))
+                        ._name(columnMapping.name)
+                        ._type(new Root_meta_relational_metamodel_datatype_Varchar_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Varchar")))
+                        ._owner(view);
+                columns.add(col);
+            }
+        }
+        if (!duplicateColumns.isEmpty())
+        {
+            MutableList<String> duplicateList = duplicateColumns.toList().sortThis();
+            context.pureModel.addWarnings(Lists.mutable.with(new Warning(
+                    srcView.sourceInformation,
+                    "Duplicate column mapping definitions " + duplicateList + " in view: " + view._name()
+            )));
+        }
         RichIterable<Column> pk = ListIterate.collect(srcView.primaryKey, s -> columns.select(column -> s.equals(column._name())).getFirst());
         return view._columns(columns)._primaryKey(pk)._schema(schema);
     }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -3329,4 +3329,129 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
                 "\n" +
                 ")");
     }
+
+    @Test
+    public void testDuplicateColumnMappingInView()
+    {
+        test("###Relational\n" +
+                "Database com::trade::TradeDatabase\n" +
+                "(\n" +
+                "  Schema Trade\n" +
+                "  (\n" +
+                "    Table Trade\n" +
+                "    (\n" +
+                "      id VARCHAR(32) PRIMARY KEY,\n" +
+                "      value INTEGER NOT NULL,\n" +
+                "      ENTITY_ID_FK VARCHAR(32) NOT NULL\n" +
+                "    )\n" +
+                "  )\n" +
+                ")\n" +
+                "\n" +
+                "Database com::entity::EntityDatabase\n" +
+                "(\n" +
+                "  Schema Entity\n" +
+                "  (\n" +
+                "    Table LegalEntity\n" +
+                "    (\n" +
+                "      ENTITY_ID VARCHAR(32) PRIMARY KEY,\n" +
+                "      name VARCHAR(32) NOT NULL\n" +
+                "    )\n" +
+                "\n" +
+                "    View LegalEntity_View\n" +
+                "    (\n" +
+                "      ENTITY_ID: Entity.LegalEntity.ENTITY_ID PRIMARY KEY,\n" +
+                "      ENTITY_ID: Entity.LegalEntity.ENTITY_ID PRIMARY KEY,\n" +
+                "      name: Entity.LegalEntity.name PRIMARY KEY\n" +
+                "    )\n" +
+                "  )\n" +
+                ")", null, Arrays.asList("COMPILATION error at [25:5-30:5]: Duplicate column mapping definitions [ENTITY_ID] in view: LegalEntity_View"));
+    }
+
+    @Test
+    public void testViewWithNoDuplicateColumnMapping()
+    {
+        test("###Relational\n" +
+                "Database com::entity::EntityDatabase\n" +
+                "(\n" +
+                "  Schema Entity\n" +
+                "  (\n" +
+                "    Table LegalEntity\n" +
+                "    (\n" +
+                "      ENTITY_ID VARCHAR(32) PRIMARY KEY,\n" +
+                "      name VARCHAR(32) NOT NULL\n" +
+                "    )\n" +
+                "\n" +
+                "    View LegalEntity_View\n" +
+                "    (\n" +
+                "      ENTITY_ID: Entity.LegalEntity.ENTITY_ID PRIMARY KEY,\n" +
+                "      name: Entity.LegalEntity.name\n" +
+                "    )\n" +
+                "  )\n" +
+                ")");
+    }
+
+    @Test
+    public void testViewWithMultipleDuplicateColumnMappings()
+    {
+        test("###Relational\n" +
+                "Database com::entity::EntityDatabase\n" +
+                "(\n" +
+                "  Schema Entity\n" +
+                "  (\n" +
+                "    Table LegalEntity\n" +
+                "    (\n" +
+                "      ENTITY_ID VARCHAR(32) PRIMARY KEY,\n" +
+                "      name VARCHAR(32) NOT NULL,\n" +
+                "      description VARCHAR(100)\n" +
+                "    )\n" +
+                "\n" +
+                "    View LegalEntity_View\n" +
+                "    (\n" +
+                "      ENTITY_ID: Entity.LegalEntity.ENTITY_ID PRIMARY KEY,\n" +
+                "      ENTITY_ID: Entity.LegalEntity.ENTITY_ID,\n" +
+                "      name: Entity.LegalEntity.name,\n" +
+                "      name: Entity.LegalEntity.name,\n" +
+                "      description: Entity.LegalEntity.description\n" +
+                "    )\n" +
+                "  )\n" +
+                ")", null, Arrays.asList("COMPILATION error at [13:5-20:5]: Duplicate column mapping definitions [ENTITY_ID, name] in view: LegalEntity_View"));
+    }
+
+    @Test
+    public void testTwoViewsWithDuplicateColumnMappings()
+    {
+        test("###Relational\n" +
+                "Database com::entity::EntityDatabase\n" +
+                "(\n" +
+                "  Schema Entity\n" +
+                "  (\n" +
+                "    Table LegalEntity\n" +
+                "    (\n" +
+                "      ENTITY_ID VARCHAR(32) PRIMARY KEY,\n" +
+                "      name VARCHAR(32) NOT NULL,\n" +
+                "      description VARCHAR(100),\n" +
+                "      status VARCHAR(20)\n" +
+                "    )\n" +
+                "\n" +
+                "    View LegalEntity_View1\n" +
+                "    (\n" +
+                "      ENTITY_ID: Entity.LegalEntity.ENTITY_ID PRIMARY KEY,\n" +
+                "      ENTITY_ID: Entity.LegalEntity.ENTITY_ID,\n" +
+                "      name: Entity.LegalEntity.name,\n" +
+                "      name: Entity.LegalEntity.name\n" +
+                "    )\n" +
+                "\n" +
+                "    View LegalEntity_View2\n" +
+                "    (\n" +
+                "      description: Entity.LegalEntity.description,\n" +
+                "      description: Entity.LegalEntity.description,\n" +
+                "      status: Entity.LegalEntity.status,\n" +
+                "      status: Entity.LegalEntity.status\n" +
+                "    )\n" +
+                "  )\n" +
+                ")", null, Arrays.asList(
+                "COMPILATION error at [14:5-20:5]: Duplicate column mapping definitions [ENTITY_ID, name] in view: LegalEntity_View1",
+                "COMPILATION error at [22:5-28:5]: Duplicate column mapping definitions [description, status] in view: LegalEntity_View2"
+        ));
+    }
 }


### PR DESCRIPTION
- Bug Fix

- This PR adds a compiler warning to detect duplicate column mappings in view definitions, preventing silent mapping conflicts. It's needed to improve code quality by alerting developers to potentially problematic duplicate mappings before they cause runtime issues.