### PR TITLE
Ensure isResultColumnsDynamic flag is serialized properly in v1_33_0

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -597,7 +597,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::processPivotForSnowflake(p:Pivot[1], dbConfig : DbConfig[1], format:Format[1], config:Config[1], extensions:Extension[*]):String[1]
 {
-  let pivotColumnName = $p.pivotColumns->toOne()->cast(@ColumnName).name;
+  let pivotColumnName = $dbConfig.identifierProcessor($p.pivotColumns->toOne()->cast(@ColumnName).name);
   let aggregateColumn = processSelectColumns($p.aggColumns->toOne(), $dbConfig, $format->indent(), $config, true, $extensions);
   ' ' + $format.separator + 'pivot (' + $aggregateColumn +
   ' ' + $format.separator + 'for ' +  $pivotColumnName +

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/v1_33_0/extension/extension_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/v1_33_0/extension/extension_relational.pure
@@ -124,7 +124,9 @@ function meta::protocols::pure::v1_33_0::extension::getRelationalExtension():met
                            sqlQuery = $rel.sqlQuery,
                            onConnectionCloseCommitQuery = $rel.onConnectionCloseCommitQuery,
                            onConnectionCloseRollbackQuery = $rel.onConnectionCloseRollbackQuery,
-                           connection = $rel.connection->meta::protocols::pure::v1_33_0::transformation::fromPureGraph::connection::transformDatabaseConnection($extensions)
+                           connection = $rel.connection->meta::protocols::pure::v1_33_0::transformation::fromPureGraph::connection::transformDatabaseConnection($extensions),
+                           isResultColumnsDynamic = $rel.isResultColumnsDynamic,
+                           isMutationSQL = $rel.isMutationSQL
                         ),
                      rel:meta::relational::mapping::RelationalSaveNode[1]|
                         ^meta::protocols::pure::v1_33_0::metamodel::executionPlan::RelationalSaveNode(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/v1_33_0/models/executionPlan_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/v1_33_0/models/executionPlan_relational.pure
@@ -22,6 +22,8 @@ Class meta::protocols::pure::v1_33_0::metamodel::executionPlan::SQLExecutionNode
    onConnectionCloseRollbackQuery : String[0..1];
    resultColumns : meta::protocols::pure::v1_33_0::metamodel::executionPlan::SQLResultColumn[*];
    connection : meta::protocols::pure::v1_33_0::metamodel::store::relational::connection::DatabaseConnection[1];
+   isResultColumnsDynamic : Boolean[0..1];
+   isMutationSQL : Boolean[0..1];
 }
 
 Class meta::protocols::pure::v1_33_0::metamodel::executionPlan::RelationalSaveNode extends meta::protocols::pure::v1_33_0::metamodel::executionPlan::ExecutionNode


### PR DESCRIPTION
Ensure isResultColumnsDynamic flag is serialized properly in v1_33_0

Reasons for not being able to reproducing issues faced by users using pivot() in their services is that
1. PCT framework uses the vX_X_X serializer, which correctly serializes the isResultColumnDynamic boolean flag. However, for any other environments, we default to v1_33_0 (https://github.com/finos/legend-engine/blob/master/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/PureClientVersions.java#L31).
2. there is currently no mechanism to test quoteIdentifiers flag in relational connection.

This fix was tested via user's service locally.