### PR TITLE
Temporarily remove assertion until relation type set correctly in compiler

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/metaExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/metaExtension.pure
@@ -428,8 +428,8 @@ function <<test.Test>> meta::pure::functions::meta::tests::testResolveResolvedTy
       assertEquals( String, $gt->at(0).typeArguments->at(0).rawType);
       assertEquals( Integer, $gt->at(0).typeArguments->at(1).rawType);
 
-      // todo-:- this is failing in compiled mode as RelationType is not being set properly - reenable once this is fixed
-      // assertEquals( true, $gt->at(1).rawType->toOne()->instanceOf( meta::pure::metamodel::relation::RelationType));
+      //todo: this is failing in compiled mode as RelationType is not being set properly (currently being set as Any type) - re-enable once this is fixed
+      //assertEquals( true, $gt->at(1).rawType->toOne()->instanceOf( meta::pure::metamodel::relation::RelationType));
     );
   true;
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/metaExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/metaExtension.pure
@@ -362,7 +362,7 @@ function <<test.Test>> meta::pure::functions::meta::tests::testAllGeneralization
   assertEquals(['Parent', 'GrandParent', 'GreatGrandParent'], meta::pure::functions::meta::hierarchicalAllGeneralizations(meta::pure::functions::meta::tests::packageA::Child)->map(t | $t.name));
 }
 
-function meta::pure::functions::meta::tests::testResolveResolvedTypeParameters():Boolean[1]
+function <<test.Test>> meta::pure::functions::meta::tests::testResolveResolvedTypeParameters():Boolean[1]
 {
   let getSfeFunc = {fd:FunctionDefinition<Any>[1]| 
       $fd
@@ -428,8 +428,8 @@ function meta::pure::functions::meta::tests::testResolveResolvedTypeParameters()
       assertEquals( String, $gt->at(0).typeArguments->at(0).rawType);
       assertEquals( Integer, $gt->at(0).typeArguments->at(1).rawType);
 
-
-      assertEquals( true, $gt->at(1).rawType->toOne()->instanceOf( meta::pure::metamodel::relation::RelationType));
+      // todo-:- this is failing in compiled mode as RelationType is not being set properly - reenable once this is fixed
+      // assertEquals( true, $gt->at(1).rawType->toOne()->instanceOf( meta::pure::metamodel::relation::RelationType));
     );
   true;
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/metaExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/metaExtension.pure
@@ -362,7 +362,7 @@ function <<test.Test>> meta::pure::functions::meta::tests::testAllGeneralization
   assertEquals(['Parent', 'GrandParent', 'GreatGrandParent'], meta::pure::functions::meta::hierarchicalAllGeneralizations(meta::pure::functions::meta::tests::packageA::Child)->map(t | $t.name));
 }
 
-function <<test.Test>> meta::pure::functions::meta::tests::testResolveResolvedTypeParameters():Boolean[1]
+function meta::pure::functions::meta::tests::testResolveResolvedTypeParameters():Boolean[1]
 {
   let getSfeFunc = {fd:FunctionDefinition<Any>[1]| 
       $fd


### PR DESCRIPTION
#### What does this PR do / why is it needed ?

- Temporarily remove assertion until relation type set correctly in compiler - it is being set as "Any" instead of "RelationType" in compiled mode

