### PR TITLE
Migrate to Maven CI-friendly versions with ${revision} property

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     name: Build
     # NOTE: Only run this when not in fork as those likely do not have access to larger runners and will fail on normal runner due to resource limitation
     # Also, skip this build for release commits
-    if: "!contains(github.event.head_commit.message, '[maven-release-plugin]') && github.repository == 'finos/legend-engine'"
+    if: "github.repository == 'finos/legend-engine'"
     runs-on: ubuntu-latest
     outputs:
       testMatrix: ${{ steps.testMatrix.outputs.testMatrix }}

--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-# This action deletes the last two commits made on the master branch and the latest tag
-# This should only be run if a release failed and the remote staging repo has been dropped:
-# [ERROR]  * Dropping failed staging repository with ID "orgfinoslegend-..." ...
+# This action deletes the latest tag after a failed release.
+# With CI-friendly versions, there are no release commits to clean up — only the tag.
 name: Clean repo after failed release
 
 on: [workflow_dispatch]
@@ -39,5 +38,3 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           git push --delete origin $LATEST_TAG
-          git reset --hard HEAD~2
-          git push --force

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -70,23 +70,30 @@ jobs:
             git push origin master
           fi
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.client_payload.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -e release:prepare -Darguments='-B -e' -DpreparationGoals=clean -DreleaseVersion=${{ github.event.client_payload.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+      - name: Build and deploy release
+        run: |
+          mvn -B -e -T2 -Drevision=${{ github.event.client_payload.releaseVersion }} \
+            deploy -P release,docker
 
-      - name: Perform release
-        run: mvn -B -e release:perform -Darguments='-B -e -T 2 -DargLine="-Xmx20g"' -P release,docker
+      - name: Create and push git tag
+        run: |
+          git tag ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+          git push origin ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+
+      - name: Compute and set next SNAPSHOT
+        run: |
+          releaseVersion=${{ github.event.client_payload.releaseVersion }}
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          nextPatch=$((${a[2]} + 1))
+          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin master
 

--- a/.github/workflows/release-large-runner.yml
+++ b/.github/workflows/release-large-runner.yml
@@ -56,22 +56,35 @@ jobs:
           gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
           gpg-passphrase: CI_GPG_PASSPHRASE
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.inputs.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -e release:prepare -Darguments='-B -e' -DpreparationGoals=clean -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+      - name: Build and install
+        run: |
+          mvn -B -e -T4 -DskipTests -Dorg.slf4j.simpleLogger.showThreadName=true \
+            -Drevision=${{ github.event.inputs.releaseVersion }} \
+            install -P release,docker,pct-cloud-test
 
-      - name: Perform release
-        run: mvn -B -e release:perform -Darguments='-B -e -T 4 -Dorg.slf4j.simpleLogger.showThreadName=true -DargLine="-Xmx6g"' -P release,docker,pct-cloud-test
+      - name: Deploy to Central
+        run: |
+          mvn -B -e -T4 -Drevision=${{ github.event.inputs.releaseVersion }} \
+            deploy -P release,docker,pct-cloud-test
+
+      - name: Create and push git tag
+        run: |
+          git tag ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+          git push origin ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+
+      - name: Compute and set next SNAPSHOT
+        run: |
+          releaseVersion=${{ github.event.inputs.releaseVersion }}
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          nextPatch=$((${a[2]} + 1))
+          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,32 +64,15 @@ jobs:
         with:
           theme: dark
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.inputs.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
-      - name: Prepare release
-        run: mvn -B -e release:prepare -Darguments='-B -e' -DpreparationGoals=clean -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
-
-      - name: Checkout Release Tag
-        uses: actions/checkout@v4
-        with:
-          path: 'target/checkout'
-          ref: ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
-          token: ${{ secrets.FINOS_GITHUB_TOKEN }}
-          fetch-depth: 1
-          persist-credentials: true
-
-      - name: Build Release Tag
-        working-directory: target/checkout
-        run: mvn -B -e -T5 -DskipTests -Dorg.slf4j.simpleLogger.showThreadName=true install -P release,docker,pct-cloud-test
+      - name: Build release
+        run: mvn -B -e -T5 -DskipTests -Dorg.slf4j.simpleLogger.showThreadName=true -Drevision=${{ github.event.inputs.releaseVersion }} install -P release,docker,pct-cloud-test
         env:
           MAVEN_OPTS: -Xmx36g
+
+      - name: Create and push git tag
+        run: |
+          git tag ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+          git push origin ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
 
       - name: Store build output artifacts
         uses: actions/upload-artifact@v4
@@ -134,13 +117,12 @@ jobs:
         run: echo EXCLUSION_MODULES=`jq -c '.include | map(.modules) | flatten | map("!org.finos.legend.engine:" + .) | join(",")' ./.github/workflows/resources/modulesToTest.json` >> $GITHUB_OUTPUT
 
       - name: Test
-        working-directory: target/checkout
         env:
           MAVEN_OPTS: "-Xmx1g"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          mvn -B -e surefire:test -pl ${{ steps.modulesToExclude.outputs.EXCLUSION_MODULES }} -P release,docker,pct-cloud-test -T2 -DargLine="-Xmx6g" -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate
+          mvn -B -e surefire:test -pl ${{ steps.modulesToExclude.outputs.EXCLUSION_MODULES }} -Drevision=${{ github.event.inputs.releaseVersion }} -P release,docker,pct-cloud-test -T2 -DargLine="-Xmx6g" -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
@@ -173,13 +155,12 @@ jobs:
           echo INCLUSION_MODULES=`jq -c 'map("org.finos.legend.engine:" + .) | join(",")' <<< $MODULES` >> $GITHUB_OUTPUT
 
       - name: Test
-        working-directory: target/checkout
         env:
           MAVEN_OPTS: "-Xmx1g"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}          
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          mvn -B -e surefire:test -pl ${{ steps.modulesToInclude.outputs.INCLUSION_MODULES }} -P release,docker,pct-cloud-test -T2 -DargLine="-Xmx6g" -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate
+          mvn -B -e surefire:test -pl ${{ steps.modulesToInclude.outputs.INCLUSION_MODULES }} -Drevision=${{ github.event.inputs.releaseVersion }} -P release,docker,pct-cloud-test -T2 -DargLine="-Xmx6g" -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
@@ -203,7 +184,6 @@ jobs:
           path: ~/
 
       - name: Create bundle to publish
-        working-directory: target/checkout
         run: |
           mkdir -p central-staging/org/finos/legend
           cp -R ~/.m2/repository/org/finos/legend/engine central-staging/org/finos/legend
@@ -214,12 +194,12 @@ jobs:
             sha256sum "$file" | awk '{print $1}' > "$file.sha256"
             sha512sum "$file" | awk '{print $1}' > "$file.sha512"
           done
-          
+
           mkdir central-publishing
           cd central-staging && zip -r ../central-publishing/central-bundle.zip org
 
       - name: Publish bundle
-        working-directory: target/checkout/central-publishing
+        working-directory: central-publishing
         run: |
           token=$(printf "$CI_DEPLOY_USERNAME:$CI_DEPLOY_PASSWORD" | base64)
           httpCode=$(curl -s -o response.json -w "%{http_code}" -X POST -H "Authorization: Bearer $token" --form bundle=@central-bundle.zip https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC)
@@ -254,3 +234,30 @@ jobs:
               exit 1
             fi
           done
+
+  bump-snapshot:
+    name: Bump Snapshot Version
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FINOS_GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "37706051+finos-admin@users.noreply.github.com"
+          git config --global user.name "FINOS Administrator"
+
+      - name: Compute and set next SNAPSHOT
+        run: |
+          releaseVersion=${{ github.event.inputs.releaseVersion }}
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          nextPatch=$((${a[2]} + 1))
+          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin master

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/lib
 **/surefire-reports-aggregate
 **/dependency-reduced-pom.xml
+**/.flattened-pom.xml
 **/*.tokens
 **/*.patch
 **/*.DS_Store

--- a/legend-engine-application-query/pom.xml
+++ b/legend-engine-application-query/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-application-query</artifactId>

--- a/legend-engine-config/legend-engine-configuration/legend-engine-configuration-contract-extension-pure/pom.xml
+++ b/legend-engine-config/legend-engine-configuration/legend-engine-configuration-contract-extension-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-configuration</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-configuration-contract-extension-pure</artifactId>

--- a/legend-engine-config/legend-engine-configuration/legend-engine-configuration-plan-generation-serialization/pom.xml
+++ b/legend-engine-config/legend-engine-configuration/legend-engine-configuration-plan-generation-serialization/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-configuration</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-configuration-plan-generation-serialization</artifactId>

--- a/legend-engine-config/legend-engine-configuration/pom.xml
+++ b/legend-engine-config/legend-engine-configuration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-config</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-extensions-collection-execution/pom.xml
+++ b/legend-engine-config/legend-engine-extensions-collection-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-config</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-extensions-collection-generation/pom.xml
+++ b/legend-engine-config/legend-engine-extensions-collection-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-config</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-app-assembly/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-repl</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-repl-app-assembly</artifactId>

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-client/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-repl</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-data-cube/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-repl</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-repl/legend-engine-repl-relational/pom.xml
+++ b/legend-engine-config/legend-engine-repl/legend-engine-repl-relational/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-repl</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-repl/pom.xml
+++ b/legend-engine-config/legend-engine-repl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-config</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/pom.xml
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-server</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-server-http-server</artifactId>

--- a/legend-engine-config/legend-engine-server/legend-engine-server-integration-tests/pom.xml
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-integration-tests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-server</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-server-integration-tests</artifactId>

--- a/legend-engine-config/legend-engine-server/legend-engine-server-support-core/pom.xml
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-support-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-server</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/legend-engine-server/pom.xml
+++ b/legend-engine-config/legend-engine-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-config</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-config/pom.xml
+++ b/legend-engine-config/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-executionPlan-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-executionPlan-dependencies</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution-authorizer/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution-authorizer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-core-executionPlan-execution</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-executionPlan-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-executionPlan-execution-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution-store-inMemory/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution-store-inMemory/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-executionPlan-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-executionPlan-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-executionPlan-execution</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-base</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-generation/legend-engine-executionPlan-generation/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-generation/legend-engine-executionPlan-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-executionPlan-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-generation/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-generation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-base</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-compiler-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-test-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-test-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-compiler</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-grammar-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-grammar</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-modelManager-sdlc-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-modelManager-sdlc-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-modelManager-sdlc-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-modelManager-sdlc/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-modelManager-sdlc/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-modelManager-sdlc</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-modelManager/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-modelManager/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-modelManager</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-protocol-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-protocol-pure</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-language-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-protocol</artifactId>

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-base</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-base/pom.xml
+++ b/legend-engine-core/legend-engine-core-base/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-execution/legend-engine-external-shared-format-runtime/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-execution/legend-engine-external-shared-format-runtime/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-external-format-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-execution/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-execution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-external-format</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-compiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-external-format-language</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-core/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-external-format-language</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-example/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-example/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-external-format-language</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-generation/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-external-format-language</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-grammar/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-external-format-language</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/legend-engine-external-format-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-external-format-language</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/legend-engine-external-format-language/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-external-format</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-external-format/pom.xml
+++ b/legend-engine-core/legend-engine-core-external-format/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-identity/legend-engine-identity-core/pom.xml
+++ b/legend-engine-core/legend-engine-core-identity/legend-engine-identity-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-core-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-identity/pom.xml
+++ b/legend-engine-core/legend-engine-core-identity/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-core</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-code-compiled-core</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-core-extension/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-core-extension/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-code-core-extension</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-functions-javaCompiler-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-functions-javaCompiler-pure/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-javaCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-functions-javaCompiler-pure</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-runtime-java-extension-compiled-functions-javaCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-runtime-java-extension-compiled-functions-javaCompiler/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-javaCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-javaCompiler</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-runtime-java-extension-interpreted-functions-javaCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-runtime-java-extension-interpreted-functions-javaCompiler/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-javaCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-javaCompiler</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-runtime-java-extension-shared-functions-javaCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/legend-engine-pure-runtime-java-extension-shared-functions-javaCompiler/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-javaCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-javaCompiler</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-javaCompiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-compiled-functions-json/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-compiled-functions-json/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-interpreted-functions-json/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-interpreted-functions-json/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-conversion/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-conversion/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-shared-functions-json/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-json</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-functions-legendCompiler-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-functions-legendCompiler-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-legendCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-runtime-java-extension-compiled-functions-legendCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-runtime-java-extension-compiled-functions-legendCompiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-legendCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-runtime-java-extension-interpreted-functions-legendCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-runtime-java-extension-interpreted-functions-legendCompiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-legendCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-runtime-java-extension-shared-functions-legendCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/legend-engine-pure-runtime-java-extension-shared-functions-legendCompiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-legendCompiler</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-legendCompiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-functions-planExecution-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-functions-planExecution-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-planExecution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-runtime-java-extension-compiled-functions-planExecution/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-runtime-java-extension-compiled-functions-planExecution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-planExecution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-runtime-java-extension-interpreted-functions-planExecution/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-runtime-java-extension-interpreted-functions-planExecution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-planExecution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-runtime-java-extension-shared-functions-planExecution/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/legend-engine-pure-runtime-java-extension-shared-functions-planExecution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-planExecution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-planExecution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-functions-pureExtensions-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-functions-pureExtensions-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-pureExtensions</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-runtime-java-extension-compiled-functions-pureExtensions/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-runtime-java-extension-compiled-functions-pureExtensions/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-pureExtensions</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-runtime-java-extension-interpreted-functions-pureExtensions/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-runtime-java-extension-interpreted-functions-pureExtensions/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-pureExtensions</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-runtime-java-extension-shared-functions-pureExtensions/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/legend-engine-pure-runtime-java-extension-shared-functions-pureExtensions/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-pureExtensions</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-pureExtensions/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-relation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <name>Legend Pure - Base - M2 Functions - Relation - Pure</name>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-relation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-relation</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-relation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-relation</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-relation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-relation</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-standard</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-functions-standard-pure</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-compiled-functions-standard/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-compiled-functions-standard/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-standard</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-standard</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-interpreted-functions-standard/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-interpreted-functions-standard/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-standard</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-standard</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-shared-functions-standard/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-shared-functions-standard/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-standard</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-standard</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-unclassified</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <name>Legend Pure - Base - M2 Functions - Base - Pure</name>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-unclassified</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-unclassified</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-unclassified</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-shared-functions-unclassified/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-shared-functions-unclassified/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-unclassified</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-unclassified</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-variant</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-compiled-functions-variant/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-compiled-functions-variant/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-variant</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-variant</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-interpreted-functions-variant/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-interpreted-functions-variant/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-variant</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-interpreted-functions-variant</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-shared-functions-variant/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-shared-functions-variant/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-functions-variant</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-runtime-java-extension-shared-functions-variant</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-reversePCT/legend-engine-pure-code-reversePCT-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-reversePCT/legend-engine-pure-code-reversePCT-http-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-reversePCT</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-code-reversePCT-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-reversePCT/legend-engine-pure-code-reversePCT-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-reversePCT/legend-engine-pure-code-reversePCT-pure/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-code-reversePCT</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-code-reversePCT-pure</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-reversePCT/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-reversePCT/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-code-scenario-quant-pure</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-ide</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-interpreted-functions/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-interpreted-functions/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-ide</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-pure-debug/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-pure-debug/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-ide</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-ide</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-diagram-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-diagram-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-dsl-diagram-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-graph-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-graph-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-dsl-graph-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-mapping-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-mapping-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-dsl-mapping-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-path-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-path-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-dsl-path-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-store-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-store-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-dsl-store-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-tds-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-tds-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-dsl-tds-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-precisePrimitives-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-precisePrimitives-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-precisePrimitives-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-store-relational-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-store-relational-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-pure-platform-modular-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-pure-platform-store-relational-java</artifactId>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-pure/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-query-pure-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-query-pure-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-core-query-pure-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-shared</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-shared-core</artifactId>

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-extensions/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-extensions/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-shared</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-shared-extensions</artifactId>

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-javaCompiler/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-javaCompiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-shared</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-shared-javaCompiler</artifactId>

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-structures/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-structures/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-shared</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-shared-structures</artifactId>

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-vault/legend-engine-shared-vault-aws/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-vault/legend-engine-shared-vault-aws/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-shared-vault</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-shared-vault-aws</artifactId>

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-vault/legend-engine-shared-vault-core/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-vault/legend-engine-shared-vault-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-shared-vault</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-shared-vault-core</artifactId>

--- a/legend-engine-core/legend-engine-core-shared/legend-engine-shared-vault/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/legend-engine-shared-vault/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-shared</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-shared/pom.xml
+++ b/legend-engine-core/legend-engine-core-shared/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-execution-test-data-generation-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-execution-test-data-generation-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-execution-test-data-generation/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-execution-test-data-generation/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-framework/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-framework/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-test-framework</artifactId>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-mft/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-mft/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <name>Legend Engine - Testable - MFT</name>
     <artifactId>legend-engine-test-mft</artifactId>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-shared/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-test-runner-shared</artifactId>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-server-shared/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-server-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-test-server-shared</artifactId>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable-http-api/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-testable-http-api</artifactId>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core-testable</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-testable</artifactId>

--- a/legend-engine-core/legend-engine-core-testable/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-core</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-core/pom.xml
+++ b/legend-engine-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-binding/legend-engine-xt-analytics-binding-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-binding/legend-engine-xt-analytics-binding-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-binding</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-binding/legend-engine-xt-analytics-binding-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-binding/legend-engine-xt-analytics-binding-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-binding</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-binding/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-binding/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-class/legend-engine-xt-analytics-class-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-class/legend-engine-xt-analytics-class-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-class</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-class/legend-engine-xt-analytics-class-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-class/legend-engine-xt-analytics-class-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-class</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-class/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-class/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-function/legend-engine-xt-analytics-function-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-function/legend-engine-xt-analytics-function-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-function</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-function/legend-engine-xt-analytics-function-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-function/legend-engine-xt-analytics-function-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-function</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-function/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-function/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-lineage</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-lineage</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-http-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-mapping</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Legend Engine - XT - Analytics - Mapping - HTTP - API</name>

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-integration/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-mapping</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Legend Engine - XT - Analytics - Mapping - Integration</name>

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-protocol/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-mapping</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Legend Engine - XT - Analytics - Mapping - Protocol</name>

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-pure/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-mapping</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-http-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-quality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-quality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-generation/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-search</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-search</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-search/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-search/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-store/legend-engine-xt-analytics-store-entitlement-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-store/legend-engine-xt-analytics-store-entitlement-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-store</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-xt-analytics-store-entitlement-http-api</artifactId>

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-store/legend-engine-xt-analytics-store-entitlement/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-store/legend-engine-xt-analytics-store-entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-analytics-store</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-store/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-store/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-test-coverage/legend-engine-xt-analytics-test-coverage-http-api/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-test-coverage/legend-engine-xt-analytics-test-coverage-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-test-coverage</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-test-coverage/legend-engine-xt-analytics-test-coverage-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-test-coverage/legend-engine-xt-analytics-test-coverage-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics-test-coverage</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-test-coverage/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-test-coverage/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-analytics</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-analytics/pom.xml
+++ b/legend-engine-xts-analytics/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-arrow/legend-engine-xt-arrow-pure/pom.xml
+++ b/legend-engine-xts-arrow/legend-engine-xt-arrow-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-arrow</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/pom.xml
+++ b/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-arrow</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-arrow/pom.xml
+++ b/legend-engine-xts-arrow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xts-arrow</artifactId>

--- a/legend-engine-xts-authentication/legend-engine-xt-authentication-grammar/pom.xml
+++ b/legend-engine-xts-authentication/legend-engine-xt-authentication-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-authentication</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-authentication/legend-engine-xt-authentication-implementation-core/pom.xml
+++ b/legend-engine-xts-authentication/legend-engine-xt-authentication-implementation-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-authentication</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-authentication/legend-engine-xt-authentication-implementation-gcp-federation/pom.xml
+++ b/legend-engine-xts-authentication/legend-engine-xt-authentication-implementation-gcp-federation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-authentication</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-authentication/legend-engine-xt-authentication-implementation-vault-aws/pom.xml
+++ b/legend-engine-xts-authentication/legend-engine-xt-authentication-implementation-vault-aws/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-authentication</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-authentication/legend-engine-xt-authentication-protocol/pom.xml
+++ b/legend-engine-xts-authentication/legend-engine-xt-authentication-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-authentication</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-authentication/legend-engine-xt-authentication-pure/pom.xml
+++ b/legend-engine-xts-authentication/legend-engine-xt-authentication-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-authentication</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-authentication/pom.xml
+++ b/legend-engine-xts-authentication/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-avro/legend-engine-xt-avro-http-api/pom.xml
+++ b/legend-engine-xts-avro/legend-engine-xt-avro-http-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-avro</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-avro-http-api</artifactId>

--- a/legend-engine-xts-avro/legend-engine-xt-avro-pure/pom.xml
+++ b/legend-engine-xts-avro/legend-engine-xt-avro-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-avro</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-avro/legend-engine-xt-avro/pom.xml
+++ b/legend-engine-xts-avro/legend-engine-xt-avro/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-avro</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-avro/pom.xml
+++ b/legend-engine-xts-avro/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-api/pom.xml
+++ b/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-bigqueryFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-compiler/pom.xml
+++ b/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-compiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-bigqueryFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-grammar/pom.xml
+++ b/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-bigqueryFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-protocol/pom.xml
+++ b/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-bigqueryFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-pure/pom.xml
+++ b/legend-engine-xts-bigqueryFunction/legend-engine-xt-bigqueryFunction-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-bigqueryFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-bigqueryFunction/pom.xml
+++ b/legend-engine-xts-bigqueryFunction/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/pom.xml
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-changetoken</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-changetoken</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-changetoken/legend-engine-xt-changetoken-test-pure/pom.xml
+++ b/legend-engine-xts-changetoken/legend-engine-xt-changetoken-test-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-changetoken</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-changetoken/pom.xml
+++ b/legend-engine-xts-changetoken/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-daml/legend-engine-xt-daml-grammar/pom.xml
+++ b/legend-engine-xts-daml/legend-engine-xt-daml-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-daml</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-daml/legend-engine-xt-daml-http-api/pom.xml
+++ b/legend-engine-xts-daml/legend-engine-xt-daml-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-daml</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-daml-http-api</artifactId>

--- a/legend-engine-xts-daml/legend-engine-xt-daml-model/pom.xml
+++ b/legend-engine-xts-daml/legend-engine-xt-daml-model/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-daml</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-daml/legend-engine-xt-daml-pure/pom.xml
+++ b/legend-engine-xts-daml/legend-engine-xt-daml-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-daml</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-daml/pom.xml
+++ b/legend-engine-xts-daml/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/pom.xml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-data-space</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/pom.xml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-data-space</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/pom.xml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-data-space</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-http-api/pom.xml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-data-space</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-protocol/pom.xml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-data-space</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/pom.xml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-data-space</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure/pom.xml
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-data-space</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-data-space/pom.xml
+++ b/legend-engine-xts-data-space/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-dataquality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-dataquality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-dataquality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-dataquality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-dataquality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-dataquality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-dataquality</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-dataquality/pom.xml
+++ b/legend-engine-xts-dataquality/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-executionPlan-test/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-executionPlan-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-executionPlan/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-executionPlan/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-deephaven-executionPlan</artifactId>

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-generator/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-generator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-deephaven-generator</artifactId>

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-grammar/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-deephaven-grammar</artifactId>

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-javaPlatformBinding-pure/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-protocol/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-pure/pom.xml
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-deephaven</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-deephaven/pom.xml
+++ b/legend-engine-xts-deephaven/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-compiler/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-compiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-diagram</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-grammar/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-diagram</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-http-api/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-diagram</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-protocol/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-diagram</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-pure-metamodel/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-pure-metamodel/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-diagram</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-diagram/legend-engine-xt-diagram-pure/pom.xml
+++ b/legend-engine-xts-diagram/legend-engine-xt-diagram-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-diagram</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-diagram/pom.xml
+++ b/legend-engine-xts-diagram/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/pom.xml
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-executionPlan/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-elasticsearch</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-grammar/pom.xml
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-elasticsearch</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-protocol/pom.xml
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-elasticsearch</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/pom.xml
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-V7-pure-metamodel/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-elasticsearch</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/pom.xml
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-executionPlan-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-elasticsearch</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-protocol-utils/pom.xml
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-protocol-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-elasticsearch</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-elasticsearch-protocol-utils</artifactId>

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-pure-specification-metamodel/pom.xml
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-pure-specification-metamodel/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-elasticsearch</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-elasticsearch/pom.xml
+++ b/legend-engine-xts-elasticsearch/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-driver-bloomberg/pom.xml
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-driver-bloomberg/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-flatdata</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-javaPlatformBinding-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-flatdata</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-javaPlatformBinding-test/pom.xml
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-javaPlatformBinding-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-flatdata</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/pom.xml
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-flatdata</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-pure/pom.xml
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-flatdata</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-runtime/pom.xml
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-runtime/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-flatdata</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/pom.xml
+++ b/legend-engine-xts-flatdata/legend-engine-xt-flatdata-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-flatdata</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-flatdata/pom.xml
+++ b/legend-engine-xts-flatdata/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-compiler/pom.xml
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-compiler/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionActivator</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-functionActivator-compiler</artifactId>

--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-deployment/pom.xml
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-deployment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionActivator</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-generation/pom.xml
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionActivator</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-grammar/pom.xml
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionActivator</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-http-api/pom.xml
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionActivator</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-protocol/pom.xml
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionActivator</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-pure/pom.xml
+++ b/legend-engine-xts-functionActivator/legend-engine-xt-functionActivator-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionActivator</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-functionActivator/pom.xml
+++ b/legend-engine-xts-functionActivator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionJar/legend-engine-xt-functionJar-api/pom.xml
+++ b/legend-engine-xts-functionJar/legend-engine-xt-functionJar-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionJar</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionJar/legend-engine-xt-functionJar-compiler/pom.xml
+++ b/legend-engine-xts-functionJar/legend-engine-xt-functionJar-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionJar</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionJar/legend-engine-xt-functionJar-generation/pom.xml
+++ b/legend-engine-xts-functionJar/legend-engine-xt-functionJar-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionJar</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionJar/legend-engine-xt-functionJar-grammar/pom.xml
+++ b/legend-engine-xts-functionJar/legend-engine-xt-functionJar-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionJar</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionJar/legend-engine-xt-functionJar-protocol/pom.xml
+++ b/legend-engine-xts-functionJar/legend-engine-xt-functionJar-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionJar</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionJar/legend-engine-xt-functionJar-pure/pom.xml
+++ b/legend-engine-xts-functionJar/legend-engine-xt-functionJar-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-functionJar</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-functionJar/pom.xml
+++ b/legend-engine-xts-functionJar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xts-functionJar</artifactId>

--- a/legend-engine-xts-generation/legend-engine-external-shared/pom.xml
+++ b/legend-engine-xts-generation/legend-engine-external-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-generation/legend-engine-language-pure-dsl-generation-pure/pom.xml
+++ b/legend-engine-xts-generation/legend-engine-language-pure-dsl-generation-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-generation/legend-engine-language-pure-dsl-generation/pom.xml
+++ b/legend-engine-xts-generation/legend-engine-language-pure-dsl-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-dsl-generation</artifactId>

--- a/legend-engine-xts-generation/legend-engine-xt-artifact-generation-http-api/pom.xml
+++ b/legend-engine-xts-generation/legend-engine-xt-artifact-generation-http-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-generation</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-generation/legend-engine-xts-deployment-model/pom.xml
+++ b/legend-engine-xts-generation/legend-engine-xts-deployment-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-generation</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-generation/pom.xml
+++ b/legend-engine-xts-generation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-compiler/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-generation-http-api/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-generation-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-graphQL-generation-http-api</artifactId>

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-grammar-integration/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-grammar-integration/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-grammar/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-http-api/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-protocol/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure-metamodel/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure-metamodel/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/pom.xml
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-relational-extension/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-graphQL</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-graphQL/pom.xml
+++ b/legend-engine-xts-graphQL/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-haskell/legend-engine-xt-haskell-grammar/pom.xml
+++ b/legend-engine-xts-haskell/legend-engine-xt-haskell-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-haskell</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-haskell/legend-engine-xt-haskell-protocol/pom.xml
+++ b/legend-engine-xts-haskell/legend-engine-xt-haskell-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-haskell</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-haskell/legend-engine-xt-haskell-pure/pom.xml
+++ b/legend-engine-xts-haskell/legend-engine-xt-haskell-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-haskell</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-haskell/pom.xml
+++ b/legend-engine-xts-haskell/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-hostedService/legend-engine-xt-hostedService-api/pom.xml
+++ b/legend-engine-xts-hostedService/legend-engine-xt-hostedService-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-hostedService</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-hostedService/legend-engine-xt-hostedService-compiler/pom.xml
+++ b/legend-engine-xts-hostedService/legend-engine-xt-hostedService-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-hostedService</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-hostedService/legend-engine-xt-hostedService-generation/pom.xml
+++ b/legend-engine-xts-hostedService/legend-engine-xt-hostedService-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-hostedService</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-hostedService/legend-engine-xt-hostedService-grammar/pom.xml
+++ b/legend-engine-xts-hostedService/legend-engine-xt-hostedService-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-hostedService</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-hostedService/legend-engine-xt-hostedService-protocol/pom.xml
+++ b/legend-engine-xts-hostedService/legend-engine-xt-hostedService-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-hostedService</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-hostedService/legend-engine-xt-hostedService-pure/pom.xml
+++ b/legend-engine-xts-hostedService/legend-engine-xt-hostedService-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-hostedService</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-hostedService/pom.xml
+++ b/legend-engine-xts-hostedService/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-iceberg/legend-engine-xt-iceberg-pure/pom.xml
+++ b/legend-engine-xts-iceberg/legend-engine-xt-iceberg-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-iceberg</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/pom.xml
+++ b/legend-engine-xts-iceberg/legend-engine-xt-iceberg-test-support/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-iceberg</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-iceberg/pom.xml
+++ b/legend-engine-xts-iceberg/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-apiToken/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-apiToken/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-gcp/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-gcp/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-kerberos/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-kerberos/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-middletier/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-middletier/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-oauth/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-oauth/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-pac4j/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-pac4j/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-plainTextUserPassword/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-plainTextUserPassword/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/legend-engine-xt-identity-privateKey/pom.xml
+++ b/legend-engine-xts-identity/legend-engine-xt-identity-privateKey/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-identity</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-identity/pom.xml
+++ b/legend-engine-xts-identity/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-external-language-java/pom.xml
+++ b/legend-engine-xts-java/legend-engine-external-language-java/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-essential-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-essential-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-standard-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-standard-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-featureBased-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-featureBased-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-externalFormat-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-java</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-java/pom.xml
+++ b/legend-engine-xts-java/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-json/legend-engine-external-format-jsonSchema/pom.xml
+++ b/legend-engine-xts-json/legend-engine-external-format-jsonSchema/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-json/legend-engine-xt-json-http-api/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-http-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-json-http-api</artifactId>

--- a/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-test/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-javaPlatformBinding-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-json/legend-engine-xt-json-model/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-json/legend-engine-xt-json-pure/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-json/legend-engine-xt-json-runtime/pom.xml
+++ b/legend-engine-xts-json/legend-engine-xt-json-runtime/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-json</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-json/pom.xml
+++ b/legend-engine-xts-json/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-mcp/legend-engine-xt-mcp-protocol/pom.xml
+++ b/legend-engine-xts-mcp/legend-engine-xt-mcp-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mcp</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-mcp/legend-engine-xt-mcp-server-orchestrator/pom.xml
+++ b/legend-engine-xts-mcp/legend-engine-xt-mcp-server-orchestrator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mcp</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-mcp/pom.xml
+++ b/legend-engine-xts-mcp/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-api/pom.xml
+++ b/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-memsqlFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-compiler/pom.xml
+++ b/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-compiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-memsqlFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-generator/pom.xml
+++ b/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-generator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-memsqlFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-grammar/pom.xml
+++ b/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-memsqlFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-protocol/pom.xml
+++ b/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-memsqlFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-pure/pom.xml
+++ b/legend-engine-xts-memsqlFunction/legend-engine-xt-memsqlFunction-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-memsqlFunction</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-memsqlFunction/pom.xml
+++ b/legend-engine-xts-memsqlFunction/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan-test/pom.xml
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mongodb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/pom.xml
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-executionPlan/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mongodb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-nonrelationalStore-mongodb-executionPlan</artifactId>

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/pom.xml
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar-integration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mongodb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-nonrelationalStore-mongodb-grammar-integration</artifactId>

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar/pom.xml
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mongodb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-nonrelationalStore-mongodb-grammar</artifactId>

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mongodb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-nonrelationalStore-mongodb-javaPlatformBinding-pure</artifactId>

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-protocol/pom.xml
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mongodb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-nonrelationalStore-mongodb-protocol</artifactId>

--- a/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/pom.xml
+++ b/legend-engine-xts-mongodb/legend-engine-xt-nonrelationalStore-mongodb-pure/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-mongodb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-nonrelationalStore-mongodb-pure</artifactId>

--- a/legend-engine-xts-mongodb/pom.xml
+++ b/legend-engine-xts-mongodb/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-morphir/legend-engine-xt-morphir-http-api/pom.xml
+++ b/legend-engine-xts-morphir/legend-engine-xt-morphir-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-morphir</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-morphir-http-api</artifactId>

--- a/legend-engine-xts-morphir/legend-engine-xt-morphir-pure/pom.xml
+++ b/legend-engine-xts-morphir/legend-engine-xt-morphir-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-morphir</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-morphir/legend-engine-xt-morphir/pom.xml
+++ b/legend-engine-xts-morphir/legend-engine-xt-morphir/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-morphir</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-morphir/pom.xml
+++ b/legend-engine-xts-morphir/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-generation/pom.xml
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-generation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-openapi</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-openapi-generation</artifactId>

--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/pom.xml
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-openapi</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-openapi-pure</artifactId>

--- a/legend-engine-xts-openapi/pom.xml
+++ b/legend-engine-xts-openapi/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-grammar/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-protocol/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-pure/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-logical-plan/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-physical-plan/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-ansi/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-bigquery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-duckdb/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-h2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-memsql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-postgres/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-persistence-component</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-http-api/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-pure/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-grammar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-protocol/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-pure/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-test-runner/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-test-runner/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-persistence</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-persistence/pom.xml
+++ b/legend-engine-xts-persistence/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-powerbi/legend-engine-xt-powerbi-generation/pom.xml
+++ b/legend-engine-xts-powerbi/legend-engine-xt-powerbi-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-powerbi</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/pom.xml
+++ b/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-powerbi</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-powerbi/pom.xml
+++ b/legend-engine-xts-powerbi/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-protobuf/legend-engine-xt-protobuf-grammar/pom.xml
+++ b/legend-engine-xts-protobuf/legend-engine-xt-protobuf-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-protobuf</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-xt-protobuf-grammar</artifactId>

--- a/legend-engine-xts-protobuf/legend-engine-xt-protobuf-http-api/pom.xml
+++ b/legend-engine-xts-protobuf/legend-engine-xt-protobuf-http-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-protobuf</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-protobuf-http-api</artifactId>

--- a/legend-engine-xts-protobuf/legend-engine-xt-protobuf-protocol/pom.xml
+++ b/legend-engine-xts-protobuf/legend-engine-xt-protobuf-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-protobuf</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-xt-protobuf-protocol</artifactId>

--- a/legend-engine-xts-protobuf/legend-engine-xt-protobuf-pure/pom.xml
+++ b/legend-engine-xts-protobuf/legend-engine-xt-protobuf-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-protobuf</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-protobuf/legend-engine-xt-protobuf/pom.xml
+++ b/legend-engine-xts-protobuf/legend-engine-xt-protobuf/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-protobuf</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -57,7 +57,7 @@
                     <dependency>
                         <groupId>org.finos.legend.engine</groupId>
                         <artifactId>legend-engine-protocol-generation</artifactId>
-                        <version>4.123.4-SNAPSHOT</version>
+                        <version>${revision}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.finos.legend.pure</groupId>

--- a/legend-engine-xts-protobuf/pom.xml
+++ b/legend-engine-xts-protobuf/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-protocol-java-generation/legend-engine-protocol-generation-pure/pom.xml
+++ b/legend-engine-xts-protocol-java-generation/legend-engine-protocol-generation-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-protocol-java-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-protocol-generation-pure</artifactId>

--- a/legend-engine-xts-protocol-java-generation/legend-engine-protocol-generation/pom.xml
+++ b/legend-engine-xts-protocol-java-generation/legend-engine-protocol-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-protocol-java-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-protocol-generation</artifactId>

--- a/legend-engine-xts-protocol-java-generation/pom.xml
+++ b/legend-engine-xts-protocol-java-generation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-pure/pom.xml
+++ b/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-python-functions-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-runtime-java-extension-compiled/pom.xml
+++ b/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-runtime-java-extension-compiled/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-python-functions-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-runtime-java-extension-interpreted/pom.xml
+++ b/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-runtime-java-extension-interpreted/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-python-functions-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-runtime-java-extension-shared/pom.xml
+++ b/legend-engine-xts-python/legend-engine-xt-python-functions-execution/legend-engine-xt-python-functions-execution-runtime-java-extension-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-python-functions-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-python/legend-engine-xt-python-functions-execution/pom.xml
+++ b/legend-engine-xts-python/legend-engine-xt-python-functions-execution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-python</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-legendQL/pom.xml
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-legendQL/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-python</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-python/pom.xml
+++ b/legend-engine-xts-python/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-MFT-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-MFT-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-relationalStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-PCT</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-runtime-java-extension-compiled-functions-relationalStore-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-runtime-java-extension-compiled-functions-relationalStore-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-PCT</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-runtime-java-extension-interpreted-functions-relationalStore-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-runtime-java-extension-interpreted-functions-relationalStore-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-PCT</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-runtime-java-extension-shared-functions-relationalStore-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-runtime-java-extension-shared-functions-relationalStore-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-PCT</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-relationalStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-analytics/legend-engine-xt-relationalStore-store-entitlement-analytics/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-analytics/legend-engine-xt-relationalStore-store-entitlement-analytics/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-analytics</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-analytics/legend-engine-xt-relationalStore-store-entitlement-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-analytics/legend-engine-xt-relationalStore-store-entitlement-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-analytics</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-analytics/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-analytics/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-relationalStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-connection-http-api/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-connection-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-relationalStore</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-athena</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-athena</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-athena</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/legend-engine-xt-relationalStore-athena-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-athena</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-athena/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-bigquery</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-bigquery</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-bigquery</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-bigquery</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-clickhouse</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-connection/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-clickhouse</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-clickhouse-connection</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-execution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-clickhouse</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-clickhouse-execution</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-clickhouse</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-clickhouse</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-databricks</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-databricks-PCT</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-databricks</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-databricks</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-databricks</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-databricks</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-duckdb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-SDT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-SDT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-duckdb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-duckdb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-duckdb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-duckdb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-duckdb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-sqlDialectTranslation-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-sqlDialectTranslation-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-duckdb</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-h2</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-SDT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-SDT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-h2</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-execution-2.1.214/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-execution-2.1.214/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-h2</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-sqlDialectTranslation-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-sqlDialectTranslation-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-h2</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-hive/legend-engine-xt-relationalStore-hive-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-hive/legend-engine-xt-relationalStore-hive-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-hive</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-hive/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-hive/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-SDT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-SDT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-connection/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-execution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-memsql-execution</artifactId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-memsql-protocol</artifactId>
-            <version>4.123.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <!-- DRIVER -->

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-memsql-protocol</artifactId>
-            <version>4.123.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-pure/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-memsql-pure</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-sqlDialectTranslation-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-sqlDialectTranslation-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-memsql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-oracle</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-execution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-oracle</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-oracle-execution</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-oracle</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-protocol/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-oracle</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-oracle</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgres</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-SDT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-SDT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgres</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-connection/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgres</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgres</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgres</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-presto/legend-engine-xt-relationalStore-presto-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-presto/legend-engine-xt-relationalStore-presto-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-presto</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-presto/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-presto/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-redshift</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-redshift</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-redshift</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/legend-engine-xt-relationalStore-redshift-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-redshift</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-redshift/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-connection/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-sqlDialectTranslation-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-sqlDialectTranslation-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-spanner</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-relationalStore-spanner-PCT</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-spanner</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-grammar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-spanner</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-jdbc-shaded/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-jdbc-shaded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-spanner</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-protocol/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-spanner</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-pure/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-spanner</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/legend-engine-xt-relationalStore-sparksql-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/legend-engine-xt-relationalStore-sparksql-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-sparksql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sparksql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-sqlserver</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-connection/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-sqlserver</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-sqlserver</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-sqlserver</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybase/legend-engine-xt-relationalStore-sybase-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybase/legend-engine-xt-relationalStore-sybase-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-sybase</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybase/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybase/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-sybaseiq</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-trino</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-trino</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-trino</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-trino</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-trino</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-relationalStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-authorizer/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-authorizer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xt-relationalStore-execution</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection-authentication-default/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection-authentication-default/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication-default</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection-authentication/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection-authentication/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication</artifactId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection-tests/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection-tests/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-http-api/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-execution</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-relationalStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-http-api/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-compiler/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlModel-extensions-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlModel-extensions-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlModel-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlModel-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-functions-compiled/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-functions-compiled/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-functions-interpreted/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-functions-interpreted/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-postgresSql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-SDT-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-SDT-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-javaPlatformBinding-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlPlanning-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlPlanning-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-test/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-testDataGeneration-http-api/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-testDataGeneration-http-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-relationalStore-generation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-relationalStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalStore/pom.xml
+++ b/legend-engine-xts-relationalStore/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalai/legend-engine-xt-relationalai-pure/pom.xml
+++ b/legend-engine-xts-relationalai/legend-engine-xt-relationalai-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-relationalai</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-relationalai/pom.xml
+++ b/legend-engine-xts-relationalai/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-rosetta/legend-engine-xt-rosetta-pure/pom.xml
+++ b/legend-engine-xts-rosetta/legend-engine-xt-rosetta-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-rosetta</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-rosetta/legend-engine-xt-rosetta/pom.xml
+++ b/legend-engine-xts-rosetta/legend-engine-xt-rosetta/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-rosetta</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-rosetta/pom.xml
+++ b/legend-engine-xts-rosetta/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/pom.xml
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-dsl-service-execution</artifactId>

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service-generation/pom.xml
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service-pure/pom.xml
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service/pom.xml
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-language-pure-dsl-service</artifactId>

--- a/legend-engine-xts-service/legend-engine-service-post-validation-runner/pom.xml
+++ b/legend-engine-xts-service/legend-engine-service-post-validation-runner/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-service/legend-engine-services-model-http-api/pom.xml
+++ b/legend-engine-xts-service/legend-engine-services-model-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-services-model-http-api</artifactId>

--- a/legend-engine-xts-service/legend-engine-services-model/pom.xml
+++ b/legend-engine-xts-service/legend-engine-services-model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-services-model</artifactId>

--- a/legend-engine-xts-service/legend-engine-test-runner-service/pom.xml
+++ b/legend-engine-xts-service/legend-engine-test-runner-service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-service</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-service/pom.xml
+++ b/legend-engine-xts-service/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-executionPlan/pom.xml
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-executionPlan/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-serviceStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-grammar/pom.xml
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-serviceStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-javaPlatformBinding-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-serviceStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-protocol/pom.xml
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-serviceStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/pom.xml
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-serviceStore</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-serviceStore/pom.xml
+++ b/legend-engine-xts-serviceStore/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-api/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-compiler/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-compiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-snowflake</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-generator/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-generator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-grammar/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-m2mudf-plan-executor/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-m2mudf-plan-executor/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-engine-xt-snowflake-m2mudf-plan-executor</artifactId>

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-protocol/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-engine-xts-snowflake</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure/pom.xml
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-snowflake</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-snowflake/pom.xml
+++ b/legend-engine-xts-snowflake/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-compiler/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-expression</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-grammar/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-expression</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-pure/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-expression</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-tests-pure/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-expression/legend-engine-xt-sql-expression-tests-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-expression</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-expression/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-expression/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-sql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-sql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-postgres-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>legend-engine-xts-sql</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-core/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-providers</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-relationalStore/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-relationalStore/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-providers</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-service/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-providers</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-shared/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-providers</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-transformation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-transformation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-reversePCT/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-reversePCT/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xt-sql-transformation</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/pom.xml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-sql</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-sql/pom.xml
+++ b/legend-engine-xts-sql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-tds/legend-engine-xt-tds-compiler/pom.xml
+++ b/legend-engine-xts-tds/legend-engine-xt-tds-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-tds</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-engine-xts-tds/legend-engine-xt-tds-grammar/pom.xml
+++ b/legend-engine-xts-tds/legend-engine-xt-tds-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-tds</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-engine-xt-tds-grammar</artifactId>

--- a/legend-engine-xts-tds/pom.xml
+++ b/legend-engine-xts-tds/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-text/legend-engine-xt-text-compiler/pom.xml
+++ b/legend-engine-xts-text/legend-engine-xt-text-compiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>legend-engine-xts-text</artifactId>
         <groupId>org.finos.legend.engine</groupId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-text/legend-engine-xt-text-grammar/pom.xml
+++ b/legend-engine-xts-text/legend-engine-xt-text-grammar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-text</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-text/legend-engine-xt-text-protocol/pom.xml
+++ b/legend-engine-xts-text/legend-engine-xt-text-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-text</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-text/legend-engine-xt-text-pure-metamodel/pom.xml
+++ b/legend-engine-xts-text/legend-engine-xt-text-pure-metamodel/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-text</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-text/pom.xml
+++ b/legend-engine-xts-text/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-xml/legend-engine-xt-xml-javaPlatformBinding-pure/pom.xml
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-javaPlatformBinding-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-xml</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-xml/legend-engine-xt-xml-model/pom.xml
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-xml</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-xml/legend-engine-xt-xml-pure/pom.xml
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-xml</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-xml/legend-engine-xt-xml-runtime/pom.xml
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-runtime/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-xml</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-xml/legend-engine-xt-xml-shared/pom.xml
+++ b/legend-engine-xts-xml/legend-engine-xt-xml-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine-xts-xml</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xts-xml/pom.xml
+++ b/legend-engine-xts-xml/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>4.123.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>Legend Engine</name>
     <groupId>org.finos.legend.engine</groupId>
     <artifactId>legend-engine</artifactId>
-    <version>4.123.4-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -113,6 +113,9 @@
     </modules>
 
     <properties>
+        <!-- CI-Friendly Version -->
+        <revision>4.123.4-SNAPSHOT</revision>
+
         <!-- Legend -->
         <legend.pure.version>5.80.0</legend.pure.version>
         <legend.shared.version>0.33.0</legend.shared.version>
@@ -403,6 +406,31 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
            <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
Replace hardcoded version with ${revision}, add flatten-maven-plugin, and rewrite release workflows to use -Drevision= instead of maven-release-plugin.
