### PR TITLE
Add relational reversePCTs for PandasAPI (PyLegend) - Aggregate, Composition, Extend, Groupby, Slice (first, last, nth, lag, lead), Over, Reduce, All Ranks

### DIFF
--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/pythonReversePCTPandasAPIApi.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/pythonReversePCTPandasAPIApi.pure
@@ -108,7 +108,7 @@ function <<access.private>> meta::external::python::reversePCT::pandasAPI::getPu
     'from pylegend.extensions.tds.pandas_api.frames.pandas_api_csv_input_frame import PandasApiCsvNonExecutableInputTdsFrame as csv_frame\n'+
     'from pylegend.core.tds.pandas_api.frames.pandas_api_applied_function_tds_frame import PandasApiAppliedFunctionTdsFrame\n' +
     'from pylegend.core.tds.pandas_api.frames.pandas_api_window_tds_frame import PandasApiWindowTdsFrame\n' +
-    'from pylegend.core.language.pandas_api.pandas_api_window_series import WindowSeries' +
+    'from pylegend.core.language.pandas_api.pandas_api_window_series import WindowSeries\n' +
     'from pylegend.core.tds.tds_column import PrimitiveType\n' +
     '\n' +
     'def func():\n'+

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/pythonReversePCTPandasAPIApi.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/pythonReversePCTPandasAPIApi.pure
@@ -109,6 +109,7 @@ function <<access.private>> meta::external::python::reversePCT::pandasAPI::getPu
     'from pylegend.core.tds.pandas_api.frames.pandas_api_applied_function_tds_frame import PandasApiAppliedFunctionTdsFrame\n' +
     'from pylegend.core.tds.pandas_api.frames.pandas_api_window_tds_frame import PandasApiWindowTdsFrame\n' +
     'from pylegend.core.language.pandas_api.pandas_api_window_series import WindowSeries' +
+    'from pylegend.core.tds.tds_column import PrimitiveType\n' +
     '\n' +
     'def func():\n'+
     '  res = (' + $pythonCodeBlock + ')\n' +
@@ -125,6 +126,12 @@ function <<access.private>> meta::external::python::reversePCT::pandasAPI::getPu
     'print(func())\n';
 
   let res = meta::python::execution::executePythonScript($script);
-  if ($res.error->trim() != '', | fail($res.error), | []);
+  if ($res.error->trim() != '',
+    | let errorLines = $res.error->trim()->split('\n');
+      let lastLine = $errorLines->last()->toOne()->trim();
+      let colonIndex = $lastLine->indexOf(': ');
+      let errorMessage = if($colonIndex >= 0, | $lastLine->substring($colonIndex + 2), | $lastLine);
+      fail($errorMessage);,
+    | []);
   $res.output;
 }

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
@@ -389,6 +389,734 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                '  frame.assign(name=lambda r: r["val"] + 1, other=lambda r: r["str"] + \'_ext\')' +
                ')(csv_frame("val,str\\n1,a\\n3,ewe\\n4,qw\\n5,wwe\\n6,weq"))')
         ]
+      ),
+
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggNoWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~newCol:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.id:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggNoWindow_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~newCol:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.id:y: Integer[*]|$y->plus());\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggNoWindowMultipleColums_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~[newCol:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.id:y: Integer[*]|$y->plus(),other:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.grp:y: Integer[*]|$y->plus()])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].sum()) or frame.__setitem__("other", frame["grp"].sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggNoWindowMultipleColums_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~[newCol:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.id:y: Integer[*]|$y->plus(),other:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.grp:y: Integer[*]|$y->plus()]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].sum()) or frame.__setitem__("other", frame["grp"].sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithPartitionWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["id"].window_frame_legend_ext(frame.rows_between(), order_by="grp").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithPartitionWindowMultipleColumns_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus(),other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.grp}:y: Integer[*]|$y->plus()])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["id"].window_frame_legend_ext(frame.rows_between(), order_by="grp").sum()) or frame.__setitem__("other", frame.groupby("grp")["grp"].window_frame_legend_ext(frame.rows_between(), order_by="grp").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithPartitionWindowMultipleColumns_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus(),other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.grp}:y: Integer[*]|$y->plus()]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["id"].window_frame_legend_ext(frame.rows_between(), order_by="grp").sum()) or frame.__setitem__("other", frame.groupby("grp")["grp"].window_frame_legend_ext(frame.rows_between(), order_by="grp").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithOrderWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~id->meta::pure::functions::relation::descending()->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].expanding(order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithOrderWindow_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~id->meta::pure::functions::relation::descending()->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus());\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].expanding(order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggStringWithPartitionAndOrderWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].expanding(order_by="id", ascending=False).agg(lambda x: x.join("")))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggStringWithPartitionAndOrderWindow_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'));\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].expanding(order_by="id", ascending=False).agg(lambda x: x.join("")))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggIntegerWithPartitionAndOrderWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["id"].expanding(order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggIntegerWithPartitionAndOrderWindow_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus());\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["id"].expanding(order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithPartitionAndOrderWindowMultipleColumns_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus()])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].expanding(order_by="id", ascending=False).agg(lambda x: x.join(""))) or frame.__setitem__("other", frame.groupby("grp")["id"].expanding(order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithPartitionAndOrderWindowMultipleColumns_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus()]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].expanding(order_by="id", ascending=False).agg(lambda x: x.join(""))) or frame.__setitem__("other", frame.groupby("grp")["id"].expanding(order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndMultipleOrderWindowMultipleColumns_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name,height\n'+
+                  '1,2,A,11\n'+
+                  '2,1,B,12\n'+
+                  '3,3,C,12\n'+
+                  '4,3,B,11\n'+
+                  '5,2,B,13\n'+
+                  '6,1,C,12\n'+
+                  '7,3,A,13\n'+
+                  '8,1,B,14\n'+
+                  '9,1,C,11\n'+
+                  '10,2,D,11}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over([~name->meta::pure::functions::relation::ascending(), ~height->meta::pure::functions::relation::ascending()]), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
+                  '',
+               '(lambda frame:' +
+               '  frame' +
+               ')(csv_frame("\\nid,grp,name,height\\n1,2,A,11\\n2,1,B,12\\n3,3,C,12\\n4,3,B,11\\n5,2,B,13\\n6,1,C,12\\n7,3,A,13\\n8,1,B,14\\n9,1,C,11\\n10,2,D,11"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndMultipleOrderWindowMultipleColumnsWithFilter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name,height\n'+
+                  '1,2,A,11\n'+
+                  '2,1,B,12\n'+
+                  '3,3,C,12\n'+
+                  '4,3,B,11\n'+
+                  '5,2,B,13\n'+
+                  '6,1,C,12\n'+
+                  '7,3,A,13\n'+
+                  '8,1,B,14\n'+
+                  '9,1,C,11\n'+
+                  '10,2,D,11}#->meta::pure::functions::relation::filter(x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$x.id < 9)->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over([~name->meta::pure::functions::relation::ascending(), ~height->meta::pure::functions::relation::ascending()]), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
+                  '',
+               '(lambda frame:' +
+               '  frame' +
+               ')(csv_frame("\\nid,grp,name,height\\n1,2,A,11\\n2,1,B,12\\n3,3,C,12\\n4,3,B,11\\n5,2,B,13\\n6,1,C,12\\n7,3,A,13\\n8,1,B,14\\n9,1,C,11\\n10,2,D,11"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndOrderWindowMultipleColumns_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
+                  '',
+               '(lambda frame:' +
+               '  frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndOrderWindowMultipleColumns_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggNoWindowChainedWithSimple_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~newCol:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.id:y: Integer[*]|$y->plus())->meta::pure::functions::relation::extend(~other:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], newCol:Integer[1])[1]|meta::pure::functions::math::floor($x.newCol->meta::pure::functions::multiplicity::toOne() / $x.id->meta::pure::functions::multiplicity::toOne()))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].sum()) or frame.__setitem__("other", (frame["newCol"] / frame["id"]).floor())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggNoWindowChainedWithSimple_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' let t2 = $t->meta::pure::functions::relation::extend(~newCol:c: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$c.id:y: Integer[*]|$y->plus());\n'+
+                  ' $t2->meta::pure::functions::relation::extend(~other:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], newCol:Integer[1])[1]|meta::pure::functions::math::floor($x.newCol->meta::pure::functions::multiplicity::toOne() / $x.id->meta::pure::functions::multiplicity::toOne()));\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["id"].sum()) or frame.__setitem__("other", (frame["newCol"] / frame["id"]).floor())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPWithMultiplePartitionsAndOrderWindowMultipleColumns_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,grp2,name\n'+
+                  '1,2,2,A\n'+
+                  '2,1,1,B\n'+
+                  '3,3,3,C\n'+
+                  '4,4,4,D\n'+
+                  '5,2,2,E\n'+
+                  '6,1,2,F\n'+
+                  '7,3,3,G\n'+
+                  '8,1,1,H\n'+
+                  '9,5,5,I\n'+
+                  '10,0,0,J}#->meta::pure::functions::relation::extend(~[grp,grp2]->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
+                  '',
+               '(lambda frame:' +
+               '  frame' +
+               ')(csv_frame("\\nid,grp,grp2,name\\n1,2,2,A\\n2,1,1,B\\n3,3,3,C\\n4,4,4,D\\n5,2,2,E\\n6,1,2,F\\n7,3,3,G\\n8,1,1,H\\n9,5,5,I\\n10,0,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPWithMultiplePartitionsAndOrderWindowMultipleColumns_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,grp2,name\n'+
+                  '1,2,2,A\n'+
+                  '2,1,1,B\n'+
+                  '3,3,3,C\n'+
+                  '4,4,4,D\n'+
+                  '5,2,2,E\n'+
+                  '6,1,2,F\n'+
+                  '7,3,3,G\n'+
+                  '8,1,1,H\n'+
+                  '9,5,5,I\n'+
+                  '10,0,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~[grp,grp2]->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame' +
+               ')(csv_frame("\\nid,grp,grp2,name\\n1,2,2,A\\n2,1,1,B\\n3,3,3,C\\n4,4,4,D\\n5,2,2,E\\n6,1,2,F\\n7,3,3,G\\n8,1,1,H\\n9,5,5,I\\n10,0,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggStringWithPartitionAndUnboundedWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].window_frame_legend_ext(frame.rows_between(), order_by="grp").agg(lambda x: x.join("")))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggStringWithPartitionAndOrderUnboundedWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].window_frame_legend_ext(frame.rows_between(), order_by="id", ascending=False).agg(lambda x: x.join("")))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggStringWithPartitionAndOrderASCUnboundedWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].window_frame_legend_ext(frame.rows_between(), order_by="id").agg(lambda x: x.join("")))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggStringWithPartitionAndOrderUnboundedWindow_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'));\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].window_frame_legend_ext(frame.rows_between(), order_by="id", ascending=False).agg(lambda x: x.join("")))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithPartitionAndOrderUnboundedWindowMultipleColumns_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus()])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].window_frame_legend_ext(frame.rows_between(), order_by="id", ascending=False).agg(lambda x: x.join(""))) or frame.__setitem__("other", frame.groupby("grp")["id"].window_frame_legend_ext(frame.rows_between(), order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testOLAPAggWithPartitionAndOrderUnboundedWindowMultipleColumns_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus()]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp")["name"].window_frame_legend_ext(frame.rows_between(), order_by="id", ascending=False).agg(lambda x: x.join(""))) or frame.__setitem__("other", frame.groupby("grp")["id"].window_frame_legend_ext(frame.rows_between(), order_by="id", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testVariantColumn_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds = #TDS{\n'+
+                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
+                  '1,"[1,2,3]"\n'+
+                  '2,"[4,5,6]"\n'+
+                  '3,"[7,8,9]"\n'+
+                  '4,"[10,11,12]"\n'+
+                  '5,"[13,14,15]"}#;\n'+
+                  ' $tds->meta::pure::functions::relation::extend(~passthru:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload)->meta::pure::functions::relation::sort(~id->meta::pure::functions::relation::ascending());\n'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testVariantColumn_indexExtraction_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds = #TDS{\n'+
+                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
+                  '1,"[1,2,3]"\n'+
+                  '2,"[4,5,6]"\n'+
+                  '3,"[7,8,9]"\n'+
+                  '4,"[10,11,12]"\n'+
+                  '5,"[13,14,15]"}#;\n'+
+                  ' $tds->meta::pure::functions::relation::extend(~atCol0:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(0))->meta::pure::functions::relation::extend(~atCol1:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], atCol0:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(1));\n'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testVariantColumn_keyExtraction_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds = #TDS{\n'+
+                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
+                  '1,"{""boolean"":true,""integer"":1,""string"":""hello""}"\n'+
+                  '2,"{""boolean"":false,""integer"":2,""string"":""world""}"\n'+
+                  '3,"{""boolean"":true,""integer"":3,""string"":""world""}"}#;\n'+
+                  ' $tds->meta::pure::functions::relation::extend(~[booleanKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'boolean\'),integerKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'integer\'),stringKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'string\')]);\n'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testVariantColumn_map_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds = #TDS{\n'+
+                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
+                  '1,"[1,2,3]"\n'+
+                  '2,"[4,5,6]"\n'+
+                  '3,"[7,8,9]"\n'+
+                  '4,"[10,11,12]"\n'+
+                  '5,"[13,14,15]"}#;\n'+
+                  ' $tds->meta::pure::functions::relation::extend(~payloadMod:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::map(t: Integer[1]|$t->meta::pure::functions::math::mod(2))->meta::pure::functions::variant::convert::toVariant());\n'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testVariantColumn_fold_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds = #TDS{\n'+
+                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
+                  '1,"[1,2,3]"\n'+
+                  '2,"[4,5,6]"\n'+
+                  '3,"[7,8,9]"\n'+
+                  '4,"[10,11,12]"\n'+
+                  '5,"[13,14,15]"}#;\n'+
+                  ' $tds->meta::pure::functions::relation::extend(~payloadFoldMult:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::fold({t: Integer[1], v: Integer[1]|$t * $v}, 1));\n'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::extend::testVariantColumn_filter_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds = #TDS{\n'+
+                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
+                  '1,"[1,2,3]"\n'+
+                  '2,"[4,5,6]"\n'+
+                  '3,"[7,8,9]"\n'+
+                  '4,"[10,11,12]"\n'+
+                  '5,"[13,14,15]"}#;\n'+
+                  ' $tds->meta::pure::functions::relation::extend(~divBy2:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::filter(t|$t->meta::pure::functions::math::mod(2) == 0)->meta::pure::functions::variant::convert::toVariant());\n'+
+                  '')
+        ]
       )
     ]->combine(),
 
@@ -940,6 +1668,5131 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                ')(csv_frame("id,name\\n1,George\\n2,Pierre\\n3,Sachin\\n4,David\\n5,James"))')
         ]
       )
+    ]->combine(),
+
+
+
+
+
+    // ============================================================
+    // /core_functions_relation/relation/functions/olap/over.pure
+    // ============================================================
+
+    [
+      meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_CurrentRow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].expanding(order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_CurrentRow_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 0->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(0, None), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_NPreceding_NPreceding_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-2, -1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(-2, -1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_NPreceding_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-1, 1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(-1, 1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_NFollowing_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 1->meta::pure::functions::relation::rows(2)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(1, 2), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_NPreceding_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(-1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(None, -1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(None, 1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_NPreceding_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-1, meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(-1, None), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_NFollowing_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 1->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(1, None), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_CurrentRow_CurrentRow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 0->meta::pure::functions::relation::rows(0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].rolling(window=1, order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_NPreceding_CurrentRow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-1, 0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].rolling(window=2, order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_CurrentRow_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 0->meta::pure::functions::relation::rows(1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(0, 1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_UnboundedFollowing_WithSinglePartition_WithoutOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between()).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_UnboundedFollowing_WithMultiplePartitions_WithoutOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].window_frame_legend_ext(frame.rows_between()).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_CurrentRow_WithMultiplePartitions_WithSingleOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(~i->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].expanding(order_by="i").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRows_InvalidWindowFrameBoundary_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(~i->meta::pure::functions::relation::ascending(), 4->meta::pure::functions::relation::rows(2)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].window_frame_legend_ext(frame.rows_between(4, 2), order_by="i").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_InvalidWindowFrameBoundary_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(~i->meta::pure::functions::relation::ascending(), 4->meta::pure::functions::relation::_range(2)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].window_frame_legend_ext(frame.range_between(4, 2), order_by="i").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 0), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 0), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, -1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, -1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(0, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(0, None), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, None), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, None), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-2, -1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-2, -1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-2, -1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-2, -1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NFollowing_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(2)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, 2), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NFollowing_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(2)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, 2), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_ExplicitOffsets_WithNullValues_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_ExplicitOffsets_WithNullValues_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_UnboundedPreceding_NFollowing_WithNullValues_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_NPreceding_UnboundedFollowing_WithNullValues_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_WithNumbers_CurrentRow_NFollowing_WithoutPartition_WithSingleOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'menu_category,menu_cogs_usd\n'+
+                  'Beverage,0.5\n'+
+                  'Beverage,0.65\n'+
+                  'Beverage,0.75\n'+
+                  'Dessert,0.50\n'+
+                  'Dessert,1.00\n'+
+                  'Dessert,1.25\n'+
+                  'Dessert,2.50\n'+
+                  'Dessert,3.00\n'+
+                  'Snack,1.25\n'+
+                  'Snack,2.25\n'+
+                  'Snack,4.00}#->meta::pure::functions::relation::extend(~menu_cogs_usd->meta::pure::functions::relation::ascending()->meta::pure::functions::relation::over(0->meta::pure::functions::relation::_range(2.1)), ~sum_cogs:{p: meta::pure::metamodel::relation::Relation<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], w: meta::pure::functions::relation::_Window<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], r: (menu_category:String[0..1], menu_cogs_usd:Float[0..1])[1]|$r.menu_cogs_usd}:y: Float[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_cogs", frame["menu_cogs_usd"].window_frame_legend_ext(frame.range_between(0, 2.1), order_by="menu_cogs_usd").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nmenu_category,menu_cogs_usd\\nBeverage,0.5\\nBeverage,0.65\\nBeverage,0.75\\nDessert,0.50\\nDessert,1.00\\nDessert,1.25\\nDessert,2.50\\nDessert,3.00\\nSnack,1.25\\nSnack,2.25\\nSnack,4.00"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRange_WithNumbers_NFollowing_NFollowing_WithoutPartition_WithSingleOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'menu_category,menu_cogs_usd\n'+
+                  'Beverage,0.5\n'+
+                  'Beverage,0.65\n'+
+                  'Beverage,0.75\n'+
+                  'Dessert,0.50\n'+
+                  'Dessert,1.00\n'+
+                  'Dessert,1.25\n'+
+                  'Dessert,2.50\n'+
+                  'Dessert,3.00\n'+
+                  'Snack,1.25\n'+
+                  'Snack,2.25\n'+
+                  'Snack,4.00}#->meta::pure::functions::relation::extend(~menu_cogs_usd->meta::pure::functions::relation::ascending()->meta::pure::functions::relation::over(0.5D->meta::pure::functions::relation::_range(2.5)), ~sum_cogs:{p: meta::pure::metamodel::relation::Relation<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], w: meta::pure::functions::relation::_Window<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], r: (menu_category:String[0..1], menu_cogs_usd:Float[0..1])[1]|$r.menu_cogs_usd}:y: Float[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_cogs", frame["menu_cogs_usd"].window_frame_legend_ext(frame.range_between(PythonDecimal("0.5"), PythonDecimal("2.5")), order_by="menu_cogs_usd").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nmenu_category,menu_cogs_usd\\nBeverage,0.5\\nBeverage,0.65\\nBeverage,0.75\\nDessert,0.50\\nDessert,1.00\\nDessert,1.25\\nDessert,2.50\\nDessert,3.00\\nSnack,1.25\\nSnack,2.25\\nSnack,4.00"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=0, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=0, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=-1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=-1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-2, meta::pure::functions::date::DurationUnit.DAYS, -1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-2, duration_start_unit="DAYS", duration_end=-1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-2, meta::pure::functions::date::DurationUnit.DAYS, -1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-2, duration_start_unit="DAYS", duration_end=-1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NFollowing_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 2, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end=2, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NFollowing_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 2, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end=2, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NFollowing_NFollowing_WithDifferentDurationUnits_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.SECONDS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="SECONDS", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::over::testRangeInterval_NFollowing_NFollowing_WithDifferentDurationUnits_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.SECONDS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="SECONDS", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      )
+    ]->combine(),
+
+    // ============================================================
+    // /core_functions_relation/relation/functions/olap/reduce.pure
+    // ============================================================
+
+    [
+      meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_CurrentRow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].expanding(order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_CurrentRow_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 0->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(0, None), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_NPreceding_NPreceding_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-2, -1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(-2, -1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_NPreceding_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-1, 1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(-1, 1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_NFollowing_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 1->meta::pure::functions::relation::rows(2)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(1, 2), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_NPreceding_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(-1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(None, -1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(None, 1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_NPreceding_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-1, meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(-1, None), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_NFollowing_UnboundedFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 1->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(1, None), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_CurrentRow_CurrentRow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 0->meta::pure::functions::relation::rows(0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].rolling(window=1, order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_NPreceding_CurrentRow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], meta::pure::functions::relation::rows(-1, 0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].rolling(window=2, order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_CurrentRow_NFollowing_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over([~o->meta::pure::functions::relation::ascending(), ~i->meta::pure::functions::relation::ascending()], 0->meta::pure::functions::relation::rows(1)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between(0, 1), order_by=["o", "i"]).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_UnboundedFollowing_WithSinglePartition_WithoutOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby("p")["i"].window_frame_legend_ext(frame.rows_between()).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_UnboundedFollowing_WithMultiplePartitions_WithoutOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(meta::pure::functions::relation::unbounded())), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].window_frame_legend_ext(frame.rows_between()).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_CurrentRow_WithMultiplePartitions_WithSingleOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(~i->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::rows(0)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].expanding(order_by="i").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRows_InvalidWindowFrameBoundary_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(~i->meta::pure::functions::relation::ascending(), 4->meta::pure::functions::relation::rows(2)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].window_frame_legend_ext(frame.rows_between(4, 2), order_by="i").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_InvalidWindowFrameBoundary_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,2,20\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,30\n'+
+                  '100,2,5\n'+
+                  '100,3,11\n'+
+                  '100,3,120\n'+
+                  '200,1,10000\n'+
+                  '200,1,200\n'+
+                  '200,1,808080\n'+
+                  '200,2,33333\n'+
+                  '200,3,0\n'+
+                  '200,3,4\n'+
+                  '300,1,0\n'+
+                  '300,2,0}#->meta::pure::functions::relation::extend(~[p,o]->meta::pure::functions::relation::over(~i->meta::pure::functions::relation::ascending(), 4->meta::pure::functions::relation::_range(2)), ~sum_i_Rows:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_i_Rows", frame.groupby(["p", "o"])["i"].window_frame_legend_ext(frame.range_between(4, 2), order_by="i").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,2,20\\n0,3,30\\n100,1,10\\n100,2,30\\n100,2,5\\n100,3,11\\n100,3,120\\n200,1,10000\\n200,1,200\\n200,1,808080\\n200,2,33333\\n200,3,0\\n200,3,4\\n300,1,0\\n300,2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 0), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 0), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, -1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, -1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(0, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(0, None), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, None), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, None), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-2, -1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-2, -1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-2, -1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-2, -1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NFollowing_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(2)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, 2), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NFollowing_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,3,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,2,20\n'+
+                  '100,3,30\n'+
+                  '100,3,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,2,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(2)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(1, 2), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,3,30\\n100,1,10\\n100,2,20\\n100,2,20\\n100,3,30\\n100,3,30\\n200,1,10\\n200,1,10\\n200,1,10\\n200,2,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_ExplicitOffsets_WithNullValues_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_ExplicitOffsets_WithNullValues_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, 1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_UnboundedPreceding_NFollowing_WithNullValues_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(None, 1), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_NPreceding_UnboundedFollowing_WithNullValues_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(-1, None), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_WithNumbers_CurrentRow_NFollowing_WithoutPartition_WithSingleOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'menu_category,menu_cogs_usd\n'+
+                  'Beverage,0.5\n'+
+                  'Beverage,0.65\n'+
+                  'Beverage,0.75\n'+
+                  'Dessert,0.50\n'+
+                  'Dessert,1.00\n'+
+                  'Dessert,1.25\n'+
+                  'Dessert,2.50\n'+
+                  'Dessert,3.00\n'+
+                  'Snack,1.25\n'+
+                  'Snack,2.25\n'+
+                  'Snack,4.00}#->meta::pure::functions::relation::extend(~menu_cogs_usd->meta::pure::functions::relation::ascending()->meta::pure::functions::relation::over(0->meta::pure::functions::relation::_range(2.1)), ~sum_cogs:{p: meta::pure::metamodel::relation::Relation<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], w: meta::pure::functions::relation::_Window<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], r: (menu_category:String[0..1], menu_cogs_usd:Float[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (menu_category:String[0..1], menu_cogs_usd:Float[0..1])[1]|$r.menu_cogs_usd, y: Float[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_cogs", frame["menu_cogs_usd"].window_frame_legend_ext(frame.range_between(0, 2.1), order_by="menu_cogs_usd").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nmenu_category,menu_cogs_usd\\nBeverage,0.5\\nBeverage,0.65\\nBeverage,0.75\\nDessert,0.50\\nDessert,1.00\\nDessert,1.25\\nDessert,2.50\\nDessert,3.00\\nSnack,1.25\\nSnack,2.25\\nSnack,4.00"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRange_WithNumbers_NFollowing_NFollowing_WithoutPartition_WithSingleOrderBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'menu_category,menu_cogs_usd\n'+
+                  'Beverage,0.5\n'+
+                  'Beverage,0.65\n'+
+                  'Beverage,0.75\n'+
+                  'Dessert,0.50\n'+
+                  'Dessert,1.00\n'+
+                  'Dessert,1.25\n'+
+                  'Dessert,2.50\n'+
+                  'Dessert,3.00\n'+
+                  'Snack,1.25\n'+
+                  'Snack,2.25\n'+
+                  'Snack,4.00}#->meta::pure::functions::relation::extend(~menu_cogs_usd->meta::pure::functions::relation::ascending()->meta::pure::functions::relation::over(0.5D->meta::pure::functions::relation::_range(2.5)), ~sum_cogs:{p: meta::pure::metamodel::relation::Relation<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], w: meta::pure::functions::relation::_Window<(menu_category:String[0..1], menu_cogs_usd:Float[0..1])>[1], r: (menu_category:String[0..1], menu_cogs_usd:Float[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (menu_category:String[0..1], menu_cogs_usd:Float[0..1])[1]|$r.menu_cogs_usd, y: Float[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("sum_cogs", frame["menu_cogs_usd"].window_frame_legend_ext(frame.range_between(PythonDecimal("0.5"), PythonDecimal("2.5")), order_by="menu_cogs_usd").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\nmenu_category,menu_cogs_usd\\nBeverage,0.5\\nBeverage,0.65\\nBeverage,0.75\\nDessert,0.50\\nDessert,1.00\\nDessert,1.25\\nDessert,2.50\\nDessert,3.00\\nSnack,1.25\\nSnack,2.25\\nSnack,4.00"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=0, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_UnboundedPreceding_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=0, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=-1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_UnboundedPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=-1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_UnboundedPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::unbounded()->meta::pure::functions::relation::_range(1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start="unbounded", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NFollowing_UnboundedFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, meta::pure::functions::relation::unbounded())), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end="unbounded"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 0, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=0, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 0->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=0, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_NPreceding_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-2, meta::pure::functions::date::DurationUnit.DAYS, -1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-2, duration_start_unit="DAYS", duration_end=-1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_NPreceding_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-2, meta::pure::functions::date::DurationUnit.DAYS, -1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-2, duration_start_unit="DAYS", duration_end=-1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NPreceding_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), meta::pure::functions::relation::_range(-1, meta::pure::functions::date::DurationUnit.DAYS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=-1, duration_start_unit="DAYS", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NFollowing_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 2, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end=2, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NFollowing_NFollowing_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.DAYS, 2, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="DAYS", duration_end=2, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NFollowing_NFollowing_WithDifferentDurationUnits_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::ascending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.SECONDS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="SECONDS", duration_end=1, duration_end_unit="DAYS"), order_by="o").sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::reduce::testRangeInterval_NFollowing_NFollowing_WithDifferentDurationUnits_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '0,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '100,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '200,2024-01-30T00:32:34.000000000+0000,20\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '200,2024-01-31T00:32:34.000000000+0000,30\n'+
+                  '300,2024-01-29T00:32:34.000000000+0000,10\n'+
+                  '300,2024-01-30T00:32:34.000000000+0000,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(~o->meta::pure::functions::relation::descending(), 1->meta::pure::functions::relation::_range(meta::pure::functions::date::DurationUnit.SECONDS, 1, meta::pure::functions::date::DurationUnit.DAYS)), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Date[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$p->meta::pure::functions::relation::reduce($w, $r, r: (p:Integer[0..1], o:Date[0..1], i:Integer[0..1])[1]|$r.i, y: Integer[*]|$y->plus())})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("p")["i"].window_frame_legend_ext(frame.range_between(duration_start=1, duration_start_unit="SECONDS", duration_end=1, duration_end_unit="DAYS"), order_by="o", ascending=False).sum())' +
+               '  or frame' +
+               ')(csv_frame("\\np,o,i\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-29T00:32:34.000000000+0000,10\\n0,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-29T00:32:34.000000000+0000,10\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-30T00:32:34.000000000+0000,20\\n100,2024-01-31T00:32:34.000000000+0000,30\\n100,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-29T00:32:34.000000000+0000,10\\n200,2024-01-30T00:32:34.000000000+0000,20\\n200,2024-01-31T00:32:34.000000000+0000,30\\n200,2024-01-31T00:32:34.000000000+0000,30\\n300,2024-01-29T00:32:34.000000000+0000,10\\n300,2024-01-30T00:32:34.000000000+0000,20"))')
+        ]
+      )
+    ]->combine(),
+
+
+
+    // ============================================================
+    // /core_functions_relation/relation/functions/transformation/aggregate.pure
+    // ============================================================
+
+    [
+      meta::pure::functions::relation::tests::aggregate::testSimpleAggregate_AggColSpec_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C}#->meta::pure::functions::relation::aggregate(~idSum:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.id:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.rename({"id":"idSum"})[["idSum"]].sum()' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::aggregate::testSimpleAggregate_AggColSpecArray_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,code\n'+
+                  '1,2,A\n'+
+                  '2,1,A\n'+
+                  '3,3,A}#->meta::pure::functions::relation::aggregate(~[idSum:x: (id:Integer[0..1], grp:Integer[0..1], code:String[0..1])[1]|$x.id:y: Integer[*]|$y->plus(),codes:x: (id:Integer[0..1], grp:Integer[0..1], code:String[0..1])[1]|$x.code:y: String[*]|$y->meta::pure::functions::string::joinStrings(\':\')])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.aggregate({"id": "sum", "code": lambda x: x.join(":")}).rename({"id": "idSum", "code": "codes"})' +
+               ')(csv_frame("\\nid,grp,code\\n1,2,A\\n2,1,A\\n3,3,A"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::aggregate::testSimpleAggregate_WithFilter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C}#->meta::pure::functions::relation::aggregate(~idSum:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.id:y: Integer[*]|$y->plus())->meta::pure::functions::relation::filter(r: (idSum:Integer[1])[1]|$r.idSum == 6)'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda r: r[r["idSum"] == 6])(frame.rename({"id": "idSum"}).aggregate({"idSum": "sum"}))' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C"))')
+        ]
+      )
+    ]->combine(),
+
+
+
+    // ============================================================
+    // /core_functions_relation/relation/functions/transformation/groupBy.pure
+    // ============================================================
+
+    [
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleSingle_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::groupBy(~grp, ~newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["name"]].agg(lambda x: x.join("")).rename({"name": "newCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleSingle_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::groupBy(~grp, ~newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'));\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["name"]].agg(lambda x: x.join("")).rename({"name": "newCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleSingle_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::groupBy(~[grp], ~newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["name"]].agg(lambda x: x.join("")).rename({"name": "newCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleSingle_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::groupBy(~[grp], ~newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'));\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["name"]].agg(lambda x: x.join("")).rename({"name": "newCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleMultiple_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::groupBy(~grp, ~[newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),YoCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.id:y: Integer[*]|$y->plus()])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["name", "id"]].agg({"name": lambda x: x.join(""), "id": "sum"}).rename({"name": "newCol", "id": "YoCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleMultiple_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::groupBy(~grp, ~[newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),YoCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.id:y: Integer[*]|$y->plus()]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["name", "id"]].agg({"name": lambda x: x.join(""), "id": "sum"}).rename({"name": "newCol", "id": "YoCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleMultiple_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::sort(~name->meta::pure::functions::relation::ascending())->meta::pure::functions::relation::groupBy(~[grp], ~[newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),YoCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.id:y: Integer[*]|$y->plus()])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.sort_values(by="name").groupby("grp", sort=False)[["name", "id"]].agg({"name": lambda x: x.join(""), "id": "sum"}).rename({"name": "newCol", "id": "YoCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleMultiple_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let t = #TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#;\n'+
+                  ' $t->meta::pure::functions::relation::groupBy(~[grp], ~[newCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.name:y: String[*]|$y->meta::pure::functions::string::joinStrings(\'\'),YoCol:x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$x.id:y: Integer[*]|$y->plus()]);\n'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["name", "id"]].agg({"name": lambda x: x.join(""), "id": "sum"}).rename({"name": "newCol", "id": "YoCol"})' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      )
+    ]->combine(),
+
+
+    // ============================================================
+    // /core_functions_relation/relation/functions/slice/
+    // ============================================================
+
+    [
+      meta::pure::functions::relation::tests::first::testOLAPWithPartitionAndOrderFirstWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("other", frame.groupby("grp").window_frame_legend_ext(frame.rows_between(None, None), order_by="id", ascending=False)["name"].first())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      )
+    ]->combine(),
+
+    [
+      meta::pure::functions::relation::tests::lag::testOLAPWithPartitionAndOrderWindowUsingLag_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lag($r).name})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(frame.rows_between(None, None), order_by="id", ascending=False)["name"].shift())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      )
+    ]->combine(),
+
+    [
+      meta::pure::functions::relation::tests::last::testOLAPWithPartitionAndOrderLastWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::last($w, $r).id})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].last())' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      )
+    ]->combine(),
+
+    [
+      meta::pure::functions::relation::tests::lead::testOLAPWithPartitionAndOrderWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(frame.rows_between(None, None), order_by="id", ascending=False)["id"].shift(-1))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      )
+    ]->combine(),
+
+    [
+      meta::pure::functions::relation::tests::nth::testOLAPWithPartitionAndOrderNthWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::nth($w, $r, 1).id})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].window_func_legend_ext(lambda p,w,r: p.nth(w,r,1)["id"]))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::nth::testOLAPWithPartitionAndOrderNthWindow2_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::nth($w, $r, 2).id})'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].window_func_legend_ext(lambda p,w,r: p.nth(w,r,2)["id"]))' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      )
+    ]->combine(),
+
+
+
+    // ============================================================
+    // composition
+    // ============================================================
+
+
+    [
+      meta::pure::functions::relation::tests::composition::testExtendFilter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str\n'+
+                  '1,a\n'+
+                  '3,ewe\n'+
+                  '4,qw\n'+
+                  '5,wwe\n'+
+                  '6,weq}#->meta::pure::functions::relation::extend(~newCol:x: (val:Integer[0..1], str:String[0..1])[1]|$x.str->meta::pure::functions::multiplicity::toOne() + $x.val->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString())->meta::pure::functions::relation::filter(x: (val:Integer[0..1], str:String[0..1], newCol:String[1])[1]|$x.newCol == \'qw4\')'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame["str"] + frame["val"].to_string())' +
+               '  or frame[frame["newCol"] == "qw4"]' +
+               ')(csv_frame("\\nval,str\\n1,a\\n3,ewe\\n4,qw\\n5,wwe\\n6,weq"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_Distinct_GroupBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str,str2\n'+
+                  '2,a,b\n'+
+                  '3,a,b\n'+
+                  '4,qw,b\n'+
+                  '5,qw,c\n'+
+                  '2,weq,c}#->meta::pure::functions::relation::distinct(~[val,str])->meta::pure::functions::relation::groupBy(~str, ~newCol:x: (val:Integer[0..1], str:String[0..1])[1]|$x.val:x: Integer[*]|$x->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.drop_duplicates(["val", "str"]).groupby("str").agg({"val": "sum"}).rename({"val": "newCol"})' +
+               ')(csv_frame("\\nval,str,str2\\n2,a,b\\n3,a,b\\n4,qw,b\\n5,qw,c\\n2,weq,c"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_Distinct_Filter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str,str2\n'+
+                  '2,a,b\n'+
+                  '3,a,b\n'+
+                  '4,qw,b\n'+
+                  '5,qw,c\n'+
+                  '2,weq,c}#->meta::pure::functions::relation::distinct(~[val,str])->meta::pure::functions::relation::filter(x: (val:Integer[0..1], str:String[0..1])[1]|$x.val > 2)'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    frame[frame["val"] > 2]' +
+               '  )(frame.drop_duplicates(["val", "str"]))' +
+               ')(csv_frame("\\nval,str,str2\\n2,a,b\\n3,a,b\\n4,qw,b\\n5,qw,c\\n2,weq,c"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_GroupBy_GroupBy_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str,str2\n'+
+                  '2,a,b\n'+
+                  '3,a,b\n'+
+                  '4,qw,b\n'+
+                  '5,qw,c\n'+
+                  '2,weq,c}#->meta::pure::functions::relation::groupBy(~[str,str2], ~newCol:x: (val:Integer[0..1], str:String[0..1], str2:String[0..1])[1]|$x.val:x: Integer[*]|$x->plus())->meta::pure::functions::relation::groupBy(~[str], ~newCol2:x: (str:String[0..1], str2:String[0..1], newCol:Integer[1])[1]|$x.newCol:x: Integer[*]|$x->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    frame.groupby("str", sort=False)[["newCol"]].sum().rename({"newCol": "newCol2"})' +
+               '  )( frame.groupby(["str","str2"], sort=False)[["val"]].sum().rename({"val": "newCol"}) )' +
+               ')(csv_frame("\\nval,str,str2\\n2,a,b\\n3,a,b\\n4,qw,b\\n5,qw,c\\n2,weq,c"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_GroupBy_Distinct_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str,str2\n'+
+                  '2,a,b\n'+
+                  '3,a,b\n'+
+                  '4,qw,b\n'+
+                  '5,qw,c\n'+
+                  '2,weq,c}#->meta::pure::functions::relation::groupBy(~[str,str2], ~newCol:x: (val:Integer[0..1], str:String[0..1], str2:String[0..1])[1]|$x.val:x: Integer[*]|$x->plus())->meta::pure::functions::relation::distinct(~[str])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby(["str","str2"], sort=False)[["val"]].sum().rename({"val": "newCol"}).drop_duplicates("str")' +
+               ')(csv_frame("\\nval,str,str2\\n2,a,b\\n3,a,b\\n4,qw,b\\n5,qw,c\\n2,weq,c"))')
+        ]
+      ),
+
+      // meta::pure::functions::relation::tests::composition::test_Pivot_Filter_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|#TDS{\n'+
+      //             'city,country,year,treePlanted\n'+
+      //             'NYC,USA,2011,5000\n'+
+      //             'NYC,USA,2000,5000\n'+
+      //             'SAN,USA,2000,2000\n'+
+      //             'SAN,USA,2011,100\n'+
+      //             'LDN,UK,2011,3000\n'+
+      //             'SAN,USA,2011,2500\n'+
+      //             'NYC,USA,2000,10000\n'+
+      //             'NYC,USA,2012,7600\n'+
+      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:y: Integer[*]|$y->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.city == \'NYC\')'+
+      //             '',
+      //          '(lambda frame:' +
+      //          '  frame' +
+      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_ComplexGroupBy_Pivot_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|#TDS{\n'+
+      //             'city,country,year,treePlanted\n'+
+      //             'NYC,USA,2011,5000\n'+
+      //             'NYC,USA,2000,5000\n'+
+      //             'SAN,USA,2000,2000\n'+
+      //             'SAN,USA,2011,100\n'+
+      //             'LDN,UK,2011,3000\n'+
+      //             'SAN,USA,2011,2500\n'+
+      //             'NYC,USA,2000,10000\n'+
+      //             'NYC,USA,2012,7600\n'+
+      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::extend(~yr:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year->meta::pure::functions::multiplicity::toOne() - 2000)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1], yr:Integer[1])[1]|$x.yr > 10)->meta::pure::functions::relation::select(~[city,country,year,treePlanted])->meta::pure::functions::relation::groupBy(~[city,country], ~[year:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year:x: Integer[*]|$x->plus(),treePlanted:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:x: Integer[*]|$x->plus()])->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (city:String[0..1], country:String[0..1], year:Integer[1], treePlanted:Integer[1])[1]|$x.treePlanted:x: Integer[*]|$x->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'4022__|__newCol\\'\':Integer[0..1], \'\\'6035__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::sort(~city->meta::pure::functions::relation::ascending())'+
+      //             '',
+      //          '(lambda frame:' +
+      //          '  frame' +
+      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_GroupBy_Pivot_Extend_Sort_Limit_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|#TDS{\n'+
+      //             'city,country,year,treePlanted\n'+
+      //             'NYC,USA,2011,5000\n'+
+      //             'NYC,USA,2000,5000\n'+
+      //             'SAN,USA,2000,2000\n'+
+      //             'SAN,USA,2011,100\n'+
+      //             'LDN,UK,2011,3000\n'+
+      //             'SAN,USA,2011,2500\n'+
+      //             'NYC,USA,2000,10000\n'+
+      //             'NYC,USA,2012,7600\n'+
+      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::extend(~yr:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year->meta::pure::functions::multiplicity::toOne() - 2000)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1], yr:Integer[1])[1]|$x.yr > 10)->meta::pure::functions::relation::select(~[city,country,year,treePlanted])->meta::pure::functions::relation::groupBy(~[year,city,country], ~treePlanted:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:x: Integer[*]|$x->plus())->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (year:Integer[0..1], city:String[0..1], country:String[0..1], treePlanted:Integer[1])[1]|$x.treePlanted:y: Integer[*]|$y->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::extend(~newCol:x: (city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.city->meta::pure::functions::multiplicity::toOne() + \'_0\')->meta::pure::functions::relation::sort(~city->meta::pure::functions::relation::ascending())->meta::pure::functions::relation::limit(3)'+
+      //             '',
+      //          '(lambda frame:' +
+      //          '  frame' +
+      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_Pivot_GroupBy_Extend_Sort_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|#TDS{\n'+
+      //             'city,country,year,treePlanted\n'+
+      //             'NYC,USA,2011,5000\n'+
+      //             'NYC,USA,2000,5000\n'+
+      //             'SAN,USA,2000,2000\n'+
+      //             'SAN,USA,2011,100\n'+
+      //             'LDN,UK,2011,3000\n'+
+      //             'SAN,USA,2011,2500\n'+
+      //             'NYC,USA,2000,10000\n'+
+      //             'NYC,USA,2012,7600\n'+
+      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::extend(~yr:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year->meta::pure::functions::multiplicity::toOne() - 2000)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1], yr:Integer[1])[1]|$x.yr > 10)->meta::pure::functions::relation::select(~[city,country,year,treePlanted])->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:x: Integer[*]|$x->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::groupBy(~[country], ~[\'\\'2011__|__newCol\\'\':x: (city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.\'\\'2011__|__newCol\\'\':x: Integer[*]|$x->plus(),\'\\'2012__|__newCol\\'\':x: (city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.\'\\'2012__|__newCol\\'\':x: Integer[*]|$x->plus()])->meta::pure::functions::relation::extend(~newCol:x: (country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[1], \'\\'2012__|__newCol\\'\':Integer[1])[1]|$x.country->meta::pure::functions::multiplicity::toOne() + \'_0\')->meta::pure::functions::relation::sort(~country->meta::pure::functions::relation::ascending())'+
+      //             '',
+      //          '(lambda frame:' +
+      //          '  frame' +
+      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
+      //   ]
+      // ),
+
+      meta::pure::functions::relation::tests::composition::test_GroupBy_Filter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str\n'+
+                  '2,a\n'+
+                  '3,a\n'+
+                  '4,qw\n'+
+                  '5,qw\n'+
+                  '2,weq}#->meta::pure::functions::relation::groupBy(~str, ~newCol:x: (val:Integer[0..1], str:String[0..1])[1]|$x.val:x: Integer[*]|$x->plus())->meta::pure::functions::relation::filter(x: (str:String[0..1], newCol:Integer[1])[1]|$x.newCol > 4)'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    frame[frame["newCol"] > 4]' +
+               '  )( frame.groupby("str", sort=False)[["val"]].sum().rename({"val": "newCol"}) )' +
+               ')(csv_frame("\\nval,str\\n2,a\\n3,a\\n4,qw\\n5,qw\\n2,weq"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_GroupBy_Distinct_Filter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str,str2\n'+
+                  '2,a,b\n'+
+                  '2,a,b\n'+
+                  '4,qw,b\n'+
+                  '5,qw,c\n'+
+                  '2,weq,c}#->meta::pure::functions::relation::groupBy(~[str,str2], ~newCol:x: (val:Integer[0..1], str:String[0..1], str2:String[0..1])[1]|$x.val:x: Integer[*]|$x->plus())->meta::pure::functions::relation::distinct(~[str,newCol])->meta::pure::functions::relation::filter(x: (str:String[0..1], newCol:Integer[1])[1]|$x.newCol > 2)'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    frame[frame["newCol"] > 2]' +
+               '  )( frame.groupby(["str", "str2"], sort=False)[["val"]].sum().rename({"val": "newCol"}).drop_duplicates(["str","newCol"]) )' +
+               ')(csv_frame("\\nval,str,str2\\n2,a,b\\n2,a,b\\n4,qw,b\\n5,qw,c\\n2,weq,c"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_Distinct_GroupBy_Filter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,str,str2\n'+
+                  '2,a,b\n'+
+                  '2,a,b\n'+
+                  '4,qw,b\n'+
+                  '5,qw,c\n'+
+                  '2,weq,c}#->meta::pure::functions::relation::distinct()->meta::pure::functions::relation::groupBy(~[str], ~newCol:x: (val:Integer[0..1], str:String[0..1], str2:String[0..1])[1]|$x.val:x: Integer[*]|$x->plus())->meta::pure::functions::relation::filter(x: (str:String[0..1], newCol:Integer[1])[1]|$x.newCol > 2)'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    frame[frame["newCol"] > 2]' +
+               '  )( frame.drop_duplicates().groupby("str", sort=False)[["val"]].sum().rename({"val": "newCol"}) )' +
+               ')(csv_frame("\\nval,str,str2\\n2,a,b\\n2,a,b\\n4,qw,b\\n5,qw,c\\n2,weq,c"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testGroupByCastBeforeAgg_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp\n'+
+                  '1,2\n'+
+                  '2,1\n'+
+                  '3,3\n'+
+                  '4,4\n'+
+                  '5,2\n'+
+                  '6,1\n'+
+                  '7,3\n'+
+                  '8,1\n'+
+                  '9,5\n'+
+                  '10,0}#->meta::pure::functions::relation::groupBy(~grp, ~newCol:x: (id:Integer[0..1], grp:Integer[0..1])[1]|$x.id:x: Integer[*]|+($x->meta::pure::functions::lang::cast(@Integer)))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.cast({"id": PrimitiveType.Integer}).groupby("grp", sort=False)[["id"]].sum().rename({"id": "newCol"})' +
+               ')(csv_frame("\\nid,grp\\n1,2\\n2,1\\n3,3\\n4,4\\n5,2\\n6,1\\n7,3\\n8,1\\n9,5\\n10,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testGroupByCastAfterAgg_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp\n'+
+                  '1,2\n'+
+                  '2,1\n'+
+                  '3,3\n'+
+                  '4,4\n'+
+                  '5,2\n'+
+                  '6,1\n'+
+                  '7,3\n'+
+                  '8,1\n'+
+                  '9,5\n'+
+                  '10,0}#->meta::pure::functions::relation::groupBy(~grp, ~newCol:x: (id:Integer[0..1], grp:Integer[0..1])[1]|$x.id:x: Integer[*]|meta::pure::functions::lang::cast($x->plus(), @Integer))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", as_index=False)[["id"]].sum().rename({"id": "newCol"})' +
+               ')(csv_frame("\\nid,grp\\n1,2\\n2,1\\n3,3\\n4,4\\n5,2\\n6,1\\n7,3\\n8,1\\n9,5\\n10,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testOLAPCastAggWithPartitionWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|meta::pure::functions::lang::cast($y->plus(), @Integer))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["id"].sum() )' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testOLAPAggCastWithPartitionWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|+($y->meta::pure::functions::lang::cast(@Integer)))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["id"].sum() )' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testOLAPCastExtractAggWithPartitionWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id->meta::pure::functions::lang::cast(@Integer)}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["id"].sum() )' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testOLAPCastExtractCastAggWithPartitionWindow_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id->meta::pure::functions::lang::cast(@Integer)}:y: Integer[*]|meta::pure::functions::lang::cast($y->plus(), @Integer))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["id"].sum() )' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testExtendWindowFilter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,B\n'+
+                  '3,3,C\n'+
+                  '4,4,D\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,H\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.id}:y: Integer[*]|$y->plus())->meta::pure::functions::relation::filter(x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], newCol:Integer[1])[1]|($x.newCol > 9) && ($x.grp == 1))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["id"].sum() )' +
+               '  or frame[(frame["newCol"] > 9) & (frame["grp"] == 1)]' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testGroupByFilterExtendFilter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,rank\n'+
+                  '1,A,1\n'+
+                  '2,A,1\n'+
+                  '3,B,2\n'+
+                  '4,D,3\n'+
+                  '5,B,2\n'+
+                  '6,A,1\n'+
+                  '7,C,4\n'+
+                  '8,A,2\n'+
+                  '9,C,3\n'+
+                  '10,D,1}#->meta::pure::functions::relation::groupBy(~[grp,rank], ~sumId:x: (id:Integer[0..1], grp:String[0..1], rank:Integer[0..1])[1]|$x.id:x: Integer[*]|$x->plus())->meta::pure::functions::relation::filter(x: (grp:String[0..1], rank:Integer[0..1], sumId:Integer[1])[1]|$x.rank <= 2)->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~sumRank:{p: meta::pure::metamodel::relation::Relation<(grp:String[0..1], rank:Integer[0..1], sumId:Integer[1])>[1], w: meta::pure::functions::relation::_Window<(grp:String[0..1], rank:Integer[0..1], sumId:Integer[1])>[1], r: (grp:String[0..1], rank:Integer[0..1], sumId:Integer[1])[1]|$r.rank}:y: Integer[*]|$y->plus())->meta::pure::functions::relation::filter(x: (grp:String[0..1], rank:Integer[0..1], sumId:Integer[1], sumRank:Integer[1])[1]|$x.sumRank == 3)'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    (lambda frame:' +
+               '      frame.__setitem__( "sumRank", frame.groupby("grp", sort=False)["rank"].sum() )' +
+               '      or frame[frame["sumRank"] == 3]' +
+               '    )(frame[frame["rank"] <= 2])' +
+               '  )(frame.groupby(["grp","rank"], sort=False)[["id"]].sum().rename({"id": "sumId"}))' +
+               ')(csv_frame("\\nid,grp,rank\\n1,A,1\\n2,A,1\\n3,B,2\\n4,D,3\\n5,B,2\\n6,A,1\\n7,C,4\\n8,A,2\\n9,C,3\\n10,D,1"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testMixColumnNamesRenameFilter_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'colOneNum,Col_two_letter,_col_3Mix\n'+
+                  '1,A,1\n'+
+                  '2,A,1\n'+
+                  '3,B,2\n'+
+                  '4,D,3\n'+
+                  '5,B,2\n'+
+                  '6,A,1\n'+
+                  '7,C,4\n'+
+                  '8,A,2\n'+
+                  '9,C,3\n'+
+                  '10,D,1}#->meta::pure::functions::relation::rename(~colOneNum, ~_col_one_num)->meta::pure::functions::relation::rename(~Col_two_letter, ~colTwoLetter)->meta::pure::functions::relation::rename(~_col_3Mix, ~Col_3mix)->meta::pure::functions::relation::rename(~Col_3mix, ~Col_3mix_)->meta::pure::functions::relation::rename(~Col_3mix_, ~_Col_3mix_)->meta::pure::functions::relation::filter(x: (_col_one_num:Integer[0..1], colTwoLetter:String[0..1], _Col_3mix_:Integer[0..1])[1]|(($x._col_one_num > 2) && ($x.colTwoLetter == \'C\')) && ($x._Col_3mix_ == 3))'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    frame[(frame["_col_one_num"] > 2) & (frame["colTwoLetter"] == "C") & (frame["_Col_3mix_"] == 3)]' +
+               '  )( frame.rename({"colOneNum":"_col_one_num","Col_two_letter":"colTwoLetter","_col_3Mix":"_Col_3mix_"}) )' +
+               ')(csv_frame("\\ncolOneNum,Col_two_letter,_col_3Mix\\n1,A,1\\n2,A,1\\n3,B,2\\n4,D,3\\n5,B,2\\n6,A,1\\n7,C,4\\n8,A,2\\n9,C,3\\n10,D,1"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testMixColumnNamesRenameExtend_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'colOneNum,_Col_two_letter,col_3Mix\n'+
+                  '1,A,1\n'+
+                  '2,A,1\n'+
+                  '3,B,2\n'+
+                  '4,D,3\n'+
+                  '5,B,2\n'+
+                  '6,A,1\n'+
+                  '7,C,4\n'+
+                  '8,A,2\n'+
+                  '9,C,3\n'+
+                  '10,D,1}#->meta::pure::functions::relation::rename(~colOneNum, ~col_one_num)->meta::pure::functions::relation::rename(~_Col_two_letter, ~colTwoLetter)->meta::pure::functions::relation::rename(~col_3Mix, ~_Col_3mix)->meta::pure::functions::relation::extend(~newCol:c: (col_one_num:Integer[0..1], colTwoLetter:String[0..1], _Col_3mix:Integer[0..1])[1]|$c.col_one_num->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString() + $c.colTwoLetter->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString() + $c._Col_3mix->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString())->meta::pure::functions::relation::rename(~newCol, ~_new_col)->meta::pure::functions::relation::filter(x: (col_one_num:Integer[0..1], colTwoLetter:String[0..1], _Col_3mix:Integer[0..1], _new_col:String[0..1])[1]|$x._new_col->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString()->meta::pure::functions::string::contains(\'A\'))->meta::pure::functions::relation::rename(~_new_col, ~Result)->meta::pure::functions::relation::select(~[col_one_num,colTwoLetter,Result])'+
+                  '',
+               '(lambda frame:' +
+               '  (lambda frame:' +
+               '    frame.__setitem__( "_new_col", frame["col_one_num"].to_string() + frame["colTwoLetter"].to_string() + frame["_Col_3mix"].to_string() )' +
+               '    or frame[frame["_new_col"].contains("A")]' +
+               '      .rename({"_new_col": "Result"})' +
+               '      [["col_one_num","colTwoLetter","Result"]]' +
+               '  )( frame.rename(columns={"colOneNum":"col_one_num","_Col_two_letter":"colTwoLetter","col_3Mix":"_Col_3mix"}) )' +
+               ')(csv_frame("\\ncolOneNum,_Col_two_letter,col_3Mix\\n1,A,1\\n2,A,1\\n3,B,2\\n4,D,3\\n5,B,2\\n6,A,1\\n7,C,4\\n8,A,2\\n9,C,3\\n10,D,1"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testExtendJoinStringOnNull_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp,name\n'+
+                  '1,2,A\n'+
+                  '2,1,null\n'+
+                  '3,3,C\n'+
+                  '4,4,V\n'+
+                  '5,2,E\n'+
+                  '6,1,F\n'+
+                  '7,3,G\n'+
+                  '8,1,null\n'+
+                  '9,5,I\n'+
+                  '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$r.name}:y: String[*]|$y->meta::pure::functions::string::joinStrings(\':\'))'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["name"].agg(lambda x: x.join(":")) )' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,null\\n3,3,C\\n4,4,V\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,null\\n9,5,I\\n10,0,J"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testGroupByOnNull_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp\n'+
+                  '1,2\n'+
+                  '2,null\n'+
+                  '5,2\n'+
+                  '2,null\n'+
+                  '8,null\n'+
+                  '9,4\n'+
+                  '2,0}#->meta::pure::functions::relation::groupBy(~grp, ~newCol:x: (id:Integer[0..1], grp:Integer[0..1])[1]|$x.id:x: Integer[*]|$x->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.groupby("grp", sort=False)[["id"]].sum().rename({"id": "newCol"})' +
+               ')(csv_frame("\\nid,grp\\n1,2\\n2,null\\n5,2\\n2,null\\n8,null\\n9,4\\n2,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_isEmpty_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,payload\n'+
+                  '0,"[]"\n'+
+                  '1,"[1]"\n'+
+                  '2,"[2,3,4]"\n'+
+                  '3,"null"}#->meta::pure::functions::relation::extend(~empty:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::isEmpty())'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_isNotEmpty_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,payload\n'+
+                  '0,"[]"\n'+
+                  '1,"[1]"\n'+
+                  '2,"[2,3,4]"\n'+
+                  '3,"null"}#->meta::pure::functions::relation::extend(~notEmpty:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::isNotEmpty())'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_indexOf_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'val,payload\n'+
+                  '1,"[1,2,3]"\n'+
+                  '3,"[1,2,3]"\n'+
+                  '4,"[1,2,3]"\n'+
+                  '5,"null"}#->meta::pure::functions::relation::extend(~index:x: (val:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::indexOf($x.val->meta::pure::functions::multiplicity::toOne()))'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testProjectOfComputedColumn_withCast_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,val2\n'+
+                  '1,2\n'+
+                  '3,5\n'+
+                  '4,9\n'+
+                  '5,14\n'+
+                  '6,20}#->meta::pure::functions::relation::project(~[val3:c: (val:Integer[0..1], val2:Integer[0..1])[1]|$c.val->meta::pure::functions::multiplicity::toOne() + $c.val2->meta::pure::functions::multiplicity::toOne()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(val3:Integer[1])>)'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "val3", frame["val"]+frame["val2"] )' +
+               '  or frame' +
+               ')(csv_frame("\\nval,val2\\n1,2\\n3,5\\n4,9\\n5,14\\n6,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_contains_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,payload,val\n'+
+                  '1,"[1,2,3]",1\n'+
+                  '2,"[1,2,3]",4\n'+
+                  '3,"null",0}#->meta::pure::functions::relation::extend(~contains:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], val:Integer[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::contains($x.val->meta::pure::functions::multiplicity::toOne()))'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_distinct_removeDuplicates_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,payload\n'+
+                  '1,"[1,2,3]"\n'+
+                  '2,"[1,2,3,4,4,3,2,3,4,1,2]"\n'+
+                  '3,"null"}#->meta::pure::functions::relation::extend(~distinct:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::distinct()->meta::pure::functions::collection::sort()->meta::pure::functions::variant::convert::toVariant())->meta::pure::functions::relation::extend(~removeDuplicates:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], distinct:meta::pure::metamodel::variant::Variant[1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::removeDuplicates()->meta::pure::functions::collection::sort()->meta::pure::functions::variant::convert::toVariant())'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_modelOutputNotSupported_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,payload\n'+
+                  '1,"{"name":"Jose"}"\n'+
+                  '2,"{"name":"Juan"}"\n'+
+                  '3,"{"name":"Pedro"}"}#->meta::pure::functions::relation::project(~[name:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::to(@meta::pure::functions::relation::tests::composition::Person)])'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_projectModelProperty_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,payload\n'+
+                  '1,"{"name":"Jose"}"\n'+
+                  '2,"{"name":"Juan"}"\n'+
+                  '3,"{"name":"Pedro"}"}#->meta::pure::functions::relation::project(~[name:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::to(@meta::pure::functions::relation::tests::composition::Person).name])'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testMultiIfTDS_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,resA,resB\n'+
+                  '1,a,b\n'+
+                  '2,aa,bb\n'+
+                  '3,aaa,bbb}#->meta::pure::functions::relation::extend(~val:x: (id:Integer[0..1], resA:String[0..1], resB:String[0..1])[1]|[meta::pure::functions::collection::pair(|$x.id == 1, |$x.resA), meta::pure::functions::collection::pair(|$x.id == 2, |$x.resB)]->meta::pure::functions::lang::if(|$x.resB))'+
+                  '')
+        ]
+      ),
+
+      // meta::pure::functions::relation::tests::composition::test_Static_Pivot_Filter_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|#TDS{\n'+
+      //             'city,country,year,treePlanted\n'+
+      //             'NYC,USA,2011,5000\n'+
+      //             'NYC,USA,2000,5000\n'+
+      //             'SAN,USA,2000,2000\n'+
+      //             'SAN,USA,2011,100\n'+
+      //             'LDN,UK,2011,3000\n'+
+      //             'SAN,USA,2011,2500\n'+
+      //             'NYC,USA,2000,10000\n'+
+      //             'NYC,USA,2012,7600\n'+
+      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::pivot(~year, [2000, 2011], ~newCol:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:y: Integer[*]|$y->plus())->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1])[1]|$x.city == \'NYC\')'+
+      //             '',
+      //          '(lambda frame:' +
+      //          '  frame' +
+      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::test_Project_Filter_Before_Static_Pivot_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|#TDS{\n'+
+      //             'city,country,year,treePlanted\n'+
+      //             'NYC,USA,2011,5000\n'+
+      //             'NYC,USA,2000,5000\n'+
+      //             'SAN,USA,2000,2000\n'+
+      //             'SAN,USA,2011,100\n'+
+      //             'LDN,UK,2011,3000\n'+
+      //             'SAN,USA,2011,2500\n'+
+      //             'NYC,USA,2000,10000\n'+
+      //             'NYC,USA,2012,7600\n'+
+      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::project(~[newCity:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.city->meta::pure::functions::multiplicity::toOne(),newCountry:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.country->meta::pure::functions::multiplicity::toOne(),newYear:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.year->meta::pure::functions::multiplicity::toOne(),newTreePlanted:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.treePlanted->meta::pure::functions::multiplicity::toOne()])->meta::pure::functions::relation::filter(x: (newCity:String[1], newCountry:String[1], newYear:Integer[1], newTreePlanted:Integer[1])[1]|$x.newCity == \'NYC\')->meta::pure::functions::relation::pivot(~newYear, [2000, 2011], ~newCol:x: (newCity:String[1], newCountry:String[1], newYear:Integer[1], newTreePlanted:Integer[1])[1]|$x.newTreePlanted:y: Integer[*]|$y->plus())->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(newCity:String[0..1], newCountry:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1])>)'+
+      //             '',
+      //          '(lambda frame:' +
+      //          '  frame' +
+      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
+      //   ]
+      // ),
+
+      meta::pure::functions::relation::tests::composition::TestJoin_CurrentUserId_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let t1 = #TDS{\n'+
+                  'id,col,user\n'+
+                  '1,MoreTest1,user1\n'+
+                  '2,MoreTest2,root}#;\n'+
+                  ' let t2 = #TDS{\n'+
+                  'id2,name\n'+
+                  '3,Pierre}#;\n'+
+                  ' $t1->meta::pure::functions::relation::join($t2, meta::pure::functions::relation::JoinKind.LEFT, {x: (id:Integer[0..1], col:String[0..1], user:String[0..1])[1], y: (id2:Integer[0..1], name:String[0..1])[1]|$x.user == meta::pure::functions::runtime::currentUserId()});\n'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testTDSPlusTimesMinus_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,val,val2\n'+
+                  '1,1,2\n'+
+                  '2,3,5\n'+
+                  '3,4,9\n'+
+                  '4,5,14\n'+
+                  '5,6,20}#->meta::pure::functions::relation::project(~[plus:c: (id:Integer[0..1], val:Integer[0..1], val2:Integer[0..1])[1]|$c.val->meta::pure::functions::multiplicity::toOne() + $c.val2->meta::pure::functions::multiplicity::toOne(),times:c: (id:Integer[0..1], val:Integer[0..1], val2:Integer[0..1])[1]|$c.val->meta::pure::functions::multiplicity::toOne() * $c.val2->meta::pure::functions::multiplicity::toOne(),minus:c: (id:Integer[0..1], val:Integer[0..1], val2:Integer[0..1])[1]|$c.val->meta::pure::functions::multiplicity::toOne() - $c.val2->meta::pure::functions::multiplicity::toOne()])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "plus", frame["val"] + frame["val2"] )' +
+               '  or frame.__setitem__( "times", frame["val"] * frame["val2"] )' +
+               '  or frame.__setitem__( "minus", frame["val"] - frame["val2"] )' +
+               '  or frame' +
+               ')(csv_frame("\\nid,val,val2\\n1,1,2\\n2,3,5\\n3,4,9\\n4,5,14\\n5,6,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_Extend_GroupBy_Project_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,firstName,lastName,age\n'+
+                  '1,aaa,ttt,25\n'+
+                  '2,bbb,uuu,30\n'+
+                  '3,ccc,vvv,35\n'+
+                  '4,ddd,xxx,40\n'+
+                  '5,eee,yyy,45}#->meta::pure::functions::relation::extend(~fullName:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1])[1]|$x.firstName->meta::pure::functions::multiplicity::toOne() + \' \' + $x.lastName->meta::pure::functions::multiplicity::toOne())->meta::pure::functions::relation::groupBy(~[id,fullName], ~[totalAges:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.age:y: Integer[*]|$y->plus()])->meta::pure::functions::relation::project(~[finalId:x: (id:Integer[0..1], fullName:String[1], totalAges:Integer[1])[1]|$x.id,finalTotalAges:x: (id:Integer[0..1], fullName:String[1], totalAges:Integer[1])[1]|$x.totalAges,finalFullName:x: (id:Integer[0..1], fullName:String[1], totalAges:Integer[1])[1]|$x.fullName])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "fullName", frame["firstName"] + " " + frame["lastName"] )' +
+               '  or frame.__setitem__( "totalAges", frame.groupby(["id","fullName"], sort=False)["age"].sum() )' +
+               '  or frame[["id", "totalAges", "fullName"]]' +
+               '    .rename({"id":"finalId", "totalAges":"finalTotalAges", "fullName":"finalFullName"})' +
+               ')(csv_frame("\\nid,firstName,lastName,age\\n1,aaa,ttt,25\\n2,bbb,uuu,30\\n3,ccc,vvv,35\\n4,ddd,xxx,40\\n5,eee,yyy,45"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_Extend_GroupBy_Extend_Select_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,firstName,lastName,age\n'+
+                  '1,aaa,ttt,25\n'+
+                  '2,bbb,uuu,30\n'+
+                  '3,ccc,vvv,35\n'+
+                  '4,ddd,xxx,40\n'+
+                  '5,eee,yyy,45}#->meta::pure::functions::relation::extend(~fullName:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1])[1]|$x.firstName->meta::pure::functions::multiplicity::toOne() + \' \' + $x.lastName->meta::pure::functions::multiplicity::toOne())->meta::pure::functions::relation::groupBy(~[id,fullName], ~[totalAges:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.age:y: Integer[*]|$y->plus()])->meta::pure::functions::relation::extend(~[finalId:x: (id:Integer[0..1], fullName:String[1], totalAges:Integer[1])[1]|$x.id,finalTotalAges:x: (id:Integer[0..1], fullName:String[1], totalAges:Integer[1])[1]|$x.totalAges,finalFullName:x: (id:Integer[0..1], fullName:String[1], totalAges:Integer[1])[1]|$x.fullName])->meta::pure::functions::relation::select(~[finalId,finalFullName,finalTotalAges])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "fullName", frame["firstName"] + " " + frame["lastName"] )' +
+               '  or frame.__setitem__( "totalAges", frame.groupby(["id","fullName"], sort=False)["age"].sum() )' +
+               '  or frame.__setitem__("finalId", frame["id"]) or frame.__setitem__("finalTotalAges", frame["totalAges"]) or frame.__setitem__("finalFullName", frame["fullName"])' +
+               '  or frame[["finalId","finalFullName","finalTotalAges"]]' +
+               ')(csv_frame("\\nid,firstName,lastName,age\\n1,aaa,ttt,25\\n2,bbb,uuu,30\\n3,ccc,vvv,35\\n4,ddd,xxx,40\\n5,eee,yyy,45"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_Extend_Sort_Project_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,firstName,lastName,age\n'+
+                  '1,aaa,ttt,25\n'+
+                  '2,bbb,uuu,30\n'+
+                  '3,ccc,vvv,35\n'+
+                  '4,ddd,xxx,40\n'+
+                  '5,eee,yyy,45}#->meta::pure::functions::relation::extend(~fullName:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1])[1]|$x.firstName->meta::pure::functions::multiplicity::toOne() + \' \' + $x.lastName->meta::pure::functions::multiplicity::toOne())->meta::pure::functions::relation::sort(~fullName->meta::pure::functions::relation::ascending())->meta::pure::functions::relation::project(~[finalId:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.id,finalAge:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.age,finalFullName:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.fullName])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "fullName", frame["firstName"] + " " + frame["lastName"] )' +
+               '  or frame.sort_values("fullName", ascending=True)' +
+               '    .rename({"id":"finalId", "age":"finalAge", "fullName":"finalFullName"})' +
+               '    [["finalId", "finalAge", "finalFullName"]]' +
+               ')(csv_frame("\\nid,firstName,lastName,age\\n1,aaa,ttt,25\\n2,bbb,uuu,30\\n3,ccc,vvv,35\\n4,ddd,xxx,40\\n5,eee,yyy,45"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::test_Extend_Sort_Extend_Select_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,firstName,lastName,age\n'+
+                  '1,aaa,ttt,25\n'+
+                  '2,bbb,uuu,30\n'+
+                  '3,ccc,vvv,35\n'+
+                  '4,ddd,xxx,40\n'+
+                  '5,eee,yyy,45}#->meta::pure::functions::relation::extend(~fullName:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1])[1]|$x.firstName->meta::pure::functions::multiplicity::toOne() + \' \' + $x.lastName->meta::pure::functions::multiplicity::toOne())->meta::pure::functions::relation::sort(~fullName->meta::pure::functions::relation::ascending())->meta::pure::functions::relation::extend(~[finalId:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.id,finalAge:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.age,finalFullName:x: (id:Integer[0..1], firstName:String[0..1], lastName:String[0..1], age:Integer[0..1], fullName:String[1])[1]|$x.fullName])->meta::pure::functions::relation::select(~[finalId,finalAge,finalFullName])'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "fullName", frame["firstName"] + " " + frame["lastName"] )' +
+               '  or frame.sort_values("fullName", ascending=True)' +
+               '    [["id", "age", "fullName"]]' +
+               '    .rename({"id":"finalId", "age":"finalAge", "fullName":"finalFullName"})' +
+               ')(csv_frame("\\nid,firstName,lastName,age\\n1,aaa,ttt,25\\n2,bbb,uuu,30\\n3,ccc,vvv,35\\n4,ddd,xxx,40\\n5,eee,yyy,45"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testFilterArithmeticComparisonExpression_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'val,val2\n'+
+                  '1,2\n'+
+                  '3,5\n'+
+                  '4,9\n'+
+                  '5,14\n'+
+                  '6,20}#->meta::pure::functions::relation::filter(x: (val:Integer[0..1], val2:Integer[0..1])[1]|($x.val2->meta::pure::functions::multiplicity::toOne() - 1) < (($x.val->meta::pure::functions::multiplicity::toOne() * 2) + 2))'+
+                  '',
+               '(lambda frame:' +
+               '  frame[(frame["val2"] - 1) < ((frame["val"] * 2) + 2)]' +
+               ')(csv_frame("\\nval,val2\\n1,2\\n3,5\\n4,9\\n5,14\\n6,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testExtendFilterOutNull_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'p,o,i\n'+
+                  '0,1,10\n'+
+                  '0,1,10\n'+
+                  '0,null,30\n'+
+                  '100,1,10\n'+
+                  '100,2,20\n'+
+                  '100,null,20\n'+
+                  '100,3,30\n'+
+                  '100,null,30\n'+
+                  '200,1,10\n'+
+                  '200,1,10\n'+
+                  '200,null,10\n'+
+                  '200,null,20\n'+
+                  '200,3,30\n'+
+                  '200,3,30\n'+
+                  '300,1,10\n'+
+                  '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())->meta::pure::functions::relation::filter(x: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1], newCol:Integer[1])[1]|$x.o->meta::pure::functions::collection::isNotEmpty())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("p", sort=False)["i"].sum() )' +
+               '  or frame[frame["o"].is_not_null()]' +
+               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testExtendAddOnNull_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                  'id,grp\n'+
+                  '1,2\n'+
+                  'null,1\n'+
+                  '3,3\n'+
+                  '4,4\n'+
+                  '5,2\n'+
+                  'null,1\n'+
+                  '7,3\n'+
+                  '8,1\n'+
+                  '9,5\n'+
+                  'null,0}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1])[1]|$r.id}:y: Integer[*]|$y->plus())'+
+                  '',
+               '(lambda frame:' +
+               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["id"].sum() )' +
+               '  or frame' +
+               ')(csv_frame("\\nid,grp\\n1,2\\nnull,1\\n3,3\\n4,4\\n5,2\\nnull,1\\n7,3\\n8,1\\n9,5\\nnull,0"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_slice_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\n'+
+                  'id,payload,fromRow,toRow\n'+
+                  '0,"null",1,2\n'+
+                  '1,"[1,2,3,4,5,6]",2,3\n'+
+                  '2,"[1,2,3,4,5,6]",0,4\n'+
+                  '3,"[1,2,3,4,5,6]",-3,-1}#->meta::pure::functions::relation::extend(~sliced:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], fromRow:Integer[0..1], toRow:Integer[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::slice($x.fromRow->meta::pure::functions::multiplicity::toOne(), $x.toRow->meta::pure::functions::multiplicity::toOne())->meta::pure::functions::variant::convert::toVariant())'+
+                  '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testProjectDistinct_Function_1__Boolean_1_->testRev(
+        [
+          rev('|$tds->meta::pure::functions::relation::project(~[id:x: (id:Integer[0..1], name:String[0..1])[1]|$x.id,name:x: (id:Integer[0..1], name:String[0..1])[1]|$x.name->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toLower()])->meta::pure::functions::relation::distinct()',
+             '(lambda frame:' +
+             '  frame.__setitem__( "id", frame["id"] )' +
+             '  or frame.__setitem__( "name", frame["name"].lower() )' +
+             '  or frame.drop_duplicates()' +
+             ')(csv_frame("\\nid,name\\n1,george\\n1,George\\n1,Sachin\\n2,David"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testProjectJoinWithProjectProject_Function_1__Boolean_1_->testRev(
+        [
+          rev('|$tds->meta::pure::functions::relation::project(~[id1:x: (id:Integer[0..1], name:String[0..1])[1]|$x.id,name1:x: (id:Integer[0..1], name:String[0..1])[1]|$x.name])->meta::pure::functions::relation::join($tds2->meta::pure::functions::relation::project(~[id2:x: (id:Integer[0..1], col:String[0..1], other:Integer[0..1])[1]|$x.id,col:x: (id:Integer[0..1], col:String[0..1], other:Integer[0..1])[1]|$x.col,other:x: (id:Integer[0..1], col:String[0..1], other:Integer[0..1])[1]|$x.other]), meta::pure::functions::relation::JoinKind.INNER, {x: (id1:Integer[0..1], name1:String[0..1])[1], y: (id2:Integer[0..1], col:String[0..1], other:Integer[0..1])[1]|$x.id1 == $y.id2})->meta::pure::functions::relation::project(~[id:x: (id1:Integer[0..1], name1:String[0..1], id2:Integer[0..1], col:String[0..1], other:Integer[0..1])[1]|$x.id1,name:x: (id1:Integer[0..1], name1:String[0..1], id2:Integer[0..1], col:String[0..1], other:Integer[0..1])[1]|$x.col])',
+             '(lambda frame1, frame2:' +
+             '  (lambda left:' +
+             '    (lambda right:' +
+             '      (lambda merged:' +
+             '        merged[["id1", "col"]].rename({"id1": "id", "col": "name"})' +
+             '      )(left.merge(right, how="inner", left_on="id1", right_on="id2"))' +
+             '    )(frame2.rename({"id": "id2"})[["id2", "col", "other"]])' +
+             '  )(frame1.rename({"id": "id1", "name": "name1"})[["id1", "name1"]])' +
+             ')(csv_frame("\\nid,name\\n1,George\\n2,Pierre\\n3,Sachin\\n4,David"),csv_frame("\\nid,col,other\\n1,More George 1,1\\n1,More George 2,2\\n4,More David,1"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testFilterPostProject_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|[^meta::pure::functions::relation::tests::composition::FirmTypeForCompositionTests(legalName=\'Firm X\', employees=[^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Peter\', lastName=\'Smith\'), ^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'John\', lastName=\'Johnson\'), ^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'John\', lastName=\'Hill\'), ^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Anthony\', lastName=\'Allen\')]), ^meta::pure::functions::relation::tests::composition::FirmTypeForCompositionTests(legalName=\'Firm A\', employees=^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Fabrice\', lastName=\'Roberts\'))]->meta::pure::functions::relation::project(~[legalName:x: meta::pure::functions::relation::tests::composition::FirmTypeForCompositionTests[1]|$x.legalName,firstName:x: meta::pure::functions::relation::tests::composition::FirmTypeForCompositionTests[1]|$x.employees.firstName])->meta::pure::functions::relation::filter(x: (legalName:String[1], firstName:String[*])[1]|$x.legalName == \'Firm X\')')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testWindowFunctionsAfterProject_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|[^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Peter\', lastName=\'Smith\'), ^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Peter\', lastName=\'Johnson\'), ^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Peter\', lastName=\'Hill\'), ^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Anthony\', lastName=\'Allen\'), ^meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests(firstName=\'Anthony\', lastName=\'Roberts\')]->meta::pure::functions::relation::project(~[first:x: meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests[1]|$x.firstName,last:x: meta::pure::functions::relation::tests::composition::PersonTypeForCompositionTests[1]|$x.lastName])->meta::pure::functions::relation::extend(~first->meta::pure::functions::relation::over(~last->meta::pure::functions::relation::ascending()), ~[leadLast:{p: meta::pure::metamodel::relation::Relation<(first:String[1], last:String[1])>[1], w: meta::pure::functions::relation::_Window<(first:String[1], last:String[1])>[1], r: (first:String[1], last:String[1])[1]|$p->meta::pure::functions::relation::lead($r).last},lagLast:{p: meta::pure::metamodel::relation::Relation<(first:String[1], last:String[1])>[1], w: meta::pure::functions::relation::_Window<(first:String[1], last:String[1])>[1], r: (first:String[1], last:String[1])[1]|$p->meta::pure::functions::relation::lag($r).last}])->meta::pure::functions::relation::sort([~first->meta::pure::functions::relation::ascending(), ~last->meta::pure::functions::relation::ascending()])')
+        ]
+      ),
+
+      // meta::pure::functions::relation::tests::composition::testVariantArrayColumn_sort_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|$tds->meta::pure::functions::relation::extend(~sorted:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::sort()->meta::pure::functions::variant::convert::toVariant())',
+      //     '')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::testVariantArrayColumn_reverse_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|$tds->meta::pure::functions::relation::extend(~reversed:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::reverse()->meta::pure::functions::variant::convert::toVariant())',
+      //     '')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::testVariantColumn_extend_indexExtraction_filter_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|$tds->meta::pure::functions::relation::extend(~atCol0:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(0)->meta::pure::functions::variant::convert::to(@Integer))->meta::pure::functions::relation::filter(x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], atCol0:Integer[0..1])[1]|$x.atCol0 < 7)',
+      //     '')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|$tds->meta::pure::functions::relation::filter(x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition_filterValues())',
+      //     '')
+      //   ]
+      // ),
+
+      // meta::pure::functions::relation::tests::composition::testVariant_if_Function_1__Boolean_1_->testRev(
+      //   [
+      //     rev('|$tds->meta::pure::functions::relation::extend(~ifOutput:x: (id:Integer[0..1], array1:meta::pure::metamodel::variant::Variant[0..1], array2:meta::pure::metamodel::variant::Variant[0..1])[1]|meta::pure::functions::lang::if($x.id->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::math::mod(2) == 0, |$x.array1, |$x.array2))',
+      //     '')
+      //   ]
+      // ),
+
+      meta::pure::functions::relation::tests::composition::testGroupBy_Conflicting_Alias_With_Table_Columns_Function_1__Boolean_1_->testRev(
+        [
+          rev('|$tds1->meta::pure::functions::relation::select(~[id,name])->meta::pure::functions::relation::join($tds2, meta::pure::functions::relation::JoinKind.INNER, {x: (id:String[0..1], name:String[0..1])[1], y: (id2:String[0..1], grp2:String[0..1], name2:String[0..1])[1]|$x.id == $y.id2})->meta::pure::functions::relation::project(~[name2:x: (id:String[0..1], name:String[0..1], id2:String[0..1], grp2:String[0..1], name2:String[0..1])[1]|$x.name->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString()])->meta::pure::functions::relation::groupBy(~name2, ~[newCol:x: (name2:String[1])[1]|1:y: Integer[*]|$y->plus()])',
+          '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testMultiCoalesceInProject_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|[^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests(firstName=\'Peter\', lastName=\'Smith\'), ^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests(lastName=\'Johnson\'), ^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests(firstName=\'Anthony\'), ^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests()]->meta::pure::functions::relation::project(~[name:x: meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests[1]|$x.firstName->meta::pure::functions::flow::coalesce($x.lastName, \'Anonymous\'),firstName:x: meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests[1]|$x.firstName->meta::pure::functions::flow::coalesce(\'Empty\')])')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testCoalesceInPreFilter_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|[^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests(firstName=\'Peter\', lastName=\'Smith\'), ^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests(firstName=\'John\', lastName=\'Johnson\'), ^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests(lastName=\'Peter\'), ^meta::pure::functions::relation::tests::composition::OptionalPersonTypeForCompositionTests(firstName=\'Anthony\', lastName=\'Allen\')]->meta::pure::functions::collection::filter(x|\'Peter\' == $x.firstName->meta::pure::functions::flow::coalesce($x.lastName))->meta::pure::functions::collection::size()')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testNestedJoinArithmeticComparisonExpression_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds->meta::pure::functions::relation::project(~[id:x: (id:Integer[0..1], val1:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$x.id,val1:x: (id:Integer[0..1], val1:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$x.val1,factor:x: (id:Integer[0..1], val1:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|2])->meta::pure::functions::relation::join($tds->meta::pure::functions::relation::project(~[id2:y: (id:Integer[0..1], val1:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$y.id,val2:y: (id:Integer[0..1], val1:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$y.val2,order:y: (id:Integer[0..1], val1:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$y.order]), meta::pure::functions::relation::JoinKind.LEFT, {r1: (id:Integer[0..1], val1:Integer[0..1], factor:Integer[1])[1], r2: (id2:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|($r1.id == $r2.id2) && ($r2.val2 >= (($r1.val1->meta::pure::functions::multiplicity::toOne() + 8 + 9) * $r1.factor))})->meta::pure::functions::relation::project(~[id:x: (id:Integer[0..1], val1:Integer[0..1], factor:Integer[1], id2:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$x.id,val1:x: (id:Integer[0..1], val1:Integer[0..1], factor:Integer[1], id2:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$x.val1,val2:x: (id:Integer[0..1], val1:Integer[0..1], factor:Integer[1], id2:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$x.val2,order:x: (id:Integer[0..1], val1:Integer[0..1], factor:Integer[1], id2:Integer[0..1], val2:Integer[0..1], order:Integer[0..1])[1]|$x.order])')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testProjectNumbersPlusTimesMinus_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|[^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=1, val1=1, val2=1, val3=1.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=2, val1=31, val2=23, val3=0.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=3, val1=7, val2=97, val3=72.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=4, val1=5, val2=3, val3=89.0)]->meta::pure::functions::relation::project(~[id:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|$v.id,plus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->plus(),times:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->times(),minus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->minus()])')
+        ]
+      )
     ]->combine()
+
+
   ]
 }

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
@@ -6791,8 +6791,379 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
           noRev('|[^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=1, val1=1, val2=1, val3=1.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=2, val1=31, val2=23, val3=0.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=3, val1=7, val2=97, val3=72.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=4, val1=5, val2=3, val3=89.0)]->meta::pure::functions::relation::project(~[id:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|$v.id,plus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->plus(),times:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->times(),minus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->minus()])')
         ]
       )
-    ]->combine()
+    ]->combine(),
 
+    // ==========================================
+    // Rank (rank with method='min')
+    // ==========================================
+    meta::pure::functions::relation::tests::rank::testOLAPWithPartitionAndOrderRank_Function_1__Boolean_1_->testRev(
+      [
+        rev('|#TDS{\n'+
+              'id,grp,name\n'+
+              '1,2,A\n'+
+              '2,1,B\n'+
+              '3,3,C\n'+
+              '4,4,D\n'+
+              '5,2,E\n'+
+              '8,1,F\n'+
+              '7,3,G\n'+
+              '8,1,H\n'+
+              '9,5,I\n'+
+              '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::rank($w, $r)})',
+            '(lambda frame:' +
+             '  frame.assign(other=frame.groupby("grp")["id"].rank(method=\'min\', ascending=False))' +
+             ')(csv_frame("id,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n8,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+      ]
+    ),
+
+    // ==========================================
+    // DenseRank (rank with method='dense')
+    // ==========================================
+    meta::pure::functions::relation::tests::denseRank::testOLAPWithPartitionAndOrderDenseRank_Function_1__Boolean_1_->testRev(
+      [
+        rev('|#TDS{\n'+
+              'id,grp,name\n'+
+              '1,2,A\n'+
+              '2,1,B\n'+
+              '3,3,C\n'+
+              '4,4,D\n'+
+              '5,2,E\n'+
+              '8,1,F\n'+
+              '7,3,G\n'+
+              '8,1,H\n'+
+              '9,5,I\n'+
+              '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::denseRank($w, $r)})',
+            '(lambda frame:' +
+             '  frame.assign(other=frame.groupby("grp")["id"].rank(method=\'dense\', ascending=False))' +
+             ')(csv_frame("id,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n8,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+      ]
+    ),
+
+    // ==========================================
+    // PercentRank (rank with pct=True)
+    // ==========================================
+    meta::pure::functions::relation::tests::percentRank::testOLAPWithPartitionAndOrderPercentRank_Function_1__Boolean_1_->testRev(
+      [
+        rev('|#TDS{\n'+
+              'id,grp,name\n'+
+              '1,1,A\n'+
+              '3,1,B\n'+
+              '3,1,C\n'+
+              '4,4,D\n'+
+              '3,1,E\n'+
+              '6,1,F\n'+
+              '7,4,G\n'+
+              '8,1,H\n'+
+              '9,5,I\n'+
+              '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::percentRank($w, $r)})',
+            '(lambda frame:' +
+             '  frame.assign(other=frame.groupby("grp")["id"].rank(pct=True, ascending=False))' +
+             ')(csv_frame("id,grp,name\\n1,1,A\\n3,1,B\\n3,1,C\\n4,4,D\\n3,1,E\\n6,1,F\\n7,4,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+      ]
+    ),
+
+    // ==========================================
+    // CumulativeDistribution (cume_dist_legend_ext)
+    // ==========================================
+    meta::pure::functions::relation::tests::cumulativeDistribution::testOLAPWithPartitionAndOrderCummulativeDistribution_Function_1__Boolean_1_->testRev(
+      [
+        rev('|#TDS{\n'+
+              'id,grp,name\n'+
+              '1,2,A\n'+
+              '2,1,B\n'+
+              '3,3,C\n'+
+              '4,4,D\n'+
+              '5,2,E\n'+
+              '6,1,F\n'+
+              '7,3,G\n'+
+              '8,1,H\n'+
+              '9,5,I\n'+
+              '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::cumulativeDistribution($w, $r)->meta::pure::functions::math::round(2)})',
+            '(lambda frame:' +
+             '  frame.assign(other=frame.groupby("grp")["id"].cume_dist_legend_ext(ascending=False).round(2))' +
+             ')(csv_frame("id,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+      ]
+    ),
+
+    // ==========================================
+    // Ntile (ntile_legend_ext)
+    // ==========================================
+    meta::pure::functions::relation::tests::ntile::testOLAPWithPartitionAndOrderNTile_Function_1__Boolean_1_->testRev(
+      [
+        rev('|#TDS{\n'+
+              'id,grp,name\n'+
+              '1,1,A\n'+
+              '3,1,B\n'+
+              '3,1,C\n'+
+              '4,4,D\n'+
+              '3,1,E\n'+
+              '6,1,F\n'+
+              '7,4,G\n'+
+              '8,1,H\n'+
+              '9,5,I\n'+
+              '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~name->meta::pure::functions::relation::descending()), ~other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::ntile($r, 2)})',
+            '(lambda frame:' +
+             '  frame.assign(other=frame.groupby("grp")["name"].ntile_legend_ext(num_buckets=2, ascending=False))' +
+             ')(csv_frame("id,grp,name\\n1,1,A\\n3,1,B\\n3,1,C\\n4,4,D\\n3,1,E\\n6,1,F\\n7,4,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+      ]
+    ),
+
+    // ==========================================
+    // RowNumber (rank with method='first')
+    // ==========================================
+    meta::pure::functions::relation::tests::rowNumber::testOLAPWithPartitionAndRowNumber_Function_1__Boolean_1_->testRev(
+      [
+        rev('|#TDS{\n'+
+              'id,grp,name\n'+
+              '1,2,A\n'+
+              '2,1,B\n'+
+              '3,3,C\n'+
+              '4,4,D\n'+
+              '5,2,E\n'+
+              '6,1,F\n'+
+              '7,3,G\n'+
+              '8,1,H\n'+
+              '9,5,I\n'+
+              '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::rowNumber($r)})',
+            '(lambda frame:' +
+             '  frame.assign(other=frame.groupby("grp")["id"].rank(method=\'first\', ascending=False))' +
+             ')(csv_frame("id,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
+      ]
+    ),
+
+    // ==========================================
+    // Concatenate (concat_legend_ext)
+    // ==========================================
+    [
+      meta::pure::functions::relation::tests::concatenate::testSimpleConcatenateShared_Function_1__Boolean_1_->testRev(
+        [
+          rev('|#TDS{\n'+
+                'val,str\n'+
+                '1,a\n'+
+                '3,ewe\n'+
+                '4,qw}#->meta::pure::functions::relation::concatenate(#TDS{\n'+
+                'val,str\n'+
+                '5,qwea\n'+
+                '6,eeewe\n'+
+                '7,qqwew}#)',
+              '(lambda frame:' +
+               '  frame.concat_legend_ext(csv_frame("val,str\\n5,qwea\\n6,eeewe\\n7,qqwew"))' +
+               ')(csv_frame("val,str\\n1,a\\n3,ewe\\n4,qw"))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::concatenate::testSimpleConcatenate_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          rev('|let a = #TDS{\n'+
+                  'val,str\n'+
+                  '1,a\n'+
+                  '3,ewe\n'+
+                  '4,qw}#;\n'+
+                  ' let b = #TDS{\n'+
+                  'val,str\n'+
+                  '5,qwea\n'+
+                  '6,eeewe\n'+
+                  '7,qqwew}#;\n'+
+                  ' let c = $a->meta::pure::functions::relation::concatenate($b);\n'+
+                  ' $c->meta::pure::functions::relation::concatenate($b);\n'+
+                  '',
+                '(lambda frame:' +
+               '  frame.concat_legend_ext(csv_frame("val,str\\n5,qwea\\n6,eeewe\\n7,qqwew")).concat_legend_ext(csv_frame("val,str\\n5,qwea\\n6,eeewe\\n7,qqwew"))' +
+               ')(csv_frame("val,str\\n1,a\\n3,ewe\\n4,qw"))')
+        ]
+      )
+    ]->combine(),
+
+    // ==========================================
+    // Lateral (not supported yet)
+    // ==========================================
+    [
+      meta::pure::functions::relation::tests::lateral::testLateralJoin_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let t1 = #TDS{\n'+
+                    'departmentId,departmentName\n'+
+                    '1,Engineering\n'+
+                    '2,Support\n'+
+                    '3,Sales}#;\n'+
+                    ' let t2 = #TDS{\n'+
+                    'employeeId,employeeName,department\n'+
+                    '101,Rafael,1\n'+
+                    '102,Pierre,1\n'+
+                    '103,Jake,1\n'+
+                    '104,John,2\n'+
+                    '105,Jane,2\n'+
+                    '106,Alice,3\n'+
+                    '107,Bob,3\n'+
+                    '108,Charlie,3\n'+
+                    '109,David,3\n'+
+                    '999,NonExistent,4}#;\n'+
+                    ' $t1->meta::pure::functions::relation::lateral(x: (departmentId:Integer[0..1], departmentName:String[0..1])[1]|$t2->meta::pure::functions::relation::filter(y: (employeeId:Integer[0..1], employeeName:String[0..1], department:Integer[0..1])[1]|$y.department == $x.departmentId));\n'+
+                    '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::lateral::testLateralJoin_Chained_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let t1 = #TDS{\n'+
+                    'departmentId,departmentName\n'+
+                    '1,Engineering\n'+
+                    '2,Support\n'+
+                    '3,Sales}#;\n'+
+                    ' let t2 = #TDS{\n'+
+                    'did,Budget,Program\n'+
+                    '1,0.5,1\n'+
+                    '1,1.0,2\n'+
+                    '2,0.5,3\n'+
+                    '3,3.0,4\n'+
+                    '3,5.0,5}#;\n'+
+                    ' let t3 = #TDS{\n'+
+                    'employeeId,employeeName,department\n'+
+                    '101,Rafael,1\n'+
+                    '102,Pierre,1\n'+
+                    '103,Jake,1\n'+
+                    '104,John,2\n'+
+                    '105,Jane,2\n'+
+                    '106,Alice,3\n'+
+                    '107,Bob,3\n'+
+                    '108,Charlie,3\n'+
+                    '109,David,3\n'+
+                    '999,NonExistent,4}#;\n'+
+                    ' $t1->meta::pure::functions::relation::lateral(x: (departmentId:Integer[0..1], departmentName:String[0..1])[1]|$t2->meta::pure::functions::relation::filter(y: (did:Integer[0..1], Budget:Float[0..1], Program:Integer[0..1])[1]|$y.did == $x.departmentId))->meta::pure::functions::relation::lateral(x: (departmentId:Integer[0..1], departmentName:String[0..1], did:Integer[0..1], Budget:Float[0..1], Program:Integer[0..1])[1]|$t3->meta::pure::functions::relation::filter(y: (employeeId:Integer[0..1], employeeName:String[0..1], department:Integer[0..1])[1]|$y.department == $x.departmentId));\n'+
+                    '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::lateral::testLateralJoinAreInnerJoins_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let t1 = #TDS{\n'+
+                    'departmentId,departmentName\n'+
+                    '1,Engineering\n'+
+                    '2,Support\n'+
+                    '3,Sales}#;\n'+
+                    ' let t2 = #TDS{\n'+
+                    'employeeId,employeeName,department\n'+
+                    '101,Rafael,1\n'+
+                    '102,Pierre,1\n'+
+                    '103,Jake,1\n'+
+                    '104,John,2\n'+
+                    '105,Jane,2\n'+
+                    '106,Alice,3\n'+
+                    '107,Bob,3\n'+
+                    '108,Charlie,3\n'+
+                    '109,David,3\n'+
+                    '999,NonExistent,4}#;\n'+
+                    ' $t2->meta::pure::functions::relation::lateral(x: (employeeId:Integer[0..1], employeeName:String[0..1], department:Integer[0..1])[1]|$t1->meta::pure::functions::relation::filter(y: (departmentId:Integer[0..1], departmentName:String[0..1])[1]|$x.department == $y.departmentId));\n'+
+                    '')
+        ]
+      )
+    ]->combine(),
+
+    // ==========================================
+    // AsOfJoin (not supported yet)
+    // ==========================================
+    [
+      meta::pure::functions::relation::tests::asOfJoin::testSimpleAsOfJoin_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() > $y.time2->meta::pure::functions::multiplicity::toOne()})'),
+          noRev('|$tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() < $y.time2->meta::pure::functions::multiplicity::toOne()})')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::asOfJoin::testSimpleAsOfJoin_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds1 = #TDS{\n'+
+                    'key,time,value\n'+
+                    '1,2000-10-25T06:30:00Z,5000\n'+
+                    '1,2000-10-25T06:31:00Z,4000\n'+
+                    '3,2000-10-25T06:32:00Z,3000\n'+
+                    '4,2000-10-25T06:33:00Z,1200\n'+
+                    '5,2000-10-25T06:34:00Z,3200\n'+
+                    '6,2000-10-25T06:35:00Z,4300}#;\n'+
+                    ' let tds2 = #TDS{\n'+
+                    'key2,time2,value2\n'+
+                    '2,2000-10-25T06:31:20Z,3000\n'+
+                    '1,2000-10-25T06:30:10Z,2000\n'+
+                    '4,2000-10-25T06:33:40Z,1400\n'+
+                    '3,2000-10-25T06:32:30Z,3200\n'+
+                    '6,2000-10-25T06:35:10Z,2900\n'+
+                    '5,2000-10-25T06:34:50Z,3200}#;\n'+
+                    ' $tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() > $y.time2->meta::pure::functions::multiplicity::toOne()});\n'+
+                    ''),
+          noRev('|let tds1 = #TDS{\n'+
+                    'key,time,value\n'+
+                    '1,2000-10-25T06:30:00Z,5000\n'+
+                    '1,2000-10-25T06:31:00Z,4000\n'+
+                    '3,2000-10-25T06:32:00Z,3000\n'+
+                    '4,2000-10-25T06:33:00Z,1200\n'+
+                    '5,2000-10-25T06:34:00Z,3200\n'+
+                    '6,2000-10-25T06:35:00Z,4300}#;\n'+
+                    ' let tds2 = #TDS{\n'+
+                    'key2,time2,value2\n'+
+                    '2,2000-10-25T06:31:20Z,3000\n'+
+                    '1,2000-10-25T06:30:10Z,2000\n'+
+                    '4,2000-10-25T06:33:40Z,1400\n'+
+                    '3,2000-10-25T06:32:30Z,3200\n'+
+                    '6,2000-10-25T06:35:10Z,2900\n'+
+                    '5,2000-10-25T06:34:50Z,3200}#;\n'+
+                    ' $tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() < $y.time2->meta::pure::functions::multiplicity::toOne()});\n'+
+                    '')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::asOfJoin::testAsOfJoinWithKeyMatch_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() > $y.time2->meta::pure::functions::multiplicity::toOne()}, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.key->meta::pure::functions::multiplicity::toOne() == $y.key2->meta::pure::functions::multiplicity::toOne()})'),
+          noRev('|$tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() < $y.time2->meta::pure::functions::multiplicity::toOne()}, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.key->meta::pure::functions::multiplicity::toOne() == $y.key2->meta::pure::functions::multiplicity::toOne()})')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::asOfJoin::testAsOfJoinWithKeyMatch_MultipleExpressions_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|let tds1 = #TDS{\n'+
+                    'key,time,value\n'+
+                    '1,2000-10-25T06:30:00Z,5000\n'+
+                    '1,2000-10-25T06:31:00Z,4000\n'+
+                    '3,2000-10-25T06:32:00Z,3000\n'+
+                    '4,2000-10-25T06:33:00Z,1200\n'+
+                    '5,2000-10-25T06:34:00Z,3200\n'+
+                    '6,2000-10-25T06:35:00Z,4300}#;\n'+
+                    ' let tds2 = #TDS{\n'+
+                    'key2,time2,value2\n'+
+                    '2,2000-10-25T06:31:20Z,3000\n'+
+                    '1,2000-10-25T06:30:10Z,2000\n'+
+                    '4,2000-10-25T06:33:40Z,1400\n'+
+                    '3,2000-10-25T06:32:30Z,3200\n'+
+                    '3,2000-10-25T06:33:30Z,3200\n'+
+                    '3,2000-10-25T06:34:30Z,3200\n'+
+                    '6,2000-10-25T06:35:10Z,2900\n'+
+                    '6,2000-10-25T06:35:50Z,2900\n'+
+                    '5,2000-10-25T06:34:50Z,3200}#;\n'+
+                    ' $tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() > $y.time2->meta::pure::functions::multiplicity::toOne()}, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.key->meta::pure::functions::multiplicity::toOne() == $y.key2->meta::pure::functions::multiplicity::toOne()});\n'+
+                    ''),
+          noRev('|let tds1 = #TDS{\n'+
+                    'key,time,value\n'+
+                    '1,2000-10-25T06:30:00Z,5000\n'+
+                    '1,2000-10-25T06:31:00Z,4000\n'+
+                    '3,2000-10-25T06:32:00Z,3000\n'+
+                    '4,2000-10-25T06:33:00Z,1200\n'+
+                    '5,2000-10-25T06:34:00Z,3200\n'+
+                    '6,2000-10-25T06:35:00Z,4300}#;\n'+
+                    ' let tds2 = #TDS{\n'+
+                    'key2,time2,value2\n'+
+                    '2,2000-10-25T06:31:20Z,3000\n'+
+                    '1,2000-10-25T06:30:10Z,2000\n'+
+                    '4,2000-10-25T06:33:40Z,1400\n'+
+                    '3,2000-10-25T06:32:30Z,3200\n'+
+                    '3,2000-10-25T06:33:30Z,3200\n'+
+                    '3,2000-10-25T06:34:30Z,3200\n'+
+                    '6,2000-10-25T06:35:10Z,2900\n'+
+                    '6,2000-10-25T06:35:50Z,2900\n'+
+                    '5,2000-10-25T06:34:50Z,3200}#;\n'+
+                    ' $tds1->meta::pure::functions::relation::asOfJoin($tds2, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.time->meta::pure::functions::multiplicity::toOne() < $y.time2->meta::pure::functions::multiplicity::toOne()}, {x: (key:Integer[0..1], time:Date[0..1], value:Integer[0..1])[1], y: (key2:Integer[0..1], time2:Date[0..1], value2:Integer[0..1])[1]|$x.key->meta::pure::functions::multiplicity::toOne() == $y.key2->meta::pure::functions::multiplicity::toOne()});\n'+
+                    '')
+        ]
+      )
+    ]->combine()
 
   ]
 }

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
@@ -5782,7 +5782,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::last($w, $r).id})'+
                   '',
                '(lambda frame:' +
-               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].last())' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(frame_spec=None, order_by="id", ascending=False)["id"].last())' +
                '  or frame' +
                ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
         ]
@@ -5830,7 +5830,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::nth($w, $r, 1).id})'+
                   '',
                '(lambda frame:' +
-               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].window_func_legend_ext(lambda p,w,r: p.nth(w,r,1)["id"]))' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].window_extend_legend_ext(lambda p,w,r: p.nth(w,r,1)["id"]))' +
                '  or frame' +
                ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
         ]
@@ -5852,7 +5852,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::nth($w, $r, 2).id})'+
                   '',
                '(lambda frame:' +
-               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].window_func_legend_ext(lambda p,w,r: p.nth(w,r,2)["id"]))' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(frame_spec=None, order_by="id", ascending=False)["id"].window_extend_legend_ext(lambda p,w,r: p.nth(w,r,2)["id"]))' +
                '  or frame' +
                ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
         ]

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
@@ -5952,86 +5952,6 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
         ]
       ),
 
-      // meta::pure::functions::relation::tests::composition::test_Pivot_Filter_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|#TDS{\n'+
-      //             'city,country,year,treePlanted\n'+
-      //             'NYC,USA,2011,5000\n'+
-      //             'NYC,USA,2000,5000\n'+
-      //             'SAN,USA,2000,2000\n'+
-      //             'SAN,USA,2011,100\n'+
-      //             'LDN,UK,2011,3000\n'+
-      //             'SAN,USA,2011,2500\n'+
-      //             'NYC,USA,2000,10000\n'+
-      //             'NYC,USA,2012,7600\n'+
-      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:y: Integer[*]|$y->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.city == \'NYC\')'+
-      //             '',
-      //          '(lambda frame:' +
-      //          '  frame' +
-      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_ComplexGroupBy_Pivot_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|#TDS{\n'+
-      //             'city,country,year,treePlanted\n'+
-      //             'NYC,USA,2011,5000\n'+
-      //             'NYC,USA,2000,5000\n'+
-      //             'SAN,USA,2000,2000\n'+
-      //             'SAN,USA,2011,100\n'+
-      //             'LDN,UK,2011,3000\n'+
-      //             'SAN,USA,2011,2500\n'+
-      //             'NYC,USA,2000,10000\n'+
-      //             'NYC,USA,2012,7600\n'+
-      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::extend(~yr:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year->meta::pure::functions::multiplicity::toOne() - 2000)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1], yr:Integer[1])[1]|$x.yr > 10)->meta::pure::functions::relation::select(~[city,country,year,treePlanted])->meta::pure::functions::relation::groupBy(~[city,country], ~[year:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year:x: Integer[*]|$x->plus(),treePlanted:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:x: Integer[*]|$x->plus()])->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (city:String[0..1], country:String[0..1], year:Integer[1], treePlanted:Integer[1])[1]|$x.treePlanted:x: Integer[*]|$x->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'4022__|__newCol\\'\':Integer[0..1], \'\\'6035__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::sort(~city->meta::pure::functions::relation::ascending())'+
-      //             '',
-      //          '(lambda frame:' +
-      //          '  frame' +
-      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_GroupBy_Pivot_Extend_Sort_Limit_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|#TDS{\n'+
-      //             'city,country,year,treePlanted\n'+
-      //             'NYC,USA,2011,5000\n'+
-      //             'NYC,USA,2000,5000\n'+
-      //             'SAN,USA,2000,2000\n'+
-      //             'SAN,USA,2011,100\n'+
-      //             'LDN,UK,2011,3000\n'+
-      //             'SAN,USA,2011,2500\n'+
-      //             'NYC,USA,2000,10000\n'+
-      //             'NYC,USA,2012,7600\n'+
-      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::extend(~yr:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year->meta::pure::functions::multiplicity::toOne() - 2000)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1], yr:Integer[1])[1]|$x.yr > 10)->meta::pure::functions::relation::select(~[city,country,year,treePlanted])->meta::pure::functions::relation::groupBy(~[year,city,country], ~treePlanted:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:x: Integer[*]|$x->plus())->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (year:Integer[0..1], city:String[0..1], country:String[0..1], treePlanted:Integer[1])[1]|$x.treePlanted:y: Integer[*]|$y->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::extend(~newCol:x: (city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.city->meta::pure::functions::multiplicity::toOne() + \'_0\')->meta::pure::functions::relation::sort(~city->meta::pure::functions::relation::ascending())->meta::pure::functions::relation::limit(3)'+
-      //             '',
-      //          '(lambda frame:' +
-      //          '  frame' +
-      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_Pivot_GroupBy_Extend_Sort_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|#TDS{\n'+
-      //             'city,country,year,treePlanted\n'+
-      //             'NYC,USA,2011,5000\n'+
-      //             'NYC,USA,2000,5000\n'+
-      //             'SAN,USA,2000,2000\n'+
-      //             'SAN,USA,2011,100\n'+
-      //             'LDN,UK,2011,3000\n'+
-      //             'SAN,USA,2011,2500\n'+
-      //             'NYC,USA,2000,10000\n'+
-      //             'NYC,USA,2012,7600\n'+
-      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::extend(~yr:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.year->meta::pure::functions::multiplicity::toOne() - 2000)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1], yr:Integer[1])[1]|$x.yr > 10)->meta::pure::functions::relation::select(~[city,country,year,treePlanted])->meta::pure::functions::relation::pivot(~[year], ~[newCol:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:x: Integer[*]|$x->plus()])->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::groupBy(~[country], ~[\'\\'2011__|__newCol\\'\':x: (city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.\'\\'2011__|__newCol\\'\':x: Integer[*]|$x->plus(),\'\\'2012__|__newCol\\'\':x: (city:String[0..1], country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1], \'\\'2012__|__newCol\\'\':Integer[0..1])[1]|$x.\'\\'2012__|__newCol\\'\':x: Integer[*]|$x->plus()])->meta::pure::functions::relation::extend(~newCol:x: (country:String[0..1], \'\\'2011__|__newCol\\'\':Integer[1], \'\\'2012__|__newCol\\'\':Integer[1])[1]|$x.country->meta::pure::functions::multiplicity::toOne() + \'_0\')->meta::pure::functions::relation::sort(~country->meta::pure::functions::relation::ascending())'+
-      //             '',
-      //          '(lambda frame:' +
-      //          '  frame' +
-      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
-      //   ]
-      // ),
-
       meta::pure::functions::relation::tests::composition::test_GroupBy_Filter_Function_1__Boolean_1_->testRev(
         [
           rev('|#TDS{\n'+
@@ -6430,12 +6350,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
 
       meta::pure::functions::relation::tests::composition::testVariantColumn_modelOutputNotSupported_Function_1__Boolean_1_->testRev(
         [
-          noRev('|#TDS{\n'+
-                  'id,payload\n'+
-                  '1,"{"name":"Jose"}"\n'+
-                  '2,"{"name":"Juan"}"\n'+
-                  '3,"{"name":"Pedro"}"}#->meta::pure::functions::relation::project(~[name:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::to(@meta::pure::functions::relation::tests::composition::Person)])'+
-                  '')
+          noRev('|#TDS{\nid,payload\n1,"{\"name\":\"Jose\"}"\n2,"{\"name\":\"Juan\"}"\n3,"{\"name\":\"Pedro\"}"}#->meta::pure::functions::relation::project(~[name:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::to(@meta::pure::functions::relation::tests::composition::Person)])')
         ]
       ),
 
@@ -6460,46 +6375,6 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '')
         ]
       ),
-
-      // meta::pure::functions::relation::tests::composition::test_Static_Pivot_Filter_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|#TDS{\n'+
-      //             'city,country,year,treePlanted\n'+
-      //             'NYC,USA,2011,5000\n'+
-      //             'NYC,USA,2000,5000\n'+
-      //             'SAN,USA,2000,2000\n'+
-      //             'SAN,USA,2011,100\n'+
-      //             'LDN,UK,2011,3000\n'+
-      //             'SAN,USA,2011,2500\n'+
-      //             'NYC,USA,2000,10000\n'+
-      //             'NYC,USA,2012,7600\n'+
-      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::pivot(~year, [2000, 2011], ~newCol:x: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$x.treePlanted:y: Integer[*]|$y->plus())->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1])>)->meta::pure::functions::relation::filter(x: (city:String[0..1], country:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1])[1]|$x.city == \'NYC\')'+
-      //             '',
-      //          '(lambda frame:' +
-      //          '  frame' +
-      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::test_Project_Filter_Before_Static_Pivot_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|#TDS{\n'+
-      //             'city,country,year,treePlanted\n'+
-      //             'NYC,USA,2011,5000\n'+
-      //             'NYC,USA,2000,5000\n'+
-      //             'SAN,USA,2000,2000\n'+
-      //             'SAN,USA,2011,100\n'+
-      //             'LDN,UK,2011,3000\n'+
-      //             'SAN,USA,2011,2500\n'+
-      //             'NYC,USA,2000,10000\n'+
-      //             'NYC,USA,2012,7600\n'+
-      //             'NYC,USA,2012,7600}#->meta::pure::functions::relation::project(~[newCity:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.city->meta::pure::functions::multiplicity::toOne(),newCountry:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.country->meta::pure::functions::multiplicity::toOne(),newYear:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.year->meta::pure::functions::multiplicity::toOne(),newTreePlanted:c: (city:String[0..1], country:String[0..1], year:Integer[0..1], treePlanted:Integer[0..1])[1]|$c.treePlanted->meta::pure::functions::multiplicity::toOne()])->meta::pure::functions::relation::filter(x: (newCity:String[1], newCountry:String[1], newYear:Integer[1], newTreePlanted:Integer[1])[1]|$x.newCity == \'NYC\')->meta::pure::functions::relation::pivot(~newYear, [2000, 2011], ~newCol:x: (newCity:String[1], newCountry:String[1], newYear:Integer[1], newTreePlanted:Integer[1])[1]|$x.newTreePlanted:y: Integer[*]|$y->plus())->meta::pure::functions::lang::cast(@meta::pure::metamodel::relation::Relation<(newCity:String[0..1], newCountry:String[0..1], \'\\'2000__|__newCol\\'\':Integer[0..1], \'\\'2011__|__newCol\\'\':Integer[0..1])>)'+
-      //             '',
-      //          '(lambda frame:' +
-      //          '  frame' +
-      //          ')(csv_frame("\\ncity,country,year,treePlanted\\nNYC,USA,2011,5000\\nNYC,USA,2000,5000\\nSAN,USA,2000,2000\\nSAN,USA,2011,100\\nLDN,UK,2011,3000\\nSAN,USA,2011,2500\\nNYC,USA,2000,10000\\nNYC,USA,2012,7600\\nNYC,USA,2012,7600"))')
-      //   ]
-      // ),
 
       meta::pure::functions::relation::tests::composition::TestJoin_CurrentUserId_Function_1__Boolean_1_->testRev(
         [
@@ -6628,7 +6503,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
 
       meta::pure::functions::relation::tests::composition::testExtendFilterOutNull_Function_1__Boolean_1_->testRev(
         [
-          rev('|#TDS{\n'+
+          noRev('|#TDS{\n'+
                   'p,o,i\n'+
                   '0,1,10\n'+
                   '0,1,10\n'+
@@ -6646,17 +6521,13 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '200,3,30\n'+
                   '300,1,10\n'+
                   '300,2,20}#->meta::pure::functions::relation::extend(~p->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])>[1], r: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1])[1]|$r.i}:y: Integer[*]|$y->plus())->meta::pure::functions::relation::filter(x: (p:Integer[0..1], o:Integer[0..1], i:Integer[0..1], newCol:Integer[1])[1]|$x.o->meta::pure::functions::collection::isNotEmpty())'+
-                  '',
-               '(lambda frame:' +
-               '  frame.__setitem__( "newCol", frame.groupby("p", sort=False)["i"].sum() )' +
-               '  or frame[frame["o"].is_not_null()]' +
-               ')(csv_frame("\\np,o,i\\n0,1,10\\n0,1,10\\n0,null,30\\n100,1,10\\n100,2,20\\n100,null,20\\n100,3,30\\n100,null,30\\n200,1,10\\n200,1,10\\n200,null,10\\n200,null,20\\n200,3,30\\n200,3,30\\n300,1,10\\n300,2,20"))')
+                  '')
         ]
       ),
 
       meta::pure::functions::relation::tests::composition::testExtendAddOnNull_Function_1__Boolean_1_->testRev(
         [
-          rev('|#TDS{\n'+
+          noRev('|#TDS{\n'+
                   'id,grp\n'+
                   '1,2\n'+
                   'null,1\n'+
@@ -6668,11 +6539,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '8,1\n'+
                   '9,5\n'+
                   'null,0}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1])[1]|$r.id}:y: Integer[*]|$y->plus())'+
-                  '',
-               '(lambda frame:' +
-               '  frame.__setitem__( "newCol", frame.groupby("grp", sort=False)["id"].sum() )' +
-               '  or frame' +
-               ')(csv_frame("\\nid,grp\\n1,2\\nnull,1\\n3,3\\n4,4\\n5,2\\nnull,1\\n7,3\\n8,1\\n9,5\\nnull,0"))')
+                  '')
         ]
       ),
 
@@ -6726,45 +6593,9 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
         ]
       ),
 
-      // meta::pure::functions::relation::tests::composition::testVariantArrayColumn_sort_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|$tds->meta::pure::functions::relation::extend(~sorted:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::sort()->meta::pure::functions::variant::convert::toVariant())',
-      //     '')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::testVariantArrayColumn_reverse_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|$tds->meta::pure::functions::relation::extend(~reversed:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::reverse()->meta::pure::functions::variant::convert::toVariant())',
-      //     '')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::testVariantColumn_extend_indexExtraction_filter_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|$tds->meta::pure::functions::relation::extend(~atCol0:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(0)->meta::pure::functions::variant::convert::to(@Integer))->meta::pure::functions::relation::filter(x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], atCol0:Integer[0..1])[1]|$x.atCol0 < 7)',
-      //     '')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|$tds->meta::pure::functions::relation::filter(x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition_filterValues())',
-      //     '')
-      //   ]
-      // ),
-
-      // meta::pure::functions::relation::tests::composition::testVariant_if_Function_1__Boolean_1_->testRev(
-      //   [
-      //     rev('|$tds->meta::pure::functions::relation::extend(~ifOutput:x: (id:Integer[0..1], array1:meta::pure::metamodel::variant::Variant[0..1], array2:meta::pure::metamodel::variant::Variant[0..1])[1]|meta::pure::functions::lang::if($x.id->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::math::mod(2) == 0, |$x.array1, |$x.array2))',
-      //     '')
-      //   ]
-      // ),
-
       meta::pure::functions::relation::tests::composition::testGroupBy_Conflicting_Alias_With_Table_Columns_Function_1__Boolean_1_->testRev(
         [
-          rev('|$tds1->meta::pure::functions::relation::select(~[id,name])->meta::pure::functions::relation::join($tds2, meta::pure::functions::relation::JoinKind.INNER, {x: (id:String[0..1], name:String[0..1])[1], y: (id2:String[0..1], grp2:String[0..1], name2:String[0..1])[1]|$x.id == $y.id2})->meta::pure::functions::relation::project(~[name2:x: (id:String[0..1], name:String[0..1], id2:String[0..1], grp2:String[0..1], name2:String[0..1])[1]|$x.name->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString()])->meta::pure::functions::relation::groupBy(~name2, ~[newCol:x: (name2:String[1])[1]|1:y: Integer[*]|$y->plus()])',
-          '')
+          noRev('|$tds1->meta::pure::functions::relation::select(~[id,name])->meta::pure::functions::relation::join($tds2, meta::pure::functions::relation::JoinKind.INNER, {x: (id:String[0..1], name:String[0..1])[1], y: (id2:String[0..1], grp2:String[0..1], name2:String[0..1])[1]|$x.id == $y.id2})->meta::pure::functions::relation::project(~[name2:x: (id:String[0..1], name:String[0..1], id2:String[0..1], grp2:String[0..1], name2:String[0..1])[1]|$x.name->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::string::toString()])->meta::pure::functions::relation::groupBy(~name2, ~[newCol:x: (name2:String[1])[1]|1:y: Integer[*]|$y->plus()])')
         ]
       ),
 
@@ -6788,7 +6619,55 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
 
       meta::pure::functions::relation::tests::composition::testProjectNumbersPlusTimesMinus_Function_1__Boolean_1_->testRev(
         [
-          noRev('|[^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=1, val1=1, val2=1, val3=1.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=2, val1=31, val2=23, val3=0.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=3, val1=7, val2=97, val3=72.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=4, val1=5, val2=3, val3=89.0)]->meta::pure::functions::relation::project(~[id:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|$v.id,plus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->plus(),times:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->times(),minus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|[$v.val1, $v.val2, $v.val3]->minus()])')
+          noRev('|[^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=1, val1=1, val2=1, val3=1.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=2, val1=31, val2=23, val3=0.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=3, val1=7, val2=97, val3=72.0), ^meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests(id=4, val1=5, val2=3, val3=89.0)]->meta::pure::functions::relation::project(~[id:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|$v.id,plus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|$v.val1 + $v.val2 + $v.val3,times:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|$v.val1 * $v.val2 * $v.val3,minus:v: meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForCompositionTests[1]|$v.val1 - $v.val2 - $v.val3])')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantArrayColumn_sort_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds->meta::pure::functions::relation::extend(~sorted:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::sort()->meta::pure::functions::variant::convert::toVariant())')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantArrayColumn_reverse_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds->meta::pure::functions::relation::extend(~reversed:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::reverse()->meta::pure::functions::variant::convert::toVariant())')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_extend_indexExtraction_filter_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds->meta::pure::functions::relation::extend(~atCol0:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(0)->meta::pure::functions::variant::convert::to(@Integer))->meta::pure::functions::relation::filter(x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], atCol0:Integer[0..1])[1]|$x.atCol0 < 7)')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds->meta::pure::functions::relation::filter(x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition_filterValues())')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testVariant_if_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|$tds->meta::pure::functions::relation::extend(~ifOutput:x: (id:Integer[0..1], array1:meta::pure::metamodel::variant::Variant[0..1], array2:meta::pure::metamodel::variant::Variant[0..1])[1]|meta::pure::functions::lang::if($x.id->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::math::mod(2) == 0, |$x.array1, |$x.array2))')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testProjectExtendNestedIfLeadAdjust_Function_1__Boolean_1_->testRev(
+        [
+          noRev('|#TDS{\nid,fromDate,toDate\n1,2026-01-07T00:00:00.000000000+0000,2026-01-08T00:00:00.000000000+0000\n1,2026-01-08T00:00:00.000000000+0000,2026-01-10T00:00:00.000000000+0000\n1,2026-01-09T00:00:00.000000000+0000,2026-01-09T00:00:00.000000000+0000\n1,2026-01-10T00:00:00.000000000+0000,9999-12-31T00:00:00.000000000+0000}#->meta::pure::functions::relation::project(~[grp:x: (id:Integer[1], fromDate:Date[1], toDate:Date[1])[1]|$x.id,dateSeq:x: (id:Integer[1], fromDate:Date[1], toDate:Date[1])[1]|$x.fromDate,endDate:x: (id:Integer[1], fromDate:Date[1], toDate:Date[1])[1]|$x.toDate,startDate:x: (id:Integer[1], fromDate:Date[1], toDate:Date[1])[1]|$x.fromDate])->meta::pure::functions::relation::extend(~[grp]->meta::pure::functions::relation::over(~dateSeq->meta::pure::functions::relation::ascending()), ~[endDateSeq:{p: meta::pure::metamodel::relation::Relation<(grp:Integer[1], dateSeq:Date[1], endDate:Date[1], startDate:Date[1])>[1], w: meta::pure::functions::relation::_Window<(grp:Integer[1], dateSeq:Date[1], endDate:Date[1], startDate:Date[1])>[1], r: (grp:Integer[1], dateSeq:Date[1], endDate:Date[1], startDate:Date[1])[1]|meta::pure::functions::lang::if($r.endDate == $p->meta::pure::functions::relation::lead($r).startDate, |$p->meta::pure::functions::relation::lead($r).dateSeq, |meta::pure::functions::boolean::not($r.startDate == $r.endDate)->meta::pure::functions::lang::if(|$r.endDate, |$r.dateSeq->meta::pure::functions::date::adjust(1, meta::pure::functions::date::DurationUnit.SECONDS)))->meta::pure::functions::lang::cast(@Date)}])')
+        ]
+      ),
+
+      meta::pure::functions::relation::tests::composition::testExtendLeadAdjustDerivedOffset_Function_1__Boolean_1_->testRev(
+        [
+          noRev(
+            '|#TDS{\n'+
+            'id,fromDate,seq,toDate\n'+
+            '1,2026-01-07T00:00:00.000000000+0000,1,2026-01-07T00:00:00.000000000+0000\n'+
+            '1,2026-01-07T00:00:00.000000000+0000,2,2026-01-08T00:00:00.000000000+0000\n'+
+            '1,2026-01-08T00:00:00.000000000+0000,1,2026-01-08T00:00:00.000000000+0000\n'+
+            '1,2026-01-08T00:00:00.000000000+0000,2,9999-12-31T00:00:00.000000000+0000}#->meta::pure::functions::relation::extend(~[id,fromDate]->meta::pure::functions::relation::over([~fromDate->meta::pure::functions::relation::ascending(), ~seq->meta::pure::functions::relation::ascending()]), ~[toDateSeq:{p: meta::pure::metamodel::relation::Relation<(id:Integer[1], fromDate:Date[1], seq:Integer[1], toDate:Date[1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[1], fromDate:Date[1], seq:Integer[1], toDate:Date[1])>[1], r: (id:Integer[1], fromDate:Date[1], seq:Integer[1], toDate:Date[1])[1]|meta::pure::functions::lang::if($r.fromDate == $r.toDate, |$p->meta::pure::functions::relation::lead($r).fromDate->meta::pure::functions::multiplicity::toOne()->meta::pure::functions::lang::cast(@Date)->meta::pure::functions::date::adjust($p->meta::pure::functions::relation::lead($r).seq->meta::pure::functions::multiplicity::toOne() - 1, meta::pure::functions::date::DurationUnit.SECONDS), |$r.toDate)->meta::pure::functions::lang::cast(@Date)}])')
         ]
       )
     ]->combine(),

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/relation/relation.pure
@@ -744,8 +744,10 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '9,1,C,11\n'+
                   '10,2,D,11}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over([~name->meta::pure::functions::relation::ascending(), ~height->meta::pure::functions::relation::ascending()]), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
                   '',
-               '(lambda frame:' +
-               '  frame' +
+              '(lambda frame:' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by=["name", "height"], ascending=[True, True])["id"].shift(periods=-1))' +
+               '  or frame.__setitem__("other", frame.groupby("grp").window_frame_legend_ext(frame_spec=frame.rows_between(), order_by=["name", "height"], ascending=[True, True])["name"].first())' +
+               '  or frame' +
                ')(csv_frame("\\nid,grp,name,height\\n1,2,A,11\\n2,1,B,12\\n3,3,C,12\\n4,3,B,11\\n5,2,B,13\\n6,1,C,12\\n7,3,A,13\\n8,1,B,14\\n9,1,C,11\\n10,2,D,11"))')
         ]
       ),
@@ -766,7 +768,11 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '10,2,D,11}#->meta::pure::functions::relation::filter(x: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$x.id < 9)->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over([~name->meta::pure::functions::relation::ascending(), ~height->meta::pure::functions::relation::ascending()]), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1], height:Integer[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
                   '',
                '(lambda frame:' +
-               '  frame' +
+               '  (lambda frame:' +
+               '    frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by=["name", "height"], ascending=[True, True])["id"].shift(periods=-1))' +
+               '    or frame.__setitem__("other", frame.groupby("grp").window_frame_legend_ext(frame_spec=frame.rows_between(), order_by=["name", "height"], ascending=[True, True])["name"].first())' +
+               '    or frame' +
+               '  )(frame[frame["id"] < 9])' +
                ')(csv_frame("\\nid,grp,name,height\\n1,2,A,11\\n2,1,B,12\\n3,3,C,12\\n4,3,B,11\\n5,2,B,13\\n6,1,C,12\\n7,3,A,13\\n8,1,B,14\\n9,1,C,11\\n10,2,D,11"))')
         ]
       ),
@@ -787,7 +793,9 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '10,0,J}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
                   '',
                '(lambda frame:' +
-               '  frame' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].shift(periods=-1))' +
+               '  or frame.__setitem__("other", frame.groupby("grp").window_frame_legend_ext(frame_spec=frame.rows_between(), order_by="id", ascending=False)["name"].first())' +
+               '  or frame' +
                ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
         ]
       ),
@@ -809,7 +817,9 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   ' $t->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}]);\n'+
                   '',
                '(lambda frame:' +
-               '  frame' +
+               '  frame.__setitem__("newCol", frame.groupby("grp").window_frame_legend_ext(order_by="id", ascending=False)["id"].shift(periods=-1))' +
+               '  or frame.__setitem__("other", frame.groupby("grp").window_frame_legend_ext(frame_spec=frame.rows_between(), order_by="id", ascending=False)["name"].first())' +
+               '  or frame' +
                ')(csv_frame("\\nid,grp,name\\n1,2,A\\n2,1,B\\n3,3,C\\n4,4,D\\n5,2,E\\n6,1,F\\n7,3,G\\n8,1,H\\n9,5,I\\n10,0,J"))')
         ]
       ),
@@ -876,7 +886,9 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   '10,0,0,J}#->meta::pure::functions::relation::extend(~[grp,grp2]->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}])'+
                   '',
                '(lambda frame:' +
-               '  frame' +
+               '  frame.__setitem__("newCol", frame.groupby(["grp", "grp2"]).window_frame_legend_ext(order_by="id", ascending=False)["id"].shift(periods=-1))' +
+               '  or frame.__setitem__("other", frame.groupby(["grp", "grp2"]).window_frame_legend_ext(frame_spec=frame.rows_between(), order_by="id", ascending=False)["name"].first())' +
+               '  or frame' +
                ')(csv_frame("\\nid,grp,grp2,name\\n1,2,2,A\\n2,1,1,B\\n3,3,3,C\\n4,4,4,D\\n5,2,2,E\\n6,1,2,F\\n7,3,3,G\\n8,1,1,H\\n9,5,5,I\\n10,0,0,J"))')
         ]
       ),
@@ -898,7 +910,9 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
                   ' $t->meta::pure::functions::relation::extend(~[grp,grp2]->meta::pure::functions::relation::over(~id->meta::pure::functions::relation::descending()), ~[newCol:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::lead($r).id},other:{p: meta::pure::metamodel::relation::Relation<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], w: meta::pure::functions::relation::_Window<(id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])>[1], r: (id:Integer[0..1], grp:Integer[0..1], grp2:Integer[0..1], name:String[0..1])[1]|$p->meta::pure::functions::relation::first($w, $r).name}]);\n'+
                   '',
                '(lambda frame:' +
-               '  frame' +
+               '  frame.__setitem__("newCol", frame.groupby(["grp", "grp2"]).window_frame_legend_ext(order_by="id", ascending=False)["id"].shift(periods=-1))' +
+               '  or frame.__setitem__("other", frame.groupby(["grp", "grp2"]).window_frame_legend_ext(frame_spec=frame.rows_between(), order_by="id", ascending=False)["name"].first())' +
+               '  or frame' +
                ')(csv_frame("\\nid,grp,grp2,name\\n1,2,2,A\\n2,1,1,B\\n3,3,3,C\\n4,4,4,D\\n5,2,2,E\\n6,1,2,F\\n7,3,3,G\\n8,1,1,H\\n9,5,5,I\\n10,0,0,J"))')
         ]
       ),
@@ -1039,83 +1053,37 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesE
 
       meta::pure::functions::relation::tests::extend::testVariantColumn_Function_1__Boolean_1_->testRev(
         [
-          noRev('|let tds = #TDS{\n'+
-                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
-                  '1,"[1,2,3]"\n'+
-                  '2,"[4,5,6]"\n'+
-                  '3,"[7,8,9]"\n'+
-                  '4,"[10,11,12]"\n'+
-                  '5,"[13,14,15]"}#;\n'+
-                  ' $tds->meta::pure::functions::relation::extend(~passthru:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload)->meta::pure::functions::relation::sort(~id->meta::pure::functions::relation::ascending());\n'+
-                  '')
+          noRev('|$tds->meta::pure::functions::relation::extend(~passthru:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload)->meta::pure::functions::relation::sort(~id->meta::pure::functions::relation::ascending())')
         ]
       ),
 
       meta::pure::functions::relation::tests::extend::testVariantColumn_indexExtraction_Function_1__Boolean_1_->testRev(
         [
-          noRev('|let tds = #TDS{\n'+
-                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
-                  '1,"[1,2,3]"\n'+
-                  '2,"[4,5,6]"\n'+
-                  '3,"[7,8,9]"\n'+
-                  '4,"[10,11,12]"\n'+
-                  '5,"[13,14,15]"}#;\n'+
-                  ' $tds->meta::pure::functions::relation::extend(~atCol0:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(0))->meta::pure::functions::relation::extend(~atCol1:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], atCol0:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(1));\n'+
-                  '')
+          noRev('|$tds->meta::pure::functions::relation::extend(~atCol0:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(0))->meta::pure::functions::relation::extend(~atCol1:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1], atCol0:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(1))')
         ]
       ),
 
       meta::pure::functions::relation::tests::extend::testVariantColumn_keyExtraction_Function_1__Boolean_1_->testRev(
         [
-          noRev('|let tds = #TDS{\n'+
-                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
-                  '1,"{""boolean"":true,""integer"":1,""string"":""hello""}"\n'+
-                  '2,"{""boolean"":false,""integer"":2,""string"":""world""}"\n'+
-                  '3,"{""boolean"":true,""integer"":3,""string"":""world""}"}#;\n'+
-                  ' $tds->meta::pure::functions::relation::extend(~[booleanKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'boolean\'),integerKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'integer\'),stringKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'string\')]);\n'+
-                  '')
+          noRev('|$tds->meta::pure::functions::relation::extend(~[booleanKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'boolean\'),integerKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'integer\'),stringKey:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::navigation::get(\'string\')])')
         ]
       ),
 
       meta::pure::functions::relation::tests::extend::testVariantColumn_map_Function_1__Boolean_1_->testRev(
         [
-          noRev('|let tds = #TDS{\n'+
-                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
-                  '1,"[1,2,3]"\n'+
-                  '2,"[4,5,6]"\n'+
-                  '3,"[7,8,9]"\n'+
-                  '4,"[10,11,12]"\n'+
-                  '5,"[13,14,15]"}#;\n'+
-                  ' $tds->meta::pure::functions::relation::extend(~payloadMod:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::map(t: Integer[1]|$t->meta::pure::functions::math::mod(2))->meta::pure::functions::variant::convert::toVariant());\n'+
-                  '')
+          noRev('|$tds->meta::pure::functions::relation::extend(~payloadMod:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::map(t: Integer[1]|$t->meta::pure::functions::math::mod(2))->meta::pure::functions::variant::convert::toVariant())')
         ]
       ),
 
       meta::pure::functions::relation::tests::extend::testVariantColumn_fold_Function_1__Boolean_1_->testRev(
         [
-          noRev('|let tds = #TDS{\n'+
-                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
-                  '1,"[1,2,3]"\n'+
-                  '2,"[4,5,6]"\n'+
-                  '3,"[7,8,9]"\n'+
-                  '4,"[10,11,12]"\n'+
-                  '5,"[13,14,15]"}#;\n'+
-                  ' $tds->meta::pure::functions::relation::extend(~payloadFoldMult:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::fold({t: Integer[1], v: Integer[1]|$t * $v}, 1));\n'+
-                  '')
+          noRev('|$tds->meta::pure::functions::relation::extend(~payloadFoldMult:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::fold({t: Integer[1], v: Integer[1]|$t * $v}, 1))')
         ]
       ),
 
       meta::pure::functions::relation::tests::extend::testVariantColumn_filter_Function_1__Boolean_1_->testRev(
         [
-          noRev('|let tds = #TDS{\n'+
-                  'id,payload:meta::pure::metamodel::variant::Variant\n'+
-                  '1,"[1,2,3]"\n'+
-                  '2,"[4,5,6]"\n'+
-                  '3,"[7,8,9]"\n'+
-                  '4,"[10,11,12]"\n'+
-                  '5,"[13,14,15]"}#;\n'+
-                  ' $tds->meta::pure::functions::relation::extend(~divBy2:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::filter(t|$t->meta::pure::functions::math::mod(2) == 0)->meta::pure::functions::variant::convert::toVariant());\n'+
-                  '')
+          noRev('|$tds->meta::pure::functions::relation::extend(~divBy2:x: (id:Integer[0..1], payload:meta::pure::metamodel::variant::Variant[0..1])[1]|$x.payload->meta::pure::functions::variant::convert::toMany(@Integer)->meta::pure::functions::collection::filter(t|$t->meta::pure::functions::math::mod(2) == 0)->meta::pure::functions::variant::convert::toVariant())')
         ]
       )
     ]->combine(),

--- a/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/standard/math.pure
+++ b/legend-engine-xts-python/legend-engine-xt-python-reversePCT-pandasAPI/src/main/resources/core_external_python_reverse_pct_pandas_api/standard/math.pure
@@ -1310,7 +1310,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesS
                 'B,22\n'+
                 'B,18}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~x_zscore:{p: meta::pure::metamodel::relation::Relation<(grp:String[0..1], x:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(grp:String[0..1], x:Integer[0..1])>[1], r: (grp:String[0..1], x:Integer[0..1])[1]|$p->meta::pure::functions::math::zScore($w, $r, ~x)})',
               '(lambda frame:' +
-               '  frame.assign(x_zscore=lambda r: frame.groupby("grp")["x"].zscore())' +
+               '  frame.assign(x_zscore=lambda r: frame.groupby("grp")["x"].zscore_legend_ext())' +
                ')(csv_frame("\\ngrp,x\\nA,11\\nA,9\\nA,13\\nA,7\\nA,10\\nB,20\\nB,26\\nB,14\\nB,22\\nB,18"))')
         ]
       ),
@@ -1324,7 +1324,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesS
                 'A,5\n'+
                 'B,10}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~x_zscore:{p: meta::pure::metamodel::relation::Relation<(grp:String[0..1], x:Integer[0..1])>[1], w: meta::pure::functions::relation::_Window<(grp:String[0..1], x:Integer[0..1])>[1], r: (grp:String[0..1], x:Integer[0..1])[1]|$p->meta::pure::functions::math::zScore($w, $r, ~x)})',
               '(lambda frame:' +
-               '  frame.assign(x_zscore=lambda r: frame.groupby("grp")["x"].zscore())' +
+               '  frame.assign(x_zscore=lambda r: frame.groupby("grp")["x"].zscore_legend_ext())' +
                ')(csv_frame("\\ngrp,x\\nA,5\\nA,5\\nA,5\\nB,10"))')
         ]
       ),
@@ -1339,7 +1339,7 @@ function meta::external::python::reversePCT::pandasAPI::pythonPandasAPIReversesS
                 'A,4.0\n'+
                 'A,5.0}#->meta::pure::functions::relation::extend(~grp->meta::pure::functions::relation::over(), ~x_zscore:{p: meta::pure::metamodel::relation::Relation<(grp:String[0..1], x:Float[0..1])>[1], w: meta::pure::functions::relation::_Window<(grp:String[0..1], x:Float[0..1])>[1], r: (grp:String[0..1], x:Float[0..1])[1]|$p->meta::pure::functions::math::zScore($w, $r, ~x)})',
               '(lambda frame:' +
-               '  frame.assign(x_zscore=lambda r: frame.groupby("grp")["x"].zscore())' +
+               '  frame.assign(x_zscore=lambda r: frame.groupby("grp")["x"].zscore_legend_ext())' +
                ')(csv_frame("\\ngrp,x\\nA,1.0\\nA,2.0\\nA,3.0\\nA,4.0\\nA,5.0"))')
         ]
       )

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <legend.pure.version>5.81.0</legend.pure.version>
         <legend.shared.version>0.34.0</legend.shared.version>
         <legend.web-application.version>13.2.0</legend.web-application.version>
-        <legend.pylegend.version>0.20.0</legend.pylegend.version>
+        <legend.pylegend.version>0.21.0</legend.pylegend.version>
 
         <!-- SONAR -->
         <sonar.projectKey>legend-engine</sonar.projectKey>


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Add relational reversePCTs for PandasAPI (PyLegend)

#### Which issue(s) this PR fixes:

Fixes #NA

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?

No
