### PR TITLE
Optimize colspecarray processing by single calculation of var Generic…

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperValueSpecificationBuilder.java
@@ -117,7 +117,23 @@ public class HelperValueSpecificationBuilder
     {
         ctx.push("new lambda");
         ctx.addVariableLevel();
-        MutableList<VariableExpression> pureParameters = ListIterate.collect(parameters, p -> (VariableExpression) p.accept(valueSpecificationBuilderFactory.value(context, Lists.mutable.empty(), ctx)));
+        MutableList<VariableExpression> pureParameters = ListIterate.collect(parameters, p ->
+        {
+            // Reuse pre-compiled parameter if available (set by ColSpecArray batch processing).
+            // This is separate from inferredVariableList to avoid incorrectly reusing
+            // same-named variables from outer scopes (e.g., nested ->exists(c | ... ->exists(c | ...))).
+            if (p.genericType != null && p.multiplicity != null)
+            {
+                VariableExpression preCompiled = ctx.getPreCompiledLambdaParameter(p.name);
+                if (preCompiled != null)
+                {
+                    ctx.addInferredVariables(p.name, preCompiled);
+                    return preCompiled;
+                }
+            }
+            return (VariableExpression) p.accept(valueSpecificationBuilderFactory.value(context, Lists.mutable.empty(), ctx));
+        });
+
         if (parameters.size() != 0 && !parameters.get(0).name.equals("v_automap"))
         {
             if (ctx.milestoningDatePropagationContext.size() == 0)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ProcessingContext.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ProcessingContext.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 
 import java.util.ListIterator;
 import java.util.Stack;
@@ -29,6 +30,43 @@ public class ProcessingContext
     public Stack<MilestoningDatePropagationContext> milestoningDatePropagationContext = new Stack<>();
     private final Stack<String> tags = new Stack<>();
     public boolean isDatePropagationSupported = true;
+
+    // Pre-compiled lambda parameters for batch processing (e.g., ColSpecArray).
+    // Kept separate from inferredVariableList so that same-named variables from
+    // outer scopes are never incorrectly reused.
+    // The targetVariableLevel tracks the exact variable level depth at which these
+    // parameters should be consumed (one level deeper than where they were set),
+    // preventing nested lambdas (e.g., c | $c.values->exists(c | true)) from
+    // incorrectly matching.
+    private MutableMap<String, VariableExpression> preCompiledLambdaParameters = null;
+    private int preCompiledLambdaParametersTargetLevel = -1;
+
+    public void setPreCompiledLambdaParameters(MutableMap<String, VariableExpression> params)
+    {
+        this.preCompiledLambdaParameters = params;
+        this.preCompiledLambdaParametersTargetLevel = this.inferredVariableList.size() + 1;
+    }
+
+    public void clearPreCompiledLambdaParameters()
+    {
+        this.preCompiledLambdaParameters = null;
+        this.preCompiledLambdaParametersTargetLevel = -1;
+    }
+
+    public VariableExpression getPreCompiledLambdaParameter(String name)
+    {
+        if (this.preCompiledLambdaParameters == null)
+        {
+            return null;
+        }
+        // Only return pre-compiled parameters at the target depth.
+        // This ensures nested lambdas which add additional variable levels) don't incorrectly reuse them.
+        if (this.inferredVariableList.size() != this.preCompiledLambdaParametersTargetLevel)
+        {
+            return null;
+        }
+        return this.preCompiledLambdaParameters.get(name);
+    }
 
     public void pushMilestoningDatePropagationContext(MilestoningDatePropagationContext milestoningContext)
     {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
@@ -422,7 +423,39 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
     {
         ProcessorSupport processorSupport = this.context.pureModel.getExecutionSupport().getProcessorSupport();
 
+        // Pre-compile shared lambda parameters once so that buildLambdaWithContext can reuse them
+        // instead of recompiling the same parameter definition for every ColSpec in the array.
+        // Uses a dedicated map on ProcessingContext (separate from inferredVariableList) to avoid
+        // incorrectly reusing same-named variables from outer scopes.
+        if (!value.colSpecs.isEmpty())
+        {
+            ColSpec firstWithFunction = ListIterate.detect(value.colSpecs, cs -> cs.function1 != null);
+            if (firstWithFunction != null && firstWithFunction.function1.parameters != null)
+            {
+                MutableMap<String, VariableExpression> preCompiled = org.eclipse.collections.impl.map.mutable.UnifiedMap.newMap();
+                for (Variable param : firstWithFunction.function1.parameters)
+                {
+                    if (param.genericType != null && param.multiplicity != null)
+                    {
+                        VariableExpression ve = new Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl("", SourceInformationHelper.toM3SourceInformation(param.sourceInformation), this.context.pureModel.getClass(M3Paths.VariableExpression))
+                                ._name(param.name)
+                                ._genericType(context.newGenericType(param.genericType))
+                                ._multiplicity(this.context.pureModel.getMultiplicity(param.multiplicity));
+                        preCompiled.put(param.name, ve);
+                    }
+                }
+                if (preCompiled.notEmpty())
+                {
+                    processingContext.setPreCompiledLambdaParameters(preCompiled);
+                }
+            }
+        }
+
         MutableList<ValueSpecification> cols = ListIterate.collect(value.colSpecs, this::proccessColSpec);
+
+        // Clean up pre-compiled parameters
+        processingContext.clearPreCompiledLambdaParameters();
+
         RichIterable<?> processedValues = cols.flatCollect(v -> ((InstanceValue) v)._values());
         Object resO = processedValues.getFirst();
 


### PR DESCRIPTION
#### What type of PR is this?
Improvement

#### What does this PR do / why is it needed ?

Currently the rel type is recalculated for every colspec instance in a colspec array. This is expensive operation especially for large relations and lots of columns. This change pre-builds the relationtype which is then reused throughout

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
