### PR TITLE
Optimize colspecarray processing by single calculation of var Generic…

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperValueSpecificationBuilder.java
@@ -117,7 +117,23 @@ public class HelperValueSpecificationBuilder
     {
         ctx.push("new lambda");
         ctx.addVariableLevel();
-        MutableList<VariableExpression> pureParameters = ListIterate.collect(parameters, p -> (VariableExpression) p.accept(valueSpecificationBuilderFactory.value(context, Lists.mutable.empty(), ctx)));
+        MutableList<VariableExpression> pureParameters = ListIterate.collect(parameters, p ->
+        {
+            // Reuse pre-compiled parameter if available (set by ColSpecArray batch processing).
+            // This is separate from inferredVariableList to avoid incorrectly reusing
+            // same-named variables from outer scopes (e.g., nested ->exists(c | ... ->exists(c | ...))).
+            if (p.genericType != null && p.multiplicity != null)
+            {
+                VariableExpression preCompiled = ctx.getPreCompiledLambdaParameter(p.name);
+                if (preCompiled != null)
+                {
+                    ctx.addInferredVariables(p.name, preCompiled);
+                    return preCompiled;
+                }
+            }
+            return (VariableExpression) p.accept(valueSpecificationBuilderFactory.value(context, Lists.mutable.empty(), ctx));
+        });
+
         if (parameters.size() != 0 && !parameters.get(0).name.equals("v_automap"))
         {
             if (ctx.milestoningDatePropagationContext.size() == 0)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ProcessingContext.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ProcessingContext.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 
 import java.util.ListIterator;
 import java.util.Stack;
@@ -29,6 +30,43 @@ public class ProcessingContext
     public Stack<MilestoningDatePropagationContext> milestoningDatePropagationContext = new Stack<>();
     private final Stack<String> tags = new Stack<>();
     public boolean isDatePropagationSupported = true;
+
+    // Pre-compiled lambda parameters for batch processing (e.g., ColSpecArray).
+    // Kept separate from inferredVariableList so that same-named variables from
+    // outer scopes are never incorrectly reused.
+    // The targetVariableLevel tracks the exact variable level depth at which these
+    // parameters should be consumed (one level deeper than where they were set),
+    // preventing nested lambdas (e.g., c | $c.values->exists(c | true)) from
+    // incorrectly matching.
+    private MutableMap<String, VariableExpression> preCompiledLambdaParameters = null;
+    private int preCompiledLambdaParametersTargetLevel = -1;
+
+    public void setPreCompiledLambdaParameters(MutableMap<String, VariableExpression> params)
+    {
+        this.preCompiledLambdaParameters = params;
+        this.preCompiledLambdaParametersTargetLevel = this.inferredVariableList.size() + 1;
+    }
+
+    public void clearPreCompiledLambdaParameters()
+    {
+        this.preCompiledLambdaParameters = null;
+        this.preCompiledLambdaParametersTargetLevel = -1;
+    }
+
+    public VariableExpression getPreCompiledLambdaParameter(String name)
+    {
+        if (this.preCompiledLambdaParameters == null)
+        {
+            return null;
+        }
+        // Only return pre-compiled parameters at the target depth.
+        // This ensures nested lambdas which add additional variable levels) don't incorrectly reuse them.
+        if (this.inferredVariableList.size() != this.preCompiledLambdaParametersTargetLevel)
+        {
+            return null;
+        }
+        return this.preCompiledLambdaParameters.get(name);
+    }
 
     public void pushMilestoningDatePropagationContext(MilestoningDatePropagationContext milestoningContext)
     {

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
@@ -422,7 +423,35 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
     {
         ProcessorSupport processorSupport = this.context.pureModel.getExecutionSupport().getProcessorSupport();
 
+        // Pre-compile shared lambda parameters once so that buildLambdaWithContext can reuse them
+        // instead of recompiling the same parameter definition for every ColSpec in the array.
+        // Uses a dedicated map on ProcessingContext (separate from inferredVariableList) to avoid
+        // incorrectly reusing same-named variables from outer scopes.
+        if (!value.colSpecs.isEmpty())
+        {
+            ColSpec firstWithFunction = ListIterate.detect(value.colSpecs, cs -> cs.function1 != null);
+            if (firstWithFunction != null && firstWithFunction.function1.parameters != null)
+            {
+                MutableMap<String, VariableExpression> preCompiled = org.eclipse.collections.impl.map.mutable.UnifiedMap.newMap();
+                for (Variable param : firstWithFunction.function1.parameters)
+                {
+                    if (param.genericType != null && param.multiplicity != null)
+                    {
+                        preCompiled.put(param.name, (VariableExpression) param.accept(new ValueSpecificationBuilder(context, Lists.mutable.empty(), new ProcessingContext("ColSpecArrayParametersPreCompilation"))));
+                    }
+                }
+                if (preCompiled.notEmpty())
+                {
+                    processingContext.setPreCompiledLambdaParameters(preCompiled);
+                }
+            }
+        }
+
         MutableList<ValueSpecification> cols = ListIterate.collect(value.colSpecs, this::proccessColSpec);
+
+        // Clean up pre-compiled parameters
+        processingContext.clearPreCompiledLambdaParameters();
+
         RichIterable<?> processedValues = cols.flatCollect(v -> ((InstanceValue) v)._values());
         Object resO = processedValues.getFirst();
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -427,22 +427,21 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
         // instead of recompiling the same parameter definition for every ColSpec in the array.
         // Uses a dedicated map on ProcessingContext (separate from inferredVariableList) to avoid
         // incorrectly reusing same-named variables from outer scopes.
+        MutableMap<String, VariableExpression> preCompiledLambdaParam = org.eclipse.collections.impl.map.mutable.UnifiedMap.newMap();
+
         if (!value.colSpecs.isEmpty())
         {
             ColSpec firstWithFunction = ListIterate.detect(value.colSpecs, cs -> cs.function1 != null);
+
             if (firstWithFunction != null && firstWithFunction.function1.parameters != null)
             {
-                MutableMap<String, VariableExpression> preCompiled = org.eclipse.collections.impl.map.mutable.UnifiedMap.newMap();
+
                 for (Variable param : firstWithFunction.function1.parameters)
                 {
                     if (param.genericType != null && param.multiplicity != null)
                     {
-                        preCompiled.put(param.name, (VariableExpression) param.accept(new ValueSpecificationBuilder(context, Lists.mutable.empty(), new ProcessingContext("ColSpecArrayParametersPreCompilation"))));
+                        preCompiledLambdaParam.put(param.name, (VariableExpression) param.accept(new ValueSpecificationBuilder(context, Lists.mutable.empty(), new ProcessingContext("ColSpecArrayParametersPreCompilation"))));
                     }
-                }
-                if (preCompiled.notEmpty())
-                {
-                    processingContext.setPreCompiledLambdaParameters(preCompiled);
                 }
             }
         }
@@ -531,6 +530,11 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
 
     private ValueSpecification proccessColSpec(ColSpec colSpec)
     {
+        return proccessColSpec(colSpec, Maps.mutable.empty());
+    }
+
+    private ValueSpecification proccessColSpec(ColSpec colSpec, MutableMap<String, VariableExpression> function1Parameters)
+    {
         ProcessorSupport processorSupport = this.context.pureModel.getExecutionSupport().getProcessorSupport();
         if (colSpec.function1 == null)
         {
@@ -560,7 +564,10 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
         }
         else if (colSpec.function2 == null)
         {
+            processingContext.setPreCompiledLambdaParameters(function1Parameters);
             InstanceValue funcVS = (InstanceValue) colSpec.function1.accept(this);
+            processingContext.clearPreCompiledLambdaParameters();
+
             org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?> func = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?>) funcVS._values().getFirst();
 
             FunctionType func1Type = (FunctionType) org.finos.legend.pure.m3.navigation.function.Function.computeFunctionType(func, this.context.pureModel.getExecutionSupport().getProcessorSupport());
@@ -605,7 +612,10 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
         }
         else
         {
+            processingContext.setPreCompiledLambdaParameters(function1Parameters);
             InstanceValue funcVS = (InstanceValue) colSpec.function1.accept(this);
+            processingContext.clearPreCompiledLambdaParameters();
+
             org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?> func1 = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition<?>) funcVS._values().getFirst();
 
             InstanceValue func2VS = (InstanceValue) colSpec.function2.accept(this);

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.list.mutable.FastList;
@@ -350,11 +351,11 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
             }
             case "colSpec":
             {
-                return proccessColSpec((ColSpec) iv.value);
+                return processColSpec((ColSpec) iv.value);
             }
             case "colSpecArray":
             {
-                return proccessColSpecArray((ColSpecArray) iv.value);
+                return processColSpecArray((ColSpecArray) iv.value);
             }
             case "propertyGraphFetchTree":
             {
@@ -419,7 +420,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
         }
     }
 
-    private ValueSpecification proccessColSpecArray(ColSpecArray value)
+    private ValueSpecification processColSpecArray(ColSpecArray value)
     {
         ProcessorSupport processorSupport = this.context.pureModel.getExecutionSupport().getProcessorSupport();
 
@@ -446,10 +447,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
             }
         }
 
-        MutableList<ValueSpecification> cols = ListIterate.collect(value.colSpecs, this::proccessColSpec);
-
-        // Clean up pre-compiled parameters
-        processingContext.clearPreCompiledLambdaParameters();
+        MutableList<ValueSpecification> cols = ListIterate.collect(value.colSpecs, c -> processColSpec(c, preCompiledLambdaParam));
 
         RichIterable<?> processedValues = cols.flatCollect(v -> ((InstanceValue) v)._values());
         Object resO = processedValues.getFirst();
@@ -528,12 +526,12 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
                 ._typeArguments(args);
     }
 
-    private ValueSpecification proccessColSpec(ColSpec colSpec)
+    private ValueSpecification processColSpec(ColSpec colSpec)
     {
-        return proccessColSpec(colSpec, Maps.mutable.empty());
+        return processColSpec(colSpec, Maps.mutable.empty());
     }
 
-    private ValueSpecification proccessColSpec(ColSpec colSpec, MutableMap<String, VariableExpression> function1Parameters)
+    private ValueSpecification processColSpec(ColSpec colSpec, MutableMap<String, VariableExpression> function1Parameters)
     {
         ProcessorSupport processorSupport = this.context.pureModel.getExecutionSupport().getProcessorSupport();
         if (colSpec.function1 == null)


### PR DESCRIPTION
…Type
Improvement

#### What does this PR do / why is it needed ?
Currently reltype is calculated for each colspec in array which is very expensive, this calculates once and reuses

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
