### PR TITLE
Enhancements to Recon API

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
@@ -68,10 +68,14 @@ import org.finos.legend.engine.shared.core.operational.logs.LogInfo;
 import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
 import org.finos.legend.engine.shared.core.operational.prometheus.MetricsHandler;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQuality;
+import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQualityRelationComparison;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQualityRelationValidation;
+import org.finos.legend.pure.generated.Root_meta_external_dataquality_MD5HashStrategy;
+import org.finos.legend.pure.generated.Root_meta_external_dataquality_ReconStrategy;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_datarecon_DataQualityReconInput;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_rule_suggestions_RuleSuggestion;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
+import org.finos.legend.pure.generated.core_dataquality_generation_dataquality;
 import org.finos.legend.pure.generated.core_dataquality_generation_datarecon;
 import org.finos.legend.pure.generated.core_dataquality_generation_rule_suggestions;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
@@ -96,6 +100,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static org.finos.legend.engine.shared.core.operational.http.InflateInterceptor.APPLICATION_ZLIB;
 
 @Api(tags = "DataQuality - Execution")
@@ -349,13 +354,25 @@ public class DataQualityExecute
     {
         LOGGER.info(new LogInfo(identity.getName(), DataQualityLoggingEventType.DATAQUALITY_RECON_START).toString());
 
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction dqLambdaFunction;
+        Root_meta_external_dataquality_DataQualityRelationComparison dqComparisonElement = getDqComparisonElement(pureModel, input.packagePath);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> sourceLambdaFunction = dqComparisonElement == null ? HelperValueSpecificationBuilder.buildLambda(input.source, pureModel.getContext()) : dqComparisonElement._source();
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> targetLambdaFunction = dqComparisonElement == null ? HelperValueSpecificationBuilder.buildLambda(input.target, pureModel.getContext()) : dqComparisonElement._target();
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> dqLambdaFunction;
+
+        if (!core_dataquality_generation_dataquality.Root_meta_external_dataquality_isEndingWithFromFunction_FunctionDefinition_1__Boolean_1_(sourceLambdaFunction, pureModel.getExecutionSupport()))
+        {
+            throw new EngineException("The source query for the Data Quality Recon Input does not end with a 'from' so unable to execute it.", ExceptionCategory.USER_EXECUTION_ERROR);
+        }
+        if (!core_dataquality_generation_dataquality.Root_meta_external_dataquality_isEndingWithFromFunction_FunctionDefinition_1__Boolean_1_(targetLambdaFunction, pureModel.getExecutionSupport()))
+        {
+            throw new EngineException("The target query for the Data Quality Recon Input does not end with a 'from' so unable to execute it.", ExceptionCategory.USER_EXECUTION_ERROR);
+        }
         MutableMap<String, Object> lambdaParameterMap = Maps.mutable.empty();
 
         if (input.runSourceQuery)
         {
             // return source query results directly
-            dqLambdaFunction = HelperValueSpecificationBuilder.buildLambda(input.source, pureModel.getContext());
+            dqLambdaFunction = sourceLambdaFunction;
             if (input.sourceLambdaParameterValues != null)
             {
                 input.sourceLambdaParameterValues.forEach(p -> lambdaParameterMap.put(p.name, p.value.accept(new PrimitiveValueSpecificationToObjectVisitor())));
@@ -364,7 +381,7 @@ public class DataQualityExecute
         else if (input.runTargetQuery)
         {
             // return target query results directly
-            dqLambdaFunction = HelperValueSpecificationBuilder.buildLambda(input.target, pureModel.getContext());
+            dqLambdaFunction = targetLambdaFunction;
             if (input.targetLambdaParameterValues != null)
             {
                 input.targetLambdaParameterValues.forEach(p -> lambdaParameterMap.put(p.name, p.value.accept(new PrimitiveValueSpecificationToObjectVisitor())));
@@ -373,9 +390,7 @@ public class DataQualityExecute
         else
         {
             // 1. create DQ recon input
-            Root_meta_external_dataquality_datarecon_DataQualityReconInput reconInput = core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_createReconInput_LambdaFunction_1__LambdaFunction_1__String_MANY__Boolean_1__String_MANY__String_$0_1$__String_$0_1$__Boolean_1__Integer_$0_1$__DataQualityReconInput_1_(
-                    HelperValueSpecificationBuilder.buildLambda(input.source, pureModel.getContext()), HelperValueSpecificationBuilder.buildLambda(input.target, pureModel.getContext()), Sets.immutable.ofAll(input.keys), input.aggregatedHash, Sets.immutable.ofAll(input.colsForHash), input.sourceHashCol, input.targetHashCol, input.includeColumnValues, input.defectLimit, pureModel.getExecutionSupport()
-            );
+            Root_meta_external_dataquality_datarecon_DataQualityReconInput reconInput = createReconInput(pureModel, dqComparisonElement, input, sourceLambdaFunction, targetLambdaFunction);
             // 2. call DQ PURE func to generate recon lambda
             dqLambdaFunction = DataQualityReconLambdaGenerator.generateLambda(pureModel, reconInput);
             // 3. build parameter map with source_/target_ prefixes for the recon lambda
@@ -394,6 +409,60 @@ public class DataQualityExecute
         LOGGER.info(new LogInfo(identity.getName(), DataQualityLoggingEventType.DATAQUALITY_RECON_END, System.currentTimeMillis() - start).toString());
         // 4. Execute plan
         return executePlanToResult(request, identity, singleExecutionPlan, lambdaParameterMap);
+    }
+
+    private static Root_meta_external_dataquality_datarecon_DataQualityReconInput createReconInput(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationComparison dqComparisonElement, DataQualityReconInput input, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> sourceLambdaFunction, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> targetLambdaFunction)
+    {
+        if (dqComparisonElement == null)
+        {
+            return core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_createReconInput_LambdaFunction_1__LambdaFunction_1__String_MANY__Boolean_1__String_MANY__String_$0_1$__String_$0_1$__Boolean_1__Integer_$0_1$__Boolean_1__DataQualityReconInput_1_(
+                    sourceLambdaFunction, targetLambdaFunction, Sets.immutable.ofAll(input.keys), input.aggregatedHash, Sets.immutable.ofAll(input.colsForHash), input.sourceHashCol, input.targetHashCol, input.includeColumnValues, input.defectLimit, false, pureModel.getExecutionSupport()
+            );
+        }
+        return core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_createReconInput_LambdaFunction_1__LambdaFunction_1__String_MANY__Boolean_1__String_MANY__String_$0_1$__String_$0_1$__Boolean_1__Integer_$0_1$__Boolean_1__DataQualityReconInput_1_(
+                dqComparisonElement._source(), dqComparisonElement._target(), dqComparisonElement._keys(), getAggregatedHash(dqComparisonElement._strategy()), dqComparisonElement._columnsToCompare(), getSourceHashColumn(dqComparisonElement._strategy()), getTargetHashColumn(dqComparisonElement._strategy()), input.includeColumnValues, input.defectLimit, false, pureModel.getExecutionSupport()
+        );
+    }
+
+    private static boolean getAggregatedHash(Root_meta_external_dataquality_ReconStrategy reconStrategy)
+    {
+        if (reconStrategy instanceof Root_meta_external_dataquality_MD5HashStrategy)
+        {
+            return ((Root_meta_external_dataquality_MD5HashStrategy) reconStrategy)._aggregatedHash();
+        }
+        return false;
+    }
+
+    private static String getSourceHashColumn(Root_meta_external_dataquality_ReconStrategy reconStrategy)
+    {
+        if (reconStrategy instanceof Root_meta_external_dataquality_MD5HashStrategy)
+        {
+            return ((Root_meta_external_dataquality_MD5HashStrategy) reconStrategy)._sourceHashColumn();
+        }
+        return null;
+    }
+
+    private static String getTargetHashColumn(Root_meta_external_dataquality_ReconStrategy reconStrategy)
+    {
+        if (reconStrategy instanceof Root_meta_external_dataquality_MD5HashStrategy)
+        {
+            return ((Root_meta_external_dataquality_MD5HashStrategy) reconStrategy)._targetHashColumn();
+        }
+        return null;
+    }
+
+    private static Root_meta_external_dataquality_DataQualityRelationComparison getDqComparisonElement(PureModel pureModel, String packagePath)
+    {
+        if (packagePath != null)
+        {
+            PackageableElement packageableElement = pureModel.getPackageableElement(packagePath);
+            if (packageableElement instanceof Root_meta_external_dataquality_DataQualityRelationComparison)
+            {
+                return (Root_meta_external_dataquality_DataQualityRelationComparison) packageableElement;
+            }
+            throw new EngineException(format("Expected package path to point to DataQualityRelationComparison but found %s", packageableElement.getClass().getSimpleName()), ExceptionCategory.USER_EXECUTION_ERROR);
+        }
+        return null;
     }
 
     private SingleExecutionPlan generateExecutionPlan(DataQualityExecuteTrialInput dataQualityExecuteInput, Identity identity, boolean rowCount, String queryType)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityReconInput.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityReconInput.java
@@ -28,11 +28,10 @@ public class DataQualityReconInput
 {
     @JsonProperty(required = true)
     public PureModelContext model;
-    public String clientVersion;
-    @JsonProperty(required = true)
+    public String clientVersion = "vX_X_X";
     public LambdaFunction source; //query pointing to source dataset
-    @JsonProperty(required = true)
     public LambdaFunction target; //query pointing to target dataset
+    public String packagePath; //optional package path to DataQualityRelationComparison element to get source/target lambdas if not provided directly in the input
     public Set<String> keys; //these must exist on both source and target dataset - can either be primary keys or grouping keys if aggregated hash required. If empty then hash column will be used.
     public boolean aggregatedHash = false; //whether aggregated hash should be created based on the keys provided
     public Set<String> colsForHash; //which columns you want the hash to be calculated on, these columns must exist on both source and target dataset. If empty then will calculate hash on all columns.

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/test/java/org/finos/legend/engine/language/dataquality/api/TestDataQualityApi.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/test/java/org/finos/legend/engine/language/dataquality/api/TestDataQualityApi.java
@@ -202,6 +202,75 @@ public class TestDataQualityApi
         assertNotNull(resultAsString);
     }
 
+    @Test
+    public void testDataQualityReconThrowsExceptionWhenSourceDoesNotHaveFrom()
+    {
+        DataQualityReconInput input = new DataQualityReconInput();
+        input.clientVersion = "vX_X_X";
+        input.model = new PureModelContextPointer();
+        input.source = lambda("|demo::Person.all()->project(~[id: x|$x.id, fullName: x|$x.fullName])");
+        input.target = lambda("|demo::Person.all()->project(~[id: x|$x.id, fullName: x|$x.fullName])->from(demo::PersonMap, demo::PersonRuntime)");
+
+        Response response = resources.target("pure/v1/dataquality/reconciliation")
+                .request()
+                .post(Entity.json(input));
+
+        assertEquals(500, response.getStatus());
+        String resultAsString = response.readEntity(String.class);
+        assertTrue(resultAsString.contains("The source query for the Data Quality Recon Input does not end with a 'from' so unable to execute it."));
+    }
+
+    @Test
+    public void testDataQualityReconThrowsExceptionWhenTargetDoesNotHaveFrom()
+    {
+        DataQualityReconInput input = new DataQualityReconInput();
+        input.clientVersion = "vX_X_X";
+        input.model = new PureModelContextPointer();
+        input.source = lambda("|demo::Person.all()->project(~[id: x|$x.id, fullName: x|$x.fullName])->from(demo::PersonMap, demo::PersonRuntime)");
+        input.target = lambda("|demo::Person.all()->project(~[id: x|$x.id, fullName: x|$x.fullName])");
+
+        Response response = resources.target("pure/v1/dataquality/reconciliation")
+                .request()
+                .post(Entity.json(input));
+
+        assertEquals(500, response.getStatus());
+        String resultAsString = response.readEntity(String.class);
+        assertTrue(resultAsString.contains("The target query for the Data Quality Recon Input does not end with a 'from' so unable to execute it."));
+    }
+
+    @Test
+    public void testDataQualityReconThrowsExceptionWhenPackagePathNotPointingToComparisonElement()
+    {
+        DataQualityReconInput input = new DataQualityReconInput();
+        input.clientVersion = "vX_X_X";
+        input.model = new PureModelContextPointer();
+        input.packagePath = "demo::PersonRuntime";
+
+        Response response = resources.target("pure/v1/dataquality/reconciliation")
+                .request()
+                .post(Entity.json(input));
+
+        assertEquals(500, response.getStatus());
+        String resultAsString = response.readEntity(String.class);
+        assertTrue(resultAsString.contains("Expected package path to point to DataQualityRelationComparison but found Root_meta_pure_runtime_PackageableRuntime_Impl"));
+    }
+
+    @Test
+    public void testDataQualityReconWhenProvidePackagePathToComparisonElement()
+    {
+        DataQualityReconInput input = new DataQualityReconInput();
+        input.packagePath = "meta::dataquality::TestRelationComparison";
+        input.model = new PureModelContextPointer();
+
+        Response response = resources.target("pure/v1/dataquality/reconciliation")
+                .request()
+                .post(Entity.json(input));
+
+        assertEquals(200, response.getStatus());
+        String resultAsString = response.readEntity(String.class);
+        assertNotNull(resultAsString);
+    }
+
     private LambdaFunction lambda(String code)
     {
         return PureGrammarParser.newInstance().parseLambda(code, "", false);

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/test/resources/inputs/test-data.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/test/resources/inputs/test-data.pure
@@ -173,3 +173,12 @@ Runtime demo::PersonRuntime
     ]
   ];
 }
+
+###DataQualityValidation
+DataQualityRelationComparison meta::dataquality::TestRelationComparison
+{
+  source: |demo::Person.all()->project(~[id: x|$x.id, fullName: x|$x.fullName])->from(demo::PersonMap, demo::PersonRuntime);
+  target: |demo::Person.all()->project(~[id: x|$x.id, fullName: x|$x.fullName])->from(demo::PersonMap, demo::PersonRuntime);
+  keys: [id, fullName];
+  strategy: MD5Hash;
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/TestDataQualityCompilationFromGrammar.java
@@ -449,7 +449,7 @@ public class TestDataQualityCompilationFromGrammar extends TestCompilationFromGr
                 "###DataQualityValidation\n" +
                 "DataQualityRelationComparison meta::dataquality::TestRelationComparison\n" +
                 "{\n" +
-                "   source: |#>{meta::dataquality::db.personTable}#->select(~[FIRSTNAME, LASTNAME, AGE])->from(meta::dataquality::DataQualityRuntime);\n" +
+                "   source: |#>{meta::dataquality::db.personTable}#->select(~[FIRSTNAME, LASTNAME, AGE]);\n" +
                 "   target: |#>{meta::dataquality::db.personTable}#->select(~[FIRSTNAME, LASTNAME, AGE])->from(meta::dataquality::DataQualityRuntime);\n" +
                 "   keys: [FIRSTNAME, LASTNAME];\n" +
                 "   strategy: MD5Hash;\n" +

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_model.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_model.pure
@@ -77,6 +77,8 @@ Class meta::external::dataquality::tests::domain::Person
   name: String[1];
   age: Integer[1];
   addresses: meta::external::dataquality::tests::domain::Address[*];
+  id: String[0..1];
+  hash: String[0..1];
 }
 
 Class meta::external::dataquality::tests::domain::Address

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
@@ -21,6 +21,8 @@ import meta::pure::functions::relation::*;
 import meta::pure::functions::meta::*;
 import meta::external::dataquality::*;
 import meta::pure::precisePrimitives::*;
+import meta::external::dataquality::tests::domain::*;
+import meta::pure::metamodel::relation::*;
 
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_dynamicHash():Boolean[1]
 {
@@ -373,6 +375,98 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
   testRecon($lambda, $source, $target, 'ID', false, ['FIRSTNAME', 'LASTNAME'], [], [], false);
 }
 
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_noFromFunctions():Boolean[1]
+{
+  let expected = {| #>{meta::external::dataquality::tests::domain::db.personTable}#
+    ->select(~[ID,HASH])
+    ->extend(~[ID_SOURCE: row | $row.ID, HASH_SOURCE: row | $row.HASH])
+    ->select(~[ID_SOURCE,HASH_SOURCE])
+    ->join(
+        #>{meta::external::dataquality::tests::domain::db.personTable}#
+          ->select(~[ID,HASH])
+          ->extend(~[ID_TARGET: row | $row.ID, HASH_TARGET: row | $row.HASH])
+          ->select(~[ID_TARGET,HASH_TARGET]),
+        JoinKind.FULL,
+        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+    )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
+  };
+
+  let input = {| #>{meta::external::dataquality::tests::domain::db.personTable}#};
+  testRecon($expected, $input, $input, 'ID', false, [], 'HASH', 'HASH', false, [], false);
+}
+
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_removesFrom():Boolean[1]
+{
+  let runtime = loadModel([])->filter(p | $p->elementToPath() == 'meta::external::dataquality::tests::domain::DataQualityRuntime')->toOne()->cast(@PackageableRuntime);
+  let expected = {| #>{meta::external::dataquality::tests::domain::db.personTable}#
+    ->select(~[ID,HASH])
+    ->extend(~[ID_SOURCE: row | $row.ID, HASH_SOURCE: row | $row.HASH])
+    ->select(~[ID_SOURCE,HASH_SOURCE])
+    ->join(
+        #>{meta::external::dataquality::tests::domain::db.personTable}#
+          ->select(~[ID,HASH])
+          ->extend(~[ID_TARGET: row | $row.ID, HASH_TARGET: row | $row.HASH])
+          ->select(~[ID_TARGET,HASH_TARGET]),
+        JoinKind.FULL,
+        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+    )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
+  };
+
+  let source = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
+  let target = {| #>{meta::external::dataquality::tests::domain::db.personTable}#};
+  testRecon($expected, $source, $target, 'ID', false, [], 'HASH', 'HASH', false, [], true);
+}
+
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_withTabularDataSet():Boolean[1]
+{
+  let runtime = loadModel([])->filter(p | $p->elementToPath() == 'meta::external::dataquality::tests::domain::DataQualityRuntime')->toOne()->cast(@PackageableRuntime);
+  let mapping = loadModel([])->filter(p | $p->elementToPath() == 'meta::external::dataquality::tests::domain::dataqualitymappings')->toOne()->cast(@Mapping);
+  let expected = {| #>{meta::external::dataquality::tests::domain::db.personTable}#
+    ->select(~[ID,HASH])
+    ->extend(~[ID_SOURCE: row | $row.ID, HASH_SOURCE: row | $row.HASH])
+    ->select(~[ID_SOURCE,HASH_SOURCE])
+    ->from($runtime)
+    ->join(
+        Person.all()->project([ x|$x.id, x|$x.hash ],[ 'ID', 'HASH'])
+          ->cast(@Relation<(ID: String[1], HASH: String[1])>)
+          ->select(~[ID,HASH])
+          ->extend(~[ID_TARGET: row | $row.ID, HASH_TARGET: row | $row.HASH])
+          ->select(~[ID_TARGET,HASH_TARGET])
+          ->from($mapping, $runtime),
+        JoinKind.FULL,
+        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+    )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
+  };
+
+  let source = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
+  let target = {| Person.all()->project([ x|$x.id, x|$x.hash ],[ 'ID', 'HASH'])->from($mapping, $runtime)};
+  testRecon($expected, $source, $target, 'ID', false, [], 'HASH', 'HASH', false, [], false);
+}
+
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_withTabularDataSetAndRemoveFrom():Boolean[1]
+{
+  let runtime = loadModel([])->filter(p | $p->elementToPath() == 'meta::external::dataquality::tests::domain::DataQualityRuntime')->toOne()->cast(@PackageableRuntime);
+  let mapping = loadModel([])->filter(p | $p->elementToPath() == 'meta::external::dataquality::tests::domain::dataqualitymappings')->toOne()->cast(@Mapping);
+  let expected = {| #>{meta::external::dataquality::tests::domain::db.personTable}#
+    ->select(~[ID,HASH])
+    ->extend(~[ID_SOURCE: row | $row.ID, HASH_SOURCE: row | $row.HASH])
+    ->select(~[ID_SOURCE,HASH_SOURCE])
+    ->join(
+        Person.all()->project([ x|$x.id, x|$x.hash ],[ 'ID', 'HASH'])
+          ->cast(@Relation<(ID: String[1], HASH: String[1])>)
+          ->select(~[ID,HASH])
+          ->extend(~[ID_TARGET: row | $row.ID, HASH_TARGET: row | $row.HASH])
+          ->select(~[ID_TARGET,HASH_TARGET]),
+        JoinKind.FULL,
+        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+    )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
+  };
+
+  let source = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
+  let target = {| Person.all()->project([ x|$x.id, x|$x.hash ],[ 'ID', 'HASH'])->from($mapping, $runtime)};
+  testRecon($expected, $source, $target, 'ID', false, [], 'HASH', 'HASH', false, [], true);
+}
+
 function meta::external::dataquality::tests::testRecon(expected:FunctionDefinition<Any>[1], runtime: PackageableRuntime[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1]):Boolean[1]
 {
   testRecon($expected, $runtime, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, []);
@@ -382,16 +476,16 @@ function meta::external::dataquality::tests::testRecon(expected:FunctionDefiniti
 {
   let source = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
   let target = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
-  testRecon($expected, $source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit);
+  testRecon($expected, $source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit, false);
 }
 
 function meta::external::dataquality::tests::testRecon(expected:FunctionDefinition<Any>[1], source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1]):Boolean[1]
 {
-  testRecon($expected, $source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, []);
+  testRecon($expected, $source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, [], false);
 }
 
-function meta::external::dataquality::tests::testRecon(expected:FunctionDefinition<Any>[1], source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1]):Boolean[1]
+function meta::external::dataquality::tests::testRecon(expected:FunctionDefinition<Any>[1], source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1], removeFrom: Boolean[1]):Boolean[1]
 {
-  let actual = getDataReconLambda(createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit));
+  let actual = getDataReconLambda(createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit, $removeFrom));
   assertLambdaEquals($expected, $actual, false);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
@@ -21,6 +21,7 @@ import meta::external::dataquality::datarecon::*;
 import system::imports::*;
 import meta::external::dataquality::dataprofile::*;
 import meta::relational::metamodel::datatype::*;
+import meta::pure::tds::schema::*;
 
 /*
   This method will:
@@ -46,8 +47,8 @@ function meta::external::dataquality::datarecon::getDataReconLambda(reconInput: 
 
   let allParams = $renamedSourceParams->concatenate($renamedTargetParams);
 
-  let sourceDataset = $sourceParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'source_' + $param.name)}, prepareDataset($reconInput.source, 'source', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.sourceHashCol, $reconInput.includeColumnValues));
-  let targetDataset = $targetParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'target_' + $param.name)}, prepareDataset($reconInput.target, 'target', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.targetHashCol, $reconInput.includeColumnValues));
+  let sourceDataset = $sourceParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'source_' + $param.name)}, prepareDataset($reconInput.source, 'source', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.sourceHashCol, $reconInput.includeColumnValues, $reconInput.removeFrom));
+  let targetDataset = $targetParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'target_' + $param.name)}, prepareDataset($reconInput.target, 'target', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.targetHashCol, $reconInput.includeColumnValues, $reconInput.removeFrom));
 
   //join by keys
   let withJoin = buildJoinExpression($sourceDataset, $targetDataset, JoinKind.FULL, getJoinColumns($reconInput.keys), $reconInput.sourceHashCol, $reconInput.targetHashCol);
@@ -70,12 +71,21 @@ function meta::external::dataquality::datarecon::getDataReconLambda(reconInput: 
   );
 }
 
-function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaFunction<Any>[1], type: String[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], hashCol: String[0..1], includeColumnValues: Boolean[1]): ValueSpecification[1]
+function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaFunction<Any>[1], type: String[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], hashCol: String[0..1], includeColumnValues: Boolean[1], removeFrom: Boolean[1]): ValueSpecification[1]
 {  
-  validateColumns($dataset, $type, $keys, $colsForHash, $hashCol);
-  //need to remove from and add back after compileViaGrammar as runtime not yet supported in compileViaGrammar flow - once fixed we can remove this code
-  let from = $dataset.expressionSequence->evaluateAndDeactivate()->last()->cast(@SimpleFunctionExpression)->toOne();
-  let input = $from.parametersValues->evaluateAndDeactivate()->at(0)->toOne();
+  let hasFrom = $dataset->isEndingWithFromFunction();
+  let withoutFrom = if ($hasFrom,
+    | $dataset->popTerminalFunctionExpression().expressionSequence->evaluateAndDeactivate()->last()->toOne(), //need to remove from and add back after compileViaGrammar as runtime not yet supported in compileViaGrammar flow - once fixed we can remove this code
+    | $dataset.expressionSequence->evaluateAndDeactivate()->last()->toOne()
+  );
+
+  //if lambda returning Tablular Data Set (TDS) then add cast to Relation
+  let input = if ($dataset->functionReturnType().rawType->toOne()->subTypeOf(TabularDataSet),
+    | $dataset->buildCastToRelation($withoutFrom),
+    | $withoutFrom
+  );
+  validateColumns($input, $type, $keys, $colsForHash, $hashCol);
+
   let suffix = '_' + $type->toUpper();
     
   //select relevant columns before normalization
@@ -109,12 +119,16 @@ function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaF
   );
 
   let compiled = $withAggregatedHash->compileViaGrammarWithContext($dataset);
-  sfe($from.func, $compiled.genericType, [], $compiled->concatenate($from.parametersValues->tail()));
+  if ($hasFrom && !$removeFrom,
+    | let from = $dataset.expressionSequence->evaluateAndDeactivate()->last()->cast(@SimpleFunctionExpression)->toOne();
+      sfe($from.func, $compiled.genericType, [], $compiled->concatenate($from.parametersValues->tail()));,
+    | $compiled
+  );
 }
 
-function meta::external::dataquality::datarecon::validateColumns(dataset: LambdaFunction<Any>[1], type: String[1], keys: String[*], colsForHash: String[*], hashCol: String[0..1]): Boolean[*]
+function meta::external::dataquality::datarecon::validateColumns(input: ValueSpecification[1], type: String[1], keys: String[*], colsForHash: String[*], hashCol: String[0..1]): Boolean[*]
 {  
-  let relType = getRelType($dataset.expressionSequence->evaluateAndDeactivate()->last()->toOne());
+  let relType = getRelType($input);
   validateColumnExists($relType, $keys, $type, 'keys');
   validateColumnExists($relType, $colsForHash, $type, 'column to include for generated hash');
   validateColumnExists($relType, $hashCol, $type, 'column with pre-calculated hash');
@@ -123,6 +137,28 @@ function meta::external::dataquality::datarecon::validateColumns(dataset: Lambda
 function meta::external::dataquality::datarecon::validateColumnExists(relType: RelationType<Any>[1], columns: String[*], type: String[1], field: String[1]): Boolean[*]
 {
   $columns->map(column | assert($relType.columns->exists(col | $col.name->toOne() == $column), 'Expected ' + $type + ' table to contain field ' + $column + ' which was specified as ' + $field));
+}
+
+function meta::external::dataquality::datarecon::buildCastToRelation(dataset: LambdaFunction<Any>[1], input: ValueSpecification[1]): ValueSpecification[1]
+{
+  let columns = $dataset->resolveSchema([])->map(c |
+    let col = ^Column<Nil,Any|*>(name = $c.name->toOne(), nameWildCard = false);
+    let type = ^GenericType(rawType = Column, typeArguments = [ ^GenericType(rawType = Nil), ^GenericType(rawType = $c.type->toOne())], multiplicityArguments = PureOne);
+    ^$col(classifierGenericType = $type); //need to copy column and set correct type as can't set type directly in constructor since this is set by the generic type provided to ^Column<Nil,Any|*>
+  );
+  let genericType = ^GenericType(rawType=Relation, typeArguments = ^GenericType(rawType=^RelationType<Nil>(columns = $columns)));
+  ^SimpleFunctionExpression
+  (
+    func = cast_Any_m__T_1__T_m_,
+    multiplicity = PureOne,
+    genericType  = $genericType,
+    importGroup  = coreImport,
+    parametersValues =
+    [
+      $input,
+      ^InstanceValue(multiplicity = PureOne, genericType = $genericType)
+    ]
+  )->evaluateAndDeactivate();
 }
 
 function meta::external::dataquality::datarecon::normalizeColumns(input: ValueSpecification[1], relType: RelationType<Any>[1], colsToNormalize: String[*], suffix: String[1]):ValueSpecification[1]
@@ -411,13 +447,13 @@ function meta::external::dataquality::datarecon::compileViaGrammarWithContext(vs
   let compiled = ^$contextLambda(expressionSequence = $contextLambda.expressionSequence->evaluateAndDeactivate()->init()->concatenate([$vs])->toOneMany())->compileViaGrammar();
   $compiled.expressionSequence->evaluateAndDeactivate()->last()->toOne();
 }
-  
+
 function meta::external::dataquality::datarecon::createReconInput(source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1]): DataQualityReconInput[1]
 {
-  createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, []);
+  createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, [], false);
 }
 
-function meta::external::dataquality::datarecon::createReconInput(source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1]): DataQualityReconInput[1]
+function meta::external::dataquality::datarecon::createReconInput(source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1], removeFrom: Boolean[1]): DataQualityReconInput[1]
 {
-  ^DataQualityReconInput(source = $source, target = $target, keys = $keys, aggregatedHash = $aggregatedHash, colsForHash = $colsForHash, sourceHashCol = $sourceHashCol, targetHashCol = $targetHashCol, includeColumnValues = $includeColumnValues, defectLimit = $defectLimit);
+  ^DataQualityReconInput(source = $source, target = $target, keys = $keys, aggregatedHash = $aggregatedHash, colsForHash = $colsForHash, sourceHashCol = $sourceHashCol, targetHashCol = $targetHashCol, includeColumnValues = $includeColumnValues, defectLimit = $defectLimit, removeFrom = $removeFrom);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
@@ -65,10 +65,8 @@ Class meta::external::dataquality::RelationValidation
 
 Class meta::external::dataquality::datarecon::DataQualityReconInput
 [
-  sourceMustEndWithRuntime: $this.source->isEndingWithFromFunction(),
-  targetMustEndWithRuntime: $this.target->isEndingWithFromFunction(),
-  sourceMustReturnRelation: $this.source->functionReturnType().rawType->toOne()->subTypeOf(Relation),
-  targetMustReturnRelation: $this.target->functionReturnType().rawType->toOne()->subTypeOf(Relation)
+  sourceMustReturnRelationOrTds: $this.source->functionReturnType().rawType->toOne()->subTypeOf(Relation) || $this.source->functionReturnType().rawType->toOne()->subTypeOf(TabularDataSet),
+  targetMustReturnRelationOrTds: $this.target->functionReturnType().rawType->toOne()->subTypeOf(Relation) || $this.target->functionReturnType().rawType->toOne()->subTypeOf(TabularDataSet)
 ]
 {
   source: LambdaFunction<Any>[1]; //query pointing to source dataset
@@ -80,12 +78,11 @@ Class meta::external::dataquality::datarecon::DataQualityReconInput
   targetHashCol: String[0..1]; //if there already exists a column on target that contains the hash that you want to use in recon
   includeColumnValues: Boolean[1]; //whether to include the compared column values in the output alongside keys and digest. Only applies when aggregatedHash is false.
   defectLimit: Integer[0..1]; //optional limit on the number of defect rows returned
+  removeFrom: Boolean[1] = false; //whether the from function should be removed on source and target queries
 }
 
 Class meta::external::dataquality::DataQualityRelationComparison extends PackageableElement
 [
-  sourceMustEndWithRuntime: $this.source->isEndingWithFromFunction(),
-  targetMustEndWithRuntime: $this.target->isEndingWithFromFunction(),
   sourceMustReturnRelation: $this.source->functionReturnType().rawType->toOne()->subTypeOf(Relation),
   targetMustReturnRelation: $this.target->functionReturnType().rawType->toOne()->subTypeOf(Relation)
 ]


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

- add support for TDS in recon API by adding a dynamic cast to Relation in the lambda generation. The new dq comparison element will still enforce that the lambda need to return Relation
- make runtime optional to support generation flows
- add ability to pop off runtime to support generation flows
- add ability for recon API input to take in package path to dq comparison element so don't need to provide the entire source, target lambdas etc to the input if already defined in that element
