### PR TITLE
Recon small fixes + generate plan API

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
@@ -27,6 +27,8 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.eclipse.collections.impl.utility.internal.IterableIterate;
 import org.finos.legend.engine.generation.dataquality.DataQualityLambdaGenerator;
@@ -350,7 +352,29 @@ public class DataQualityExecute
         }
     }
 
-    private Result getDataReconciliation(HttpServletRequest request, PureModel pureModel, DataQualityReconInput input, long start, Identity identity)
+    @POST
+    @Path("reconciliation/generatePlan")
+    @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response reconciliationPlanGeneration(DataQualityReconInput dataQualityReconInput, @ApiParam(hidden = true) @Pac4JProfileManager() ProfileManager<CommonProfile> pm)
+    {
+        MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
+        Identity identity = Identity.makeIdentity(profiles);
+        long start = System.currentTimeMillis();
+        try (Scope ignored = GlobalTracer.get().buildSpan("DataQuality - recon: planGeneration").startActive(true))
+        {
+            PureModel pureModel = this.modelManager.loadModel(dataQualityReconInput.model, dataQualityReconInput.clientVersion, identity, null);
+            SingleExecutionPlan singleExecutionPlan = generateDataReconciliationPlan(pureModel, dataQualityReconInput, start, identity).getOne();
+            return ManageConstantResult.manageResult(identity.getName(), singleExecutionPlan, objectMapper);
+        }
+        catch (Exception ex)
+        {
+            LOGGER.error(new LogInfo(identity.getName(), LoggingEventType.GENERATE_PLAN_ERROR, (double) System.currentTimeMillis() - start).toString(), ex);
+            return ExceptionTool.exceptionManager(ex, LoggingEventType.GENERATE_PLAN_ERROR, identity.getName());
+        }
+    }
+
+    private Pair<SingleExecutionPlan, MutableMap<String, Object>> generateDataReconciliationPlan(PureModel pureModel, DataQualityReconInput input, long start, Identity identity)
     {
         LOGGER.info(new LogInfo(identity.getName(), DataQualityLoggingEventType.DATAQUALITY_RECON_START).toString());
 
@@ -405,10 +429,15 @@ public class DataQualityExecute
         }
 
         // 3. Generate Plan from the lambda generated in the previous step
-        SingleExecutionPlan singleExecutionPlan = PlanGenerator.generateExecutionPlan(dqLambdaFunction, null, null, null, pureModel, input.clientVersion, PlanPlatform.JAVA, null, this.extensions.apply(pureModel), this.transformers);
+        SingleExecutionPlan plan = PlanGenerator.generateExecutionPlan(dqLambdaFunction, null, null, null, pureModel, input.clientVersion, PlanPlatform.JAVA, null, this.extensions.apply(pureModel), this.transformers);
         LOGGER.info(new LogInfo(identity.getName(), DataQualityLoggingEventType.DATAQUALITY_RECON_END, System.currentTimeMillis() - start).toString());
-        // 4. Execute plan
-        return executePlanToResult(request, identity, singleExecutionPlan, lambdaParameterMap);
+        return Tuples.pair(plan, lambdaParameterMap);
+    }
+
+    private Result getDataReconciliation(HttpServletRequest request, PureModel pureModel, DataQualityReconInput input, long start, Identity identity)
+    {
+        Pair<SingleExecutionPlan, MutableMap<String, Object>> plan = generateDataReconciliationPlan(pureModel, input, start, identity);
+        return executePlanToResult(request, identity, plan.getOne(), plan.getTwo());
     }
 
     private static Root_meta_external_dataquality_datarecon_DataQualityReconInput createReconInput(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationComparison dqComparisonElement, DataQualityReconInput input, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> sourceLambdaFunction, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> targetLambdaFunction)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_relation_helper_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_relation_helper_test.pure
@@ -201,7 +201,8 @@ function <<test.Test>> meta::external::dataquality::tests::rowsWithColumnDiffers
 
 function <<test.Test>> meta::external::dataquality::tests::normalizeDateTimeWithValueTest():Boolean[1]
 {
-  assertEquals('2026-02-18T15:30:15.999999999', %2026-02-18T15:30:15.999999999->normalizeDateTime());
+  assertEquals('2026-02-18T04:07:03.000000000', %2026-02-18T04:07:03->normalizeDateTime());
+  assertEquals('2026-02-18T15:30:15.000000000', %2026-02-18T15:30:15.999999999->normalizeDateTime());
 }
 
 function <<test.Test>> meta::external::dataquality::tests::normalizeDateTimeWithoutValueTest():Boolean[1]

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
@@ -31,7 +31,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[ID,FIRSTNAME,LASTNAME])
     ->extend(~[ID_SOURCE: row | $row.ID, FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[ID_SOURCE,FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[ID_SOURCE,DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -39,7 +39,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID,FIRSTNAME,LASTNAME])
           ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
@@ -132,7 +132,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[ID,LASTNAME])
     ->extend(~[ID_SOURCE: row | $row.ID, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[ID_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.ID_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[ID_SOURCE,DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -140,7 +140,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID,LASTNAME])
           ->extend(~[ID_TARGET: row | $row.ID, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[ID_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.ID_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.ID_TARGET->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
@@ -158,7 +158,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[FIRSTNAME,LASTNAME])
     ->extend(~[FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -166,7 +166,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[FIRSTNAME,LASTNAME])
           ->extend(~[FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
@@ -184,7 +184,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[FIRSTNAME,LASTNAME])
     ->extend(~[FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -208,7 +208,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[FIRSTNAME,LASTNAME])
     ->extend(~[FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[DIGEST_SOURCE])
     ->sort(~DIGEST_SOURCE->ascending())
     ->aggregate(~AGG_HASH : x | $x.DIGEST_SOURCE : y | $y->joinStrings(''))
@@ -220,7 +220,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[FIRSTNAME,LASTNAME])
           ->extend(~[FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[DIGEST_TARGET])
           ->sort(~DIGEST_TARGET->ascending())
           ->aggregate(~AGG_HASH : x | $x.DIGEST_TARGET : y | $y->joinStrings(''))
@@ -242,21 +242,20 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[ID,FIRSTNAME,LASTNAME])
     ->extend(~[ID_SOURCE: row | $row.ID, FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[ID_SOURCE,FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->from($runtime)
     ->join(
         #>{meta::external::dataquality::tests::domain::db.personTable}#
-          ->select(~[ID,FIRSTNAME,LASTNAME])
-          ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
-          ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->select(~[ID,HASH,FIRSTNAME,LASTNAME])
+          ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME, HASH_TARGET: row | $row.HASH])
+          ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET,HASH_TARGET])
           ->from($runtime),
         JoinKind.FULL,
         {x,y| $x.ID_SOURCE == $y.ID_TARGET}
-    )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
+    )->filter(row | not($row.DIGEST_SOURCE == $row.HASH_TARGET))
   };
 
-  testRecon($lambda, $runtime, 'ID', false, ['FIRSTNAME', 'LASTNAME'], [], [], true);
+  testRecon($lambda, $runtime, 'ID', false, ['FIRSTNAME', 'LASTNAME'], [], 'HASH', true);
 }
 
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_withDefectLimit():Boolean[1]
@@ -266,7 +265,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[ID,FIRSTNAME,LASTNAME])
     ->extend(~[ID_SOURCE: row | $row.ID, FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[ID_SOURCE,FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[ID_SOURCE,DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -274,7 +273,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID,FIRSTNAME,LASTNAME])
           ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
@@ -296,7 +295,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[ID,FIRSTNAME,LASTNAME])
     ->extend(~[ID_SOURCE: row | $row.ID, FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[ID_SOURCE,FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[ID_SOURCE,DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -305,7 +304,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID,FIRSTNAME,LASTNAME])
           ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
@@ -326,7 +325,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[ID,FIRSTNAME,LASTNAME])
     ->extend(~[ID_SOURCE: row | $row.ID, FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[ID_SOURCE,FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[ID_SOURCE,DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -334,7 +333,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID,FIRSTNAME,LASTNAME])
           ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
@@ -355,7 +354,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     ->select(~[ID,FIRSTNAME,LASTNAME])
     ->extend(~[ID_SOURCE: row | $row.ID, FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
     ->select(~[ID_SOURCE,FIRSTNAME_SOURCE,LASTNAME_SOURCE])
-    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
     ->select(~[ID_SOURCE,DIGEST_SOURCE])
     ->from($runtime)
     ->join(
@@ -364,7 +363,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID,FIRSTNAME,LASTNAME])
           ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME])
           ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET])
-          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'FIRSTNAME' + '\\x1E\\x1F\\x1D' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'ID' + '\\x1E\\x1F\\x1D' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'\\x1E\\x1F\\x1D' + 'LASTNAME' + '\\x1E\\x1F\\x1D' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
+          ->extend(~DIGEST_TARGET: row | hash(if($row.FIRSTNAME_TARGET->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_TARGET->toOne()->toString()) + if($row.ID_TARGET->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_TARGET->toOne()->toString()) + if($row.LASTNAME_TARGET->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_TARGET->toOne()->toString()), HashType.MD5))
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -1252,7 +1252,7 @@ function meta::external::dataquality::addColumnNameToValue(columnValue: ValueSpe
         ^InstanceValue (
           genericType = ^GenericType(rawType=String),
           multiplicity = OneMany,
-          values = ['\\x1E\\x1F\\x1D', $colName, '\\x1E\\x1F\\x1D', $columnValue]
+          values = ['', $colName, '', $columnValue]
         )
      ]
    )->evaluateAndDeactivate();

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality_relation_helper.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality_relation_helper.pure
@@ -112,9 +112,11 @@ function <<functionType.NormalizeRequiredFunction>> meta::external::dataquality:
 
 function meta::external::dataquality::normalizeDateTime(value:DateTime[0..1]):String[0..1]
 {
+  //TODO - this is converting to ISO8601 format but change to use formatDate function when available
   if ($value->isEmpty(),
     | [],
-    | convertTimeZone($value->toOne(), 'UTC', 'yyyy-MM-dd"T"HH:mm:ss.SSSSSSSSS')
+    | $value->toOne()->year()->toString() + '-' + $value->toOne()->monthNumber()->toString()->lpad(2, '0') + '-' + $value->toOne()->dayOfMonth()->toString()->lpad(2, '0') + 'T' + 
+        $value->toOne()->hour()->toString()->lpad(2, '0') + ':' + $value->toOne()->minute()->toString()->lpad(2, '0') + ':' + $value->toOne()->second()->toString()->lpad(2, '0') + '.000000000';
   );
 }
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
@@ -92,7 +92,8 @@ function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaF
   let colsToSelect = if ($colsForHash->isEmpty() && $hashCol->isEmpty(),
     | [], //if no cols given for hash then we will calculate hash on all columns
     | let colsRequiredForHash = if ($hashCol->isNotEmpty(), | $hashCol, | $colsForHash);
-      let selectColsBeforeNormalize = $keys->union($colsRequiredForHash)->distinct();
+      let withIncludedCols = if ($includeColumnValues, | $colsRequiredForHash->union($colsForHash), | $colsRequiredForHash);
+      let selectColsBeforeNormalize = $keys->union($withIncludedCols)->distinct();
   );
   let withSelectBeforeNormalize = if ($colsToSelect->isEmpty(), | $input, | buildSelectExpression($input, $colsToSelect));
   


### PR DESCRIPTION
#### What type of PR is this?

- Improvement
- Small Bug fixes

#### What does this PR do / why is it needed ?

- Add new API that gives back plan for recon
- Change the character used when building the input for the hash for recon to use the unicode encoding to ensure we have same behaviour across multiple dbs like h2. Behaviour is the same, doesn't impact other dbs like snowflake
- Fix bug where if include columns flag is true and hash column provided then columns to compare were not being returned
- Change implementation of normalize date time to remove usage of convert timezone since this method is not recommended to be used as it does not have consistent behaviour across dbs. This implementation can be changed to use format date once that function is available
