### PR TITLE
Add extraRepositories config to par-generating modules

### DIFF
--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-lineage/legend-engine-xt-analytics-lineage-pure/pom.xml
@@ -62,6 +62,11 @@
                         <repository>core_relational</repository>
                         <repository>core_analytics_lineage</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_analytics_lineage.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-mapping/legend-engine-xt-analytics-mapping-pure/pom.xml
@@ -47,6 +47,11 @@
                         <repository>core_external_compiler</repository>
                         <repository>core_analytics_mapping</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_analytics_mapping.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/pom.xml
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/pom.xml
@@ -61,6 +61,11 @@
                     <repositories>
                         <repository>core_analytics_search</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_analytics_search.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>

--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/pom.xml
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/pom.xml
@@ -60,6 +60,11 @@
                     <repositories>
                         <repository>core_external_format_openapi</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_external_format_openapi.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-pure/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-cloud-pure/pom.xml
@@ -58,6 +58,11 @@
                     <repositories>
                         <repository>core_persistence_cloud</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_persistence_cloud.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-pure/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-pure/pom.xml
@@ -57,6 +57,11 @@
                     <repositories>
                         <repository>core_persistence</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_persistence.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-pure/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-target-relational-pure/pom.xml
@@ -58,6 +58,11 @@
                     <repositories>
                         <repository>core_persistence_relational</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_persistence_relational.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>

--- a/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/pom.xml
+++ b/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/pom.xml
@@ -58,6 +58,11 @@
                     <repositories>
                         <repository>core_external_format_powerbi</repository>
                     </repositories>
+                    <extraRepositories>
+                        <extraRepository>
+                            ${project.basedir}/src/main/resources/core_external_format_powerbi.definition.json
+                        </extraRepository>
+                    </extraRepositories>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Adds `<extraRepositories>` configuration to par-generating maven modules so par generation can locate each module's own `core_*.definition.json` from `src/main/resources/`. Needed after `projectOutputDirectory` was removed from the par-generation classpath in legend-pure (https://github.com/finos/legend-pure/pull/1259).

Affected modules:
- legend-engine-xt-analytics-lineage-pure
- legend-engine-xt-analytics-mapping-pure
- legend-engine-xt-analytics-search-pure
- legend-engine-xt-openapi-pure
- legend-engine-xt-persistence-pure
- legend-engine-xt-persistence-cloud-pure
- legend-engine-xt-persistence-target-relational-pure
- legend-engine-xt-powerbi-pure

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

Companion change to https://github.com/finos/legend-pure/pull/1259.

#### Does this PR introduce a user-facing change?

No.