### PR TITLE
Ability to enrich dq columns in recon api

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
@@ -444,12 +444,12 @@ public class DataQualityExecute
     {
         if (dqComparisonElement == null)
         {
-            return core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_createReconInput_LambdaFunction_1__LambdaFunction_1__String_MANY__Boolean_1__String_MANY__String_$0_1$__String_$0_1$__Boolean_1__Integer_$0_1$__Boolean_1__DataQualityReconInput_1_(
-                    sourceLambdaFunction, targetLambdaFunction, Sets.immutable.ofAll(input.keys), input.aggregatedHash, Sets.immutable.ofAll(input.colsForHash), input.sourceHashCol, input.targetHashCol, input.includeColumnValues, input.defectLimit, false, pureModel.getExecutionSupport()
+            return core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_createReconInput_LambdaFunction_1__LambdaFunction_1__String_MANY__Boolean_1__String_MANY__String_$0_1$__String_$0_1$__Boolean_1__Integer_$0_1$__Boolean_1__Boolean_1__DataQualityReconInput_1_(
+                    sourceLambdaFunction, targetLambdaFunction, Sets.immutable.ofAll(input.keys), input.aggregatedHash, Sets.immutable.ofAll(input.colsForHash), input.sourceHashCol, input.targetHashCol, input.includeColumnValues, input.defectLimit, false, input.enrichDQColumns, pureModel.getExecutionSupport()
             );
         }
-        return core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_createReconInput_LambdaFunction_1__LambdaFunction_1__String_MANY__Boolean_1__String_MANY__String_$0_1$__String_$0_1$__Boolean_1__Integer_$0_1$__Boolean_1__DataQualityReconInput_1_(
-                dqComparisonElement._source(), dqComparisonElement._target(), dqComparisonElement._keys(), getAggregatedHash(dqComparisonElement._strategy()), dqComparisonElement._columnsToCompare(), getSourceHashColumn(dqComparisonElement._strategy()), getTargetHashColumn(dqComparisonElement._strategy()), input.includeColumnValues, input.defectLimit, false, pureModel.getExecutionSupport()
+        return core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_createReconInput_LambdaFunction_1__LambdaFunction_1__String_MANY__Boolean_1__String_MANY__String_$0_1$__String_$0_1$__Boolean_1__Integer_$0_1$__Boolean_1__Boolean_1__DataQualityReconInput_1_(
+                dqComparisonElement._source(), dqComparisonElement._target(), dqComparisonElement._keys(), getAggregatedHash(dqComparisonElement._strategy()), dqComparisonElement._columnsToCompare(), getSourceHashColumn(dqComparisonElement._strategy()), getTargetHashColumn(dqComparisonElement._strategy()), input.includeColumnValues, input.defectLimit, false, input.enrichDQColumns, pureModel.getExecutionSupport()
         );
     }
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityReconInput.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityReconInput.java
@@ -38,6 +38,7 @@ public class DataQualityReconInput
     public String sourceHashCol; //if there already exists a column on source that contains the hash that you want to use in recon
     public String targetHashCol; //if there already exists a column on target that contains the hash that you want to use in recon
     public boolean includeColumnValues = false; //whether to include the compared column values in the output alongside keys and digest. Only applies when aggregatedHash is false.
+    public boolean enrichDQColumns = false; //whether to enrich the DQ columns to the response
     public boolean runSourceQuery = false;
     public boolean runTargetQuery = false;
     public Long defectLimit; //optional limit on the number of defect rows returned

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
@@ -466,6 +466,34 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
   testRecon($expected, $source, $target, 'ID', false, [], 'HASH', 'HASH', false, [], true);
 }
 
+function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_enrichesDqCols():Boolean[1]
+{
+  let runtime = loadModel([])->filter(p | $p->elementToPath() == 'meta::external::dataquality::tests::domain::DataQualityRuntime')->toOne()->cast(@PackageableRuntime);
+  let expected = {| #>{meta::external::dataquality::tests::domain::db.personTable}#
+    ->select(~[ID,FIRSTNAME,LASTNAME])
+    ->extend(~[ID_SOURCE: row | $row.ID, FIRSTNAME_SOURCE: row | $row.FIRSTNAME, LASTNAME_SOURCE: row | $row.LASTNAME])
+    ->select(~[ID_SOURCE,FIRSTNAME_SOURCE,LASTNAME_SOURCE])
+    ->extend(~DIGEST_SOURCE: row | hash(if($row.FIRSTNAME_SOURCE->isEmpty(), | '', |'' + 'FIRSTNAME' + '' + $row.FIRSTNAME_SOURCE->toOne()->toString()) + if($row.ID_SOURCE->isEmpty(), | '', |'' + 'ID' + '' + $row.ID_SOURCE->toOne()->toString()) + if($row.LASTNAME_SOURCE->isEmpty(), | '', |'' + 'LASTNAME' + '' + $row.LASTNAME_SOURCE->toOne()->toString()), HashType.MD5))
+    ->from($runtime)
+    ->join(
+        #>{meta::external::dataquality::tests::domain::db.personTable}#
+          ->select(~[ID,HASH,FIRSTNAME,LASTNAME])
+          ->extend(~[ID_TARGET: row | $row.ID, FIRSTNAME_TARGET: row | $row.FIRSTNAME, LASTNAME_TARGET: row | $row.LASTNAME, HASH_TARGET: row | $row.HASH])
+          ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET,HASH_TARGET])
+          ->from($runtime),
+        JoinKind.FULL,
+        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+    )->filter(row | not($row.DIGEST_SOURCE == $row.HASH_TARGET))
+    ->extend(~DQ_RULE_NAME: row | 'DQ_RECONCILIATION')
+    ->extend(~DQ_LOGICAL_DEFECT_ID: row | hash(if($row.DIGEST_SOURCE->isEmpty(), | '', |$row.DIGEST_SOURCE->toOne()->toString()) + if($row.HASH_TARGET->isEmpty(), | '', |$row.HASH_TARGET->toOne()->toString()), HashType.MD5))
+  };
+
+  let source = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
+  let target = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
+  let actual = getDataReconLambda(^DataQualityReconInput(source = $source, target = $target, keys = 'ID', colsForHash = ['FIRSTNAME', 'LASTNAME'], targetHashCol = 'HASH', includeColumnValues = true, enrichDQColumns = true));
+  assertLambdaEquals($expected, $actual, false);
+}
+
 function meta::external::dataquality::tests::testRecon(expected:FunctionDefinition<Any>[1], runtime: PackageableRuntime[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1]):Boolean[1]
 {
   testRecon($expected, $runtime, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, []);
@@ -485,6 +513,6 @@ function meta::external::dataquality::tests::testRecon(expected:FunctionDefiniti
 
 function meta::external::dataquality::tests::testRecon(expected:FunctionDefinition<Any>[1], source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1], removeFrom: Boolean[1]):Boolean[1]
 {
-  let actual = getDataReconLambda(createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit, $removeFrom));
+  let actual = getDataReconLambda(createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit, $removeFrom, false));
   assertLambdaEquals($expected, $actual, false);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
@@ -64,10 +64,16 @@ function meta::external::dataquality::datarecon::getDataReconLambda(reconInput: 
     | $withFilter->buildRelationLimitFilterExpression($reconInput.defectLimit->toOne(), $withFilter.genericType)
   );
 
+  //enrich DQ columns if required
+  let withDqCols = if ($reconInput.enrichDQColumns,
+    | enrichDqColumns($withLimit, $sourceHashCol, $targetHashCol, $joinRelType),
+    | $withLimit
+  );
+
   // Build final lambda - if there are parameters, create new lambda with merged params; otherwise preserve baseLambda structure
   if ($allParams->isEmpty(),
-    | ^$baseLambda(expressionSequence=$withLimit),
-    | lambda(^FunctionType(returnMultiplicity=$withLimit.multiplicity, returnType=$withLimit.genericType, parameters=$allParams), $withLimit)
+    | ^$baseLambda(expressionSequence=$withDqCols),
+    | lambda(^FunctionType(returnMultiplicity=$withLimit.multiplicity, returnType=$withLimit.genericType, parameters=$allParams), $withDqCols)
   );
 }
 
@@ -138,6 +144,17 @@ function meta::external::dataquality::datarecon::validateColumns(input: ValueSpe
 function meta::external::dataquality::datarecon::validateColumnExists(relType: RelationType<Any>[1], columns: String[*], type: String[1], field: String[1]): Boolean[*]
 {
   $columns->map(column | assert($relType.columns->exists(col | $col.name->toOne() == $column), 'Expected ' + $type + ' table to contain field ' + $column + ' which was specified as ' + $field));
+}
+
+function meta::external::dataquality::datarecon::enrichDqColumns(input: ValueSpecification[1], sourceHasCol: String[1], targetHashCol: String[1], relType: RelationType<Any>[1]): ValueSpecification[1]
+{  
+  let relParamName = 'row';
+
+  let newRelTypeWithRuleName = $relType->addColumns(~[DQ_RULE_NAME: String[1]])->evaluateAndDeactivate();
+  let withRuleName = $input->buildExtendExpression('DQ_RULE_NAME', ^InstanceValue(values='DQ_RECONCILIATION', genericType=^GenericType(rawType=String), multiplicity=PureOne), $relParamName, $relType, $newRelTypeWithRuleName, String);
+
+  let newRelTypeWithLogicalDefectId = $newRelTypeWithRuleName->addColumns(~[DQ_LOGICAL_DEFECT_ID: String[1]])->evaluateAndDeactivate();
+  $withRuleName->buildExtendExpression('DQ_LOGICAL_DEFECT_ID', buildHashFunctionExpression($newRelTypeWithRuleName, [$sourceHasCol, $targetHashCol], $relParamName, false, []), $relParamName, $newRelTypeWithRuleName, $newRelTypeWithLogicalDefectId, String);
 }
 
 function meta::external::dataquality::datarecon::buildCastToRelation(dataset: LambdaFunction<Any>[1], input: ValueSpecification[1]): ValueSpecification[1]
@@ -451,10 +468,10 @@ function meta::external::dataquality::datarecon::compileViaGrammarWithContext(vs
 
 function meta::external::dataquality::datarecon::createReconInput(source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1]): DataQualityReconInput[1]
 {
-  createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, [], false);
+  createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, [], false, false);
 }
 
-function meta::external::dataquality::datarecon::createReconInput(source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1], removeFrom: Boolean[1]): DataQualityReconInput[1]
+function meta::external::dataquality::datarecon::createReconInput(source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1], removeFrom: Boolean[1], enrichDQColumns: Boolean[1]): DataQualityReconInput[1]
 {
-  ^DataQualityReconInput(source = $source, target = $target, keys = $keys, aggregatedHash = $aggregatedHash, colsForHash = $colsForHash, sourceHashCol = $sourceHashCol, targetHashCol = $targetHashCol, includeColumnValues = $includeColumnValues, defectLimit = $defectLimit, removeFrom = $removeFrom);
+  ^DataQualityReconInput(source = $source, target = $target, keys = $keys, aggregatedHash = $aggregatedHash, colsForHash = $colsForHash, sourceHashCol = $sourceHashCol, targetHashCol = $targetHashCol, includeColumnValues = $includeColumnValues, defectLimit = $defectLimit, removeFrom = $removeFrom, enrichDQColumns = $enrichDQColumns);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
@@ -72,13 +72,14 @@ Class meta::external::dataquality::datarecon::DataQualityReconInput
   source: LambdaFunction<Any>[1]; //query pointing to source dataset
   target: LambdaFunction<Any>[1]; //query pointing to target dataset
   keys: String[*]; //these must exist on both source and target dataset - can either be primary keys or grouping keys if aggregated hash required. If empty then hash column will be used.
-  aggregatedHash: Boolean[1]; //whether aggregated hash should be created based on the keys provided
+  aggregatedHash: Boolean[1] = false; //whether aggregated hash should be created based on the keys provided
   colsForHash: String[*]; //which columns you want the hash to be calculated on, these columns must exist on both source and target dataset. If empty then will calculate hash on all columns.
   sourceHashCol: String[0..1]; //if there already exists a column on source that contains the hash that you want to use in recon
   targetHashCol: String[0..1]; //if there already exists a column on target that contains the hash that you want to use in recon
-  includeColumnValues: Boolean[1]; //whether to include the compared column values in the output alongside keys and digest. Only applies when aggregatedHash is false.
+  includeColumnValues: Boolean[1] = false; //whether to include the compared column values in the output alongside keys and digest. Only applies when aggregatedHash is false.
   defectLimit: Integer[0..1]; //optional limit on the number of defect rows returned
   removeFrom: Boolean[1] = false; //whether the from function should be removed on source and target queries
+  enrichDQColumns: Boolean[1] = false; //whether to add DQ columns to the response
 }
 
 Class meta::external::dataquality::DataQualityRelationComparison extends PackageableElement


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

Ability to enrich dq columns in recon api based on a flag. If this flag is true then 2 new columns "DQ_RULE_NAME" and "DQ_LOGICAL_DEFECT_ID" will be added to the response in the same way that is done in the existing DQ API.
