### PR TITLE
EMIT Framework

### DIFF
--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -1,0 +1,748 @@
+# Engine Model Integration Test (EMIT) — A Legend Engine Test Harness
+
+## 1. Motivation
+
+Today, the canonical way to validate a Legend model end-to-end — parsing, compiling, running
+generations, executing tests, and generating execution plans — is through a
+**legend-sdlc project build**. This requires a full Maven project structure, SDLC Maven plugins
+(`legend-sdlc-generation-model-maven-plugin`, `legend-sdlc-generation-file-maven-plugin`,
+`legend-sdlc-test-maven-plugin`, `legend-sdlc-generation-service-execution-maven-plugin`), and
+the associated project configuration (GAV coordinates, dependency management, etc.).
+
+There is a need for a **lightweight alternative** that lives entirely inside `legend-engine`.
+Given a set of `.pure` files (written in Legend grammar — i.e., the grammar used in Legend Studio,
+not the M3/Pure grammar), the harness should:
+
+1. **Parse** the `.pure` files into `PureModelContextData`.
+2. **Compile** the `PureModelContextData` into a `PureModel`.
+3. **Run model generations** (via `ModelGenerationExtension` SPI).
+4. **Run artifact/file generations** (via `GenerationExtension` and `ArtifactGenerationExtension` SPIs).
+5. **Run all tests** defined in the model (via the `Testable` infrastructure / `TestableRunner`).
+6. **Generate execution plans** for any `Service` elements in the model (via `ServicePlanGenerator`).
+
+Each phase must succeed for the overall test to pass, and failures in any phase should produce
+clear, actionable diagnostics.
+
+### Secondary Goal: A Searchable Example Catalog
+
+Beyond validation, EMIT tests should serve as a **living repository of examples** showing how
+different Legend features can be used — both individually and in combination. Over time, this
+collection should become the canonical reference for "how do I do X with Y?" questions, covering
+simple patterns (a class with a constraint) through complex compositions (a service with a
+relational mapping, connection, and test suite using shared test data).
+
+To support this, the EMIT framework lays the metadata foundations from the
+start:
+- A **structured directory layout** with machine-readable metadata per model
+  (`*.emit.yaml`).
+- A **tagging taxonomy** for features, stores, and complexity levels (§6.2).
+- A descriptor model (`EMITModelDescriptor`) and classpath discovery
+  (`EMITModelDiscovery`) that an indexer can build on.
+
+A queryable **catalog index** and user-friendly search/browsing tools are
+future work, but the metadata foundations make them straightforward to add
+later.
+
+---
+
+## 2. Comparison with Existing Test Harnesses
+
+### 2.1 PCT (Pure Compatibility Testing)
+
+| Aspect | PCT | EMIT |
+|---|---|---|
+| **What is tested** | Individual Pure platform functions (e.g., `between`, `timeBucket`) | An entire Legend model, end-to-end |
+| **Input** | Pure function definitions, already part of the compiled core | `.pure` files in Legend grammar (user-authored models) |
+| **Scope** | Functional correctness of a single function across target runtimes (databases) | Full build pipeline: parse → compile → generate → test → plan. |
+| **Target runtimes** | Executes against multiple database adapters (DuckDB, Snowflake, etc.) | Engine-only; no external database targets required (though model tests may use them) |
+| **Test discovery** | Tests tagged with `@PCT` stereotypes in Pure code | Tests discovered from `Testable` elements (services, mappings, functions) in the input model |
+| **JUnit integration** | Custom `TestSuite` builders (`PureTestBuilderCompiled`) | JUnit 5 integration via a `@TestFactory` yielding granular dynamic tasks |
+| **Location** | `legend-engine-core/legend-engine-core-pure` and per-database PCT modules | New modules under `legend-engine-core/legend-engine-core-emit/` (`legend-engine-emit` + `legend-engine-emit-junit`) |
+
+### 2.2 MFT (Mapping Feature Testing)
+
+| Aspect | MFT | EMIT |
+|---|---|---|
+| **What is tested** | Mapping features (e.g., union, filter, groupBy) against store targets | An entire Legend model build pipeline |
+| **Input** | Pure functions annotated with `@MFT{testCollection}` stereotypes | `.pure` files in Legend grammar |
+| **Scope** | Validates that specific model constructs work correctly against a given store runtime | Validates the full lifecycle: parsing, compilation, generation, testing, plan generation |
+| **Evaluator/Adaptor** | Uses evaluator and adaptor functions (e.g., relational adaptor, M2M evaluator) | N/A — runs against the engine directly; store-specific behavior is tested via model-embedded tests |
+| **Test structure** | Test collections organized by Pure package hierarchy | One test per model (or per `.pure` file set), with sub-results per phase |
+| **Compiled mode only** | Yes (uses `CompiledExecutionSupport`) | Uses the standard `PureModel` compilation path (protocol → PureModel), same as Studio/SDLC |
+
+### 2.3 Legend SDLC Project Build
+
+| Aspect | SDLC Build | EMIT |
+|---|---|---|
+| **What is tested** | Effectively the same pipeline: compile, generate, test, plan | Same pipeline |
+| **Input** | A full Maven project with entity JSON files, `pom.xml`, and SDLC project structure | One or more `.pure` files — no project infrastructure required |
+| **Execution mechanism** | Maven plugins (`legend-sdlc-generation-*-maven-plugin`) | Direct Java API calls in `legend-engine` |
+| **Dependency** | Requires `legend-sdlc` | No `legend-sdlc` dependency; self-contained in `legend-engine` |
+| **Use case** | CI/CD validation of production projects | Rapid testing of model snippets, regression testing, engine development |
+| **Where it runs** | Maven build (`mvn install`) | JUnit test execution |
+
+### Summary
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                        Legend Test Harnesses                             │
+├────────────┬─────────────────────────────────────────────────────────────┤
+│    PCT     │ Tests individual Pure platform functions across target      │
+│            │ runtimes (databases). Focus: function-level correctness.    │
+├────────────┼─────────────────────────────────────────────────────────────┤
+│    MFT     │ Tests mapping features (M2M, relational, etc.) against      │
+│            │ store adaptors. Focus: store-target feature correctness.    │
+├────────────┼─────────────────────────────────────────────────────────────┤
+│  EMIT (new) │ Tests an entire model through the full build pipeline      │
+│            │ (parse → compile → generate → test → plan).                 │
+│            │ Focus: model-level end-to-end correctness.                  │
+├────────────┼─────────────────────────────────────────────────────────────┤
+│ SDLC Build │ Same pipeline as EMIT, but via Maven plugins and full       │
+│            │ project structure. Focus: production project validation.    │
+└────────────┴─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Architecture
+
+### 3.1 High-Level Pipeline
+
+```
+                    ┌─────────────────────────────────────┐
+                    │       *.emit.yaml (input)           │
+                    │   (descriptor + .pure source set)   │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │  Phase 0: INITIALIZATION            │
+                    │  Load descriptor, resolve files,    │
+                    │  validate clashes, segment scope    │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │  Phase 1: PARSE                     │
+                    │  PureGrammarParser.parseModel()     │
+                    │  → PureModelContextData             │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │  Phase 2: COMPILE                   │
+                    │  PureModel(pmcd, ...)               │
+                    │  → PureModel                        │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │  Phase 3: MODEL GENERATION          │
+                    │  ModelGenerationExtension SPI       │
+                    │  (if GenerationSpecification exists)│
+                    │  → PureModelContextData (generated) │
+                    │  Re-compile with generated model    │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │  Phase 4: FILE GENERATION           │
+                    │  a) GenerationExtension SPI         │
+                    │     (FileGenerationSpecification)   │
+                    │  b) ArtifactGenerationExtension SPI │
+                    │     (per-element artifact gen)      │
+                    │  → generated files                  │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │  Phase 5: TEST EXECUTION            │
+                    │  - TestableRunner.doTests()         │
+                    │  - Legacy MappingTestRunner         │
+                    │  - Legacy ServiceTestRunner         │
+                    │  → Test results                     │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │  Phase 6: PLAN GENERATION           │
+                    │  For each Service:                  │
+                    │  ServicePlanGenerator               │
+                    │    .generateServiceExecutionPlan()  │
+                    │  → ExecutionPlan                    │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │         RESULT / REPORT             │
+                    │  Per-phase pass/fail + diagnostics  │
+                    └─────────────────────────────────────┘
+```
+
+### 3.2 Module Layout
+
+#### Framework Modules
+
+The EMIT framework is split across two modules under a parent aggregator:
+
+```
+legend-engine-core/
+  legend-engine-core-emit/                ← Parent aggregator (pom-only)
+    pom.xml
+    legend-engine-emit/                   ← Core runner module
+      pom.xml
+      src/
+        main/java/.../emit/
+          EMITRunner.java                 ← Pipeline orchestrator (calls EMITTasks)
+          EMITTasks.java                  ← Stateless per-item engine for each phase
+          EMITModel.java                  ← Compiled model + primary-scope filter
+          EMITResult.java                 ← Aggregated pipeline result
+          EMITPhase.java                  ← Phase enum
+          EMITPhaseResult.java            ← Per-phase result
+          EMITModelLoader.java            ← .pure file loading utility
+          EMITSourceFile.java             ← Resolved source file
+          EMITSourceSet.java              ← Collection of source files
+          catalog/
+            EMITModelDescriptor.java      ← Parsed emit.yaml metadata
+          error/
+            EMITException.java            ← Wrapped infrastructure failure
+            EMITAssertionError.java       ← Test/assertion failure
+            EMITErrorTools.java           ← Diagnostic helpers
+        test/java/.../emit/
+          TestEMITRunner.java             ← Self-test: drives the framework itself
+        test/resources/
+          emit-models/                    ← Bootstrap models for self-testing
+            basic/
+              class-simple.emit.yaml      ← Trivial parse + compile fixture
+              compile-failure.emit.yaml   ← Negative case: compile error
+              m2m-passing.emit.yaml       ← M2M mapping with a passing test
+              m2m-mixed.emit.yaml         ← M2M mapping with a passing and a failing test
+              m2m-with-dep.emit.yaml      ← Pulls in m2m-dep-source as a dependency
+    legend-engine-emit-junit/             ← JUnit 5 binding module
+      pom.xml
+      src/
+        main/java/.../emit/junit/
+          EMITTestSuiteBuilder.java       ← @TestFactory task builder
+          EMITModelDiscovery.java         ← Classpath .emit.yaml scanner
+```
+
+- **`legend-engine-emit`** contains the core pipeline (runner, result models, model loader, catalog
+  infrastructure) and has no JUnit dependency. It can be used standalone in scripts or CI pipelines.
+- **`legend-engine-emit-junit`** depends on `legend-engine-emit` and adds the JUnit 5 integration
+  layer (`EMITTestSuiteBuilder`, `EMITModelDiscovery`). Test modules that want `@TestFactory`-based
+  EMIT execution depend on this module.
+
+The parent aggregator sits directly under `legend-engine-core/` (as a sibling of
+`legend-engine-core-testable`, `legend-engine-core-pure`, etc.) because EMIT spans the full engine
+pipeline — parsing, compilation, generation, test execution, and plan generation — rather than
+being scoped to the `Testable` metamodel concept alone.
+
+#### Distributed Test Locations
+
+Actual EMIT tests are **spread throughout the codebase**, living in the modules that own the
+features being tested. Each module that contributes EMIT tests adds a test-scoped dependency
+on `legend-engine-emit-junit` and places its models under `src/test/resources/emit-models/`:
+
+```
+legend-engine-xts-relationalStore/
+  legend-engine-xt-relationalStore-emit/    ← Module owning the relational EMIT examples
+    src/test/resources/
+      emit-models/
+        relational-simple.emit.yaml         ← Test descriptor configures sources
+        relational-simple/                  ← Model sources (paths resolved relative to YAML)
+          store/db.pure
+          mapping/personMapping.pure
+          data/testData.pure
+        relational-joins.emit.yaml          ← Sibling tests at the same level
+        relational-joins/
+          ...
+        relational-shared-domain.emit.yaml  ← Reusable shared model (types only)
+        relational-shared-domain/
+          model/person.pure
+          model/firm.pure
+          model/employment.pure
+```
+
+(Tests reuse `relational-shared-domain` via the descriptor `dependencies`
+mechanism; see §4.1.)
+
+The same pattern applies to other extension modules (`legend-engine-xts-service`, `legend-engine-xts-generation`, etc.) — each owns the EMIT models for its feature area, with one `*.emit.yaml` per test and a sibling source-root directory.
+
+The `EMITRunner` automatically discovers all `*.emit.yaml` files. The YAML file explicitly configures which directories and files comprise the test.
+
+This distribution model has several advantages:
+- **Ownership**: Tests live near the code they exercise, so feature owners maintain them.
+- **Dependencies**: Each test module has the right classpath for its feature (e.g., a relational
+  EMIT test module naturally has relational store dependencies on its classpath).
+- **Parallelism**: Tests run as part of each module's build, not as a single bottleneck module.
+- **Catalog aggregation**: The `EMITCatalogBuilder` can scan across multiple classpath roots
+  to assemble a unified catalog from all distributed models.
+
+### 3.3 Core API
+
+```java
+public class EMITRunner
+{
+  public EMITRunner();
+  public EMITRunner(EMITModelLoader loader);
+
+  /**
+   * Run the full build pipeline against an already-loaded descriptor.
+   * The descriptor carries the resolved primary model files and the
+   * dependency files (already segmented by scope).
+   */
+  public EMITResult run(EMITModelDescriptor descriptor);
+
+  /**
+   * Convenience: load the descriptor at the given *.emit.yaml path
+   * (resolving its model and dependencies) and run the full pipeline.
+   */
+  public EMITResult runFromYaml(Path emitYaml);
+}
+```
+
+```java
+public class EMITResult
+{
+    public List<EMITPhaseResult> getPhaseResults();
+    public EMITPhaseResult       getPhase(EMITPhase phase);
+    public boolean               isSuccess();      // true iff no phase is FAILURE
+    public String                getSummary();     // human-readable per-phase report
+    public void                  add(EMITPhaseResult result);
+}
+```
+
+```java
+public enum EMITPhase
+{
+    INITIALIZATION,    // descriptor load, file resolution, clash validation
+    PARSE,
+    COMPILE,
+    MODEL_GENERATION,
+    FILE_GENERATION,
+    TEST_EXECUTION,
+    PLAN_GENERATION
+}
+```
+
+```java
+public class EMITPhaseResult
+{
+    public enum Status { SUCCESS, FAILURE, SKIPPED, NOT_RUN }
+
+    public EMITPhase  getPhase();
+    public Status     getStatus();
+    public long       getDurationMs();
+    public String     getMessage();      // human-readable summary or skip/failure reason
+    public Throwable  getThrowable();    // populated on FAILURE; may be null
+    public List<?>    getOutputs();      // phase-specific outputs: PureModelContextData,
+                                         // PureModel, FileGenerationOutput, RunTestsResult,
+                                         // ExecutionPlan map, etc.
+
+    public boolean    isSuccess();       // true for SUCCESS or SKIPPED
+    public boolean    isFailure();       // true only for FAILURE
+
+    public static EMITPhaseResult success(...);
+    public static EMITPhaseResult failure(...);
+    public static EMITPhaseResult skipped(EMITPhase phase, String reason);
+    public static EMITPhaseResult notRun(EMITPhase phase, String reason);
+}
+```
+
+---
+
+## 4. Phase Details
+
+### 4.1 Phase 0: Initialization
+
+- Parse the `*.emit.yaml` file to read the explicit source configuration, which includes `model` (the primary model files) and optionally `dependencies`.
+- `model`: Specified using a `root` directory and a list of `files`, which are resolved relative to the root.
+- `dependencies`: Each dependency can be specified in one of two ways:
+    - An `*.emit.yaml` file path (using `source`) with an optional `excludes` list supporting `*` and `**` wildcards.
+    - A `root` directory and a list of `files`, exactly like the `model` specification.
+- **Scope Segmentation**: Maintain a distinction between files loaded from the primary `model` and those loaded via `dependencies`. Dependencies are not in scope for generations, tests, etc.
+- **Clash Validation**: Assert that no two files resolve to the same virtual path.
+- **Success criteria**: Descriptor is well-formed and all source files resolve uniquely.
+- **Failure mode**: An `EMITPhaseResult` for `INITIALIZATION` is produced with the error; subsequent phases are skipped.
+
+### 4.2 Phase 1: Parse
+
+- Read the content of each discovered file (from both the primary model and dependencies).
+- Call `PureGrammarParser.newInstance().parseModel(content)` for each file.
+- Combine the resulting `PureModelContextData` objects using the builder's `addPureModelContextData()`.
+- **Success criteria**: No grammar parse exceptions.
+- **Failure mode**: `EngineException` with source location information.
+
+### 4.3 Phase 2: Compile
+
+- Construct a `PureModel` from the merged `PureModelContextData` via
+  `new PureModel(pmcd, null, DeploymentMode.PROD)`.
+- **Success criteria**: No compilation errors.
+- **Failure mode**: `EngineException` or `CompilationException` with details.
+
+### 4.4 Phase 3: Model Generation
+
+- Discover `GenerationSpecification` elements in the `PureModelContextData`.
+- If present, use the `ModelGenerationExtension` SPI (loaded via `ServiceLoader`) to produce
+  additional `PureModelContextData`.
+- Merge the generated data with the original data and re-compile to produce an enriched
+  `PureModel`.
+- This is functionally equivalent to what the SDLC model generation Maven plugin does.
+- **Success criteria**: Generation completes without exceptions; re-compilation succeeds.
+- **Skipped if**: No `GenerationSpecification` elements exist in the model.
+
+### 4.5 Phase 4: File Generation
+
+This phase covers both types of file generation:
+
+#### 4.5a Specification-Driven File Generations
+
+- Discover the `GenerationSpecification` element and iterate over its `fileGenerations` list.
+- For each `FileGenerationSpecification` referenced, find the corresponding `GenerationExtension` SPI (loaded via `ServiceLoader`) matching the specification's type.
+- Execute the generation extension to produce a list of `GenerationOutput` (e.g., Avro schemas, JSON Schemas, Protobuf definitions).
+- **Skipped if**: No `GenerationSpecification` exists, or its `fileGenerations` list is empty.
+
+#### 4.5b Element-Driven Artifact Generations
+
+- Load all registered `ArtifactGenerationExtension` SPIs via `ServiceLoader`.
+- For each packageable element, iterate over extensions and call `canGenerate(element)` to check applicability.
+- For applicable elements, call `extension.generate(element, pureModel, pmcd, clientVersion)` to produce a list of `Artifact` objects.
+- **Skipped if**: No elements are candidates for any registered artifact generation extension.
+
+**Success criteria**: Both sub-phases complete without exceptions.
+
+### 4.6 Phase 5: Test Execution
+
+- **Run Testable tests**: Find all `Testable` elements in the compiled `PureModel` (e.g., services, mappings, functions with test suites).
+- **Run Legacy Mapping tests**: Find `Mapping` elements with legacy `MappingTest` / `MappingTestSuite` elements.
+- **Run Legacy Service tests**: Find `Service` elements with legacy `ServiceTest` elements.
+- **Dependency Exclusion**: Only execute tests for elements defined in the primary `model`. Any test defined in an element loaded via `dependencies` MUST be ignored.
+- Use `TestableRunner.doTests(...)`, the legacy `MappingTestRunner`, and the legacy `ServiceTestRunner` to execute the in-scope tests, producing their respective result objects.
+- **Success criteria**: All in-scope tests (Testable and legacy) pass.
+- **Failure mode**: Failed/error `TestResult`, `RichMappingTestResult`, or `RichServiceTestResult` entries.
+- **Skipped if**: No test elements (Testable or legacy) exist in the primary model.
+
+### 4.7 Phase 6: Plan Generation
+
+- Find all `Service` elements in the `PureModelContextData`.
+- For each service, call
+  `ServicePlanGenerator.generateServiceExecutionPlan(service, context, pureModel, ...)`.
+- This handles both `PureSingleExecution` (producing a `SingleExecutionPlan`) and
+  `PureMultiExecution` (producing a `CompositeExecutionPlan`).
+- Collect and report the generated `ExecutionPlan` objects.
+- **Success criteria**: Plan generation completes without exceptions for all services.
+- **Skipped if**: No `Service` elements exist.
+
+---
+
+## 5. Execution and Reporting
+
+EMIT models can be executed both programmatically (standalone) and through JUnit.
+
+### 5.1 Standalone Execution
+
+The `EMITRunner` can be invoked directly to execute the full pipeline for a given model descriptor:
+
+```java
+EMITRunner runner = new EMITRunner();
+EMITResult result = runner.run(descriptor);
+
+if (!result.isSuccess())
+{
+    System.err.println(result.getSummary());
+}
+```
+
+This is useful for scripting, CI pipelines, or any context where JUnit is not the execution harness.
+
+### 5.2 JUnit Integration
+
+The JUnit 5 integration lives in the `legend-engine-emit-junit` module, separate from the core runner. To achieve granular pass/fail reporting without forcing developers to write individual tests by hand, EMIT uses JUnit 5's `@TestFactory` mechanism. The framework provides a builder that discovers models, parses and compiles them upfront, and flattens their downstream operations into discrete `DynamicTest` tasks.
+
+To test EMIT models in a module, create a single test class:
+
+```java
+public class MyModuleEMITTestSuite
+{
+    @TestFactory
+    Stream<DynamicTest> emit()
+    {
+        // Discovers models, performs initialization + parse + compile, and
+        // returns a flattened stream of granular dynamic tests for generation,
+        // testing, and plan creation.
+        return EMITTestSuiteBuilder.taskStream("emit-models/");
+    }
+}
+```
+
+`EMITTestSuiteBuilder` also exposes `taskList(String)` for callers that prefer
+a `List<DynamicTest>` (e.g., for fan-out into nested containers).
+
+When JUnit invokes the factory method, `EMITTestSuiteBuilder` scans for `*.emit.yaml` files. For each model, it performs Phase 0 (Initialization), Phase 1 (Parse), and Phase 2 (Compile). By inspecting the compiled model, it identifies every file-generation specification, every artifact-generation candidate, every test (modern Testable plus legacy Mapping/Service tests), and every service.
+
+It then yields one `DynamicTest` per granular operation, with descriptive names:
+
+- `[service-simple] Initialization (Init, Parse & Compile)`
+- `[service-simple] File Generation: demo::MyAvroGenerationSpec`
+- `[service-simple] Artifact Generation: demo::PersonService (ServiceArtifactExtension)`
+- `[service-simple] Test: demo::PersonService / testSuite_1 / test_1`
+- `[service-simple] Test: demo::PersonService / testSuite_1 / test_2`
+- `[service-simple] Plan: demo::PersonService`
+- `[service-simple] Legacy Mapping Test: demo::PersonMapping / legacyTest_1`
+- `[service-simple] Legacy Service Test: demo::PersonService`
+
+Phase 3 (Model Generation) is currently exposed only through the standalone
+`EMITRunner`; the JUnit builder does not yield a per-spec dynamic test for it.
+
+Because each `DynamicTest` is a distinct JUnit test, IDEs and build servers (like Maven Surefire) report granular pass/fail statuses, durations, and diffs natively.
+
+To optimize performance, the `PureModel` compiled during discovery is cached and shared among all tasks belonging to the same model. If a model fails initialization, parse, or compile during discovery, `EMITTestSuiteBuilder` yields a single `Initialization` task that is guaranteed to fail upon execution, skipping discovery of downstream tasks.
+
+### 5.3 Result Model and Reporting
+
+Each phase captures:
+- **Success/failure status**
+- **Duration** (milliseconds)
+- **Exception** with full stack trace (on failure)
+- **Error message** with source location (for parse/compile failures)
+- **Phase-specific artifacts** (on success)
+
+The `EMITResult.getSummary()` method produces a human-readable report. Status
+markers are `OK` (success), `FAIL` (failure), `SKIP` (phase intentionally
+skipped because there was nothing to do), and `--` (phase not run because an
+earlier phase failed):
+
+```
+EMIT Result: FAILED
+  OK   INITIALIZATION   (8ms) - 4 model files, 1 dependency file
+  OK   PARSE            (42ms) - 5 files, 12 elements
+  OK   COMPILE          (318ms) - PureModel built successfully
+  SKIP MODEL_GENERATION (0ms) - no GenerationSpecification
+  OK   FILE_GENERATION  (87ms) - 3 file generations, 4 artifact extensions
+  FAIL TEST_EXECUTION   (203ms) - 3 tests (testable: 3, legacy mapping: 0, legacy service: 0); 1 failed
+        EMITAssertionError: Test did not pass; status=FAIL; assertions=[...]
+  --   PLAN_GENERATION  (0ms) - skipped due to failure in TEST_EXECUTION
+```
+
+---
+
+## 6. Example Catalog Design
+
+The EMIT model collection doubles as a **searchable catalog of feature examples**. This section
+defines the metadata conventions and tooling foundations that make this possible.
+
+### 6.1 Model Metadata (`*.emit.yaml`)
+
+Every EMIT test is defined by a `*.emit.yaml` file with structured metadata and source configurations:
+
+```yaml
+# service-relational-with-generation.emit.yaml
+name: service-relational-with-generation
+title: "Relational Service with File Generation"
+description: |
+  Demonstrates a service backed by a relational mapping with a
+  Relational-to-H2 connection, including test data, test suites,
+  and an Avro file generation specification.
+
+# Explicit source configuration. The primary model is specified with a root
+# directory and an explicit list of files relative to that root.
+# Dependencies can be specified either as another emit.yaml file with exclusions
+# or as a root and list of files similar to the primary model.
+modelSources:
+  model:
+    root: emit-models/complex/service-relational-with-generation
+    files:
+      - model/types.pure
+      - store/db.pure
+      - mapping/mapping.pure
+      - service/myService.pure
+  dependencies:
+    - root: emit-models/shared-types
+      files:
+        - model/common.pure
+    - source: emit-models/core-api.emit.yaml
+      excludes:
+        - emit-models/core-api/**/*_experimental.pure
+
+# Features exercised by this model.
+# Uses a controlled taxonomy (see §7.2).
+features:
+  - class
+  - association
+  - relational-mapping
+  - relational-store
+  - relational-connection
+  - service
+  - service-test
+  - file-generation
+
+# Store types involved.
+stores:
+  - relational
+
+# Complexity level: basic, intermediate, advanced
+complexity: advanced
+
+# Optional: free-form tags for additional discoverability.
+tags:
+  - avro
+  - h2
+  - test-data
+```
+
+### 6.2 Feature Taxonomy
+
+The `features` field uses values from a controlled vocabulary. The taxonomy is extensible;
+new features can be added as the catalog grows. The initial set:
+
+| Category | Feature Tags |
+|---|---|
+| **Types** | `class`, `enumeration`, `association`, `profile`, `measure`, `function` |
+| **Constraints** | `constraint`, `derived-property`, `qualified-property` |
+| **Mapping** | `mapping`, `m2m-mapping`, `relational-mapping`, `enumeration-mapping`, `aggregation-aware-mapping`, `operation-mapping` |
+| **Store** | `relational-store`, `service-store`, `flat-data-store` |
+| **Connection** | `relational-connection`, `model-connection`, `service-store-connection` |
+| **Runtime** | `runtime`, `embedded-runtime` |
+| **Service** | `service`, `service-test`, `multi-execution-service`, `post-validation` |
+| **Generation** | `file-generation`, `model-generation`, `generation-specification` |
+| **Data** | `data-element`, `test-data`, `shared-test-data` |
+| **External Format** | `external-format`, `binding`, `schema-set` |
+| **Function Activator** | `hosted-service`, `snowflake-app`, `bigquery-function` |
+
+### 6.3 Catalog Index
+
+Today the catalog metadata is captured by `EMITModelDescriptor` (under
+`org.finos.legend.engine.test.emit.catalog`), which is parsed from each
+`*.emit.yaml` and carries the descriptor fields plus the resolved primary /
+dependency file paths.
+
+The classpath scan that discovers descriptors is implemented in
+`EMITModelDiscovery` (in `legend-engine-emit-junit`), but it is currently
+oriented toward the JUnit `@TestFactory` flow rather than catalog query.
+
+A dedicated catalog index — querying models by feature, store, complexity,
+and free-text search over titles/descriptions/tags — is **not yet
+implemented**. The descriptor and discovery primitives are designed so that
+an in-memory index (and later a JSON serialisation for a search UI) can be
+layered on top without disrupting the existing pipeline. See §9.
+
+---
+
+## 7. Sample `.pure` Model Input
+
+A minimal example model for EMIT testing, with its accompanying `emit.yaml`:
+
+**`service-simple.emit.yaml`**:
+```yaml
+name: service-simple
+title: "Simple Service with M2M Mapping"
+description: |
+  A basic service using a model-to-model mapping. Demonstrates
+  class definition, empty mapping, service definition with a
+  query and test suite.
+
+modelSources:
+  model:
+    root: emit-models/basic/service-simple
+    files:
+      - model/model.pure
+  dependencies:
+    - source: emit-models/basic/base-types.emit.yaml
+
+features:
+  - class
+  - derived-property
+  - mapping
+  - service
+  - service-test
+complexity: basic
+tags:
+  - m2m
+  - getting-started
+```
+
+**`model/model.pure`**:
+```pure
+###Pure
+Class demo::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+  fullName() { $this.firstName + ' ' + $this.lastName }: String[1];
+}
+
+###Mapping
+Mapping demo::PersonMapping
+(
+)
+
+###Service
+Service demo::PersonService
+{
+  pattern: '/api/person';
+  documentation: 'A simple person service';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Person.all()->project([x|$x.firstName, x|$x.lastName], ['First Name', 'Last Name']);
+    mapping: demo::PersonMapping;
+  }
+  testSuites:
+  [
+    testSuite_1:
+    {
+      tests:
+      [
+        test_1:
+        {
+          asserts:
+          [
+            assert_1:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 8. Dependencies
+
+Both EMIT modules depend only on existing `legend-engine` modules — there is no dependency on `legend-sdlc`.
+
+The core runner module (`legend-engine-emit`) has dependencies that fall into a small set of categories, each contributing one stage of the pipeline:
+
+- **Protocol & grammar** — `PureModelContextData`, version registry, and the `PureGrammarParser` that turns `.pure` source into protocol POJOs.
+- **Compiler** — `PureModel` construction from a `PureModelContextData`.
+- **Generation SPIs** — `ModelGenerationExtension`, `GenerationExtension`, and `ArtifactGenerationExtension`, plus their shared base modules.
+- **Test runners** — `TestableRunner` for the modern `Testable` infrastructure, plus the legacy `MappingTestRunner` and `ServiceTestRunner` for backward compatibility.
+- **Plan generation** — `ServicePlanGenerator` (for `Service` elements) and the underlying `PlanGenerator`.
+- **Service DSL** — protocol/compiler artifacts for the `Service` element type, since `Service` is special-cased by Phase 6.
+
+The JUnit binding module (`legend-engine-emit-junit`) depends on `legend-engine-emit` and on JUnit 5 (`junit-jupiter-api`).
+
+Concrete artifact coordinates are kept in each module's `pom.xml`; listing them here would drift.
+
+---
+
+## 9. Future Extensions
+
+- **Store implementation variation**: Run a model against alternative implementations of
+  its stores (e.g., a relational model against DuckDB, Postgres, Snowflake) without
+  duplicating the model. The available variations should be **discovered from the model
+  and the classpath**, not declared in `emit.yaml` — keeping the test descriptor focused
+  on what the model is, and letting an external tool decide which variations to actually
+  run.
+- **Catalog search tool**: A web UI or CLI tool for searching and browsing the catalog index
+  (e.g., `emit search --feature relational-mapping --complexity basic`).
+- **Auto-derived metadata**: Introspect `PureModelContextData` to supplement `emit.yaml` tags.
+- **Catalog completeness CI check**: Validate that every model has `emit.yaml`, required fields
+  are present, and feature tags come from the controlled vocabulary.
+- **Model diff testing**: Compare EMIT results between two model versions.
+- **Performance benchmarking**: Track phase durations over time.
+- **Model coverage**: Track which model elements are exercised by tests.
+- **Feature coverage matrix**: Auto-generate a matrix showing which features are covered by
+  examples and which lack coverage, helping guide the creation of new examples.

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-core-emit</artifactId>
+        <version>4.129.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-engine-emit-junit</artifactId>
+    <name>Legend Engine - Testing - EMIT JUnit Integration</name>
+
+    <dependencies>
+        <!-- ENGINE -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-emit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-generation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+        </dependency>
+        <!-- ENGINE -->
+
+        <!-- ECLIPSE COLLECTIONS -->
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <!-- ECLIPSE COLLECTIONS -->
+
+        <!-- JUNIT 5 (compile scope: this module IS a JUnit integration) -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <!-- JUNIT 5 -->
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- TEST: M2M mapping execution. Pulls in MappingTestableRunnerExtension
+             so EMIT models containing Mapping testSuites can actually run. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-configuration-plan-generation-serialization</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
+    </dependencies>
+</project>

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITModelDiscovery.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITModelDiscovery.java
@@ -1,0 +1,92 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.junit;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+final class EMITModelDiscovery
+{
+    private EMITModelDiscovery()
+    {
+    }
+
+    static MutableList<Path> findEmitYamls(String classpathRoot)
+    {
+        if (classpathRoot == null || classpathRoot.isEmpty())
+        {
+            throw new IllegalArgumentException("classpathRoot must be non-empty");
+        }
+        String normalised = classpathRoot.endsWith("/") ? classpathRoot.substring(0, classpathRoot.length() - 1) : classpathRoot;
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null)
+        {
+            classLoader = EMITModelDiscovery.class.getClassLoader();
+        }
+        try
+        {
+            MutableList<Path> result = Lists.mutable.empty();
+            Enumeration<URL> urls = classLoader.getResources(normalised);
+            while (urls.hasMoreElements())
+            {
+                walkRoot(urls.nextElement(), result::add);
+            }
+            return result.sortThis();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException("Failed to enumerate classpath resources under '" + classpathRoot + "'", e);
+        }
+    }
+
+    private static void walkRoot(URL url, Consumer<? super Path> consumer)
+    {
+        if (!"file".equals(url.getProtocol()))
+        {
+            throw new UnsupportedOperationException("EMIT JUnit discovery currently only supports file: classpath roots, but got: " + url);
+        }
+        Path root;
+        try
+        {
+            root = Paths.get(url.toURI());
+        }
+        catch (URISyntaxException e)
+        {
+            throw new IllegalStateException("Invalid classpath URL: " + url, e);
+        }
+        if (Files.isDirectory(root))
+        {
+            try (Stream<Path> walk = Files.walk(root))
+            {
+                walk.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".emit.yaml")).forEach(consumer);
+            }
+            catch (IOException e)
+            {
+                throw new UncheckedIOException("Failed to walk classpath root '" + root + "'", e);
+            }
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
@@ -1,0 +1,209 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.junit;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.test.emit.EMITModel;
+import org.finos.legend.engine.test.emit.EMITModelLoader;
+import org.finos.legend.engine.test.emit.EMITSourceSet;
+import org.finos.legend.engine.test.emit.EMITTasks;
+import org.finos.legend.engine.test.emit.EMITTasks.ParseResult;
+import org.finos.legend.engine.test.emit.EMITTasks.TestCandidate;
+import org.finos.legend.engine.test.emit.error.EMITAssertionError;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.function.Executable;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * JUnit 5 integration for EMIT. Discovers {@code *.emit.yaml} files on the
+ * classpath under a given root, eagerly initialises (load + parse + compile)
+ * each model, then yields one {@link DynamicTest} per granular operation
+ * (file generation, artifact generation, individual test, service plan).
+ *
+ * <p>Each dynamic test calls into {@link EMITTasks} for its body, so that
+ * the standalone {@code EMITRunner} and this JUnit integration share a single
+ * per-item engine.
+ *
+ * <p>Typical usage in a test module:
+ *
+ * <pre>{@code
+ * public class MyModuleEMITTestSuite
+ * {
+ *     @TestFactory
+ *     Stream<DynamicTest> emit()
+ *     {
+ *         return EMITTestSuiteBuilder.taskStream("emit-models/");
+ *     }
+ * }
+ * }</pre>
+ */
+public final class EMITTestSuiteBuilder
+{
+    private static final String INIT_TASK_NAME = "Initialization (Init, Parse & Compile)";
+
+    private EMITTestSuiteBuilder()
+    {
+    }
+
+    /**
+     * Discovers EMIT models under the given classpath root and returns a stream
+     * of dynamic tests covering every granular operation across every model.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     */
+    public static Stream<DynamicTest> taskStream(String classpathRoot)
+    {
+        MutableList<Path> yamls = EMITModelDiscovery.findEmitYamls(classpathRoot);
+        EMITModelLoader loader = new EMITModelLoader();
+        return yamls.stream().flatMap(yaml -> tasksFor(yaml, loader).stream());
+    }
+
+    public static List<DynamicTest> taskList(String classpathRoot)
+    {
+        MutableList<Path> yamls = EMITModelDiscovery.findEmitYamls(classpathRoot);
+        EMITModelLoader loader = new EMITModelLoader();
+        return yamls.flatCollect(yaml -> tasksFor(yaml, loader));
+    }
+
+    private static List<DynamicTest> tasksFor(Path yaml, EMITModelLoader loader)
+    {
+        String fallbackLabel = stripExtension(yaml.getFileName().toString());
+
+        EMITSourceSet sourceSet;
+        try
+        {
+            sourceSet = loader.load(yaml);
+        }
+        catch (Exception e)
+        {
+            return Lists.mutable.with(failingTask(fallbackLabel, INIT_TASK_NAME, e));
+        }
+        String label = (sourceSet.getDescriptor() != null && sourceSet.getDescriptor().getName() != null) ? sourceSet.getDescriptor().getName() : fallbackLabel;
+
+        ParseResult parsed;
+        try
+        {
+            parsed = EMITTasks.parse(sourceSet);
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            return Lists.mutable.with(failingTask(label, INIT_TASK_NAME, e));
+        }
+
+        PureModel pureModel;
+        try
+        {
+            pureModel = EMITTasks.compile(parsed.getPmcd());
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            return Lists.mutable.with(failingTask(label, INIT_TASK_NAME, e));
+        }
+
+        EMITModel model = new EMITModel(sourceSet, parsed.getPmcd(), pureModel, parsed.getPrimarySourceIds());
+
+        MutableList<DynamicTest> tasks = Lists.mutable.empty();
+        tasks.add(passingTask(label, INIT_TASK_NAME));
+
+        ListIterate.collect(EMITTasks.findFileGenerationSpecs(model), spec ->
+        {
+            String name = "File Generation: " + spec.getPath();
+            return test(label, name, () -> EMITTasks.runFileGeneration(spec, model.getPureModel()));
+        }, tasks);
+
+        ListIterate.collect(EMITTasks.findArtifactGenerationCandidates(model), candidate ->
+        {
+            String name = "Artifact Generation: " + candidate.elementPath + " (" + candidate.extension.getKey() + ")";
+            return test(label, name, () -> EMITTasks.runArtifactGeneration(candidate.extension, candidate.pureElement, model.getPmcd(), model.getPureModel()));
+        }, tasks);
+
+        ListIterate.collect(EMITTasks.findTestCandidates(model), candidate ->
+        {
+            String suitePart = (candidate.suiteId == null) ? "" : (" / " + candidate.suiteId);
+            String name = "Test: " + candidate.testablePath + suitePart + " / " + candidate.atomicTestId;
+            return test(label, name, () -> assertTestPassed(model, candidate));
+        }, tasks);
+
+        ListIterate.collect(EMITTasks.findServices(model), service ->
+        {
+            String name = "Plan: " + service.getPath();
+            return test(label, name, () -> EMITTasks.runPlan(service, model.getPureModel()));
+        }, tasks);
+
+        ListIterate.collect(EMITTasks.findLegacyMappingTestCandidates(model), candidate ->
+        {
+            String name = "Legacy Mapping Test: " + candidate.mappingPath + " / " + candidate.test.name;
+            return test(label, name, () -> EMITTasks.assertLegacyMappingTestPassed(
+                    EMITTasks.runLegacyMappingTest(candidate.mappingPath, candidate.test, model.getPureModel())));
+        }, tasks);
+
+        ListIterate.collect(EMITTasks.findLegacyServiceTestCandidates(model), candidate ->
+        {
+            String name = "Legacy Service Test: " + candidate.servicePath;
+            return test(label, name, () -> EMITTasks.assertLegacyServiceTestPassed(
+                    EMITTasks.runLegacyServiceTest(candidate.service, model.getPmcd(), model.getPureModel())));
+        }, tasks);
+
+        return tasks;
+    }
+
+    private static void assertTestPassed(EMITModel model, TestCandidate candidate)
+    {
+        EMITTasks.assertTestPassed(EMITTasks.runTest(candidate.testablePath, candidate.suiteId, candidate.atomicTestId, model.getPmcd(), model.getPureModel()));
+    }
+
+    private static DynamicTest test(String label, String taskName, Executable executable)
+    {
+        return DynamicTest.dynamicTest(format(label, taskName), executable);
+    }
+
+    private static DynamicTest passingTask(String label, String taskName)
+    {
+        return DynamicTest.dynamicTest(format(label, taskName), () ->
+        {
+            // do nothing for pass
+        });
+    }
+
+    private static DynamicTest failingTask(String label, String taskName, Throwable failure)
+    {
+        return DynamicTest.dynamicTest(format(label, taskName), () ->
+        {
+            throw failure;
+        });
+    }
+
+    private static String format(String label, String taskName)
+    {
+        return "[" + label + "] " + taskName;
+    }
+
+    private static String stripExtension(String fileName)
+    {
+        if (fileName.endsWith(".emit.yaml"))
+        {
+            return fileName.substring(0, fileName.length() - ".emit.yaml".length());
+        }
+        int lastDot = fileName.lastIndexOf('.');
+        return (lastDot < 0) ? fileName : fileName.substring(0, lastDot);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
@@ -1,0 +1,119 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.junit;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TestEMITTestSuiteBuilder
+{
+    @Test
+    void buildTasksDiscoversAllYamlsUnderRoot()
+    {
+        List<DynamicTest> tasks = EMITTestSuiteBuilder.taskList("emit-models/");
+
+        int initTasks = ListIterate.count(tasks, t -> t.getDisplayName().endsWith("Initialization (Init, Parse & Compile)"));
+        Assertions.assertEquals(2, initTasks,
+                () -> "Expected one Initialization task per discovered model (class-simple, m2m-passing); got names:\n" + names(tasks));
+    }
+
+    @Test
+    void classSimpleYieldsOnlyAnInitTask() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "class-simple");
+
+        // class-simple has no Testable elements and no Services; the only mandatory
+        // task is Initialization. Artifact generators registered on the classpath
+        // could in principle yield additional Artifact Generation tasks for the
+        // demo::Person class — assert the init task exists, and assert the
+        // ones that do exist all execute successfully.
+        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Initialization (Init, Parse & Compile)".equals(t.getDisplayName())),
+                () -> "Missing init task; got:\n" + names(tasks));
+        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Test:")),
+                () -> "class-simple should not produce any Test tasks; got:\n" + names(tasks));
+        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Plan:")),
+                () -> "class-simple should not produce any Plan tasks; got:\n" + names(tasks));
+        for (DynamicTest task : tasks)
+        {
+            task.getExecutable().execute();
+        }
+    }
+
+    @Test
+    void m2mPassingYieldsInitPlusOneTaskPerAtomicTest() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "m2m-passing");
+
+        MutableList<String> names = tasks.collect(DynamicTest::getDisplayName);
+        Assertions.assertTrue(names.contains("[m2m-passing] Initialization (Init, Parse & Compile)"),
+                () -> "Missing init task; got: " + names);
+        Assertions.assertTrue(names.contains("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / johnSmith"),
+                () -> "Missing johnSmith test task; got: " + names);
+        Assertions.assertTrue(names.contains("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / janeDoe"),
+                () -> "Missing janeDoe test task; got: " + names);
+
+        int testTasks = tasks.count(t -> t.getDisplayName().contains("] Test:"));
+        Assertions.assertEquals(2, testTasks,
+                () -> "Expected exactly 2 Test tasks for m2m-passing; got:\n" + names);
+
+        for (DynamicTest task : tasks)
+        {
+            task.getExecutable().execute();
+        }
+    }
+
+    @Test
+    void compileFailureYieldsSingleFailingInitTask()
+    {
+        List<DynamicTest> tasks = EMITTestSuiteBuilder.taskList("emit-models-failure/");
+
+        Assertions.assertEquals(1, tasks.size(),
+                () -> "compile-failure should yield exactly one task (failing Init); got:\n" + names(tasks));
+        DynamicTest only = tasks.get(0);
+        Assertions.assertEquals("[compile-failure] Initialization (Init, Parse & Compile)", only.getDisplayName());
+
+        Throwable thrown = Assertions.assertThrows(Throwable.class, () -> only.getExecutable().execute(),
+                "Expected the init task to throw because the model fails to compile");
+        Assertions.assertNotNull(thrown);
+    }
+
+    @Test
+    void taskStreamEqualsTaskList()
+    {
+        List<DynamicTest> listTasks = EMITTestSuiteBuilder.taskList("emit-models-failure/");
+        List<DynamicTest> streamTasks = EMITTestSuiteBuilder.taskStream("emit-models-failure/").collect(Collectors.toList());
+        Assertions.assertEquals(ListIterate.collect(listTasks, DynamicTest::getDisplayName), ListIterate.collect(streamTasks, DynamicTest::getDisplayName));
+    }
+
+    private static MutableList<DynamicTest> tasksForLabel(String classpathRoot, String label)
+    {
+        String prefix = "[" + label + "] ";
+        return Lists.mutable.fromStream(EMITTestSuiteBuilder.taskStream(classpathRoot).filter(t -> t.getDisplayName().startsWith(prefix)));
+    }
+
+    private static String names(List<DynamicTest> tasks)
+    {
+        StringBuilder sb = new StringBuilder();
+        tasks.forEach(t -> sb.append("  - ").append(t.getDisplayName()).append('\n'));
+        return sb.toString();
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models-failure/compile-failure.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models-failure/compile-failure.emit.yaml
@@ -1,0 +1,18 @@
+name: compile-failure
+title: "Class Referencing an Undefined Type"
+description: |
+  A Class whose property type does not exist. PARSE succeeds but COMPILE fails.
+  Used to verify that a compile failure surfaces as a single failing
+  Initialization (Init, Parse & Compile) DynamicTest.
+
+modelSources:
+  model:
+    root: compile-failure
+    files:
+      - model.pure
+
+features:
+  - class
+complexity: basic
+tags:
+  - failure-mode

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models-failure/compile-failure/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models-failure/compile-failure/model.pure
@@ -1,0 +1,21 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+  address: demo::DoesNotExist[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/class-simple.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/class-simple.emit.yaml
@@ -1,0 +1,16 @@
+name: class-simple
+title: "Simple Class"
+description: |
+  A bootstrap EMIT test exercising parse and compile of a single class.
+
+modelSources:
+  model:
+    root: class-simple
+    files:
+      - model.pure
+
+features:
+  - class
+complexity: basic
+tags:
+  - getting-started

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/class-simple/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/class-simple/model.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing.emit.yaml
@@ -1,0 +1,23 @@
+name: m2m-passing
+title: "M2M Mapping with Passing Tests"
+description: |
+  A model-to-model mapping with an embedded test suite that passes. Used to
+  verify that the JUnit integration emits one DynamicTest per atomic test
+  inside a TestSuite.
+
+modelSources:
+  model:
+    root: m2m-passing
+    files:
+      - model/source.pure
+      - model/target.pure
+      - mapping/personMapping.pure
+
+features:
+  - class
+  - m2m-mapping
+  - mapping
+complexity: basic
+tags:
+  - m2m
+  - mapping-test

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing/mapping/personMapping.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing/mapping/personMapping.pure
@@ -1,0 +1,90 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonM2MMapping
+(
+  *demo::target::Person: Pure
+  {
+    ~src demo::source::Person
+    fullName: $src.firstName + ' ' + $src.lastName
+  }
+
+  testSuites:
+  [
+    fullNameSuite:
+    {
+      function: |demo::target::Person.all()->graphFetch(#{demo::target::Person{fullName}}#)->serialize(#{demo::target::Person{fullName}}#);
+      tests:
+      [
+        johnSmith:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::source::Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"John","lastName":"Smith"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"John Smith"}';
+                  }#;
+              }#
+          ];
+        },
+        janeDoe:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::source::Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"Jane","lastName":"Doe"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"Jane Doe"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing/model/source.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing/model/source.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::source::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing/model/target.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/m2m-passing/model/target.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::target::Person
+{
+  fullName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/pom.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-core-emit</artifactId>
+        <version>4.129.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-engine-emit</artifactId>
+    <name>Legend Engine - Testing - EMIT (Engine Model Integration Test) Framework</name>
+
+    <dependencies>
+        <!-- PURE -->
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+        <!-- PURE -->
+
+        <!-- ENGINE -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-compiler</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-generation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-generation-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-shared</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-testable</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-test-runner-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-test-runner-mapping</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-test-runner-service</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-generation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-core-extension</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-service-generation</artifactId>
+        </dependency>
+        <!-- ENGINE -->
+
+        <!-- ECLIPSE COLLECTIONS -->
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <!-- ECLIPSE COLLECTIONS -->
+
+        <!-- JACKSON (descriptor parsing) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <!-- JACKSON -->
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-configuration-plan-generation-serialization</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
+    </dependencies>
+</project>

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModel.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModel.java
@@ -1,0 +1,79 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.eclipse.collections.api.set.SetIterable;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+
+/**
+ * The compiled-and-loaded state of one EMIT model: the original source set, the
+ * combined {@link PureModelContextData} (primary + dependency files), the
+ * compiled {@link PureModel}, and the set of source IDs that came from the
+ * primary {@code model:} section of the {@code *.emit.yaml} (used to scope
+ * downstream phases away from dependency-loaded elements).
+ */
+public final class EMITModel
+{
+    private final EMITSourceSet sourceSet;
+    private final PureModelContextData pmcd;
+    private final PureModel pureModel;
+    private final SetIterable<String> primarySourceIds;
+
+    public EMITModel(EMITSourceSet sourceSet, PureModelContextData pmcd, PureModel pureModel, SetIterable<String> primarySourceIds)
+    {
+        this.sourceSet = sourceSet;
+        this.pmcd = pmcd;
+        this.pureModel = pureModel;
+        this.primarySourceIds = primarySourceIds;
+    }
+
+    public EMITSourceSet getSourceSet()
+    {
+        return this.sourceSet;
+    }
+
+    public PureModelContextData getPmcd()
+    {
+        return this.pmcd;
+    }
+
+    public PureModel getPureModel()
+    {
+        return this.pureModel;
+    }
+
+    public SetIterable<String> getPrimarySourceIds()
+    {
+        return this.primarySourceIds;
+    }
+
+    public boolean isPrimary(PackageableElement element)
+    {
+        return (element.sourceInformation == null) ||
+                (element.sourceInformation.sourceId == null) ||
+                this.primarySourceIds.contains(element.sourceInformation.sourceId);
+    }
+
+    /**
+     * Return a new {@code EMITModel} sharing the source set and primary scope,
+     * but pointing at a different (post-model-generation) PMCD and PureModel.
+     */
+    public EMITModel withModel(PureModelContextData newPmcd, PureModel newPureModel)
+    {
+        return new EMITModel(this.sourceSet, newPmcd, newPureModel, this.primarySourceIds);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModelLoader.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModelLoader.java
@@ -1,0 +1,174 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.test.emit.catalog.EMITModelDescriptor;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.List;
+
+public class EMITModelLoader
+{
+    private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
+
+    public EMITModelDescriptor parseDescriptor(Path emitYaml) throws IOException
+    {
+        EMITModelDescriptor descriptor = YAML.readValue(emitYaml.toFile(), EMITModelDescriptor.class);
+        descriptor.setSource(emitYaml.toAbsolutePath().normalize());
+        return descriptor;
+    }
+
+    public EMITSourceSet load(Path emitYaml) throws IOException
+    {
+        return load(parseDescriptor(emitYaml));
+    }
+
+    public EMITSourceSet load(EMITModelDescriptor descriptor) throws IOException
+    {
+        if (descriptor.getSource() == null)
+        {
+            throw new IllegalArgumentException("Descriptor has no source path; load it via parseDescriptor or set descriptor source explicitly");
+        }
+        if (descriptor.getModelSources() == null || descriptor.getModelSources().getModel() == null)
+        {
+            throw new IllegalArgumentException("Descriptor at " + descriptor.getSource() + " has no modelSources.model section");
+        }
+
+        Path baseDir = descriptor.getSource().getParent();
+        MutableList<EMITSourceFile> modelFiles = resolveSource(baseDir, descriptor.getModelSources().getModel(), true);
+
+        MutableList<EMITSourceFile> dependencyFiles = Lists.mutable.empty();
+        for (EMITModelDescriptor.Dependency dep : descriptor.getModelSources().getDependencies())
+        {
+            dependencyFiles.addAll(resolveDependency(baseDir, dep));
+        }
+
+        validateNoClashes(modelFiles, dependencyFiles);
+
+        return EMITSourceSet.newSourceSet(descriptor, modelFiles, dependencyFiles);
+    }
+
+    private MutableList<EMITSourceFile> resolveSource(Path baseDir, EMITModelDescriptor.Source source, boolean primary) throws IOException
+    {
+        if (source.getRoot() == null)
+        {
+            throw new IllegalArgumentException("Source has no 'root' field");
+        }
+        Path rootDir = baseDir.resolve(source.getRoot()).normalize();
+        MutableList<EMITSourceFile> resolved = Lists.mutable.empty();
+        for (String file : source.getFiles())
+        {
+            Path absolute = rootDir.resolve(file).normalize();
+            if (!Files.exists(absolute))
+            {
+                throw new IOException("Source file does not exist: " + absolute + " (declared as '" + file + "' under root '" + rootDir + "')");
+            }
+            resolved.add(new EMITSourceFile(file, absolute, primary));
+        }
+        return resolved;
+    }
+
+    private List<EMITSourceFile> resolveDependency(Path baseDir, EMITModelDescriptor.Dependency dep) throws IOException
+    {
+        if (dep.isInline())
+        {
+            EMITModelDescriptor.Source inline = EMITModelDescriptor.Source.newSource(dep.getRoot(), dep.getFiles());
+            return resolveSource(baseDir, inline, false);
+        }
+        if (dep.isReference())
+        {
+            Path referencedYaml = baseDir.resolve(dep.getSource()).normalize();
+            EMITSourceSet referenced = load(referencedYaml);
+            ListIterable<PathMatcher> excludeMatchers = compileGlobs(dep.getExcludes());
+
+            MutableList<EMITSourceFile> result = Lists.mutable.empty();
+            referenced.forEachFile(f ->
+            {
+                if (!matchesAny(excludeMatchers, baseDir, f))
+                {
+                    result.add(f);
+                }
+            });
+            return result;
+        }
+        throw new IllegalArgumentException("Dependency must specify either ('root' + 'files') or 'source' (with optional 'excludes')");
+    }
+
+    private ListIterable<PathMatcher> compileGlobs(List<String> patterns)
+    {
+        if (patterns == null)
+        {
+            return Lists.immutable.empty();
+        }
+        FileSystem fs = FileSystems.getDefault();
+        return ListIterate.collect(patterns, p -> fs.getPathMatcher("glob:" + p));
+    }
+
+    private boolean matchesAny(ListIterable<PathMatcher> matchers, Path baseDir, EMITSourceFile file)
+    {
+        return matchesAny(matchers, baseDir, file.getAbsolutePath());
+    }
+
+    private boolean matchesAny(ListIterable<PathMatcher> matchers, Path baseDir, Path absolute)
+    {
+        if (matchers.isEmpty())
+        {
+            return false;
+        }
+        Path relative = tryRelativize(baseDir, absolute);
+        return matchers.anySatisfy((relative == null) ? m -> m.matches(absolute) : m -> m.matches(relative) || m.matches(absolute));
+    }
+
+    private Path tryRelativize(Path baseDir, Path absolute)
+    {
+        try
+        {
+            return baseDir.relativize(absolute);
+        }
+        catch (IllegalArgumentException ignore)
+        {
+            return null;
+        }
+    }
+
+    private void validateNoClashes(ListIterable<EMITSourceFile> modelFiles, ListIterable<EMITSourceFile> dependencyFiles)
+    {
+        MutableMap<String, Path> seen = Maps.mutable.empty();
+        MutableSet<String> clashes = modelFiles.asLazy().concatenate(dependencyFiles).collectIf(f ->
+        {
+            Path prior = seen.put(f.getVirtualPath(), f.getAbsolutePath());
+            return (prior != null) && !prior.equals(f.getAbsolutePath());
+        }, EMITSourceFile::getVirtualPath, Sets.mutable.empty());
+        if (clashes.notEmpty())
+        {
+            throw new IllegalStateException(clashes.toSortedList().makeString("Source file virtual-path clashes: ", ", ", ""));
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITPhase.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITPhase.java
@@ -1,0 +1,26 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+public enum EMITPhase
+{
+    INITIALIZATION,
+    PARSE,
+    COMPILE,
+    MODEL_GENERATION,
+    FILE_GENERATION,
+    TEST_EXECUTION,
+    PLAN_GENERATION
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITPhaseResult.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITPhaseResult.java
@@ -1,0 +1,137 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class EMITPhaseResult
+{
+    public enum Status
+    {
+        SUCCESS,
+        FAILURE,
+        SKIPPED,
+        NOT_RUN
+    }
+
+    private final EMITPhase phase;
+    private final Status status;
+    private final long durationMs;
+    private final String message;
+    private final Throwable throwable;
+    private final List<?> outputs;
+
+    private EMITPhaseResult(EMITPhase phase, Status status, long durationMs, String message, Throwable throwable, List<?> outputs)
+    {
+        this.phase = phase;
+        this.status = status;
+        this.durationMs = durationMs;
+        this.message = message;
+        this.throwable = throwable;
+        this.outputs = outputs;
+    }
+
+    private EMITPhaseResult(EMITPhase phase, Status status, long durationMs, String message, Throwable exception)
+    {
+        this(phase, status, durationMs, message, exception, Collections.emptyList());
+    }
+
+    public EMITPhase getPhase()
+    {
+        return this.phase;
+    }
+
+    public Status getStatus()
+    {
+        return this.status;
+    }
+
+    public long getDurationMs()
+    {
+        return this.durationMs;
+    }
+
+    public String getMessage()
+    {
+        return this.message;
+    }
+
+    public Throwable getThrowable()
+    {
+        return this.throwable;
+    }
+
+    public List<?> getOutputs()
+    {
+        return this.outputs;
+    }
+
+    public static EMITPhaseResult success(EMITPhase phase, long durationMs, String message, List<?> outputs)
+    {
+        return new EMITPhaseResult(phase, Status.SUCCESS, durationMs, message, null, wrapList(outputs));
+    }
+
+    public static EMITPhaseResult success(EMITPhase phase, long durationMs, String message, Object... outputs)
+    {
+        return new EMITPhaseResult(phase, Status.SUCCESS, durationMs, message, null, wrapList(outputs));
+    }
+
+    public static EMITPhaseResult failure(EMITPhase phase, long durationMs, String message)
+    {
+        return failure(phase, durationMs, message, null);
+    }
+
+    public static EMITPhaseResult failure(EMITPhase phase, long durationMs, String message, Throwable throwable, Object... outputs)
+    {
+        return new EMITPhaseResult(phase, Status.FAILURE, durationMs, message, throwable, wrapList(outputs));
+    }
+
+    public static EMITPhaseResult failure(EMITPhase phase, long durationMs, String message, Throwable throwable, List<?> outputs)
+    {
+        return new EMITPhaseResult(phase, Status.FAILURE, durationMs, message, throwable, wrapList(outputs));
+    }
+
+    public static EMITPhaseResult skipped(EMITPhase phase, String reason)
+    {
+        return new EMITPhaseResult(phase, Status.SKIPPED, 0L, reason, null);
+    }
+
+    public static EMITPhaseResult notRun(EMITPhase phase, String reason)
+    {
+        return new EMITPhaseResult(phase, Status.NOT_RUN, 0L, reason, null);
+    }
+
+    public boolean isSuccess()
+    {
+        return this.status == Status.SUCCESS || this.status == Status.SKIPPED;
+    }
+
+    public boolean isFailure()
+    {
+        return this.status == Status.FAILURE;
+    }
+
+    private static List<?> wrapList(List<?> list)
+    {
+        return ((list == null) || list.isEmpty()) ? Collections.emptyList() : Collections.unmodifiableList(list);
+    }
+
+    private static List<?> wrapList(Object... objects)
+    {
+        return ((objects == null) || (objects.length == 0)) ? Collections.emptyList() : Collections.unmodifiableList(Arrays.asList(objects));
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITResult.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITResult.java
@@ -1,0 +1,102 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+
+import java.util.Formatter;
+import java.util.List;
+
+public class EMITResult
+{
+    private final MutableList<EMITPhaseResult> phaseResults = Lists.mutable.empty();
+    private final MutableMap<EMITPhase, EMITPhaseResult> byPhase = Maps.mutable.empty();
+
+    public List<EMITPhaseResult> getPhaseResults()
+    {
+        return this.phaseResults.asUnmodifiable();
+    }
+
+    public EMITPhaseResult getPhase(EMITPhase phase)
+    {
+        return this.byPhase.get(phase);
+    }
+
+    public void add(EMITPhaseResult result)
+    {
+        this.phaseResults.add(result);
+        this.byPhase.put(result.getPhase(), result);
+    }
+
+    public boolean isSuccess()
+    {
+        return this.phaseResults.noneSatisfy(EMITPhaseResult::isFailure);
+    }
+
+    public String getSummary()
+    {
+        StringBuilder builder = new StringBuilder("EMIT Result: ").append(isSuccess() ? "PASSED" : "FAILED").append('\n');
+        Formatter formatter = new Formatter(builder);
+        for (EMITPhase phase : EMITPhase.values())
+        {
+            EMITPhaseResult r = this.byPhase.get(phase);
+            if (r != null)
+            {
+                formatter.format("%s%-18s (%dms)", getStatusMarker(r), r.getPhase().name(), r.getDurationMs());
+                if (r.getMessage() != null && !r.getMessage().isEmpty())
+                {
+                    builder.append(" - ").append(r.getMessage());
+                }
+                builder.append('\n');
+                if (r.getThrowable() != null)
+                {
+                    builder.append("        ").append(r.getThrowable().getClass().getSimpleName())
+                            .append(": ").append(r.getThrowable().getMessage()).append('\n');
+                }
+            }
+        }
+        return builder.toString();
+    }
+
+    private String getStatusMarker(EMITPhaseResult result)
+    {
+        switch (result.getStatus())
+        {
+            case SUCCESS:
+            {
+                return "  OK   ";
+            }
+            case FAILURE:
+            {
+                return "  FAIL ";
+            }
+            case SKIPPED:
+            {
+                return "  SKIP ";
+            }
+            case NOT_RUN:
+            {
+                return "  --   ";
+            }
+            default:
+            {
+                return "  ?    ";
+            }
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITRunner.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITRunner.java
@@ -1,0 +1,389 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.eclipse.collections.impl.utility.MapIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
+import org.finos.legend.engine.test.emit.EMITTasks.ArtifactCandidate;
+import org.finos.legend.engine.test.emit.EMITTasks.LegacyMappingTestCandidate;
+import org.finos.legend.engine.test.emit.EMITTasks.LegacyServiceTestCandidate;
+import org.finos.legend.engine.test.emit.EMITTasks.ModelGenResult;
+import org.finos.legend.engine.test.emit.EMITTasks.ParseResult;
+import org.finos.legend.engine.test.emit.catalog.EMITModelDescriptor;
+import org.finos.legend.engine.test.emit.error.EMITAssertionError;
+import org.finos.legend.engine.test.runner.mapping.RichMappingTestResult;
+import org.finos.legend.engine.test.runner.service.RichServiceTestResult;
+import org.finos.legend.engine.test.runner.shared.TestResult;
+import org.finos.legend.engine.testable.model.RunTestsResult;
+import org.finos.legend.engine.testable.model.RunTestsTestableInput;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Orchestrates the full EMIT pipeline (init → parse → compile → model gen →
+ * file gen → test execution → plan generation) and aggregates per-phase
+ * results into an {@link EMITResult}. The actual per-item work is delegated
+ * to {@link EMITTasks} so that the JUnit integration can drive the same
+ * primitives at a finer granularity without duplicating logic.
+ */
+public class EMITRunner
+{
+    private final EMITModelLoader loader;
+
+    public EMITRunner()
+    {
+        this(new EMITModelLoader());
+    }
+
+    public EMITRunner(EMITModelLoader loader)
+    {
+        this.loader = loader;
+    }
+
+    public EMITResult runFromYaml(Path emitYaml)
+    {
+        EMITResult result = new EMITResult();
+        EMITSourceSet sourceSet = init(result, () -> this.loader.load(emitYaml));
+        return (sourceSet == null) ? result : run(sourceSet, result);
+    }
+
+    public EMITResult run(EMITModelDescriptor descriptor)
+    {
+        EMITResult result = new EMITResult();
+        EMITSourceSet sourceSet = init(result, () -> this.loader.load(descriptor));
+        return (sourceSet == null) ? result : run(sourceSet, result);
+    }
+
+    private EMITSourceSet init(EMITResult result, ThrowingSupplier<EMITSourceSet> loader)
+    {
+        long start = System.currentTimeMillis();
+        try
+        {
+            EMITSourceSet sourceSet = loader.get();
+            long elapsed = System.currentTimeMillis() - start;
+            String message = sourceSet.getModelFiles().size() + " model files, " + sourceSet.getDependencyFiles().size() + " dependency files";
+            result.add(EMITPhaseResult.success(EMITPhase.INITIALIZATION, elapsed, message, sourceSet));
+            return sourceSet;
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.failure(EMITPhase.INITIALIZATION, elapsed, e.getMessage(), e));
+            markRemainingNotRun(result, EMITPhase.INITIALIZATION);
+            return null;
+        }
+    }
+
+    private EMITResult run(EMITSourceSet sourceSet, EMITResult result)
+    {
+        ParseResult parsed = parse(result, sourceSet);
+        if (parsed == null)
+        {
+            markRemainingNotRun(result, EMITPhase.PARSE);
+            return result;
+        }
+
+        PureModel pureModel = compile(result, parsed.getPmcd());
+        if (pureModel == null)
+        {
+            markRemainingNotRun(result, EMITPhase.COMPILE);
+            return result;
+        }
+
+        EMITModel model = new EMITModel(sourceSet, parsed.getPmcd(), pureModel, parsed.getPrimarySourceIds());
+        EMITModel effective = runModelGeneration(result, model);
+        if (effective == null)
+        {
+            markRemainingNotRun(result, EMITPhase.MODEL_GENERATION);
+            return result;
+        }
+
+        runFileGeneration(result, effective);
+        runTestExecution(result, effective);
+        runPlanGeneration(result, effective);
+
+        return result;
+    }
+
+    // ----- Phase 1 -----
+
+    private ParseResult parse(EMITResult result, EMITSourceSet sourceSet)
+    {
+        long start = System.currentTimeMillis();
+        try
+        {
+            ParseResult parsed = EMITTasks.parse(sourceSet);
+            long elapsed = System.currentTimeMillis() - start;
+            String message = sourceSet.getTotalFileCount() + " files, " + parsed.getTotalElementCount() + " elements";
+            result.add(EMITPhaseResult.success(EMITPhase.PARSE, elapsed, message, parsed.getPmcd()));
+            return parsed;
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.failure(EMITPhase.PARSE, elapsed, e.getMessage(), e));
+            return null;
+        }
+    }
+
+    // ----- Phase 2 -----
+
+    private PureModel compile(EMITResult result, PureModelContextData pmcd)
+    {
+        long start = System.currentTimeMillis();
+        try
+        {
+            PureModel pureModel = EMITTasks.compile(pmcd);
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.success(EMITPhase.COMPILE, elapsed, "PureModel built successfully", pureModel));
+            return pureModel;
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.failure(EMITPhase.COMPILE, elapsed, e.getMessage(), e));
+            return null;
+        }
+    }
+
+    // ----- Phase 3 -----
+
+    private EMITModel runModelGeneration(EMITResult result, EMITModel model)
+    {
+        long start = System.currentTimeMillis();
+        try
+        {
+            ModelGenResult genResult = EMITTasks.runModelGeneration(model);
+            long elapsed = System.currentTimeMillis() - start;
+            if (!genResult.isApplicable())
+            {
+                result.add(EMITPhaseResult.skipped(EMITPhase.MODEL_GENERATION, "no GenerationSpecification"));
+                return model;
+            }
+            if (genResult.getNewModel() == null)
+            {
+                result.add(EMITPhaseResult.success(EMITPhase.MODEL_GENERATION, elapsed, "no generators produced output", model.getPmcd()));
+                return model;
+            }
+            String message = "generated " + genResult.getGeneratedElementCount() + " elements from " + genResult.getGenerationCount() + " extension calls";
+            result.add(EMITPhaseResult.success(EMITPhase.MODEL_GENERATION, elapsed, message, genResult.getNewModel().getPmcd()));
+            return genResult.getNewModel();
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.failure(EMITPhase.MODEL_GENERATION, elapsed, e.getMessage(), e));
+            return null;
+        }
+    }
+
+    // ----- Phase 4: file gen specs + artifact gen extensions -----
+
+    public static class FileGenerationOutput
+    {
+        private final Map<String, List<Root_meta_pure_generation_metamodel_GenerationOutput>> bySpecification = new LinkedHashMap<>();
+        private final Map<String, List<Artifact>> byArtifactExtension = new LinkedHashMap<>();
+
+        public Map<String, List<Root_meta_pure_generation_metamodel_GenerationOutput>> getBySpecification()
+        {
+            return Collections.unmodifiableMap(this.bySpecification);
+        }
+
+        public Map<String, List<Artifact>> getByArtifactExtension()
+        {
+            return Collections.unmodifiableMap(this.byArtifactExtension);
+        }
+    }
+
+    private void runFileGeneration(EMITResult result, EMITModel model)
+    {
+        long start = System.currentTimeMillis();
+        List<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification> specs = EMITTasks.findFileGenerationSpecs(model);
+        List<ArtifactCandidate> artifactCandidates = EMITTasks.findArtifactGenerationCandidates(model);
+
+        if (specs.isEmpty() && artifactCandidates.isEmpty())
+        {
+            result.add(EMITPhaseResult.skipped(EMITPhase.FILE_GENERATION, "no FileGenerationSpecification or ArtifactGenerationExtension applies"));
+            return;
+        }
+
+        try
+        {
+            FileGenerationOutput output = new FileGenerationOutput();
+
+            specs.forEach(spec -> output.bySpecification.put(spec.getPath(), EMITTasks.runFileGeneration(spec, model.getPureModel())));
+
+            artifactCandidates.forEach(candidate ->
+            {
+                List<Artifact> artifacts = EMITTasks.runArtifactGeneration(candidate.extension, candidate.pureElement, model.getPmcd(), model.getPureModel());
+                if (!artifacts.isEmpty())
+                {
+                    output.byArtifactExtension.computeIfAbsent(candidate.extension.getKey(), k -> Lists.mutable.empty()).addAll(artifacts);
+                }
+            });
+
+            long elapsed = System.currentTimeMillis() - start;
+            String message = output.bySpecification.size() + " file generations, " + output.byArtifactExtension.size() + " artifact extensions";
+            result.add(EMITPhaseResult.success(EMITPhase.FILE_GENERATION, elapsed, message, output));
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.failure(EMITPhase.FILE_GENERATION, elapsed, e.getMessage(), e));
+        }
+    }
+
+    // ----- Phase 5 -----
+
+    private void runTestExecution(EMITResult result, EMITModel model)
+    {
+        long start = System.currentTimeMillis();
+        MutableList<Object> outputs = Lists.mutable.empty();
+        MutableList<RunTestsTestableInput> testableInputs = EMITTasks.findTestableInputs(model);
+        List<LegacyMappingTestCandidate> legacyMappingCandidates = EMITTasks.findLegacyMappingTestCandidates(model);
+        List<LegacyServiceTestCandidate> legacyServiceCandidates = EMITTasks.findLegacyServiceTestCandidates(model);
+
+        if (testableInputs.isEmpty() && legacyMappingCandidates.isEmpty() && legacyServiceCandidates.isEmpty())
+        {
+            result.add(EMITPhaseResult.skipped(EMITPhase.TEST_EXECUTION, "no Testable or legacy test elements in primary scope"));
+            return;
+        }
+        EMITPhaseResult phaseResult;
+        try
+        {
+            int total = 0;
+            int failed = 0;
+
+            // Modern Testable tests
+            if (testableInputs.notEmpty())
+            {
+                RunTestsResult runTestsResult = EMITTasks.runTests(testableInputs, model.getPmcd(), model.getPureModel());
+                outputs.add(runTestsResult);
+                total += runTestsResult.results.size();
+                failed += ListIterate.count(runTestsResult.results, r -> !(r instanceof TestExecuted) || (((TestExecuted) r).testExecutionStatus == TestExecutionStatus.FAIL));
+            }
+
+            // Legacy Mapping tests
+            for (LegacyMappingTestCandidate candidate : legacyMappingCandidates)
+            {
+                total++;
+                try
+                {
+                    RichMappingTestResult mappingResult = EMITTasks.runLegacyMappingTest(candidate.mappingPath, candidate.test, model.getPureModel());
+                    outputs.add(mappingResult);
+                    if (mappingResult.getResult() != TestResult.SUCCESS)
+                    {
+                        failed++;
+                    }
+                }
+                catch (Exception e)
+                {
+                    failed++;
+                }
+            }
+
+            // Legacy Service tests
+            for (LegacyServiceTestCandidate candidate : legacyServiceCandidates)
+            {
+                total++;
+                try
+                {
+                    List<RichServiceTestResult> serviceResults = EMITTasks.runLegacyServiceTest(candidate.service, model.getPmcd(), model.getPureModel());
+                    outputs.addAll(serviceResults);
+                    boolean anyFail = ListIterate.anySatisfy(serviceResults, r -> r.getResults() != null && MapIterate.anySatisfy(r.getResults(), v -> v != TestResult.SUCCESS));
+                    if (anyFail)
+                    {
+                        failed++;
+                    }
+                }
+                catch (Exception e)
+                {
+                    failed++;
+                }
+            }
+
+            long elapsed = System.currentTimeMillis() - start;
+            String message = total + " tests (testable: " + testableInputs.size() + ", legacy mapping: " + legacyMappingCandidates.size() + ", legacy service: " + legacyServiceCandidates.size() + "); " + failed + " failed";
+            phaseResult = (failed == 0)
+                          ? EMITPhaseResult.success(EMITPhase.TEST_EXECUTION, elapsed, message, outputs)
+                          : EMITPhaseResult.failure(EMITPhase.TEST_EXECUTION, elapsed, message, null, outputs);
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            long elapsed = System.currentTimeMillis() - start;
+            phaseResult = EMITPhaseResult.failure(EMITPhase.TEST_EXECUTION, elapsed, e.getMessage(), e);
+        }
+        result.add(phaseResult);
+    }
+
+    // ----- Phase 6 -----
+
+    private void runPlanGeneration(EMITResult result, EMITModel model)
+    {
+        long start = System.currentTimeMillis();
+        List<org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service> services = EMITTasks.findServices(model);
+        if (services.isEmpty())
+        {
+            result.add(EMITPhaseResult.skipped(EMITPhase.PLAN_GENERATION, "no Service elements in primary scope"));
+            return;
+        }
+        try
+        {
+            Map<String, ExecutionPlan> plans = new LinkedHashMap<>();
+            services.forEach(service -> plans.put(service.getPath(), EMITTasks.runPlan(service, model.getPureModel())));
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.success(EMITPhase.PLAN_GENERATION, elapsed, "plans for " + plans.size() + " service(s)", Collections.unmodifiableMap(plans)));
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            long elapsed = System.currentTimeMillis() - start;
+            result.add(EMITPhaseResult.failure(EMITPhase.PLAN_GENERATION, elapsed, e.getMessage(), e));
+        }
+    }
+
+    // ----- helpers -----
+
+    private static void markRemainingNotRun(EMITResult result, EMITPhase failed)
+    {
+        EMITPhase[] values = EMITPhase.values();
+        for (int i = failed.ordinal() + 1; i < values.length; i++)
+        {
+            EMITPhase phase = values[i];
+            if (result.getPhase(phase) == null)
+            {
+                result.add(EMITPhaseResult.notRun(phase, "skipped due to failure in " + failed.name()));
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T>
+    {
+        T get() throws Exception;
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITSourceFile.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITSourceFile.java
@@ -1,0 +1,46 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import java.nio.file.Path;
+
+public class EMITSourceFile
+{
+    private final String virtualPath;
+    private final Path absolutePath;
+    private final boolean primary;
+
+    public EMITSourceFile(String virtualPath, Path absolutePath, boolean primary)
+    {
+        this.virtualPath = virtualPath;
+        this.absolutePath = absolutePath;
+        this.primary = primary;
+    }
+
+    public String getVirtualPath()
+    {
+        return this.virtualPath;
+    }
+
+    public Path getAbsolutePath()
+    {
+        return this.absolutePath;
+    }
+
+    public boolean isPrimary()
+    {
+        return this.primary;
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITSourceSet.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITSourceSet.java
@@ -1,0 +1,67 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.finos.legend.engine.test.emit.catalog.EMITModelDescriptor;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public class EMITSourceSet
+{
+    private final EMITModelDescriptor descriptor;
+    private final ImmutableList<EMITSourceFile> modelFiles;
+    private final ImmutableList<EMITSourceFile> dependencyFiles;
+
+    public EMITSourceSet(EMITModelDescriptor descriptor, List<EMITSourceFile> modelFiles, List<EMITSourceFile> dependencyFiles)
+    {
+        this.descriptor = descriptor;
+        this.modelFiles = (modelFiles == null) ? Lists.immutable.empty() : Lists.immutable.withAll(modelFiles);
+        this.dependencyFiles = (dependencyFiles == null) ? Lists.immutable.empty() : Lists.immutable.withAll(dependencyFiles);
+    }
+
+    public EMITModelDescriptor getDescriptor()
+    {
+        return this.descriptor;
+    }
+
+    public List<EMITSourceFile> getModelFiles()
+    {
+        return this.modelFiles.castToList();
+    }
+
+    public List<EMITSourceFile> getDependencyFiles()
+    {
+        return this.dependencyFiles.castToList();
+    }
+
+    public int getTotalFileCount()
+    {
+        return this.modelFiles.size() + this.dependencyFiles.size();
+    }
+
+    public void forEachFile(Consumer<? super EMITSourceFile> consumer)
+    {
+        this.modelFiles.forEach(consumer);
+        this.dependencyFiles.forEach(consumer);
+    }
+
+    public static EMITSourceSet newSourceSet(EMITModelDescriptor descriptor, List<EMITSourceFile> modelFiles, List<EMITSourceFile> dependencyFiles)
+    {
+        return new EMITSourceSet(descriptor, modelFiles, dependencyFiles);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
@@ -1,0 +1,874 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.utility.Iterate;
+import org.eclipse.collections.impl.utility.LazyIterate;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.external.shared.format.extension.GenerationExtension;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.compiler.toPureGraph.GenerationCompilerExtension;
+import org.finos.legend.engine.language.pure.dsl.generation.compiler.toPureGraph.HelperGenerationSpecificationBuilder;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtensionLoader;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ModelGenerationExtension;
+import org.finos.legend.engine.language.pure.dsl.service.generation.ServicePlanGenerator;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
+import org.finos.legend.engine.plan.execution.PlanExecutor;
+import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
+import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransformers;
+import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
+import org.finos.legend.engine.plan.platform.PlanPlatform;
+import org.finos.legend.engine.protocol.pure.PureClientVersions;
+import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
+import org.finos.legend.engine.protocol.pure.m3.function.Function;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.generationSpecification.GenerationSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.MappingTest_Legacy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTest_Legacy;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertFail;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertPass;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertionStatus;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.EqualToJsonAssertFail;
+import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.EqualToRelationAssertFail;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
+import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
+import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.engine.test.emit.error.EMITAssertionError;
+import org.finos.legend.engine.test.emit.error.EMITException;
+import org.finos.legend.engine.test.runner.mapping.MappingTestRunner;
+import org.finos.legend.engine.test.runner.mapping.RichMappingTestResult;
+import org.finos.legend.engine.test.runner.service.RichServiceTestResult;
+import org.finos.legend.engine.test.runner.service.ServiceTestRunner;
+import org.finos.legend.engine.testable.TestableRunner;
+import org.finos.legend.engine.testable.extension.TestableRunnerExtensionLoader;
+import org.finos.legend.engine.testable.model.RunTestsResult;
+import org.finos.legend.engine.testable.model.RunTestsTestableInput;
+import org.finos.legend.engine.testable.model.UniqueTestId;
+import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput;
+import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
+import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.testable.Testable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+/**
+ * Stateless per-item engine for the EMIT pipeline. {@link EMITRunner} drives
+ * these methods to produce an aggregated {@link EMITResult}; the JUnit
+ * integration drives them per-item to produce one {@code DynamicTest} per
+ * granular operation. Both paths share this single implementation.
+ */
+public final class EMITTasks
+{
+    public static final String CLIENT_VERSION = PureClientVersions.production;
+
+    private EMITTasks()
+    {
+    }
+
+    // ----- Phase 1: Parse -----
+
+    public static ParseResult parse(EMITSourceSet sourceSet)
+    {
+        try
+        {
+            PureGrammarParser parser = PureGrammarParser.newInstance();
+            PureModelContextData.Builder builder = PureModelContextData.newBuilder();
+            MutableSet<String> primarySourceIds = Sets.mutable.empty();
+            int[] totalElements = {0};
+            sourceSet.forEachFile(file ->
+            {
+                PureModelContextData fileData = parser.parseModel(readFile(file), file.getVirtualPath(), 0, 0, true);
+                builder.addPureModelContextData(fileData);
+                totalElements[0] += fileData.getElements().size();
+                if (file.isPrimary())
+                {
+                    primarySourceIds.add(file.getVirtualPath());
+                }
+            });
+            return new ParseResult(builder.build(), primarySourceIds, totalElements[0]);
+        }
+        catch (Exception e)
+        {
+            if ((e instanceof EngineException) && (((EngineException) e).getErrorType() == EngineErrorType.PARSER))
+            {
+                throw new EMITAssertionError(EMITPhase.PARSE, "Error parsing source set", e);
+            }
+            throw new EMITException(EMITPhase.PARSE, "Error parsing source set", e);
+        }
+    }
+
+    // ----- Phase 2: Compile -----
+
+    public static PureModel compile(PureModelContextData pmcd)
+    {
+        try
+        {
+            return new PureModel(pmcd, null, DeploymentMode.PROD);
+        }
+        catch (Exception e)
+        {
+            if ((e instanceof EngineException) && (((EngineException) e).getErrorType() == EngineErrorType.COMPILATION))
+            {
+                throw new EMITAssertionError(EMITPhase.PARSE, "Compilation failed", e);
+            }
+            throw new EMITException(EMITPhase.COMPILE, "Error during compilation", e);
+        }
+    }
+
+    // ----- Phase 3: Model Generation (node-ordered, incremental recompile) -----
+
+    /**
+     * Runs model generation aligned with the SDLC {@code ModelGenerationFactory}:
+     * <ol>
+     *   <li>Finds the (first) {@link GenerationSpecification} in the PMCD.</li>
+     *   <li>Iterates over {@code generationNodes} in declared order.</li>
+     *   <li>For each node, resolves the generation element via the
+     *       {@link GenerationCompilerExtension} resolver chain.</li>
+     *   <li>Finds the matching {@link ModelGenerationExtension} SPI generator
+     *       and invokes it.</li>
+     *   <li>After each node, merges generated elements and <b>recompiles</b>
+     *       so that subsequent nodes can reference newly generated elements.</li>
+     *   <li>After all nodes, validates that no generated element overwrites a
+     *       core (original) element.</li>
+     * </ol>
+     */
+    public static ModelGenResult runModelGeneration(EMITModel model)
+    {
+        PureModelContextData corePmcd = model.getPmcd();
+        List<GenerationSpecification> genSpecs = corePmcd.getElementsOfType(GenerationSpecification.class);
+        if (genSpecs.isEmpty())
+        {
+            return ModelGenResult.notApplicable();
+        }
+        if (genSpecs.size() > 1)
+        {
+            throw new EMITException(EMITPhase.MODEL_GENERATION, "Only one generation specification allowed, found: " + genSpecs.size());
+        }
+
+        GenerationSpecification genSpec = genSpecs.get(0);
+        if (genSpec.generationNodes == null || genSpec.generationNodes.isEmpty())
+        {
+            return ModelGenResult.applicableButNoOutput();
+        }
+
+        // Index core element paths for overwrite validation
+        MutableMap<String, PackageableElement> coreElementIndex = Iterate.groupByUniqueKey(corePmcd.getElements(), PackageableElement::getPath);
+
+        // Load all model generation extensions once
+        MutableList<ModelGenerationExtension> extensions = Lists.mutable.withAll(ServiceLoader.load(ModelGenerationExtension.class));
+
+        PureModelContextData.Builder fullModelBuilder = PureModelContextData.newBuilder().withPureModelContextData(corePmcd);
+        PureModelContextData.Builder generatedModelBuilder = PureModelContextData.newBuilder();
+        PureModel pureModel = ListIterate.injectInto(model.getPureModel(), genSpec.generationNodes, (pm, node) ->
+        {
+            // Resolve the generation element using the standard resolver chain
+            CompileContext compileContext = pm.getContext();
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement generationElement = LazyIterate.flatCollect(
+                            HelperGenerationSpecificationBuilder.getGenerationCompilerExtensions(compileContext),
+                            GenerationCompilerExtension::getExtraModelGenerationSpecificationResolvers)
+                    .collect(resolver -> resolver.value(node.generationElement, node.sourceInformation, compileContext))
+                    .detect(Objects::nonNull);
+            if (generationElement == null)
+            {
+                throw new EngineException("Can't find generation element '" + node.generationElement + "'", node.sourceInformation, EngineErrorType.COMPILATION);
+            }
+
+            // Find matching generator from extensions
+            PureModelContextData genOutput = extensions.asLazy()
+                    .flatCollect(ModelGenerationExtension::getPureModelContextDataGenerators)
+                    .collect(g -> g.value(generationElement, compileContext, CLIENT_VERSION))
+                    .detect(Objects::nonNull);
+            if (genOutput == null)
+            {
+                throw new EngineException(org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.writeUserPathForPackageableElement(new StringBuilder("No model generator found for element '"), generationElement).append("'").toString(), EngineErrorType.COMPILATION);
+            }
+
+            if (genOutput.getElements().isEmpty())
+            {
+                return pm;
+            }
+
+            fullModelBuilder.withPureModelContextData(genOutput).distinct().sorted();
+            generatedModelBuilder.withPureModelContextData(genOutput).distinct().sorted();
+            // Incremental recompile so next node can reference newly generated elements
+            return compile(fullModelBuilder.build());
+        });
+
+        // Validate that generated elements don't overwrite core elements
+        PureModelContextData generatedPmcd = generatedModelBuilder.build();
+        generatedPmcd.getElements().forEach(generated ->
+        {
+            String path = generated.getPath();
+            PackageableElement coreElement = coreElementIndex.get(path);
+            if (coreElement != null)
+            {
+                throw new EMITAssertionError(EMITPhase.MODEL_GENERATION, "Generated element '" + path + "' of type " + generated.getClass().getSimpleName() + " can't override existing element of type " + coreElement.getClass().getSimpleName());
+            }
+        });
+
+
+        PureModelContextData enriched = fullModelBuilder.build();
+        int newElements = enriched.getElements().size() - corePmcd.getElements().size();
+        return ModelGenResult.generated(model.withModel(enriched, pureModel), newElements, genSpec.generationNodes.size());
+    }
+
+    // ----- Phase 4a: per-spec file generation -----
+
+    public static List<Root_meta_pure_generation_metamodel_GenerationOutput> runFileGeneration(FileGenerationSpecification spec, PureModel pureModel)
+    {
+        try
+        {
+            MutableList<GenerationExtension> extensions = Lists.mutable.withAll(ServiceLoader.load(GenerationExtension.class));
+            GenerationExtension match = (spec.type == null) ? null : extensions.detect(c -> spec.type.equals(c.getKey()));
+            if (match == null)
+            {
+                throw new EMITAssertionError(EMITPhase.FILE_GENERATION, "No GenerationExtension registered for FileGenerationSpecification type '" + spec.type + "' (element " + spec.getPath() + ")");
+            }
+            List<Root_meta_pure_generation_metamodel_GenerationOutput> outputs = match.generateFromElement(spec, pureModel.getContext());
+            return (outputs == null) ? Lists.fixedSize.empty() : outputs;
+        }
+        catch (EMITException | EMITAssertionError e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new EMITException(EMITPhase.FILE_GENERATION, "Error running file generation for specification: " + spec.getPath(), e);
+        }
+    }
+
+    // ----- Phase 4b: per-(extension, element) artifact generation -----
+
+    public static List<Artifact> runArtifactGeneration(ArtifactGenerationExtension extension, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pureElement, PureModelContextData pmcd, PureModel pureModel)
+    {
+        List<Artifact> artifacts = extension.generate(pureElement, pureModel, pmcd, CLIENT_VERSION);
+        return (artifacts == null) ? Lists.fixedSize.empty() : artifacts;
+    }
+
+    // ----- Phase 5: tests (bulk-capable; granularity controlled by the inputs) -----
+
+    public static RunTestsResult runTests(List<RunTestsTestableInput> inputs, PureModelContextData pmcd, PureModel pureModel)
+    {
+        try
+        {
+            return new TestableRunner().doTests(inputs, pureModel, pmcd);
+        }
+        catch (Exception e)
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, e);
+        }
+    }
+
+    /**
+     * Convenience: run exactly one atomic test, identified by its containing
+     * testable element path, optional suite ID (null for top-level atomics),
+     * and atomic test ID. Returns the single resulting {@link TestResult}.
+     */
+    public static TestResult runTest(String testablePath, String suiteId, String atomicTestId, PureModelContextData pmcd, PureModel pureModel)
+    {
+        RunTestsTestableInput input = new RunTestsTestableInput();
+        input.testable = testablePath;
+        UniqueTestId id = new UniqueTestId();
+        id.testSuiteId = suiteId;
+        id.atomicTestId = atomicTestId;
+        input.unitTestIds.add(id);
+
+        RunTestsResult result;
+        try
+        {
+            result = runTests(Lists.mutable.with(input), pmcd, pureModel);
+        }
+        catch (EMITException | EMITAssertionError e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, "Error running tests for " + testablePath, e);
+        }
+        if (result.results.isEmpty())
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, "Test runner returned no results for " + testablePath + " / " + suiteId + " / " + atomicTestId);
+        }
+        return result.results.get(0);
+    }
+
+    /**
+     * Throws an {@link EMITAssertionError} if the given test result is anything other than {@code PASS}.
+     *
+     * @param result test result
+     * @throws EMITAssertionError if the given test result is anything other than {@code PASS}
+     */
+    public static void assertTestPassed(TestResult result)
+    {
+        if (result instanceof TestError)
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, ((TestError) result).error);
+        }
+        if (result instanceof TestExecuted)
+        {
+            TestExecuted executed = (TestExecuted) result;
+            if (executed.testExecutionStatus != TestExecutionStatus.PASS)
+            {
+                StringBuilder builder = new StringBuilder("Test did not pass; status=").append(executed.testExecutionStatus).append("; assertions=[");
+                executed.assertStatuses.forEach(s -> printAssertStatus(builder, s).append(", "));
+                builder.setLength(builder.length() - 2);
+                builder.append(']');
+                throw new EMITAssertionError(EMITPhase.TEST_EXECUTION, builder.toString());
+            }
+            return;
+        }
+        throw new EMITException(EMITPhase.TEST_EXECUTION, "Unexpected test result type: " + result.getClass().getSimpleName());
+    }
+
+    private static StringBuilder printAssertStatus(StringBuilder builder, AssertionStatus status)
+    {
+        builder.append("{id=").append(status.id).append(" status=");
+        if (status instanceof AssertPass)
+        {
+            builder.append("PASS");
+        }
+        else if (status instanceof AssertFail)
+        {
+            builder.append("FAIL");
+            String message = ((AssertFail) status).message;
+            if (message != null)
+            {
+                builder.append(" message='").append(message).append('\'');
+            }
+            if (status instanceof EqualToJsonAssertFail)
+            {
+                EqualToJsonAssertFail jsonAssertFail = (EqualToJsonAssertFail) status;
+                builder.append(" expected='").append(jsonAssertFail.expected).append("' actual='").append(jsonAssertFail.actual).append('\'');
+            }
+            else if (status instanceof EqualToRelationAssertFail)
+            {
+                EqualToRelationAssertFail jsonAssertFail = (EqualToRelationAssertFail) status;
+                builder.append(" expected='").append(jsonAssertFail.expected).append("' actual='").append(jsonAssertFail.actual).append('\'');
+            }
+        }
+        else
+        {
+            builder.append("UNKNOWN (").append(status.getClass().getSimpleName()).append(')');
+        }
+        return builder.append('}');
+    }
+
+    // ----- Phase 6: per-service plan -----
+
+    public static ExecutionPlan runPlan(Service service, PureModel pureModel)
+    {
+        try
+        {
+            RichIterable<? extends Root_meta_pure_extension_Extension> extensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
+            MutableList<PlanTransformer> planTransformers = Iterate.flatCollect(ServiceLoader.load(PlanGeneratorExtension.class), PlanGeneratorExtension::getExtraPlanTransformers, Lists.mutable.empty());
+            if (planTransformers.isEmpty())
+            {
+                planTransformers.addAllIterable(LegendPlanTransformers.transformers);
+            }
+            ExecutionPlan plan = ServicePlanGenerator.generateServiceExecutionPlan(service, null, pureModel, CLIENT_VERSION, PlanPlatform.JAVA, extensions, planTransformers);
+            if (plan == null)
+            {
+                throw new EMITAssertionError(EMITPhase.PLAN_GENERATION, "Failed to generate plan for service: " + service.getPath());
+            }
+            return plan;
+        }
+        catch (EMITException | EMITAssertionError e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new EMITException(EMITPhase.PLAN_GENERATION, "Error generating execution plan for service: " + service.getPath(), e);
+        }
+    }
+
+    // ----- Discovery (primary-scope filtered) -----
+
+    public static List<FileGenerationSpecification> findFileGenerationSpecs(EMITModel model)
+    {
+        return ListIterate.collectIf(model.getPmcd().getElements(),
+                e -> (e instanceof FileGenerationSpecification) && model.isPrimary(e),
+                e -> (FileGenerationSpecification) e);
+    }
+
+    public static List<Service> findServices(EMITModel model)
+    {
+        return ListIterate.collectIf(model.getPmcd().getElements(),
+                e -> (e instanceof Service) && model.isPrimary(e),
+                e -> (Service) e);
+    }
+
+    public static List<ArtifactCandidate> findArtifactGenerationCandidates(EMITModel model)
+    {
+        List<ArtifactGenerationExtension> extensions = ArtifactGenerationExtensionLoader.extensions();
+        MutableList<ArtifactCandidate> candidates = Lists.mutable.empty();
+        if (!extensions.isEmpty())
+        {
+            model.getPmcd().getElements().forEach(protocolElement ->
+            {
+                if (model.isPrimary(protocolElement))
+                {
+                    org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pureElement = resolvePureElement(model.getPureModel(), protocolElement);
+                    if (pureElement != null)
+                    {
+                        String path = protocolElement.getPath();
+                        ListIterate.collectIf(extensions,
+                                ext -> ext.canGenerate(pureElement),
+                                ext -> new ArtifactCandidate(ext, pureElement, path),
+                                candidates);
+                    }
+                }
+            });
+        }
+        return candidates;
+    }
+
+    /**
+     * Resolves a protocol element to its compiled Pure element, with a fallback
+     * for {@link Function} elements whose Pure path includes the type signature.
+     * Mirrors the resolution logic in SDLC's {@code ArtifactGenerationFactory}.
+     */
+    private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement resolvePureElement(PureModel pureModel, PackageableElement protocolElement)
+    {
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement element = pureModel.getPackageableElement_safe(protocolElement.getPath());
+        if (element != null)
+        {
+            return element;
+        }
+        // Function elements have mangled paths in Pure that include the type signature
+        if (protocolElement instanceof Function)
+        {
+            String fullPath = pureModel.buildPackageString(protocolElement._package, HelperModelBuilder.getSignature((Function) protocolElement));
+            element = pureModel.getPackageableElement_safe(fullPath);
+        }
+        return element;
+    }
+
+    public static List<TestCandidate> findTestCandidates(EMITModel model)
+    {
+        MutableList<TestCandidate> candidates = Lists.mutable.empty();
+        model.getPmcd().getElements().forEach(protocolElement ->
+        {
+            if (model.isPrimary(protocolElement) && TestableRunnerExtensionLoader.isTestable(protocolElement) && !TestableRunnerExtensionLoader.isTestableEmpty(protocolElement))
+            {
+                org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pureElement;
+                try
+                {
+                    pureElement = model.getPureModel().getPackageableElement(protocolElement.getPath());
+                }
+                catch (Exception ignored)
+                {
+                    return;
+                }
+                if (pureElement instanceof Testable)
+                {
+                    String testablePath = protocolElement.getPath();
+                    ((Testable) pureElement)._tests().forEach(test ->
+                    {
+                        if (test instanceof Root_meta_pure_test_AtomicTest)
+                        {
+                            candidates.add(new TestCandidate(testablePath, null, test._id()));
+                        }
+                        else if (test instanceof Root_meta_pure_test_TestSuite)
+                        {
+                            Root_meta_pure_test_TestSuite suite = (Root_meta_pure_test_TestSuite) test;
+                            String suiteId = suite._id();
+                            suite._tests().collect(t -> new TestCandidate(testablePath, suiteId, t._id()), candidates);
+                        }
+                    });
+                }
+            }
+        });
+        return candidates;
+    }
+
+    /**
+     * Build {@link RunTestsTestableInput}s for every primary-scope testable
+     * element that has at least one test. Each input has empty {@code unitTestIds},
+     * meaning all tests on that testable will be executed.
+     */
+    public static MutableList<RunTestsTestableInput> findTestableInputs(EMITModel model)
+    {
+        return ListIterate.collectIf(model.getPmcd().getElements(),
+                e -> model.isPrimary(e) && TestableRunnerExtensionLoader.isTestable(e) && !TestableRunnerExtensionLoader.isTestableEmpty(e),
+                e ->
+                {
+                    RunTestsTestableInput input = new RunTestsTestableInput();
+                    input.testable = e.getPath();
+                    return input;
+                });
+    }
+
+    // ----- helpers -----
+
+    private static String readFile(EMITSourceFile file)
+    {
+        try
+        {
+            return new String(Files.readAllBytes(file.getAbsolutePath()), StandardCharsets.UTF_8);
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // ----- Result records -----
+
+    /**
+     * Output of {@link #parse(EMITSourceSet)}.
+     */
+    public static final class ParseResult
+    {
+        private final PureModelContextData pmcd;
+        private final MutableSet<String> primarySourceIds;
+        private final int totalElementCount;
+
+        ParseResult(PureModelContextData pmcd, MutableSet<String> primarySourceIds, int totalElementCount)
+        {
+            this.pmcd = pmcd;
+            this.primarySourceIds = primarySourceIds;
+            this.totalElementCount = totalElementCount;
+        }
+
+        public PureModelContextData getPmcd()
+        {
+            return this.pmcd;
+        }
+
+        public MutableSet<String> getPrimarySourceIds()
+        {
+            return this.primarySourceIds;
+        }
+
+        public int getTotalElementCount()
+        {
+            return this.totalElementCount;
+        }
+    }
+
+    /**
+     * Output of {@link #runModelGeneration(EMITModel)}.
+     */
+    public static final class ModelGenResult
+    {
+        private final boolean applicable;
+        private final EMITModel newModel;
+        private final int generatedElementCount;
+        private final int generationCount;
+
+        private ModelGenResult(boolean applicable, EMITModel newModel, int generatedElementCount, int generationCount)
+        {
+            this.applicable = applicable;
+            this.newModel = newModel;
+            this.generatedElementCount = generatedElementCount;
+            this.generationCount = generationCount;
+        }
+
+        public boolean isApplicable()
+        {
+            return this.applicable;
+        }
+
+        /**
+         * Non-null only when {@link #isApplicable()} is true and at least one element was generated.
+         *
+         * @return new model
+         */
+        public EMITModel getNewModel()
+        {
+            return this.newModel;
+        }
+
+        public int getGeneratedElementCount()
+        {
+            return this.generatedElementCount;
+        }
+
+        public int getGenerationCount()
+        {
+            return this.generationCount;
+        }
+
+        static ModelGenResult notApplicable()
+        {
+            return new ModelGenResult(false, null, 0, 0);
+        }
+
+        static ModelGenResult applicableButNoOutput()
+        {
+            return new ModelGenResult(true, null, 0, 0);
+        }
+
+        static ModelGenResult generated(EMITModel newModel, int generatedElementCount, int generationCount)
+        {
+            return new ModelGenResult(true, newModel, generatedElementCount, generationCount);
+        }
+    }
+
+    /**
+     * A {@code (extension, element)} pair returned by {@link #findArtifactGenerationCandidates(EMITModel)}.
+     */
+    public static final class ArtifactCandidate
+    {
+        public final ArtifactGenerationExtension extension;
+        public final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pureElement;
+        public final String elementPath;
+
+        ArtifactCandidate(ArtifactGenerationExtension extension, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pureElement, String elementPath)
+        {
+            this.extension = extension;
+            this.pureElement = pureElement;
+            this.elementPath = elementPath;
+        }
+    }
+
+    /**
+     * A {@code (testable, suite, atomicTest)} tuple returned by {@link #findTestCandidates(EMITModel)}.
+     */
+    public static final class TestCandidate
+    {
+        public final String testablePath;
+        /**
+         * {@code null} for a top-level atomic test that is not inside any suite.
+         */
+        public final String suiteId;
+        public final String atomicTestId;
+
+        TestCandidate(String testablePath, String suiteId, String atomicTestId)
+        {
+            this.testablePath = testablePath;
+            this.suiteId = suiteId;
+            this.atomicTestId = atomicTestId;
+        }
+    }
+
+    /**
+     * A legacy Mapping test candidate: a Mapping with at least one {@link MappingTest_Legacy}.
+     */
+    public static final class LegacyMappingTestCandidate
+    {
+        public final String mappingPath;
+        public final MappingTest_Legacy test;
+
+        LegacyMappingTestCandidate(String mappingPath, MappingTest_Legacy test)
+        {
+            this.mappingPath = mappingPath;
+            this.test = test;
+        }
+    }
+
+    /**
+     * A legacy Service test candidate: a Service with a non-null deprecated {@code test} field.
+     */
+    public static final class LegacyServiceTestCandidate
+    {
+        public final String servicePath;
+        public final Service service;
+
+        LegacyServiceTestCandidate(String servicePath, Service service)
+        {
+            this.servicePath = servicePath;
+            this.service = service;
+        }
+    }
+
+    // ----- Legacy test discovery -----
+
+    /**
+     * Finds primary-scope {@link Mapping} elements with non-empty legacy {@code tests}.
+     * Returns one candidate per individual {@link MappingTest_Legacy}.
+     */
+    public static List<LegacyMappingTestCandidate> findLegacyMappingTestCandidates(EMITModel model)
+    {
+        MutableList<LegacyMappingTestCandidate> candidates = Lists.mutable.empty();
+        model.getPmcd().getElements().forEach(e ->
+        {
+            if (model.isPrimary(e) && (e instanceof Mapping))
+            {
+                Mapping mapping = (Mapping) e;
+                if (mapping.tests != null && !mapping.tests.isEmpty())
+                {
+                    String path = mapping.getPath();
+                    mapping.tests.forEach(test -> candidates.add(new LegacyMappingTestCandidate(path, test)));
+                }
+            }
+        });
+        return candidates;
+    }
+
+    /**
+     * Finds primary-scope {@link Service} elements with a non-null deprecated
+     * {@code test} field ({@link ServiceTest_Legacy}).
+     */
+    public static List<LegacyServiceTestCandidate> findLegacyServiceTestCandidates(EMITModel model)
+    {
+        MutableList<LegacyServiceTestCandidate> candidates = Lists.mutable.empty();
+        model.getPmcd().getElements().forEach(e ->
+        {
+            if (model.isPrimary(e) && (e instanceof Service))
+            {
+                Service service = (Service) e;
+                if (service.test != null)
+                {
+                    candidates.add(new LegacyServiceTestCandidate(service.getPath(), service));
+                }
+            }
+        });
+        return candidates;
+    }
+
+    // ----- Legacy test execution -----
+
+    /**
+     * Runs a single legacy {@link MappingTest_Legacy} using the engine's
+     * {@link MappingTestRunner}. Mirrors the SDLC's {@code LegacyMappingTestCase}.
+     */
+    public static RichMappingTestResult runLegacyMappingTest(String mappingPath, MappingTest_Legacy test, PureModel pureModel)
+    {
+        RichIterable<? extends Root_meta_pure_extension_Extension> extensions = loadExtensions(pureModel);
+        Iterable<? extends PlanTransformer> transformers = loadPlanTransformers();
+        PlanExecutor executor = PlanExecutor.newPlanExecutorBuilder().withAvailableStoreExecutors().build();
+        MappingTestRunner runner = new MappingTestRunner(pureModel, mappingPath, test, executor, extensions, transformers, null);
+        return runner.setupAndRunTest();
+    }
+
+    /**
+     * Runs legacy service tests using the engine's {@link ServiceTestRunner}.
+     * Mirrors the SDLC's {@code LegacyServiceTestCase}.
+     */
+    public static List<RichServiceTestResult> runLegacyServiceTest(Service service, PureModelContextData pmcd, PureModel pureModel)
+    {
+        RichIterable<? extends Root_meta_pure_extension_Extension> extensions = loadExtensions(pureModel);
+        Iterable<? extends PlanTransformer> transformers = loadPlanTransformers();
+        PlanExecutor executor = PlanExecutor.newPlanExecutorBuilder().withAvailableStoreExecutors().build();
+        ServiceTestRunner runner = new ServiceTestRunner(service, null, pmcd, pureModel, null, executor, extensions, transformers, null);
+        try
+        {
+            return runner.executeTests();
+        }
+        catch (Exception e)
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, "Error running legacy service test for service " + service.getPath(), e);
+        }
+    }
+
+    // ----- Legacy test assertions -----
+
+    public static void assertLegacyMappingTestPassed(RichMappingTestResult result)
+    {
+        switch (result.getResult())
+        {
+            case ERROR:
+            {
+                Exception e = result.getException();
+                throw new EMITException(EMITPhase.TEST_EXECUTION, "Legacy mapping test errored: " + result.getMappingPath() + " / " + result.getTestName(), e);
+            }
+            case FAILURE:
+            {
+                StringBuilder builder = new StringBuilder("Legacy mapping test failed: ").append(result.getMappingPath()).append(" / ").append(result.getTestName());
+                if (result.getExpected().isPresent() || result.getActual().isPresent())
+                {
+                    builder.append("\n  Expected: ").append(result.getExpected().orElse("<none>")).append("\n  Actual: ").append(result.getActual().orElse("<none>"));
+                }
+                throw new EMITAssertionError(EMITPhase.TEST_EXECUTION, builder.toString());
+            }
+        }
+    }
+
+    /**
+     * Throws an {@link AssertionError} if any of the legacy service test
+     * results contain failures or errors.
+     */
+    public static void assertLegacyServiceTestPassed(List<RichServiceTestResult> results)
+    {
+        MutableList<String> failures = Lists.mutable.empty();
+        MutableList<String> errors = Lists.mutable.empty();
+        results.forEach(run ->
+        {
+            if (run.getResults() != null)
+            {
+                run.getResults().forEach((key, r) ->
+                {
+                    switch (r)
+                    {
+                        case FAILURE:
+                        {
+                            failures.add(key);
+                            break;
+                        }
+                        case ERROR:
+                        {
+                            errors.add(key);
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+        if (failures.notEmpty() || errors.notEmpty())
+        {
+            StringBuilder builder = new StringBuilder("Legacy service test failures/errors:");
+            if (failures.notEmpty())
+            {
+                builder.append("\n  Failures: ").append(failures.makeString(", "));
+            }
+            if (errors.notEmpty())
+            {
+                builder.append("\n  Errors: ").append(errors.makeString(", "));
+            }
+            throw new EMITAssertionError(EMITPhase.TEST_EXECUTION, builder.toString());
+        }
+    }
+
+    // ----- Extension loading helpers -----
+
+    private static RichIterable<? extends Root_meta_pure_extension_Extension> loadExtensions(PureModel pureModel)
+    {
+        return PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
+    }
+
+    private static MutableList<PlanTransformer> loadPlanTransformers()
+    {
+        return Iterate.flatCollect(ServiceLoader.load(PlanGeneratorExtension.class), PlanGeneratorExtension::getExtraPlanTransformers, Lists.mutable.empty());
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/catalog/EMITModelDescriptor.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/catalog/EMITModelDescriptor.java
@@ -1,0 +1,251 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.catalog;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
+
+import java.nio.file.Path;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EMITModelDescriptor
+{
+    private final String name;
+    private final String title;
+    private final String description;
+    private final ModelSources modelSources;
+    private final ImmutableList<String> features;
+    private final ImmutableList<String> stores;
+    private final String complexity;
+    private final ImmutableList<String> tags;
+    private Path source;
+
+    private EMITModelDescriptor(String name,
+                                String title,
+                                String description,
+                                ModelSources modelSources,
+                                ImmutableList<String> features,
+                                ImmutableList<String> stores,
+                                String complexity,
+                                ImmutableList<String> tags)
+    {
+        this.name = name;
+        this.title = title;
+        this.description = description;
+        this.modelSources = modelSources;
+        this.features = features;
+        this.stores = stores;
+        this.complexity = complexity;
+        this.tags = tags;
+    }
+
+    @JsonCreator
+    public static EMITModelDescriptor newDescriptor(@JsonProperty("name") String name,
+                                                    @JsonProperty("title") String title,
+                                                    @JsonProperty("description") String description,
+                                                    @JsonProperty("modelSources") ModelSources modelSources,
+                                                    @JsonProperty("features") List<String> features,
+                                                    @JsonProperty("stores") List<String> stores,
+                                                    @JsonProperty("complexity") String complexity,
+                                                    @JsonProperty("tags") List<String> tags)
+    {
+        return new EMITModelDescriptor(
+                name,
+                title,
+                description,
+                modelSources,
+                immutable(features),
+                immutable(stores),
+                complexity,
+                immutable(tags));
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public String getTitle()
+    {
+        return this.title;
+    }
+
+    public String getDescription()
+    {
+        return this.description;
+    }
+
+    public ModelSources getModelSources()
+    {
+        return this.modelSources;
+    }
+
+    public List<String> getFeatures()
+    {
+        return this.features.castToList();
+    }
+
+    public List<String> getStores()
+    {
+        return this.stores.castToList();
+    }
+
+    public String getComplexity()
+    {
+        return this.complexity;
+    }
+
+    public List<String> getTags()
+    {
+        return this.tags.castToList();
+    }
+
+    @JsonIgnore
+    public Path getSource()
+    {
+        return this.source;
+    }
+
+    public void setSource(Path source)
+    {
+        this.source = source;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ModelSources
+    {
+        private final Source model;
+        private final ImmutableList<Dependency> dependencies;
+
+        private ModelSources(Source model, ImmutableList<Dependency> dependencies)
+        {
+            this.model = model;
+            this.dependencies = dependencies;
+        }
+
+        @JsonCreator
+        public static ModelSources newModelSources(@JsonProperty("model") Source model,
+                                                   @JsonProperty("dependencies") List<Dependency> dependencies)
+        {
+            return new ModelSources(model, immutable(dependencies));
+        }
+
+        public Source getModel()
+        {
+            return this.model;
+        }
+
+        public List<Dependency> getDependencies()
+        {
+            return this.dependencies.castToList();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Source
+    {
+        private final String root;
+        private final ImmutableList<String> files;
+
+        private Source(String root, ImmutableList<String> files)
+        {
+            this.root = root;
+            this.files = files;
+        }
+
+        @JsonCreator
+        public static Source newSource(@JsonProperty("root") String root,
+                                       @JsonProperty("files") List<String> files)
+        {
+            return new Source(root, immutable(files));
+        }
+
+        public String getRoot()
+        {
+            return this.root;
+        }
+
+        public List<String> getFiles()
+        {
+            return this.files.castToList();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Dependency
+    {
+        private final String root;
+        private final ImmutableList<String> files;
+        private final String source;
+        private final ImmutableList<String> excludes;
+
+        private Dependency(String root, ImmutableList<String> files, String source, ImmutableList<String> excludes)
+        {
+            this.root = root;
+            this.files = files;
+            this.source = source;
+            this.excludes = excludes;
+        }
+
+        public String getRoot()
+        {
+            return this.root;
+        }
+
+        public List<String> getFiles()
+        {
+            return this.files.castToList();
+        }
+
+        public String getSource()
+        {
+            return this.source;
+        }
+
+        public List<String> getExcludes()
+        {
+            return this.excludes.castToList();
+        }
+
+        public boolean isInline()
+        {
+            return this.root != null;
+        }
+
+        public boolean isReference()
+        {
+            return this.source != null;
+        }
+
+        @JsonCreator
+        public static Dependency newDependency(@JsonProperty("root") String root,
+                                               @JsonProperty("files") List<String> files,
+                                               @JsonProperty("source") String source,
+                                               @JsonProperty("excludes") List<String> excludes)
+        {
+            return new Dependency(root, immutable(files), source, immutable(excludes));
+        }
+    }
+
+    private static <T> ImmutableList<T> immutable(List<T> list)
+    {
+        return (list == null) ? Lists.immutable.empty() : Lists.immutable.withAll(list);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/error/EMITAssertionError.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/error/EMITAssertionError.java
@@ -1,0 +1,41 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.error;
+
+import org.finos.legend.engine.test.emit.EMITPhase;
+
+public class EMITAssertionError extends AssertionError
+{
+    private static final String DESCRIPTION = "FAILURE";
+
+    private final EMITPhase phase;
+
+    public EMITAssertionError(EMITPhase phase, String message, Throwable cause)
+    {
+        super(EMITErrorTools.formatMessage(DESCRIPTION, phase, message), cause);
+        this.phase = phase;
+    }
+
+    public EMITAssertionError(EMITPhase phase, String message)
+    {
+        super(EMITErrorTools.formatMessage(DESCRIPTION, phase, message));
+        this.phase = phase;
+    }
+
+    public EMITPhase getPhase()
+    {
+        return this.phase;
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/error/EMITErrorTools.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/error/EMITErrorTools.java
@@ -1,0 +1,73 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.error;
+
+import org.finos.legend.engine.test.emit.EMITPhase;
+
+class EMITErrorTools
+{
+    static String formatMessage(String description, EMITPhase phase, String message)
+    {
+        StringBuilder builder = new StringBuilder(description);
+        if (phase != null)
+        {
+            builder.append(" [").append(getPhaseDescription(phase)).append(']');
+        }
+        if (message != null)
+        {
+            builder.append(": ").append(message);
+        }
+        return builder.toString();
+    }
+
+    private static String getPhaseDescription(EMITPhase phase)
+    {
+        switch (phase)
+        {
+            case INITIALIZATION:
+            {
+                return "Initialization";
+            }
+            case PARSE:
+            {
+                return "Parsing";
+            }
+            case COMPILE:
+            {
+                return "Compilation";
+            }
+            case MODEL_GENERATION:
+            {
+                return "Model Generation";
+            }
+            case FILE_GENERATION:
+            {
+                return "File Generation";
+            }
+            case TEST_EXECUTION:
+            {
+                return "Test Execution";
+            }
+            case PLAN_GENERATION:
+            {
+                return "Plan Generation";
+            }
+            default:
+            {
+                return phase.name().replace('_', ' ');
+            }
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/error/EMITException.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/error/EMITException.java
@@ -1,0 +1,46 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.error;
+
+import org.finos.legend.engine.test.emit.EMITPhase;
+
+public class EMITException extends RuntimeException
+{
+    private static final String DESCRIPTION = "ERROR";
+
+    private final EMITPhase phase;
+
+    public EMITException(EMITPhase phase, String message, Throwable cause)
+    {
+        super(EMITErrorTools.formatMessage(DESCRIPTION, phase, message), cause);
+        this.phase = phase;
+    }
+
+    public EMITException(EMITPhase phase, String message)
+    {
+        super(EMITErrorTools.formatMessage(DESCRIPTION, phase, message));
+        this.phase = phase;
+    }
+
+    public EMITException(EMITPhase phase, Throwable cause)
+    {
+        this(phase, cause.getMessage(), cause);
+    }
+
+    public EMITPhase getPhase()
+    {
+        return this.phase;
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITRunner.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITRunner.java
@@ -1,0 +1,211 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
+import org.finos.legend.engine.test.emit.EMITPhaseResult.Status;
+import org.finos.legend.engine.testable.model.RunTestsResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class TestEMITRunner
+{
+    @Test
+    void classSimpleRunsThroughAllPhases()
+    {
+        Path emitYaml = resource("emit-models/basic/class-simple.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertTrue(result.isSuccess(), () -> "Expected EMIT run to succeed but got:\n" + result.getSummary());
+
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.INITIALIZATION).getStatus());
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.PARSE).getStatus());
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.COMPILE).getStatus());
+        Assertions.assertEquals(Status.SKIPPED, result.getPhase(EMITPhase.MODEL_GENERATION).getStatus());
+        Assertions.assertEquals(Status.SKIPPED, result.getPhase(EMITPhase.TEST_EXECUTION).getStatus());
+        Assertions.assertEquals(Status.SKIPPED, result.getPhase(EMITPhase.PLAN_GENERATION).getStatus());
+    }
+
+    @Test
+    void initializationFailureSkipsRemainingPhases()
+    {
+        Path missing = Paths.get("does-not-exist.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(missing);
+
+        Assertions.assertFalse(result.isSuccess(), "Expected failure on missing descriptor");
+        Assertions.assertEquals(Status.FAILURE, result.getPhase(EMITPhase.INITIALIZATION).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.PARSE).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.COMPILE).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.MODEL_GENERATION).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.TEST_EXECUTION).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.PLAN_GENERATION).getStatus());
+    }
+
+    @Test
+    void compileFailureSkipsDownstreamPhases()
+    {
+        Path emitYaml = resource("emit-models/basic/compile-failure.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertFalse(result.isSuccess(), "Expected EMIT run to fail at COMPILE");
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.INITIALIZATION).getStatus());
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.PARSE).getStatus());
+        Assertions.assertEquals(Status.FAILURE, result.getPhase(EMITPhase.COMPILE).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.MODEL_GENERATION).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.FILE_GENERATION).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.TEST_EXECUTION).getStatus());
+        Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.PLAN_GENERATION).getStatus());
+    }
+
+    @Test
+    void m2mMappingTestsExecuteAndPass()
+    {
+        Path emitYaml = resource("emit-models/basic/m2m-passing.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.PARSE).getStatus());
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.COMPILE).getStatus());
+
+        EMITPhaseResult testPhase = result.getPhase(EMITPhase.TEST_EXECUTION);
+        List<?> outputs = testPhase.getOutputs();
+        Assertions.assertEquals(1, outputs.size());
+        RunTestsResult runTests = (RunTestsResult) outputs.get(0);
+        Assertions.assertEquals(Status.SUCCESS, testPhase.getStatus(),
+                () -> "Expected TEST_EXECUTION SUCCESS but got:\n" + result.getSummary() + "\n" + describeTestResults(runTests));
+
+        Assertions.assertEquals(2, runTests.results.size(), "Expected exactly 2 mapping tests to be executed");
+        runTests.results.forEach(r ->
+        {
+            Assertions.assertTrue(r instanceof TestExecuted, () -> "Expected TestExecuted, got " + r.getClass().getSimpleName());
+            Assertions.assertEquals(TestExecutionStatus.PASS, ((TestExecuted) r).testExecutionStatus,
+                    () -> "Expected test " + r.atomicTestId + " to PASS but got "
+                            + ((TestExecuted) r).testExecutionStatus + "; assertions=" + ((TestExecuted) r).assertStatuses);
+        });
+
+        Assertions.assertTrue(result.isSuccess(), () -> "Expected EMIT run to succeed but got:\n" + result.getSummary());
+        Assertions.assertEquals(Status.SKIPPED, result.getPhase(EMITPhase.PLAN_GENERATION).getStatus());
+    }
+
+    @Test
+    void m2mMappingTestFailureIsReported()
+    {
+        Path emitYaml = resource("emit-models/basic/m2m-mixed.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertFalse(result.isSuccess(), "Expected EMIT run to fail because one mapping test fails");
+
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.COMPILE).getStatus());
+
+        EMITPhaseResult testPhase = result.getPhase(EMITPhase.TEST_EXECUTION);
+        List<?> outputs = testPhase.getOutputs();
+        Assertions.assertEquals(1, outputs.size());
+        RunTestsResult runTests = (RunTestsResult) outputs.get(0);
+        Assertions.assertEquals(Status.FAILURE, testPhase.getStatus(),
+                () -> "Expected TEST_EXECUTION FAILURE but got:\n" + result.getSummary() + "\n" + describeTestResults(runTests));
+        Assertions.assertTrue(testPhase.getMessage() != null && testPhase.getMessage().contains("1 failed"),
+                () -> "Expected message to mention '1 failed', got: " + testPhase.getMessage()
+                        + "\n" + result.getSummary() + "\n" + describeTestResults(runTests));
+
+        // PLAN_GENERATION still runs (failure of TEST_EXECUTION does not short-circuit it).
+        Assertions.assertEquals(Status.SKIPPED, result.getPhase(EMITPhase.PLAN_GENERATION).getStatus());
+    }
+
+    @Test
+    void dependencyTestsAreNotExecuted()
+    {
+        Path emitYaml = resource("emit-models/basic/m2m-with-dep.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.COMPILE).getStatus());
+
+        EMITPhaseResult testPhase = result.getPhase(EMITPhase.TEST_EXECUTION);
+        List<?> outputs = testPhase.getOutputs();
+        Assertions.assertEquals(1, outputs.size());
+        RunTestsResult runTests = (RunTestsResult) outputs.get(0);
+        Assertions.assertEquals(1, runTests.results.size(),
+                () -> "Expected exactly 1 test (only the primary mapping's test should run); got "
+                        + runTests.results.size() + " results: " + describe(runTests));
+        TestResult only = runTests.results.get(0);
+        Assertions.assertEquals("demo::primary::PrimaryMapping", only.testable);
+
+        Assertions.assertEquals(Status.SUCCESS, testPhase.getStatus(),
+                () -> "TEST_EXECUTION did not succeed:\n" + result.getSummary() + "\n" + describeTestResults(runTests));
+        Assertions.assertTrue(result.isSuccess(), () -> "Expected EMIT run to succeed (dep tests must be ignored):\n" + result.getSummary());
+    }
+
+    private static String describe(RunTestsResult runTests)
+    {
+        StringBuilder sb = new StringBuilder();
+        runTests.results.forEach(r -> sb.append(r.testable).append('/').append(r.testSuiteId).append('/').append(r.atomicTestId).append(' '));
+        return sb.toString();
+    }
+
+    private static String describeTestResults(RunTestsResult runTests)
+    {
+        if (runTests == null)
+        {
+            return "(no test results)";
+        }
+        StringBuilder sb = new StringBuilder("Test results:\n");
+        runTests.results.forEach(r ->
+        {
+            sb.append("  ").append(r.testable).append('/').append(r.testSuiteId).append('/').append(r.atomicTestId).append(" -> ");
+            if (r instanceof TestExecuted)
+            {
+                TestExecuted te = (TestExecuted) r;
+                sb.append(te.testExecutionStatus).append("; assertions=").append(te.assertStatuses);
+            }
+            else if (r instanceof TestError)
+            {
+                sb.append("ERROR: ").append(((TestError) r).error);
+            }
+            else
+            {
+                sb.append(r.getClass().getSimpleName()).append(": ").append(r);
+            }
+            sb.append('\n');
+        });
+        return sb.toString();
+    }
+
+    private static Path resource(String name)
+    {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(name);
+        Assertions.assertNotNull(url, "test resource not found: " + name);
+        try
+        {
+            return Paths.get(url.toURI());
+        }
+        catch (URISyntaxException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/class-simple.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/class-simple.emit.yaml
@@ -1,0 +1,16 @@
+name: class-simple
+title: "Simple Class"
+description: |
+  A bootstrap EMIT test exercising parse and compile of a single class.
+
+modelSources:
+  model:
+    root: class-simple
+    files:
+      - model.pure
+
+features:
+  - class
+complexity: basic
+tags:
+  - getting-started

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/class-simple/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/class-simple/model.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/compile-failure.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/compile-failure.emit.yaml
@@ -1,0 +1,18 @@
+name: compile-failure
+title: "Class Referencing an Undefined Type"
+description: |
+  A Class whose property type does not exist. PARSE succeeds (the grammar
+  is well-formed) but COMPILE fails. Used to verify that a COMPILE failure
+  correctly cascades — downstream phases are reported as NOT_RUN.
+
+modelSources:
+  model:
+    root: compile-failure
+    files:
+      - model.pure
+
+features:
+  - class
+complexity: basic
+tags:
+  - failure-mode

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/compile-failure/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/compile-failure/model.pure
@@ -1,0 +1,21 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+  address: demo::DoesNotExist[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-dep-source/mapping/depMapping.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-dep-source/mapping/depMapping.pure
@@ -1,0 +1,62 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::dep::DepMapping
+(
+  *demo::dep::TargetPerson: Pure
+  {
+    ~src demo::dep::SourcePerson
+    fullName: $src.firstName + ' ' + $src.lastName
+  }
+
+  testSuites:
+  [
+    depSuite:
+    {
+      function: |demo::dep::TargetPerson.all()->graphFetch(#{demo::dep::TargetPerson{fullName}}#)->serialize(#{demo::dep::TargetPerson{fullName}}#);
+      tests:
+      [
+        depTestThatWouldFailIfRun:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::dep::SourcePerson:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"Dep","lastName":"Person"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"this would not match"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-dep-source/model/depModel.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-dep-source/model/depModel.pure
@@ -1,0 +1,25 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::dep::SourcePerson
+{
+  firstName: String[1];
+  lastName: String[1];
+}
+
+Class demo::dep::TargetPerson
+{
+  fullName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-mixed.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-mixed.emit.yaml
@@ -1,0 +1,23 @@
+name: m2m-mixed
+title: "M2M Mapping with Passing and Failing Tests"
+description: |
+  A model-to-model mapping with one passing test and one failing test.
+  Used to verify that EMIT TEST_EXECUTION reports failure when at least
+  one assertion fails.
+
+modelSources:
+  model:
+    root: m2m-mixed
+    files:
+      - model/model.pure
+      - mapping/mapping.pure
+
+features:
+  - class
+  - m2m-mapping
+  - mapping
+complexity: basic
+tags:
+  - m2m
+  - mapping-test
+  - failure-reporting

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-mixed/mapping/mapping.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-mixed/mapping/mapping.pure
@@ -1,0 +1,90 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonM2MMapping
+(
+  *demo::target::Person: Pure
+  {
+    ~src demo::source::Person
+    fullName: $src.firstName + ' ' + $src.lastName
+  }
+
+  testSuites:
+  [
+    fullNameSuite:
+    {
+      function: |demo::target::Person.all()->graphFetch(#{demo::target::Person{fullName}}#)->serialize(#{demo::target::Person{fullName}}#);
+      tests:
+      [
+        passing:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::source::Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"John","lastName":"Smith"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"John Smith"}';
+                  }#;
+              }#
+          ];
+        },
+        failing:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::source::Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"John","lastName":"Smith"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"intentionally wrong"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-mixed/model/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-mixed/model/model.pure
@@ -1,0 +1,25 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::source::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}
+
+Class demo::target::Person
+{
+  fullName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing.emit.yaml
@@ -1,0 +1,25 @@
+name: m2m-passing
+title: "M2M Mapping with Passing Tests"
+description: |
+  A model-to-model mapping with an embedded test suite that passes.
+  Sources are split across three files (source class, target class, mapping)
+  to exercise multi-file parse + SectionIndex merging in addition to the
+  PARSE, COMPILE, and TEST_EXECUTION phases of the EMIT runner.
+
+modelSources:
+  model:
+    root: m2m-passing
+    files:
+      - model/source.pure
+      - model/target.pure
+      - mapping/personMapping.pure
+
+features:
+  - class
+  - m2m-mapping
+  - mapping
+  - data-element
+complexity: basic
+tags:
+  - m2m
+  - mapping-test

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing/mapping/personMapping.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing/mapping/personMapping.pure
@@ -1,0 +1,90 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonM2MMapping
+(
+  *demo::target::Person: Pure
+  {
+    ~src demo::source::Person
+    fullName: $src.firstName + ' ' + $src.lastName
+  }
+
+  testSuites:
+  [
+    fullNameSuite:
+    {
+      function: |demo::target::Person.all()->graphFetch(#{demo::target::Person{fullName}}#)->serialize(#{demo::target::Person{fullName}}#);
+      tests:
+      [
+        johnSmith:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::source::Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"John","lastName":"Smith"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"John Smith"}';
+                  }#;
+              }#
+          ];
+        },
+        janeDoe:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::source::Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"Jane","lastName":"Doe"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"Jane Doe"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing/model/source.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing/model/source.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::source::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing/model/target.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-passing/model/target.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::target::Person
+{
+  fullName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep.emit.yaml
@@ -1,0 +1,29 @@
+name: m2m-with-dep
+title: "M2M Mapping with Out-of-Scope Dependency Tests"
+description: |
+  Primary model contains a Mapping with one passing test. The dependency
+  contains a different Mapping whose embedded test would fail if executed.
+  Used to verify that EMIT TEST_EXECUTION respects primary scope and does
+  not run tests from elements loaded via dependencies.
+
+modelSources:
+  model:
+    root: m2m-with-dep
+    files:
+      - model/primarySource.pure
+      - model/primaryTarget.pure
+      - mapping/primaryMapping.pure
+  dependencies:
+    - root: m2m-dep-source
+      files:
+        - model/depModel.pure
+        - mapping/depMapping.pure
+
+features:
+  - class
+  - m2m-mapping
+  - mapping
+complexity: basic
+tags:
+  - dependency
+  - primary-scope

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep/mapping/primaryMapping.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep/mapping/primaryMapping.pure
@@ -1,0 +1,62 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::primary::PrimaryMapping
+(
+  *demo::primary::TargetPerson: Pure
+  {
+    ~src demo::primary::SourcePerson
+    fullName: $src.firstName + ' ' + $src.lastName
+  }
+
+  testSuites:
+  [
+    primarySuite:
+    {
+      function: |demo::primary::TargetPerson.all()->graphFetch(#{demo::primary::TargetPerson{fullName}}#)->serialize(#{demo::primary::TargetPerson{fullName}}#);
+      tests:
+      [
+        primaryTest:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::primary::SourcePerson:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"Primary","lastName":"Person"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"Primary Person"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep/model/primarySource.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep/model/primarySource.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::primary::SourcePerson
+{
+  firstName: String[1];
+  lastName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep/model/primaryTarget.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/m2m-with-dep/model/primaryTarget.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+
+Class demo::primary::TargetPerson
+{
+  fullName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-core</artifactId>
+        <version>4.129.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-engine-core-emit</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>legend-engine-emit</module>
+        <module>legend-engine-emit-junit</module>
+    </modules>
+</project>

--- a/legend-engine-core/pom.xml
+++ b/legend-engine-core/pom.xml
@@ -34,5 +34,6 @@
         <module>legend-engine-core-external-format</module>
         <module>legend-engine-core-query-pure-http-api</module>
         <module>legend-engine-core-identity</module>
+        <module>legend-engine-core-emit</module>
     </modules>
 </project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xts-relationalStore</artifactId>
+        <version>4.129.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-engine-xt-relationalStore-emit</artifactId>
+    <name>Legend Engine - XT - Relational Store - EMIT Examples</name>
+    <description>Example EMIT (Engine Model Integration Test) models exercising the relational store: parse, compile and execute relational mapping tests against an in-memory H2.</description>
+
+    <dependencies>
+        <!-- EMIT framework + JUnit integration -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-emit-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- EMIT -->
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- JUnit 5 -->
+
+        <!-- Mapping test runner: registers MappingTestableRunnerExtension via ServiceLoader,
+             so EMIT models with Mapping testSuites can actually execute tests. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-test-runner-mapping</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Relational store: grammar (also carries compiler extensions) / protocol / Pure / execution / Java binding. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-core-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- H2 driver shaded for Legend's relational execution. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-h2-execution-2.1.214</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Plan generation + serialisation, in-memory store, json model, java binding —
+             same set as the EMIT framework's own tests, kept here to mirror that profile. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-configuration-plan-generation-serialization</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/java/org/finos/legend/engine/test/emit/relational/RelationalEMITTestSuite.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/java/org/finos/legend/engine/test/emit/relational/RelationalEMITTestSuite.java
@@ -1,0 +1,36 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.relational;
+
+import org.finos.legend.engine.test.emit.junit.EMITTestSuiteBuilder;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+/**
+ * Example wiring of {@link EMITTestSuiteBuilder} into JUnit 5 for the relational
+ * store. Discovers EMIT models under {@code emit-models/} on the test classpath
+ * and yields one dynamic test per granular operation (init/parse/compile,
+ * file generation, individual mapping tests, service plans).
+ */
+public class RelationalEMITTestSuite
+{
+    @TestFactory
+    Stream<DynamicTest> emit()
+    {
+        return EMITTestSuiteBuilder.taskStream("emit-models/");
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration.emit.yaml
@@ -1,0 +1,31 @@
+name: relational-enumeration
+title: "Relational Mapping with Enumeration Mapping"
+description: |
+  An Employee class whose `type` property is an `Enum` (FULL_TIME / CONTRACT)
+  mapped to a string column via an `EnumerationMapping`. Demonstrates the
+  `enumProperty: EnumerationMapping <name>: <column>` syntax, including
+  mapping multiple source values to a single enum constant.
+
+modelSources:
+  model:
+    root: relational-enumeration
+    files:
+      - model/types.pure
+      - store/db.pure
+      - data/testData.pure
+      - mapping/employeeMapping.pure
+
+features:
+  - class
+  - enumeration
+  - relational-store
+  - relational-mapping
+  - enumeration-mapping
+  - data-element
+  - test-data
+stores:
+  - relational
+complexity: basic
+tags:
+  - h2
+  - enumeration-mapping

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/data/testData.pure
@@ -1,0 +1,26 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Data
+Data demo::data::EmployeeData
+{
+  Relational
+  #{
+    default.EmployeeTable:
+      'id,firstName,employeeType\n' +
+      '1,John,FTE\n' +
+      '2,Jane,FTC\n' +
+      '3,Bob,FTO\n';
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/mapping/employeeMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/mapping/employeeMapping.pure
@@ -1,0 +1,69 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::EmployeeMapping
+(
+  demo::EmployeeType: EnumerationMapping TypeMapping
+  {
+    FULL_TIME: ['FTE'],
+    CONTRACT:  ['FTC', 'FTO']
+  }
+
+  *demo::Employee: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::EmployeeDB]EmployeeTable.id
+    )
+    ~mainTable [demo::store::EmployeeDB]EmployeeTable
+    firstName: [demo::store::EmployeeDB]EmployeeTable.firstName,
+    type: EnumerationMapping TypeMapping: [demo::store::EmployeeDB]EmployeeTable.employeeType
+  }
+
+  testSuites:
+  [
+    enumSuite:
+    {
+      function: |demo::Employee.all()->sortBy(x|$x.firstName)->project([x|$x.firstName, x|$x.type], ['First Name', 'Type']);
+      tests:
+      [
+        enumMapping:
+        {
+          data:
+          [
+            demo::store::EmployeeDB:
+              Reference
+              #{
+                demo::data::EmployeeData
+              }#
+          ];
+          asserts:
+          [
+            shouldMap:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"Bob","Type":"CONTRACT"},{"First Name":"Jane","Type":"CONTRACT"},{"First Name":"John","Type":"FULL_TIME"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/model/types.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/model/types.pure
@@ -1,0 +1,26 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Enum demo::EmployeeType
+{
+  FULL_TIME,
+  CONTRACT
+}
+
+Class demo::Employee
+{
+  firstName: String[1];
+  type: demo::EmployeeType[1];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-enumeration/store/db.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::store::EmployeeDB
+(
+  Table EmployeeTable
+  (
+    id INTEGER PRIMARY KEY,
+    firstName VARCHAR(200),
+    employeeType VARCHAR(10)
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter.emit.yaml
@@ -1,0 +1,33 @@
+name: relational-filter
+title: "Relational Mapping with Class-Level Filter"
+description: |
+  Reuses the Person class from `relational-shared-domain`. The class mapping
+  applies a `~filter` clause restricting which rows flow into the materialised
+  entities. The Database defines a named `Filter` expression and the class
+  mapping references it; only rows satisfying the predicate are returned by
+  the test query. The store stays local because the schema needs an extra
+  `active` column not present in the shared FirmDB.
+
+modelSources:
+  model:
+    root: relational-filter
+    files:
+      - store/db.pure
+      - data/testData.pure
+      - mapping/personMapping.pure
+  dependencies:
+    - source: relational-shared-domain.emit.yaml
+
+features:
+  - class
+  - relational-store
+  - relational-mapping
+  - data-element
+  - test-data
+stores:
+  - relational
+complexity: basic
+tags:
+  - h2
+  - filter
+  - shared-domain

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter/data/testData.pure
@@ -1,0 +1,26 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Data
+Data demo::data::PersonData
+{
+  Relational
+  #{
+    default.PersonTable:
+      'id,firstName,lastName,active\n' +
+      '1,John,Doe,1\n' +
+      '2,Jane,Smith,0\n' +
+      '3,Bob,Jones,1\n';
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter/mapping/personMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter/mapping/personMapping.pure
@@ -1,0 +1,64 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonMapping
+(
+  *demo::Person: Relational
+  {
+    ~filter [demo::store::PersonDB] ActiveFilter
+    ~primaryKey
+    (
+      [demo::store::PersonDB]PersonTable.id
+    )
+    ~mainTable [demo::store::PersonDB]PersonTable
+    firstName: [demo::store::PersonDB]PersonTable.firstName,
+    lastName: [demo::store::PersonDB]PersonTable.lastName
+  }
+
+  testSuites:
+  [
+    filterSuite:
+    {
+      function: |demo::Person.all()->sortBy(x|$x.firstName)->project([x|$x.firstName, x|$x.lastName], ['First Name', 'Last Name']);
+      tests:
+      [
+        onlyActive:
+        {
+          data:
+          [
+            demo::store::PersonDB:
+              Reference
+              #{
+                demo::data::PersonData
+              }#
+          ];
+          asserts:
+          [
+            shouldFilter:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"Bob","Last Name":"Jones"},{"First Name":"John","Last Name":"Doe"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-filter/store/db.pure
@@ -1,0 +1,27 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::store::PersonDB
+(
+  Table PersonTable
+  (
+    id INTEGER PRIMARY KEY,
+    firstName VARCHAR(200),
+    lastName VARCHAR(200),
+    active INTEGER
+  )
+
+  Filter ActiveFilter(PersonTable.active = 1)
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-joins.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-joins.emit.yaml
@@ -1,0 +1,39 @@
+name: relational-joins
+title: "Relational Mapping with Join and Association"
+description: |
+  Person and Firm — connected by an Association in the shared
+  `relational-shared-domain` model — are mapped onto the FirmDB tables in
+  the shared `relational-shared-firm-db` store, joined on a foreign key.
+  The mapping demonstrates the `[db]@JoinName` property-mapping syntax for
+  navigating both directions of the association. A mapping test suite
+  loads CSV data into both tables and asserts that projecting
+  `Person.firm.legalName` resolves through the join. This example also
+  shows how an EMIT test composes multiple shared models via the
+  `dependencies` mechanism.
+
+modelSources:
+  model:
+    root: relational-joins
+    files:
+      - data/testData.pure
+      - mapping/joinMapping.pure
+  dependencies:
+    - source: relational-shared-domain.emit.yaml
+    - source: relational-shared-firm-db.emit.yaml
+
+features:
+  - class
+  - association
+  - relational-store
+  - relational-mapping
+  - data-element
+  - test-data
+stores:
+  - relational
+complexity: basic
+tags:
+  - h2
+  - join
+  - mapping-test
+  - shared-domain
+  - shared-store

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-joins/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-joins/data/testData.pure
@@ -1,0 +1,30 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Data
+Data demo::data::FirmData
+{
+  Relational
+  #{
+    default.PersonTable:
+      'id,firmId,firstName,lastName\n' +
+      '1,1,John,Doe\n' +
+      '2,1,Jane,Smith\n' +
+      '3,2,Bob,Jones\n';
+    default.FirmTable:
+      'id,legalName\n' +
+      '1,Finos\n' +
+      '2,Goldman\n';
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-joins/mapping/joinMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-joins/mapping/joinMapping.pure
@@ -1,0 +1,75 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::JoinMapping
+(
+  *demo::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::FirmDB]PersonTable.id
+    )
+    ~mainTable [demo::store::FirmDB]PersonTable
+    firstName: [demo::store::FirmDB]PersonTable.firstName,
+    lastName: [demo::store::FirmDB]PersonTable.lastName,
+    firm: [demo::store::FirmDB]@PersonFirm
+  }
+
+  *demo::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::FirmDB]FirmTable.id
+    )
+    ~mainTable [demo::store::FirmDB]FirmTable
+    legalName: [demo::store::FirmDB]FirmTable.legalName,
+    employees: [demo::store::FirmDB]@PersonFirm
+  }
+
+  testSuites:
+  [
+    joinSuite:
+    {
+      function: |demo::Person.all()->sortBy(x|$x.firstName)->project([x|$x.firstName, x|$x.firm.legalName], ['First Name', 'Firm']);
+      tests:
+      [
+        joinedPersonFirm:
+        {
+          data:
+          [
+            demo::store::FirmDB:
+              Reference
+              #{
+                demo::data::FirmData
+              }#
+          ];
+          asserts:
+          [
+            shouldJoin:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"Bob","Firm":"Goldman"},{"First Name":"Jane","Firm":"Finos"},{"First Name":"John","Firm":"Finos"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join.yaml
@@ -1,0 +1,45 @@
+name: relational-service-with-join
+title: "Relational Service: Joins, Derived Property, Service Tests, Plan Generation"
+description: |
+  Layers a service on top of the shared firm domain. Reuses Person, Firm and
+  the Employment association from `relational-shared-domain`, the FirmDB
+  tables from `relational-shared-firm-db`, and adds a Mapping (with both
+  class mappings joined via [db]@PersonFirm), a Connection, a Runtime, and
+  a Service whose query projects a derived property (`Person.fullName()`)
+  plus the joined firm legal name. The Service has a testSuite that primes
+  test data per Connection. A single example exercising joins, associations,
+  derived properties, service tests (Phase 5) and plan generation (Phase 6),
+  composing two shared models that other tests also reuse.
+
+modelSources:
+  model:
+    root: relational-service-with-join
+    files:
+      - mapping/joinMapping.pure
+      - connection/h2Connection.pure
+      - runtime/firmRuntime.pure
+      - service/firmService.pure
+  dependencies:
+    - source: relational-shared-domain.emit.yaml
+    - source: relational-shared-firm-db.emit.yaml
+
+features:
+  - class
+  - association
+  - derived-property
+  - relational-store
+  - relational-mapping
+  - relational-connection
+  - runtime
+  - service
+  - service-test
+stores:
+  - relational
+complexity: basic
+tags:
+  - h2
+  - join
+  - service-test
+  - plan-generation
+  - shared-domain
+  - shared-store

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/connection/h2Connection.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/connection/h2Connection.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Connection
+RelationalDatabaseConnection demo::connection::FirmH2Connection
+{
+  store: demo::store::FirmDB;
+  type: H2;
+  specification: LocalH2
+  {
+  };
+  auth: DefaultH2;
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/mapping/joinMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/mapping/joinMapping.pure
@@ -1,0 +1,40 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::FirmMapping
+(
+  *demo::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::FirmDB]PersonTable.id
+    )
+    ~mainTable [demo::store::FirmDB]PersonTable
+    firstName: [demo::store::FirmDB]PersonTable.firstName,
+    lastName: [demo::store::FirmDB]PersonTable.lastName,
+    firm: [demo::store::FirmDB]@PersonFirm
+  }
+
+  *demo::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::FirmDB]FirmTable.id
+    )
+    ~mainTable [demo::store::FirmDB]FirmTable
+    legalName: [demo::store::FirmDB]FirmTable.legalName,
+    employees: [demo::store::FirmDB]@PersonFirm
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/runtime/firmRuntime.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/runtime/firmRuntime.pure
@@ -1,0 +1,29 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Runtime
+Runtime demo::runtime::FirmRuntime
+{
+  mappings:
+  [
+    demo::FirmMapping
+  ];
+  connections:
+  [
+    demo::store::FirmDB:
+    [
+      h2: demo::connection::FirmH2Connection
+    ]
+  ];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/service/firmService.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service-with-join/service/firmService.pure
@@ -1,0 +1,72 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Service
+Service demo::service::EmployeesByFirmService
+{
+  pattern: '/api/employeesByFirm';
+  documentation: 'List each person with their employer.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Person.all()->sortBy(x|$x.firstName)->project([x|$x.fullName(), x|$x.firm.legalName], ['Full Name', 'Firm']);
+    mapping: demo::FirmMapping;
+    runtime: demo::runtime::FirmRuntime;
+  }
+  testSuites:
+  [
+    serviceSuite:
+    {
+      data:
+      [
+        connections:
+        [
+          h2:
+            Relational
+            #{
+              default.PersonTable:
+                'id,firmId,firstName,lastName\n' +
+                '1,1,John,Doe\n' +
+                '2,1,Jane,Smith\n' +
+                '3,2,Bob,Jones\n';
+              default.FirmTable:
+                'id,legalName\n' +
+                '1,Finos\n' +
+                '2,Goldman\n';
+            }#
+        ]
+      ]
+      tests:
+      [
+        joinedQuery:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldJoin:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"Full Name":"Bob Jones","Firm":"Goldman"},{"Full Name":"Jane Smith","Firm":"Finos"},{"Full Name":"John Doe","Firm":"Finos"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service.emit.yaml
@@ -1,0 +1,38 @@
+name: relational-service
+title: "Relational-backed Service with Test Suite and Plan Generation"
+description: |
+  A Service whose execution targets a relational mapping (over the Person
+  class from `relational-shared-domain`) on an in-memory H2 database.
+  Demonstrates the full plumbing — RelationalDatabaseConnection, Runtime
+  referencing the connection, Service with PureSingleExecution, and a Service
+  test suite that primes test data per Connection. Exercises EMIT Phase 5
+  (Testable test execution) and Phase 6 (plan generation).
+
+modelSources:
+  model:
+    root: relational-service
+    files:
+      - store/db.pure
+      - mapping/personMapping.pure
+      - connection/h2Connection.pure
+      - runtime/personRuntime.pure
+      - service/personService.pure
+  dependencies:
+    - source: relational-shared-domain.emit.yaml
+
+features:
+  - class
+  - relational-store
+  - relational-mapping
+  - relational-connection
+  - runtime
+  - service
+  - service-test
+stores:
+  - relational
+complexity: basic
+tags:
+  - h2
+  - service-test
+  - plan-generation
+  - shared-domain

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/connection/h2Connection.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/connection/h2Connection.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Connection
+RelationalDatabaseConnection demo::connection::PersonH2Connection
+{
+  store: demo::store::PersonDB;
+  type: H2;
+  specification: LocalH2
+  {
+  };
+  auth: DefaultH2;
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/mapping/personMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/mapping/personMapping.pure
@@ -1,0 +1,28 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonMapping
+(
+  *demo::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::PersonDB]PersonTable.id
+    )
+    ~mainTable [demo::store::PersonDB]PersonTable
+    firstName: [demo::store::PersonDB]PersonTable.firstName,
+    lastName: [demo::store::PersonDB]PersonTable.lastName
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/runtime/personRuntime.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/runtime/personRuntime.pure
@@ -1,0 +1,29 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Runtime
+Runtime demo::runtime::PersonRuntime
+{
+  mappings:
+  [
+    demo::PersonMapping
+  ];
+  connections:
+  [
+    demo::store::PersonDB:
+    [
+      h2: demo::connection::PersonH2Connection
+    ]
+  ];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/service/personService.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/service/personService.pure
@@ -1,0 +1,67 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Service
+Service demo::service::PersonService
+{
+  pattern: '/api/persons';
+  documentation: 'List all persons.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Person.all()->project([x|$x.firstName, x|$x.lastName], ['First Name', 'Last Name']);
+    mapping: demo::PersonMapping;
+    runtime: demo::runtime::PersonRuntime;
+  }
+  testSuites:
+  [
+    serviceSuite:
+    {
+      data:
+      [
+        connections:
+        [
+          h2:
+            Relational
+            #{
+              default.PersonTable:
+                'id,firstName,lastName\n' +
+                '1,John,Doe\n' +
+                '2,Jane,Smith\n';
+            }#
+        ]
+      ]
+      tests:
+      [
+        allPersons:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldMatch:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"John","Last Name":"Doe"},{"First Name":"Jane","Last Name":"Smith"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-service/store/db.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::store::PersonDB
+(
+  Table PersonTable
+  (
+    id INTEGER PRIMARY KEY,
+    firstName VARCHAR(200),
+    lastName VARCHAR(200)
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain.emit.yaml
@@ -1,0 +1,27 @@
+name: relational-shared-domain
+title: "Shared Domain Types (Person, Firm, Employment)"
+description: |
+  A reusable, store-agnostic domain consumed by most of the relational EMIT
+  examples. Defines a Person class (with a `fullName` derived property), a
+  Firm class, and an Employment association connecting the two — split into
+  one file per element so consumers see a clean separation. This shared model
+  declares no store, mapping or runtime; downstream tests layer those on top
+  via the EMIT `dependencies` mechanism. Its own EMIT run only exercises
+  parse + compile.
+
+modelSources:
+  model:
+    root: relational-shared-domain
+    files:
+      - model/person.pure
+      - model/firm.pure
+      - model/employment.pure
+
+features:
+  - class
+  - association
+  - derived-property
+stores: []
+complexity: basic
+tags:
+  - shared-domain

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain/model/employment.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain/model/employment.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Association demo::Employment
+{
+  firm: demo::Firm[1];
+  employees: demo::Person[*];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain/model/firm.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain/model/firm.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::Firm
+{
+  legalName: String[1];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain/model/person.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-domain/model/person.pure
@@ -1,0 +1,21 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+  fullName() {$this.firstName + ' ' + $this.lastName}: String[1];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-firm-db.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-firm-db.emit.yaml
@@ -1,0 +1,25 @@
+name: relational-shared-firm-db
+title: "Shared Firm Database (PersonTable + FirmTable + Join)"
+description: |
+  A reusable relational store consumed by the joined-domain EMIT examples.
+  Defines `demo::store::FirmDB` with a PersonTable, a FirmTable, and a
+  PersonFirm join on PersonTable.firmId = FirmTable.id. Contains no Pure
+  types or mappings; pair with `relational-shared-domain` for the matching
+  Person / Firm / Employment classes. Its own EMIT run only exercises
+  parse + compile.
+
+modelSources:
+  model:
+    root: relational-shared-firm-db
+    files:
+      - store/firmDb.pure
+
+features:
+  - relational-store
+stores:
+  - relational
+complexity: basic
+tags:
+  - shared-store
+  - h2
+  - join

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-firm-db/store/firmDb.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-shared-firm-db/store/firmDb.pure
@@ -1,0 +1,32 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::store::FirmDB
+(
+  Table PersonTable
+  (
+    id INTEGER PRIMARY KEY,
+    firmId INTEGER,
+    firstName VARCHAR(200),
+    lastName VARCHAR(200)
+  )
+  Table FirmTable
+  (
+    id INTEGER PRIMARY KEY,
+    legalName VARCHAR(200)
+  )
+
+  Join PersonFirm(PersonTable.firmId = FirmTable.id)
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple.emit.yaml
@@ -1,0 +1,31 @@
+name: relational-simple
+title: "Relational Mapping with Embedded Test"
+description: |
+  The Person class from `relational-shared-domain` is mapped relationally to
+  an H2-shaped table, with an embedded mapping test suite that loads CSV-
+  style test data via a Data element. Verifies that EMIT can drive parse,
+  compile, and test execution against a relational mapping end-to-end.
+
+modelSources:
+  model:
+    root: relational-simple
+    files:
+      - store/db.pure
+      - data/testData.pure
+      - mapping/personMapping.pure
+  dependencies:
+    - source: relational-shared-domain.emit.yaml
+
+features:
+  - class
+  - relational-store
+  - relational-mapping
+  - data-element
+  - test-data
+stores:
+  - relational
+complexity: basic
+tags:
+  - h2
+  - mapping-test
+  - shared-domain

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple/data/testData.pure
@@ -1,0 +1,25 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Data
+Data demo::data::PersonData
+{
+  Relational
+  #{
+    default.PersonTable:
+      'id,firstName,lastName\n' +
+      '1,John,Doe\n' +
+      '2,Jane,Smith\n';
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple/mapping/personMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple/mapping/personMapping.pure
@@ -1,0 +1,63 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonMapping
+(
+  *demo::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::PersonDB]PersonTable.id
+    )
+    ~mainTable [demo::store::PersonDB]PersonTable
+    firstName: [demo::store::PersonDB]PersonTable.firstName,
+    lastName: [demo::store::PersonDB]PersonTable.lastName
+  }
+
+  testSuites:
+  [
+    personSuite:
+    {
+      function: |demo::Person.all()->project([x|$x.firstName, x|$x.lastName], ['First Name', 'Last Name']);
+      tests:
+      [
+        allPeople:
+        {
+          data:
+          [
+            demo::store::PersonDB:
+              Reference
+              #{
+                demo::data::PersonData
+              }#
+          ];
+          asserts:
+          [
+            shouldMatch:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"John","Last Name":"Doe"},{"First Name":"Jane","Last Name":"Smith"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/emit-models/relational-simple/store/db.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::store::PersonDB
+(
+  Table PersonTable
+  (
+    id INTEGER PRIMARY KEY,
+    firstName VARCHAR(200),
+    lastName VARCHAR(200)
+  )
+)

--- a/legend-engine-xts-relationalStore/pom.xml
+++ b/legend-engine-xts-relationalStore/pom.xml
@@ -36,6 +36,7 @@
         <module>legend-engine-xt-relationalStore-PCT</module>
         <module>legend-engine-xt-relationalStore-connection-http-api</module>
         <module>legend-engine-xt-relationalStore-MFT-pure</module>
+        <module>legend-engine-xt-relationalStore-emit</module>
 
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2579,6 +2579,16 @@
             </dependency>
             <dependency>
                 <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-emit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-emit-junit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
                 <artifactId>legend-engine-testable</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -3857,6 +3867,11 @@
             </dependency>
             <!-- JSON-UNIT -->
 
+            <dependency>
+                <groupId>org.opentest4j</groupId>
+                <artifactId>opentest4j</artifactId>
+                <version>1.3.0</version>
+            </dependency>
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>


### PR DESCRIPTION
Engine Model Integration Test (EMIT) Framework: a test framework that will validate a Legend Engine model end-to-end. This runs a model through all the steps of its pipeline: parsing, compiling, running generations, executing tests, and generating execution plans. EMIT can be used on its own, or through its JUnit integration. Sample usage of the JUnit integration is included for some basic relational models.