### PR TITLE
Revert merging section indexes when building a PMCD

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/context/PureModelContextData.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/context/PureModelContextData.java
@@ -20,9 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
 import org.eclipse.collections.impl.utility.ArrayIterate;
@@ -321,10 +319,8 @@ public class PureModelContextData extends PureModelContextConcrete
                 return false;
             }
 
-            boolean mergedAny = mergeSectionIndexes();
             MutableSet<PackageableElement> set = UnifiedSetWithHashingStrategy.newSet(ELEMENT_PATH_HASH, this.elements.size());
-            boolean removedAny = this.elements.removeIf(e -> !set.add(e));
-            return mergedAny || removedAny;
+            return this.elements.removeIf(e -> !set.add(e));
         }
 
         public Builder distinct()
@@ -349,41 +345,7 @@ public class PureModelContextData extends PureModelContextConcrete
 
         public PureModelContextData build()
         {
-            mergeSectionIndexes();
             return new PureModelContextData(this.serializer, this.origin, this.elements.toList());
-        }
-
-        private boolean mergeSectionIndexes()
-        {
-            if (this.elements.size() <= 1)
-            {
-                return false;
-            }
-
-            MutableMap<String, MutableList<SectionIndex>> sectionIndexesByPath = Maps.mutable.empty();
-            boolean removed = this.elements.removeIf(e -> (e instanceof SectionIndex) &&
-                    (sectionIndexesByPath.getIfAbsentPut(e.getPath(), Lists.mutable::empty).with((SectionIndex) e).size() > 1));
-            if (removed)
-            {
-                this.elements.forEachWithIndex((element, i) ->
-                {
-                    if (element instanceof SectionIndex)
-                    {
-                        String path = element.getPath();
-                        MutableList<SectionIndex> sectionIndexes = sectionIndexesByPath.get(path);
-                        if (sectionIndexes.size() > 1)
-                        {
-                            SectionIndex merged = new SectionIndex();
-                            merged._package = sectionIndexes.get(0)._package;
-                            merged.name = sectionIndexes.get(0).name;
-                            merged.sourceInformation = sectionIndexes.get(0).sourceInformation;
-                            sectionIndexes.forEach(si -> merged.sections.addAll(si.sections));
-                            this.elements.set(i, merged);
-                        }
-                    }
-                });
-            }
-            return removed;
         }
     }
 }

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
@@ -123,7 +123,7 @@ public final class EMITTasks
                     primarySourceIds.add(file.getVirtualPath());
                 }
             });
-            return new ParseResult(builder.build(), primarySourceIds, totalElements[0]);
+            return new ParseResult(builder.distinct().build(), primarySourceIds, totalElements[0]);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Revert merging section indexes when building a PMCD, and add a call to distinct when building the PMCD from an EMIT model.

This reverts 378428dfa15d74524678f98aab0b13cb71ffab75
