### PR TITLE
Fix handling of dependencies for EMIT models

### DIFF
--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModelLoader.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModelLoader.java
@@ -64,13 +64,41 @@ public class EMITModelLoader
         Path baseDir = descriptor.getSource().getParent();
         MutableList<EMITSourceFile> modelFiles = resolveSource(baseDir, descriptor.getModelSources().getModel(), true);
 
+        MutableMap<String, Path> seen = Maps.mutable.empty();
+        MutableSet<String> clashes = modelFiles.collectIf(
+                f ->
+                {
+                    Path prior = seen.put(f.getVirtualPath(), f.getAbsolutePath());
+                    return (prior != null) && !prior.equals(f.getAbsolutePath());
+                },
+                EMITSourceFile::getVirtualPath,
+                Sets.mutable.empty());
+
         MutableList<EMITSourceFile> dependencyFiles = Lists.mutable.empty();
         for (EMITModelDescriptor.Dependency dep : descriptor.getModelSources().getDependencies())
         {
-            dependencyFiles.addAll(resolveDependency(baseDir, dep));
+            resolveDependency(baseDir, dep).forEach(f ->
+            {
+                Path prior = seen.get(f.getVirtualPath());
+                if (prior == null)
+                {
+                    seen.put(f.getVirtualPath(), f.getAbsolutePath());
+                    dependencyFiles.add(f);
+                }
+                else if (!prior.equals(f.getAbsolutePath()))
+                {
+                    clashes.add(f.getVirtualPath());
+                }
+                // else: same virtual path resolving to the same absolute path; the file has already
+                // been loaded via another dependency path. Drop it so the same file is not loaded
+                // (and parsed) twice when a dependency graph forms a diamond.
+            });
         }
 
-        validateNoClashes(modelFiles, dependencyFiles);
+        if (clashes.notEmpty())
+        {
+            throw new IllegalStateException(clashes.toSortedList().makeString("Source file virtual-path clashes: ", ", ", ""));
+        }
 
         return EMITSourceSet.newSourceSet(descriptor, modelFiles, dependencyFiles);
     }
@@ -155,20 +183,6 @@ public class EMITModelLoader
         catch (IllegalArgumentException ignore)
         {
             return null;
-        }
-    }
-
-    private void validateNoClashes(ListIterable<EMITSourceFile> modelFiles, ListIterable<EMITSourceFile> dependencyFiles)
-    {
-        MutableMap<String, Path> seen = Maps.mutable.empty();
-        MutableSet<String> clashes = modelFiles.asLazy().concatenate(dependencyFiles).collectIf(f ->
-        {
-            Path prior = seen.put(f.getVirtualPath(), f.getAbsolutePath());
-            return (prior != null) && !prior.equals(f.getAbsolutePath());
-        }, EMITSourceFile::getVirtualPath, Sets.mutable.empty());
-        if (clashes.notEmpty())
-        {
-            throw new IllegalStateException(clashes.toSortedList().makeString("Source file virtual-path clashes: ", ", ", ""));
         }
     }
 }

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITModelLoader.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITModelLoader.java
@@ -1,0 +1,94 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestEMITModelLoader
+{
+    @Test
+    void diamondDependencyLoadsSharedFileOnce()
+    {
+        Path emitYaml = resource("emit-models/diamond/diamond.emit.yaml");
+
+        EMITSourceSet sourceSet = loadSilently(emitYaml);
+
+        // Primary scope: only the diamond's own model file.
+        MutableList<String> modelVirtualPaths = ListIterate.collect(sourceSet.getModelFiles(), EMITSourceFile::getVirtualPath);
+        Assertions.assertEquals(Lists.fixedSize.with("model/main.pure"), modelVirtualPaths,
+                "Primary model scope should contain only the diamond's own file");
+
+        // Dependency scope: left.pure, right.pure, and the shared file exactly once
+        // (despite being reachable via both left-dep and right-dep).
+        MutableList<String> depVirtualPaths = ListIterate.collect(sourceSet.getDependencyFiles(), EMITSourceFile::getVirtualPath).sortThis();
+        Assertions.assertEquals(
+                Lists.fixedSize.with("model/left.pure", "model/right.pure", "model/shared.pure"),
+                depVirtualPaths,
+                "Diamond dependency must load shared.pure exactly once");
+
+        int sharedCount = ListIterate.count(sourceSet.getDependencyFiles(), f -> "model/shared.pure".equals(f.getVirtualPath()));
+        Assertions.assertEquals(1, sharedCount, "shared.pure must appear exactly once in the dependency list");
+    }
+
+    @Test
+    void clashingVirtualPathsAcrossDependenciesAreReported()
+    {
+        Path emitYaml = resource("emit-models/diamond/clash-test.emit.yaml");
+
+        EMITModelLoader loader = new EMITModelLoader();
+        IllegalStateException error = Assertions.assertThrows(IllegalStateException.class, () -> loader.load(emitYaml));
+        Assertions.assertEquals(
+                "Source file virtual-path clashes: model/shared.pure",
+                error.getMessage(),
+                () -> "Expected clash error to name the offending virtual path; got: " + error.getMessage());
+    }
+
+    private static EMITSourceSet loadSilently(Path emitYaml)
+    {
+        try
+        {
+            return new EMITModelLoader().load(emitYaml);
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Path resource(String name)
+    {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(name);
+        Assertions.assertNotNull(url, "test resource not found: " + name);
+        try
+        {
+            return Paths.get(url.toURI());
+        }
+        catch (URISyntaxException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-a.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-a.emit.yaml
@@ -1,0 +1,15 @@
+name: diamond-clash-a
+title: "Clash dependency A"
+description: |
+  Declares a file at virtual path 'model/shared.pure' with one absolute
+  resolution. Combined with clash-b in clash-test to verify that the
+  loader still raises a clash error when two dependencies contribute
+  the same virtual path with different absolute paths.
+
+modelSources:
+  model:
+    root: clash-a
+    files:
+      - model/shared.pure
+
+complexity: basic

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-a/model/shared.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-a/model/shared.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::clash::FromA
+{
+  id: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-b.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-b.emit.yaml
@@ -1,0 +1,14 @@
+name: diamond-clash-b
+title: "Clash dependency B"
+description: |
+  Declares a file at virtual path 'model/shared.pure' resolving to a
+  different absolute path than clash-a, exercising the loader's clash
+  detection.
+
+modelSources:
+  model:
+    root: clash-b
+    files:
+      - model/shared.pure
+
+complexity: basic

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-b/model/shared.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-b/model/shared.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::clash::FromB
+{
+  id: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-test.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-test.emit.yaml
@@ -1,0 +1,18 @@
+name: diamond-clash-test
+title: "Clash detection across dependencies"
+description: |
+  Top-level descriptor that pulls in clash-a and clash-b as dependencies.
+  Both contribute a file at virtual path 'model/shared.pure' but with
+  different absolute paths, so the loader should raise a clash error
+  rather than silently dedupe.
+
+modelSources:
+  model:
+    root: clash-test
+    files:
+      - model/main.pure
+  dependencies:
+    - source: clash-a.emit.yaml
+    - source: clash-b.emit.yaml
+
+complexity: basic

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-test/model/main.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/clash-test/model/main.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::clash::Main
+{
+  name: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/diamond.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/diamond.emit.yaml
@@ -1,0 +1,18 @@
+name: diamond
+title: "Diamond dependency graph"
+description: |
+  Top-level model that depends on left-dep and right-dep. Both intermediates
+  pull in the same shared-dep, so the shared file is reachable via two
+  distinct dependency paths. The loader must recognise this and load the
+  shared file only once.
+
+modelSources:
+  model:
+    root: diamond
+    files:
+      - model/main.pure
+  dependencies:
+    - source: left-dep.emit.yaml
+    - source: right-dep.emit.yaml
+
+complexity: basic

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/diamond/model/main.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/diamond/model/main.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::diamond::Top
+{
+  left: demo::diamond::Left[1];
+  right: demo::diamond::Right[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/left-dep.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/left-dep.emit.yaml
@@ -1,0 +1,15 @@
+name: diamond-left-dep
+title: "Left arm of the diamond"
+description: |
+  Intermediate dependency that pulls in the shared-dep. Combined with right-dep
+  in the top-level diamond test to form a diamond dependency graph.
+
+modelSources:
+  model:
+    root: left-dep
+    files:
+      - model/left.pure
+  dependencies:
+    - source: shared-dep.emit.yaml
+
+complexity: basic

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/left-dep/model/left.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/left-dep/model/left.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::diamond::Left
+{
+  sharedRef: demo::diamond::Shared[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/right-dep.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/right-dep.emit.yaml
@@ -1,0 +1,15 @@
+name: diamond-right-dep
+title: "Right arm of the diamond"
+description: |
+  Intermediate dependency that pulls in the shared-dep. Combined with left-dep
+  in the top-level diamond test to form a diamond dependency graph.
+
+modelSources:
+  model:
+    root: right-dep
+    files:
+      - model/right.pure
+  dependencies:
+    - source: shared-dep.emit.yaml
+
+complexity: basic

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/right-dep/model/right.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/right-dep/model/right.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::diamond::Right
+{
+  sharedRef: demo::diamond::Shared[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/shared-dep.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/shared-dep.emit.yaml
@@ -1,0 +1,14 @@
+name: diamond-shared-dep
+title: "Shared leaf dependency for the diamond test"
+description: |
+  Single Pure file referenced via two intermediate dependencies in the diamond
+  test. Used to verify that the loader does not load the same file twice when
+  reached via multiple dependency paths.
+
+modelSources:
+  model:
+    root: shared-dep
+    files:
+      - model/shared.pure
+
+complexity: basic

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/shared-dep/model/shared.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/diamond/shared-dep/model/shared.pure
@@ -1,0 +1,19 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::diamond::Shared
+{
+  id: String[1];
+}


### PR DESCRIPTION
Fix handling of dependencies for EMIT models. In particular, ensure that files are not multiple times even if they are brought in via multiple dependencies.