### PR TITLE
Minor improvements to EMIT framework

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/context/PureModelContextData.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/context/PureModelContextData.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
 import org.eclipse.collections.impl.utility.ArrayIterate;
@@ -309,6 +311,45 @@ public class PureModelContextData extends PureModelContextConcrete
         public Builder withPureModelContextData(PureModelContextData pureModelContextData)
         {
             addPureModelContextData(pureModelContextData);
+            return this;
+        }
+
+        public boolean mergeSectionIndexes()
+        {
+            if (this.elements.size() <= 1)
+            {
+                return false;
+            }
+
+            MutableMap<String, MutableList<SectionIndex>> sectionIndexesByPath = Maps.mutable.empty();
+            boolean removed = this.elements.removeIf(e -> (e instanceof SectionIndex) &&
+                    (sectionIndexesByPath.getIfAbsentPut(e.getPath(), Lists.mutable::empty).with((SectionIndex) e).size() > 1));
+            if (removed)
+            {
+                this.elements.forEachWithIndex((element, i) ->
+                {
+                    if (element instanceof SectionIndex)
+                    {
+                        String path = element.getPath();
+                        MutableList<SectionIndex> sectionIndexes = sectionIndexesByPath.get(path);
+                        if (sectionIndexes.size() > 1)
+                        {
+                            SectionIndex merged = new SectionIndex();
+                            merged._package = sectionIndexes.get(0)._package;
+                            merged.name = sectionIndexes.get(0).name;
+                            merged.sourceInformation = sectionIndexes.get(0).sourceInformation;
+                            sectionIndexes.forEach(si -> merged.sections.addAll(si.sections));
+                            this.elements.set(i, merged);
+                        }
+                    }
+                });
+            }
+            return removed;
+        }
+
+        public Builder withSectionIndexesMerged()
+        {
+            mergeSectionIndexes();
             return this;
         }
 

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
@@ -50,6 +50,11 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- ECLIPSE COLLECTIONS -->

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
@@ -17,6 +17,9 @@ package org.finos.legend.engine.test.emit.junit;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.engine.test.emit.error.EMITAssertionError;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
@@ -91,9 +94,11 @@ public class TestEMITTestSuiteBuilder
         DynamicTest only = tasks.get(0);
         Assertions.assertEquals("[compile-failure] Initialization (Init, Parse & Compile)", only.getDisplayName());
 
-        Throwable thrown = Assertions.assertThrows(Throwable.class, () -> only.getExecutable().execute(),
+        EMITAssertionError thrown = Assertions.assertThrows(EMITAssertionError.class, () -> only.getExecutable().execute(),
                 "Expected the init task to throw because the model fails to compile");
-        Assertions.assertNotNull(thrown);
+        Assertions.assertEquals("FAILURE [Compilation]: COMPILATION error at model.pure[20:12-29]: Can't find type 'demo::DoesNotExist'", thrown.getMessage());
+        Assertions.assertInstanceOf(EngineException.class, thrown.getCause());
+        Assertions.assertSame(EngineErrorType.COMPILATION, ((EngineException) thrown.getCause()).getErrorType());
     }
 
     @Test

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModelLoader.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITModelLoader.java
@@ -135,6 +135,12 @@ public class EMITModelLoader
             Path referencedYaml = baseDir.resolve(dep.getSource()).normalize();
             EMITSourceSet referenced = load(referencedYaml);
             ListIterable<PathMatcher> excludeMatchers = compileGlobs(dep.getExcludes());
+            if (excludeMatchers.isEmpty())
+            {
+                return Lists.mutable.<EMITSourceFile>ofInitialCapacity(referenced.getTotalFileCount())
+                        .withAll(referenced.getModelFiles())
+                        .withAll(referenced.getDependencyFiles());
+            }
 
             MutableList<EMITSourceFile> result = Lists.mutable.empty();
             referenced.forEachFile(f ->

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
@@ -124,7 +124,7 @@ public final class EMITTasks
                     primarySourceIds.add(file.getVirtualPath());
                 }
             });
-            return new ParseResult(builder.distinct().build(), primarySourceIds, totalElements[0]);
+            return new ParseResult(builder.withSectionIndexesMerged().build(), primarySourceIds, totalElements[0]);
         }
         catch (EngineException e)
         {

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
@@ -42,6 +42,7 @@ import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.plan.platform.PlanPlatform;
 import org.finos.legend.engine.protocol.pure.PureClientVersions;
 import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
+import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
 import org.finos.legend.engine.protocol.pure.m3.function.Function;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
@@ -125,12 +126,16 @@ public final class EMITTasks
             });
             return new ParseResult(builder.distinct().build(), primarySourceIds, totalElements[0]);
         }
+        catch (EngineException e)
+        {
+            if (e.getErrorType() == EngineErrorType.PARSER)
+            {
+                throw new EMITAssertionError(EMITPhase.PARSE, buildEngineExceptionMessage(e), e);
+            }
+            throw new EMITException(EMITPhase.PARSE, buildEngineExceptionMessage(e), e);
+        }
         catch (Exception e)
         {
-            if ((e instanceof EngineException) && (((EngineException) e).getErrorType() == EngineErrorType.PARSER))
-            {
-                throw new EMITAssertionError(EMITPhase.PARSE, "Error parsing source set", e);
-            }
             throw new EMITException(EMITPhase.PARSE, "Error parsing source set", e);
         }
     }
@@ -143,12 +148,16 @@ public final class EMITTasks
         {
             return new PureModel(pmcd, null, DeploymentMode.PROD);
         }
+        catch (EngineException e)
+        {
+            if (e.getErrorType() == EngineErrorType.COMPILATION)
+            {
+                throw new EMITAssertionError(EMITPhase.COMPILE, buildEngineExceptionMessage(e), e);
+            }
+            throw new EMITException(EMITPhase.COMPILE, buildEngineExceptionMessage(e), e);
+        }
         catch (Exception e)
         {
-            if ((e instanceof EngineException) && (((EngineException) e).getErrorType() == EngineErrorType.COMPILATION))
-            {
-                throw new EMITAssertionError(EMITPhase.PARSE, "Compilation failed", e);
-            }
             throw new EMITException(EMITPhase.COMPILE, "Error during compilation", e);
         }
     }
@@ -550,6 +559,53 @@ public final class EMITTasks
         {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private static String buildEngineExceptionMessage(EngineException e)
+    {
+        return appendEngineExceptionMessage(new StringBuilder(), e).toString();
+    }
+
+    private static StringBuilder appendEngineExceptionMessage(StringBuilder builder, EngineException e)
+    {
+        EngineErrorType errorType = e.getErrorType();
+        if (errorType != null)
+        {
+            builder.append(errorType).append(" error");
+        }
+
+        SourceInformation sourceInfo = e.getSourceInformation();
+        if ((sourceInfo != null) && (sourceInfo != SourceInformation.getUnknownSourceInformation()))
+        {
+            builder.append(" at ").append(sourceInfo.sourceId);
+            builder.append('[');
+            if (sourceInfo.startLine == sourceInfo.endLine)
+            {
+                builder.append(sourceInfo.startLine).append(':');
+                if (sourceInfo.startColumn == sourceInfo.endColumn)
+                {
+                    builder.append(sourceInfo.startColumn);
+                }
+                else
+                {
+                    builder.append(sourceInfo.startColumn).append('-').append(sourceInfo.endColumn);
+                }
+                builder.append(']');
+            }
+            else
+            {
+                builder.append(sourceInfo.startLine).append(':').append(sourceInfo.startColumn)
+                        .append('-')
+                        .append(sourceInfo.endLine).append(':').append(sourceInfo.endColumn).append(']');
+            }
+        }
+
+        String message = e.getMessage();
+        if (message != null)
+        {
+            builder.append(": ").append(message);
+        }
+        return builder;
     }
 
     // ----- Result records -----

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITRunner.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITRunner.java
@@ -14,11 +14,14 @@
 
 package org.finos.legend.engine.test.emit;
 
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.engine.test.emit.EMITPhaseResult.Status;
+import org.finos.legend.engine.test.emit.error.EMITAssertionError;
 import org.finos.legend.engine.testable.model.RunTestsResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -71,14 +74,29 @@ public class TestEMITRunner
 
         EMITResult result = new EMITRunner().runFromYaml(emitYaml);
 
+        // result as a whole is not a success
         Assertions.assertFalse(result.isSuccess(), "Expected EMIT run to fail at COMPILE");
+
+        // init and parse phases should succeed
         Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.INITIALIZATION).getStatus());
         Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.PARSE).getStatus());
-        Assertions.assertEquals(Status.FAILURE, result.getPhase(EMITPhase.COMPILE).getStatus());
+
+        // compile phase should fail
+        String expectedMessage = "FAILURE [Compilation]: COMPILATION error at model.pure[20:12-29]: Can't find type 'demo::DoesNotExist'";
+        EMITPhaseResult compileResult = result.getPhase(EMITPhase.COMPILE);
+        Assertions.assertEquals(Status.FAILURE, compileResult.getStatus());
+        Assertions.assertEquals(expectedMessage, compileResult.getMessage());
+        Assertions.assertInstanceOf(EMITAssertionError.class, compileResult.getThrowable(), "Expected an assertion error from the failing test");
+        Assertions.assertEquals(expectedMessage, compileResult.getThrowable().getMessage());
+        Assertions.assertInstanceOf(EngineException.class, compileResult.getThrowable().getCause());
+        Assertions.assertSame(EngineErrorType.COMPILATION, ((EngineException) compileResult.getThrowable().getCause()).getErrorType());
+
+        // remaining phases are skipped
         Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.MODEL_GENERATION).getStatus());
         Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.FILE_GENERATION).getStatus());
         Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.TEST_EXECUTION).getStatus());
         Assertions.assertEquals(Status.NOT_RUN, result.getPhase(EMITPhase.PLAN_GENERATION).getStatus());
+
     }
 
     @Test
@@ -101,10 +119,9 @@ public class TestEMITRunner
         Assertions.assertEquals(2, runTests.results.size(), "Expected exactly 2 mapping tests to be executed");
         runTests.results.forEach(r ->
         {
-            Assertions.assertTrue(r instanceof TestExecuted, () -> "Expected TestExecuted, got " + r.getClass().getSimpleName());
+            Assertions.assertInstanceOf(TestExecuted.class, r, () -> "Expected TestExecuted, got " + r.getClass().getSimpleName());
             Assertions.assertEquals(TestExecutionStatus.PASS, ((TestExecuted) r).testExecutionStatus,
-                    () -> "Expected test " + r.atomicTestId + " to PASS but got "
-                            + ((TestExecuted) r).testExecutionStatus + "; assertions=" + ((TestExecuted) r).assertStatuses);
+                    () -> "Expected test " + r.atomicTestId + " to PASS but got " + ((TestExecuted) r).testExecutionStatus + "; assertions=" + ((TestExecuted) r).assertStatuses);
         });
 
         Assertions.assertTrue(result.isSuccess(), () -> "Expected EMIT run to succeed but got:\n" + result.getSummary());


### PR DESCRIPTION
Minor improvements to EMIT framework. Also, the ability to merge section indexes is back in PureModelContextData.Builder; however, it is now optional.