### PR TITLE
Update EMITTestSuiteBuilder to run model generations

### DIFF
--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -470,11 +470,14 @@ public class MyModuleEMITTestSuite
 `EMITTestSuiteBuilder` also exposes `taskList(String)` for callers that prefer
 a `List<DynamicTest>` (e.g., for fan-out into nested containers).
 
-When JUnit invokes the factory method, `EMITTestSuiteBuilder` scans for `*.emit.yaml` files. For each model, it performs Phase 0 (Initialization), Phase 1 (Parse), and Phase 2 (Compile). By inspecting the compiled model, it identifies every file-generation specification, every artifact-generation candidate, every test (modern Testable plus legacy Mapping/Service tests), and every service.
+When JUnit invokes the factory method, `EMITTestSuiteBuilder` scans for `*.emit.yaml` files. For each model, it eagerly performs Phase 0 (Initialization), Phase 1 (Parse), Phase 2 (Compile), and Phase 3 (Model Generation), each reported as its own DynamicTest. If an eager phase fails, its task is failing and no subsequent tasks are emitted for that model. Discovery operates on the model-generation-enriched PMCD, so any element produced by a `GenerationSpecification` is eligible for downstream tasks. By inspecting that enriched model it identifies every file-generation specification, every artifact-generation candidate, every test (modern Testable plus legacy Mapping/Service tests), and every service.
 
 It then yields one `DynamicTest` per granular operation, with descriptive names:
 
-- `[service-simple] Initialization (Init, Parse & Compile)`
+- `[service-simple] Initialization`
+- `[service-simple] Parsing`
+- `[service-simple] Compilation`
+- `[service-simple] Model Generation`
 - `[service-simple] File Generation: demo::MyAvroGenerationSpec`
 - `[service-simple] Artifact Generation: demo::PersonService (ServiceArtifactExtension)`
 - `[service-simple] Test: demo::PersonService / testSuite_1 / test_1`
@@ -482,9 +485,6 @@ It then yields one `DynamicTest` per granular operation, with descriptive names:
 - `[service-simple] Plan: demo::PersonService`
 - `[service-simple] Legacy Mapping Test: demo::PersonMapping / legacyTest_1`
 - `[service-simple] Legacy Service Test: demo::PersonService`
-
-Phase 3 (Model Generation) is currently exposed only through the standalone
-`EMITRunner`; the JUnit builder does not yield a per-spec dynamic test for it.
 
 Because each `DynamicTest` is a distinct JUnit test, IDEs and build servers (like Maven Surefire) report granular pass/fail statuses, durations, and diffs natively.
 

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
@@ -28,6 +28,18 @@
     <name>Legend Engine - Testing - EMIT JUnit Integration</name>
 
     <dependencies>
+        <!-- PURE -->
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
+        </dependency>
+        <!-- PURE -->
+
         <!-- ENGINE -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -36,11 +48,23 @@
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-dsl-generation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-generation-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
@@ -34,9 +34,16 @@ import java.util.stream.Stream;
 
 /**
  * JUnit 5 integration for EMIT. Discovers {@code *.emit.yaml} files on the
- * classpath under a given root, eagerly initialises (load + parse + compile)
- * each model, then yields one {@link DynamicTest} per granular operation
- * (file generation, artifact generation, individual test, service plan).
+ * classpath under a given root, eagerly runs load + parse + compile + model
+ * generation on each model, then yields one {@link DynamicTest} per granular
+ * operation: an Initialization task, a Parsing task, a Compilation task, and
+ * a Model Generation task that report the outcome of the eager phases,
+ * followed by one task per file-generation spec, artifact-generation
+ * candidate, individual test, and service. If an eager phase fails, its task
+ * is failing and no subsequent tasks are emitted for that model. Discovery
+ * operates on the model-generation-enriched PMCD, so any element produced by
+ * a {@code GenerationSpecification} is eligible for the downstream tasks
+ * just like a hand-authored element.
  *
  * <p>Each dynamic test calls into {@link EMITTasks} for its body, so that
  * the standalone {@code EMITRunner} and this JUnit integration share a single
@@ -57,8 +64,6 @@ import java.util.stream.Stream;
  */
 public final class EMITTestSuiteBuilder
 {
-    private static final String INIT_TASK_NAME = "Initialization (Init, Parse & Compile)";
-
     private EMITTestSuiteBuilder()
     {
     }
@@ -88,6 +93,8 @@ public final class EMITTestSuiteBuilder
     {
         String fallbackLabel = stripExtension(yaml.getFileName().toString());
 
+        MutableList<DynamicTest> tasks = Lists.mutable.empty();
+
         EMITSourceSet sourceSet;
         try
         {
@@ -95,34 +102,46 @@ public final class EMITTestSuiteBuilder
         }
         catch (Exception e)
         {
-            return Lists.mutable.with(failingTask(fallbackLabel, INIT_TASK_NAME, e));
+            return tasks.with(failingTask(fallbackLabel, "Initialization", e));
         }
         String label = (sourceSet.getDescriptor() != null && sourceSet.getDescriptor().getName() != null) ? sourceSet.getDescriptor().getName() : fallbackLabel;
+        tasks.add(passingTask(label, "Initialization"));
 
-        ParseResult parsed;
+        ParseResult parseResult;
         try
         {
-            parsed = EMITTasks.parse(sourceSet);
+            parseResult = EMITTasks.parse(sourceSet);
+            tasks.add(passingTask(label, "Parsing"));
         }
         catch (EMITAssertionError | Exception e)
         {
-            return Lists.mutable.with(failingTask(label, INIT_TASK_NAME, e));
+            return tasks.with(failingTask(label, "Parsing", e));
         }
 
         PureModel pureModel;
         try
         {
-            pureModel = EMITTasks.compile(parsed.getPmcd());
+            pureModel = EMITTasks.compile(parseResult.getPmcd());
+            tasks.add(passingTask(label, "Compilation"));
         }
         catch (EMITAssertionError | Exception e)
         {
-            return Lists.mutable.with(failingTask(label, INIT_TASK_NAME, e));
+            return tasks.with(failingTask(label, "Compilation", e));
         }
 
-        EMITModel model = new EMITModel(sourceSet, parsed.getPmcd(), pureModel, parsed.getPrimarySourceIds());
-
-        MutableList<DynamicTest> tasks = Lists.mutable.empty();
-        tasks.add(passingTask(label, INIT_TASK_NAME));
+        EMITModel coreModel = new EMITModel(sourceSet, parseResult.getPmcd(), pureModel, parseResult.getPrimarySourceIds());
+        EMITTasks.ModelGenResult modelGenResult;
+        try
+        {
+            modelGenResult = EMITTasks.runModelGeneration(coreModel);
+            tasks.add(passingTask(label, "Model Generation"));
+        }
+        catch (EMITAssertionError | Exception e)
+        {
+            modelGenResult = null;
+            tasks.add(failingTask(label, "Model Generation", e));
+        }
+        EMITModel model = ((modelGenResult == null) || (modelGenResult.getNewModel() == null)) ? coreModel : modelGenResult.getNewModel();
 
         ListIterate.collect(EMITTasks.findFileGenerationSpecs(model), spec ->
         {

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
@@ -34,9 +34,11 @@ public class TestEMITTestSuiteBuilder
     {
         List<DynamicTest> tasks = EMITTestSuiteBuilder.taskList("emit-models/");
 
-        int initTasks = ListIterate.count(tasks, t -> t.getDisplayName().endsWith("Initialization (Init, Parse & Compile)"));
-        Assertions.assertEquals(2, initTasks,
-                () -> "Expected one Initialization task per discovered model (class-simple, m2m-passing); got names:\n" + names(tasks));
+        // An Initialization task is added for every discovered yaml regardless of whether
+        // its downstream phases succeed, so it is the most accurate per-model marker.
+        int initTasks = ListIterate.count(tasks, t -> t.getDisplayName().endsWith("] Initialization"));
+        Assertions.assertEquals(5, initTasks,
+                () -> "Expected one Initialization task per discovered model (artifact-generation, class-simple, file-generation, m2m-passing, model-generation); got names:\n" + names(tasks));
     }
 
     @Test
@@ -49,8 +51,14 @@ public class TestEMITTestSuiteBuilder
         // could in principle yield additional Artifact Generation tasks for the
         // demo::Person class — assert the init task exists, and assert the
         // ones that do exist all execute successfully.
-        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Initialization (Init, Parse & Compile)".equals(t.getDisplayName())),
-                () -> "Missing init task; got:\n" + names(tasks));
+        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Initialization".equals(t.getDisplayName())),
+                () -> "Missing Initialization task; got:\n" + names(tasks));
+        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Parsing".equals(t.getDisplayName())),
+                () -> "Missing Parsing task; got:\n" + names(tasks));
+        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Compilation".equals(t.getDisplayName())),
+                () -> "Missing Compilation task; got:\n" + names(tasks));
+        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Model Generation".equals(t.getDisplayName())),
+                () -> "Missing Model Generation task; got:\n" + names(tasks));
         Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Test:")),
                 () -> "class-simple should not produce any Test tasks; got:\n" + names(tasks));
         Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Plan:")),
@@ -67,8 +75,14 @@ public class TestEMITTestSuiteBuilder
         MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "m2m-passing");
 
         MutableList<String> names = tasks.collect(DynamicTest::getDisplayName);
-        Assertions.assertTrue(names.contains("[m2m-passing] Initialization (Init, Parse & Compile)"),
-                () -> "Missing init task; got: " + names);
+        Assertions.assertTrue(names.contains("[m2m-passing] Initialization"),
+                () -> "Missing Initialization task; got: " + names);
+        Assertions.assertTrue(names.contains("[m2m-passing] Parsing"),
+                () -> "Missing Parsing task; got: " + names);
+        Assertions.assertTrue(names.contains("[m2m-passing] Compilation"),
+                () -> "Missing Compilation task; got: " + names);
+        Assertions.assertTrue(names.contains("[m2m-passing] Model Generation"),
+                () -> "Missing Model Generation task; got: " + names);
         Assertions.assertTrue(names.contains("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / johnSmith"),
                 () -> "Missing johnSmith test task; got: " + names);
         Assertions.assertTrue(names.contains("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / janeDoe"),
@@ -85,17 +99,101 @@ public class TestEMITTestSuiteBuilder
     }
 
     @Test
-    void compileFailureYieldsSingleFailingInitTask()
+    void modelGenerationYieldsInitPlusModelGenTask() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "model-generation");
+
+        Assertions.assertEquals(4, tasks.size(),
+                () -> "model-generation should yield exactly four tasks (Initialization, Parsing, Compilation, and Model Generation); got:\n" + names(tasks));
+        Assertions.assertEquals("[model-generation] Initialization", tasks.get(0).getDisplayName());
+        Assertions.assertEquals("[model-generation] Parsing", tasks.get(1).getDisplayName());
+        Assertions.assertEquals("[model-generation] Compilation", tasks.get(2).getDisplayName());
+        Assertions.assertEquals("[model-generation] Model Generation", tasks.get(3).getDisplayName());
+
+        for (DynamicTest task : tasks)
+        {
+            task.getExecutable().execute();
+        }
+    }
+
+    @Test
+    void fileGenerationYieldsInitPlusOneFileGenTask() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "file-generation");
+
+        MutableList<String> taskNames = tasks.collect(DynamicTest::getDisplayName);
+        Assertions.assertTrue(taskNames.contains("[file-generation] Initialization"),
+                () -> "Missing Initialization task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[file-generation] Parsing"),
+                () -> "Missing Parsing task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[file-generation] Compilation"),
+                () -> "Missing Compilation task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[file-generation] Model Generation"),
+                () -> "Missing Model Generation task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[file-generation] File Generation: demo::filegen::PersonFileGen"),
+                () -> "Missing File Generation task; got: " + taskNames);
+
+        int fileGenTasks = tasks.count(t -> t.getDisplayName().contains("] File Generation:"));
+        Assertions.assertEquals(1, fileGenTasks,
+                () -> "Expected exactly 1 File Generation task; got:\n" + taskNames);
+        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Artifact Generation:")),
+                () -> "file-generation should not produce any Artifact Generation tasks; got:\n" + taskNames);
+
+        for (DynamicTest task : tasks)
+        {
+            task.getExecutable().execute();
+        }
+    }
+
+    @Test
+    void artifactGenerationYieldsInitPlusOneArtifactTaskPerClass() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "artifact-generation");
+
+        MutableList<String> taskNames = tasks.collect(DynamicTest::getDisplayName);
+        Assertions.assertTrue(taskNames.contains("[artifact-generation] Initialization"),
+                () -> "Missing Initialization task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[artifact-generation] Parsing"),
+                () -> "Missing Parsing task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[artifact-generation] Compilation"),
+                () -> "Missing Compilation task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[artifact-generation] Model Generation"),
+                () -> "Missing Model Generation task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[artifact-generation] Artifact Generation: demo::artifactgen::Person (emit-demo-artifact)"),
+                () -> "Missing Person Artifact Generation task; got: " + taskNames);
+        Assertions.assertTrue(taskNames.contains("[artifact-generation] Artifact Generation: demo::artifactgen::Firm (emit-demo-artifact)"),
+                () -> "Missing Firm Artifact Generation task; got: " + taskNames);
+
+        int artifactTasks = tasks.count(t -> t.getDisplayName().contains("] Artifact Generation:"));
+        Assertions.assertEquals(2, artifactTasks,
+                () -> "Expected exactly 2 Artifact Generation tasks; got:\n" + taskNames);
+        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] File Generation:")),
+                () -> "artifact-generation should not produce any File Generation tasks; got:\n" + taskNames);
+
+        for (DynamicTest task : tasks)
+        {
+            task.getExecutable().execute();
+        }
+    }
+
+    @Test
+    void compileFailureYieldsFailingCompilationTask() throws Throwable
     {
         List<DynamicTest> tasks = EMITTestSuiteBuilder.taskList("emit-models-failure/");
 
-        Assertions.assertEquals(1, tasks.size(),
-                () -> "compile-failure should yield exactly one task (failing Init); got:\n" + names(tasks));
-        DynamicTest only = tasks.get(0);
-        Assertions.assertEquals("[compile-failure] Initialization (Init, Parse & Compile)", only.getDisplayName());
+        Assertions.assertEquals(3, tasks.size(),
+                () -> "compile-failure should yield exactly three tasks (Initialization, Parsing, failing Compilation); got:\n" + names(tasks));
+        Assertions.assertEquals("[compile-failure] Initialization", tasks.get(0).getDisplayName());
+        Assertions.assertEquals("[compile-failure] Parsing", tasks.get(1).getDisplayName());
+        Assertions.assertEquals("[compile-failure] Compilation", tasks.get(2).getDisplayName());
 
-        EMITAssertionError thrown = Assertions.assertThrows(EMITAssertionError.class, () -> only.getExecutable().execute(),
-                "Expected the init task to throw because the model fails to compile");
+        // Initialization and Parsing must pass; Compilation is where the failure surfaces.
+        tasks.get(0).getExecutable().execute();
+        tasks.get(1).getExecutable().execute();
+
+        DynamicTest compilation = tasks.get(2);
+        EMITAssertionError thrown = Assertions.assertThrows(EMITAssertionError.class, () -> compilation.getExecutable().execute(),
+                "Expected the Compilation task to throw because the model fails to compile");
         Assertions.assertEquals("FAILURE [Compilation]: COMPILATION error at model.pure[20:12-29]: Can't find type 'demo::DoesNotExist'", thrown.getMessage());
         Assertions.assertInstanceOf(EngineException.class, thrown.getCause());
         Assertions.assertSame(EngineErrorType.COMPILATION, ((EngineException) thrown.getCause()).getErrorType());

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoArtifactGenerationExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoArtifactGenerationExtension.java
@@ -1,0 +1,58 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.junit.extensions;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+
+import java.util.List;
+
+/**
+ * Test-only {@link ArtifactGenerationExtension} used by the EMIT JUnit
+ * integration self-tests to exercise the per-element artifact generation
+ * task emitted by {@link org.finos.legend.engine.test.emit.junit.EMITTestSuiteBuilder}.
+ * Restricted to elements under {@code demo::artifactgen::} so it does not
+ * accidentally fire on classes from other test fixtures.
+ */
+public class EmitDemoArtifactGenerationExtension implements ArtifactGenerationExtension
+{
+    public static final String KEY = "emit-demo-artifact";
+    public static final String PACKAGE_PREFIX = "demo::artifactgen::";
+
+    @Override
+    public String getKey()
+    {
+        return KEY;
+    }
+
+    @Override
+    public boolean canGenerate(PackageableElement element)
+    {
+        String path = org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(element);
+        return path != null && path.startsWith(PACKAGE_PREFIX);
+    }
+
+    @Override
+    public List<Artifact> generate(PackageableElement element, PureModel pureModel, PureModelContextData data, String clientVersion)
+    {
+        String path = org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(element);
+        Artifact artifact = new Artifact("artifact-for:" + path, path.replace("::", "/") + ".artifact.txt", "text/plain");
+        return Lists.fixedSize.with(artifact);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoFileGenerationExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoFileGenerationExtension.java
@@ -1,0 +1,110 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.junit.extensions;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.external.shared.format.extension.GenerationExtension;
+import org.finos.legend.engine.external.shared.format.extension.GenerationMode;
+import org.finos.legend.engine.external.shared.format.generations.description.GenerationConfigurationDescription;
+import org.finos.legend.engine.external.shared.format.generations.description.GenerationProperty;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationConfiguration;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationConfiguration_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput_Impl;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test-only {@link GenerationExtension} used by the EMIT JUnit integration
+ * self-tests to exercise the per-spec "File Generation" task emitted by
+ * {@link org.finos.legend.engine.test.emit.junit.EMITTestSuiteBuilder}.
+ * Matches FileGenerationSpecifications written as {@code EmitDemoFile} in the
+ * grammar (the parser lowercases the first letter of the type identifier).
+ */
+public class EmitDemoFileGenerationExtension implements GenerationExtension
+{
+    public static final String KEY = "emitDemoFile";
+    public static final String GREETING_PROPERTY = "greeting";
+    public static final String DEFAULT_GREETING = "hello";
+
+    @Override
+    public String getLabel()
+    {
+        return "EMIT Demo File";
+    }
+
+    @Override
+    public String getKey()
+    {
+        return KEY;
+    }
+
+    @Override
+    public GenerationMode getMode()
+    {
+        return GenerationMode.Schema;
+    }
+
+    @Override
+    public GenerationConfigurationDescription getGenerationDescription()
+    {
+        return new GenerationConfigurationDescription()
+        {
+            @Override
+            public String getKey()
+            {
+                return KEY;
+            }
+
+            @Override
+            public List<GenerationProperty> getProperties(PureModel pureModel)
+            {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    @Override
+    public Root_meta_pure_generation_metamodel_GenerationConfiguration defaultConfig(CompileContext context)
+    {
+        return new Root_meta_pure_generation_metamodel_GenerationConfiguration_Impl("EmitDemoFileGenerationConfig", null, null);
+    }
+
+    @Override
+    public List<Root_meta_pure_generation_metamodel_GenerationOutput> generateFromElement(PackageableElement element, CompileContext compileContext)
+    {
+        if (!(element instanceof FileGenerationSpecification))
+        {
+            return null;
+        }
+        FileGenerationSpecification spec = (FileGenerationSpecification) element;
+        String greeting = (spec.configurationProperties == null)
+                          ? DEFAULT_GREETING
+                          : ListIterate.detectOptional(spec.configurationProperties, p -> GREETING_PROPERTY.equals(p.name) && (p.value instanceof String))
+                            .map(p -> (String) p.value)
+                            .orElse(DEFAULT_GREETING);
+        Root_meta_pure_generation_metamodel_GenerationOutput output = new Root_meta_pure_generation_metamodel_GenerationOutput_Impl("emit-demo-output", null, null);
+        output._fileName(spec.getPath() + ".txt");
+        output._content(greeting + " from " + spec.getPath());
+        output._format("text/plain");
+        return Lists.fixedSize.with(output);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoModelGenerationCompilerExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoModelGenerationCompilerExtension.java
@@ -1,0 +1,77 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.junit.extensions;
+
+import org.eclipse.collections.api.block.function.Function3;
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
+import org.finos.legend.engine.language.pure.dsl.generation.compiler.toPureGraph.GenerationCompilerExtension;
+import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test-only {@link GenerationCompilerExtension} that resolves generation
+ * specification nodes for paths in the {@code demo::modelgen::} namespace by
+ * looking the element up directly in the compiled Pure model. Paired with
+ * {@link EmitDemoModelGenerationExtension}.
+ */
+public class EmitDemoModelGenerationCompilerExtension implements GenerationCompilerExtension
+{
+    public static final String PACKAGE_PREFIX = "demo::modelgen::";
+
+    @Override
+    public CompilerExtension build()
+    {
+        return new EmitDemoModelGenerationCompilerExtension();
+    }
+
+    @Override
+    public Iterable<? extends Processor<?>> getExtraProcessors()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Function3<String, SourceInformation, CompileContext, PackageableElement>> getExtraModelGenerationSpecificationResolvers()
+    {
+        return Lists.fixedSize.with((path, sourceInformation, context) ->
+        {
+            if ((path == null) || !path.startsWith(PACKAGE_PREFIX))
+            {
+                return null;
+            }
+            try
+            {
+                return context.resolveClass(path, sourceInformation);
+            }
+            catch (Exception ignore)
+            {
+                int lastColon = path.lastIndexOf(':');
+                String pkgName = (lastColon == -1) ? M3Paths.Root : path.substring(0, lastColon - 1);
+                String name = (lastColon == -1) ? path : path.substring(lastColon + 1);
+                return new Root_meta_pure_metamodel_type_Class_Impl<>(name, null, context.resolveClass(M3Paths.Class))
+                        ._name(name)
+                        ._package(context.pureModel.getOrCreatePackage(pkgName));
+            }
+        });
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoModelGenerationExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/extensions/EmitDemoModelGenerationExtension.java
@@ -1,0 +1,64 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.junit.extensions;
+
+import org.eclipse.collections.api.block.function.Function3;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ModelGenerationExtension;
+import org.finos.legend.engine.protocol.pure.m3.function.property.Property;
+import org.finos.legend.engine.protocol.pure.m3.multiplicity.Multiplicity;
+import org.finos.legend.engine.protocol.pure.m3.type.generics.GenericType;
+import org.finos.legend.engine.protocol.pure.m3.valuespecification.constant.PackageableType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test-only {@link ModelGenerationExtension} paired with
+ * {@link EmitDemoModelGenerationCompilerExtension}.
+ * For any Pure {@link Class} resolved by the companion compiler extension it
+ * generates a sibling {@code <name>Generated} class.
+ */
+public class EmitDemoModelGenerationExtension implements ModelGenerationExtension
+{
+    public static final String GENERATED_PACKAGE = "demo::modelgen::generated";
+    public static final String GENERATED_SUFFIX = "Generated";
+
+    @Override
+    public List<Function3<PackageableElement, CompileContext, String, PureModelContextData>> getPureModelContextDataGenerators()
+    {
+        return Collections.singletonList((element, context, clientVersion) ->
+        {
+            if (!(element instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class))
+            {
+                return null;
+            }
+
+            org.finos.legend.engine.protocol.pure.m3.type.Class cls = new org.finos.legend.engine.protocol.pure.m3.type.Class();
+            cls.name = element._name() + GENERATED_SUFFIX;
+            cls._package = GENERATED_PACKAGE;
+            Property property = new Property();
+            property.name = "generatedAt";
+            property.multiplicity = Multiplicity.PURE_ONE;
+            property.genericType = new GenericType(new PackageableType("String"));
+            cls.properties = Collections.singletonList(property);
+            return PureModelContextData.newBuilder()
+                    .withElement(cls)
+                    .build();
+        });
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.external.shared.format.extension.GenerationExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.external.shared.format.extension.GenerationExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.junit.extensions.EmitDemoFileGenerationExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.junit.extensions.EmitDemoModelGenerationCompilerExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.junit.extensions.EmitDemoArtifactGenerationExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ModelGenerationExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ModelGenerationExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.junit.extensions.EmitDemoModelGenerationExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models-failure/compile-failure.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models-failure/compile-failure.emit.yaml
@@ -2,8 +2,8 @@ name: compile-failure
 title: "Class Referencing an Undefined Type"
 description: |
   A Class whose property type does not exist. PARSE succeeds but COMPILE fails.
-  Used to verify that a compile failure surfaces as a single failing
-  Initialization (Init, Parse & Compile) DynamicTest.
+  Used to verify that a compile failure surfaces as a failing Compilation
+  DynamicTest (with Initialization and Parsing tasks passing before it).
 
 modelSources:
   model:

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/artifact-generation.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/artifact-generation.emit.yaml
@@ -1,0 +1,20 @@
+name: artifact-generation
+title: "Element-driven artifact generation"
+description: |
+  Exercises the JUnit integration's "Artifact Generation: <element> (<key>)"
+  tasks by declaring classes whose paths are picked up by
+  EmitDemoArtifactGenerationExtension (a test-only ArtifactGenerationExtension
+  SPI registered under src/test/resources/META-INF/services).
+
+modelSources:
+  model:
+    root: artifact-generation
+    files:
+      - model.pure
+
+features:
+  - class
+  - file-generation
+complexity: basic
+tags:
+  - artifact-generation

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/artifact-generation/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/artifact-generation/model.pure
@@ -1,0 +1,25 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::artifactgen::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}
+
+Class demo::artifactgen::Firm
+{
+  legalName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/file-generation.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/file-generation.emit.yaml
@@ -1,0 +1,20 @@
+name: file-generation
+title: "FileGenerationSpecification with custom GenerationExtension"
+description: |
+  Exercises the JUnit integration's "File Generation: <spec>" task by declaring
+  a FileGenerationSpecification whose type is handled by
+  EmitDemoFileGenerationExtension (a test-only GenerationExtension SPI
+  registered under src/test/resources/META-INF/services).
+
+modelSources:
+  model:
+    root: file-generation
+    files:
+      - model.pure
+
+features:
+  - class
+  - file-generation
+complexity: basic
+tags:
+  - file-generation

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/file-generation/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/file-generation/model.pure
@@ -1,0 +1,27 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::filegen::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}
+
+###FileGeneration
+EmitDemoFile demo::filegen::PersonFileGen
+{
+  scopeElements: [demo::filegen::Person];
+  greeting: 'hello';
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/model-generation.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/model-generation.emit.yaml
@@ -1,0 +1,22 @@
+name: model-generation
+title: "Model generation via GenerationSpecification"
+description: |
+  A model with a GenerationSpecification whose generationNodes reference a
+  class in the demo::modelgen:: namespace. The JUnit integration does not
+  itself run model generation (that is the EMITRunner's job), so the only
+  task emitted here is Initialization — the fixture exists to assert the
+  builder is well-behaved on models that declare a GenerationSpecification.
+
+modelSources:
+  model:
+    root: model-generation
+    files:
+      - model.pure
+
+features:
+  - class
+  - model-generation
+  - generation-specification
+complexity: basic
+tags:
+  - model-generation

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/model-generation/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/resources/emit-models/basic/model-generation/model.pure
@@ -1,0 +1,29 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::modelgen::Source
+{
+  name: String[1];
+}
+
+###GenerationSpecification
+GenerationSpecification demo::modelgen::Spec
+{
+  generationNodes: [
+    {
+      generationElement: demo::modelgen::Source;
+    }
+  ];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/pom.xml
@@ -33,6 +33,11 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
+        </dependency>
         <!-- PURE -->
 
         <!-- ENGINE -->

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITRunner.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITRunner.java
@@ -14,15 +14,23 @@
 
 package org.finos.legend.engine.test.emit;
 
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
+import org.finos.legend.engine.protocol.pure.m3.type.Class;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.engine.test.emit.EMITPhaseResult.Status;
+import org.finos.legend.engine.test.emit.EMITRunner.FileGenerationOutput;
 import org.finos.legend.engine.test.emit.error.EMITAssertionError;
+import org.finos.legend.engine.test.emit.extensions.EmitDemoArtifactGenerationExtension;
+import org.finos.legend.engine.test.emit.extensions.EmitDemoModelGenerationExtension;
 import org.finos.legend.engine.testable.model.RunTestsResult;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +39,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 
 public class TestEMITRunner
 {
@@ -151,6 +160,97 @@ public class TestEMITRunner
 
         // PLAN_GENERATION still runs (failure of TEST_EXECUTION does not short-circuit it).
         Assertions.assertEquals(Status.SKIPPED, result.getPhase(EMITPhase.PLAN_GENERATION).getStatus());
+    }
+
+    @Test
+    void modelGenerationProducesAdditionalElements()
+    {
+        Path emitYaml = resource("emit-models/basic/model-generation.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertTrue(result.isSuccess(), () -> "Expected EMIT run to succeed but got:\n" + result.getSummary());
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.COMPILE).getStatus());
+
+        EMITPhaseResult modelGenPhase = result.getPhase(EMITPhase.MODEL_GENERATION);
+        Assertions.assertEquals(Status.SUCCESS, modelGenPhase.getStatus(), () -> "Expected MODEL_GENERATION SUCCESS but got:\n" + result.getSummary());
+
+        PureModelContextData enriched = (PureModelContextData) modelGenPhase.getOutputs().get(0);
+        String generatedPath = EmitDemoModelGenerationExtension.GENERATED_PACKAGE + "::Source" + EmitDemoModelGenerationExtension.GENERATED_SUFFIX;
+        PackageableElement generated = enriched.getElements().stream().filter(e -> generatedPath.equals(e.getPath())).findFirst()
+                .orElseGet(() -> Assertions.fail(() -> "Generated element '" + generatedPath + "' missing from enriched PMCD; elements: "
+                        + enriched.getElements().stream().map(PackageableElement::getPath).reduce("", (l, r) -> l + " " + r)));
+        Assertions.assertInstanceOf(Class.class, generated);
+        Class generatedClass = (Class) generated;
+        Assertions.assertEquals(1, generatedClass.properties.size(), "Expected exactly one property on the generated class");
+        Assertions.assertEquals("generatedAt", generatedClass.properties.get(0).name);
+
+        // Original element must survive the merge.
+        Assertions.assertTrue(enriched.getElements().stream().anyMatch(e -> "demo::modelgen::Source".equals(e.getPath())), "Source element must remain in enriched PMCD");
+
+        // FILE_GENERATION runs because the artifact extension does not match this fixture's namespace.
+        Assertions.assertEquals(Status.SKIPPED, result.getPhase(EMITPhase.FILE_GENERATION).getStatus());
+    }
+
+    @Test
+    void fileGenerationProducesExpectedOutput()
+    {
+        Path emitYaml = resource("emit-models/basic/file-generation.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertTrue(result.isSuccess(), () -> "Expected EMIT run to succeed but got:\n" + result.getSummary());
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.COMPILE).getStatus());
+
+        EMITPhaseResult fileGenPhase = result.getPhase(EMITPhase.FILE_GENERATION);
+        Assertions.assertEquals(Status.SUCCESS, fileGenPhase.getStatus(), () -> "Expected FILE_GENERATION SUCCESS but got:\n" + result.getSummary());
+
+        FileGenerationOutput output = (FileGenerationOutput) fileGenPhase.getOutputs().get(0);
+        Map<String, List<Root_meta_pure_generation_metamodel_GenerationOutput>> bySpec = output.getBySpecification();
+        Assertions.assertEquals(1, bySpec.size(), "Expected exactly one FileGenerationSpecification to fire");
+        Assertions.assertTrue(bySpec.containsKey("demo::filegen::PersonFileGen"), () -> "Expected output keyed by demo::filegen::PersonFileGen but got: " + bySpec.keySet());
+
+        List<Root_meta_pure_generation_metamodel_GenerationOutput> outputs = bySpec.get("demo::filegen::PersonFileGen");
+        Assertions.assertEquals(1, outputs.size(), "Expected exactly one GenerationOutput from the fake extension");
+        Root_meta_pure_generation_metamodel_GenerationOutput genOutput = outputs.get(0);
+        Assertions.assertEquals("demo::filegen::PersonFileGen.txt", genOutput._fileName());
+        Assertions.assertEquals("hello from demo::filegen::PersonFileGen", genOutput._content());
+        Assertions.assertEquals("text/plain", genOutput._format());
+
+        // No ArtifactGenerationExtension should match this fixture's package.
+        Assertions.assertTrue(output.getByArtifactExtension().isEmpty(), () -> "Did not expect any artifact extensions to fire; got: " + output.getByArtifactExtension().keySet());
+    }
+
+    @Test
+    void artifactGenerationProducesExpectedArtifacts()
+    {
+        Path emitYaml = resource("emit-models/basic/artifact-generation.emit.yaml");
+
+        EMITResult result = new EMITRunner().runFromYaml(emitYaml);
+
+        Assertions.assertTrue(result.isSuccess(), () -> "Expected EMIT run to succeed but got:\n" + result.getSummary());
+        Assertions.assertEquals(Status.SUCCESS, result.getPhase(EMITPhase.COMPILE).getStatus());
+
+        EMITPhaseResult fileGenPhase = result.getPhase(EMITPhase.FILE_GENERATION);
+        Assertions.assertEquals(Status.SUCCESS, fileGenPhase.getStatus(), () -> "Expected FILE_GENERATION SUCCESS but got:\n" + result.getSummary());
+
+        FileGenerationOutput output = (FileGenerationOutput) fileGenPhase.getOutputs().get(0);
+        Assertions.assertTrue(output.getBySpecification().isEmpty(), "No FileGenerationSpecification should be present in this fixture");
+
+        Map<String, List<Artifact>> byExtension = output.getByArtifactExtension();
+        Assertions.assertEquals(1, byExtension.size(), () -> "Expected exactly one artifact extension to fire; got: " + byExtension.keySet());
+        List<Artifact> artifacts = byExtension.get(EmitDemoArtifactGenerationExtension.KEY);
+        Assertions.assertNotNull(artifacts, () -> "Expected artifacts under key '" + EmitDemoArtifactGenerationExtension.KEY + "' but found keys: " + byExtension.keySet());
+        Assertions.assertEquals(2, artifacts.size(), "Expected one artifact per primary class");
+
+        Artifact person = artifacts.stream().filter(a -> "demo/artifactgen/Person.artifact.txt".equals(a.path)).findFirst()
+                .orElseGet(() -> Assertions.fail("Did not find Person artifact; got: " + artifacts.stream().map(a -> a.path).reduce("", (l, r) -> l + " " + r)));
+        Assertions.assertEquals("artifact-for:demo::artifactgen::Person", person.content);
+        Assertions.assertEquals("text/plain", person.format);
+
+        Artifact firm = artifacts.stream().filter(a -> "demo/artifactgen/Firm.artifact.txt".equals(a.path)).findFirst()
+                .orElseGet(() -> Assertions.fail("Did not find Firm artifact; got: " + artifacts.stream().map(a -> a.path).reduce("", (l, r) -> l + " " + r)));
+        Assertions.assertEquals("artifact-for:demo::artifactgen::Firm", firm.content);
     }
 
     @Test

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoArtifactGenerationExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoArtifactGenerationExtension.java
@@ -1,0 +1,58 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.extensions;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+
+import java.util.List;
+
+/**
+ * Test-only {@link ArtifactGenerationExtension} used by the EMIT runner self-tests
+ * to exercise the per-element artifact generation flow inside
+ * {@link org.finos.legend.engine.test.emit.EMITPhase#FILE_GENERATION}.
+ * Restricted to elements under {@code demo::artifactgen::} so it does not
+ * accidentally fire on classes from other test fixtures.
+ */
+public class EmitDemoArtifactGenerationExtension implements ArtifactGenerationExtension
+{
+    public static final String KEY = "emit-demo-artifact";
+    public static final String PACKAGE_PREFIX = "demo::artifactgen::";
+
+    @Override
+    public String getKey()
+    {
+        return KEY;
+    }
+
+    @Override
+    public boolean canGenerate(PackageableElement element)
+    {
+        String path = org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(element);
+        return path != null && path.startsWith(PACKAGE_PREFIX);
+    }
+
+    @Override
+    public List<Artifact> generate(PackageableElement element, PureModel pureModel, PureModelContextData data, String clientVersion)
+    {
+        String path = org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(element);
+        Artifact artifact = new Artifact("artifact-for:" + path, path.replace("::", "/") + ".artifact.txt", "text/plain");
+        return Lists.fixedSize.with(artifact);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoFileGenerationExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoFileGenerationExtension.java
@@ -1,0 +1,109 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.extensions;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.external.shared.format.extension.GenerationExtension;
+import org.finos.legend.engine.external.shared.format.extension.GenerationMode;
+import org.finos.legend.engine.external.shared.format.generations.description.GenerationConfigurationDescription;
+import org.finos.legend.engine.external.shared.format.generations.description.GenerationProperty;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationConfiguration;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationConfiguration_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput;
+import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput_Impl;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test-only {@link GenerationExtension} used by the EMIT runner self-tests to
+ * exercise {@link org.finos.legend.engine.test.emit.EMITPhase#FILE_GENERATION}.
+ * Matches FileGenerationSpecifications written as {@code EmitDemoFile} in the
+ * grammar (the parser lowercases the first letter of the type identifier).
+ */
+public class EmitDemoFileGenerationExtension implements GenerationExtension
+{
+    public static final String KEY = "emitDemoFile";
+    public static final String GREETING_PROPERTY = "greeting";
+    public static final String DEFAULT_GREETING = "hello";
+
+    @Override
+    public String getLabel()
+    {
+        return "EMIT Demo File";
+    }
+
+    @Override
+    public String getKey()
+    {
+        return KEY;
+    }
+
+    @Override
+    public GenerationMode getMode()
+    {
+        return GenerationMode.Schema;
+    }
+
+    @Override
+    public GenerationConfigurationDescription getGenerationDescription()
+    {
+        return new GenerationConfigurationDescription()
+        {
+            @Override
+            public String getKey()
+            {
+                return KEY;
+            }
+
+            @Override
+            public List<GenerationProperty> getProperties(PureModel pureModel)
+            {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    @Override
+    public Root_meta_pure_generation_metamodel_GenerationConfiguration defaultConfig(CompileContext context)
+    {
+        return new Root_meta_pure_generation_metamodel_GenerationConfiguration_Impl("EmitDemoFileGenerationConfig", null, null);
+    }
+
+    @Override
+    public List<Root_meta_pure_generation_metamodel_GenerationOutput> generateFromElement(PackageableElement element, CompileContext compileContext)
+    {
+        if (!(element instanceof FileGenerationSpecification))
+        {
+            return null;
+        }
+        FileGenerationSpecification spec = (FileGenerationSpecification) element;
+        String greeting = (spec.configurationProperties == null)
+                          ? DEFAULT_GREETING
+                          : ListIterate.detectOptional(spec.configurationProperties, p -> GREETING_PROPERTY.equals(p.name) && (p.value instanceof String))
+                            .map(p -> (String) p.value)
+                            .orElse(DEFAULT_GREETING);
+        Root_meta_pure_generation_metamodel_GenerationOutput output = new Root_meta_pure_generation_metamodel_GenerationOutput_Impl("emit-demo-output", null, null);
+        output._fileName(spec.getPath() + ".txt");
+        output._content(greeting + " from " + spec.getPath());
+        output._format("text/plain");
+        return Lists.fixedSize.with(output);
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoModelGenerationCompilerExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoModelGenerationCompilerExtension.java
@@ -1,0 +1,78 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.extensions;
+
+import org.eclipse.collections.api.block.function.Function3;
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.Processor;
+import org.finos.legend.engine.language.pure.dsl.generation.compiler.toPureGraph.GenerationCompilerExtension;
+import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test-only {@link GenerationCompilerExtension} that resolves generation
+ * specification nodes for paths in the {@code demo::modelgen::} namespace by
+ * looking the element up directly in the compiled Pure model. Paired with
+ * {@link EmitDemoModelGenerationExtension} to exercise
+ * {@link org.finos.legend.engine.test.emit.EMITPhase#MODEL_GENERATION}.
+ */
+public class EmitDemoModelGenerationCompilerExtension implements GenerationCompilerExtension
+{
+    public static final String PACKAGE_PREFIX = "demo::modelgen::";
+
+    @Override
+    public CompilerExtension build()
+    {
+        return new EmitDemoModelGenerationCompilerExtension();
+    }
+
+    @Override
+    public Iterable<? extends Processor<?>> getExtraProcessors()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Function3<String, SourceInformation, CompileContext, PackageableElement>> getExtraModelGenerationSpecificationResolvers()
+    {
+        return Lists.fixedSize.with((path, sourceInformation, context) ->
+        {
+            if ((path == null) || !path.startsWith(PACKAGE_PREFIX))
+            {
+                return null;
+            }
+            try
+            {
+                return context.resolveClass(path, sourceInformation);
+            }
+            catch (Exception ignore)
+            {
+                int lastColon = path.lastIndexOf(':');
+                String pkgName = (lastColon == -1) ? M3Paths.Root : path.substring(0, lastColon - 1);
+                String name = (lastColon == -1) ? path : path.substring(lastColon + 1);
+                return new Root_meta_pure_metamodel_type_Class_Impl<>(name, null, context.resolveClass(M3Paths.Class))
+                        ._name(name)
+                        ._package(context.pureModel.getOrCreatePackage(pkgName));
+            }
+        });
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoModelGenerationExtension.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/extensions/EmitDemoModelGenerationExtension.java
@@ -1,0 +1,66 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.extensions;
+
+import org.eclipse.collections.api.block.function.Function3;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ModelGenerationExtension;
+import org.finos.legend.engine.protocol.pure.m3.function.property.Property;
+import org.finos.legend.engine.protocol.pure.m3.multiplicity.Multiplicity;
+import org.finos.legend.engine.protocol.pure.m3.type.generics.GenericType;
+import org.finos.legend.engine.protocol.pure.m3.valuespecification.constant.PackageableType;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test-only {@link ModelGenerationExtension} paired with
+ * {@link EmitDemoModelGenerationCompilerExtension} to exercise
+ * {@link org.finos.legend.engine.test.emit.EMITPhase#MODEL_GENERATION}.
+ * For any Pure {@link Class} resolved by the companion compiler extension it
+ * generates a sibling {@code <name>Generated} class so the test can assert
+ * the merged PMCD picked up the new element and a recompile succeeded.
+ */
+public class EmitDemoModelGenerationExtension implements ModelGenerationExtension
+{
+    public static final String GENERATED_PACKAGE = "demo::modelgen::generated";
+    public static final String GENERATED_SUFFIX = "Generated";
+
+    @Override
+    public List<Function3<PackageableElement, CompileContext, String, PureModelContextData>> getPureModelContextDataGenerators()
+    {
+        return Collections.singletonList((element, context, clientVersion) ->
+        {
+            if (!(element instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class))
+            {
+                return null;
+            }
+
+            org.finos.legend.engine.protocol.pure.m3.type.Class cls = new org.finos.legend.engine.protocol.pure.m3.type.Class();
+            cls.name = element._name() + GENERATED_SUFFIX;
+            cls._package = GENERATED_PACKAGE;
+            Property property = new Property();
+            property.name = "generatedAt";
+            property.multiplicity = Multiplicity.PURE_ONE;
+            property.genericType = new GenericType(new PackageableType("String"));
+            cls.properties = Collections.singletonList(property);
+            return PureModelContextData.newBuilder()
+                    .withElement(cls)
+                    .build();
+        });
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.external.shared.format.extension.GenerationExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.external.shared.format.extension.GenerationExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.extensions.EmitDemoFileGenerationExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.extensions.EmitDemoModelGenerationCompilerExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.extensions.EmitDemoArtifactGenerationExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ModelGenerationExtension
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ModelGenerationExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.test.emit.extensions.EmitDemoModelGenerationExtension

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/artifact-generation.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/artifact-generation.emit.yaml
@@ -1,0 +1,21 @@
+name: artifact-generation
+title: "Element-driven artifact generation"
+description: |
+  Exercises Phase 4b (FILE_GENERATION via ArtifactGenerationExtension) by
+  declaring classes whose paths are picked up by EmitDemoArtifactGenerationExtension
+  (a test-only ArtifactGenerationExtension SPI registered under
+  src/test/resources/META-INF/services). The fake extension produces one
+  deterministic Artifact per class so the test can assert exact content.
+
+modelSources:
+  model:
+    root: artifact-generation
+    files:
+      - model.pure
+
+features:
+  - class
+  - file-generation
+complexity: basic
+tags:
+  - artifact-generation

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/artifact-generation/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/artifact-generation/model.pure
@@ -1,0 +1,25 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::artifactgen::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}
+
+Class demo::artifactgen::Firm
+{
+  legalName: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/file-generation.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/file-generation.emit.yaml
@@ -1,0 +1,21 @@
+name: file-generation
+title: "FileGenerationSpecification with custom GenerationExtension"
+description: |
+  Exercises Phase 4a (FILE_GENERATION) by declaring a FileGenerationSpecification
+  whose type is handled by EmitDemoFileGenerationExtension (a test-only
+  GenerationExtension SPI registered under src/test/resources/META-INF/services).
+  The fake extension produces a single deterministic GenerationOutput so the
+  test can assert exact content.
+
+modelSources:
+  model:
+    root: file-generation
+    files:
+      - model.pure
+
+features:
+  - class
+  - file-generation
+complexity: basic
+tags:
+  - file-generation

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/file-generation/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/file-generation/model.pure
@@ -1,0 +1,27 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::filegen::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}
+
+###FileGeneration
+EmitDemoFile demo::filegen::PersonFileGen
+{
+  scopeElements: [demo::filegen::Person];
+  greeting: 'hello';
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/model-generation.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/model-generation.emit.yaml
@@ -1,0 +1,22 @@
+name: model-generation
+title: "Model generation via GenerationSpecification"
+description: |
+  Exercises Phase 3 (MODEL_GENERATION) with a GenerationSpecification whose
+  generationNodes reference a class in the demo::modelgen:: namespace.
+  EmitDemoModelGenerationCompilerExtension resolves the referenced element and
+  EmitDemoModelGenerationExtension produces a sibling generated class which
+  must be merged into the model and survive recompilation.
+
+modelSources:
+  model:
+    root: model-generation
+    files:
+      - model.pure
+
+features:
+  - class
+  - model-generation
+  - generation-specification
+complexity: basic
+tags:
+  - model-generation

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/model-generation/model.pure
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/basic/model-generation/model.pure
@@ -1,0 +1,29 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::modelgen::Source
+{
+  name: String[1];
+}
+
+###GenerationSpecification
+GenerationSpecification demo::modelgen::Spec
+{
+  generationNodes: [
+    {
+      generationElement: demo::modelgen::Source;
+    }
+  ];
+}


### PR DESCRIPTION
Update EMITTestSuiteBuilder to run model generations. Also, add generation tests for both EMITTestSuiteBuilder and EMITRunner.