### PR TITLE
Fix dsl-tds-java codegen against legend-pure platform_dsl_tds tests

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-tds-java/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-tds-java/pom.xml
@@ -91,6 +91,10 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-extension-compiled-dsl-tds</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-tds-grammar</artifactId>
         </dependency>
 


### PR DESCRIPTION
## Summary

- legend-pure PR finos/legend-pure#1268 adds `<<test.Test>>` functions to `platform_dsl_tds/tds.pure` that call the `stringToTDS` native.
- The engine module `legend-engine-pure-platform-dsl-tds-java` regenerates that Pure repo via `legend-pure-maven-generation-java`, but its codegen classpath lacked the compiled-mode binding for `stringToTDS` (lives in `legend-pure-runtime-java-extension-compiled-dsl-tds` as `TDSExtensionCompiled` / `StringToTDS`), so codegen failed with:
  ```
  stringToTDS_String_1__TDS_1_ Not supported yet
  ```
  See failed CI run https://github.com/finos/legend-engine/actions/runs/26036531275/job/76562298681.
- Fix: add the runtime extension as a dependency on the modular-generation module so its `CompiledExtension` SPI is loaded by the codegen plugin and `stringToTDS` resolves.
- The artifact is already a transitive runtime dep of higher-layer engine modules (`legend-engine-pure-code-compiled-core`, `legend-engine-pure-runtime-java-extension-compiled-functions-relation`, `legend-engine-xt-relationalStore-core-pure`, `legend-engine-xt-deephaven-pure`), so this introduces no new runtime exposure.

## Notes

- I originally tried `<generatePureTests>false</generatePureTests>` on the plugin config, but that is a no-op in modular mode: `JavaStandaloneLibraryGenerator.java:286` calls a 3-arg `Generate.generateJavaCodeForSources` overload that hardcodes `generatePureTests=true`. That looks like an upstream legend-pure bug worth fixing separately; out of scope here.

## Test plan

- [x] `mvn clean install -DskipTests -pl legend-engine-core/legend-engine-core-pure/legend-engine-pure-platform-modular-generation/legend-engine-pure-platform-dsl-tds-java -am -Dlegend.pure.version=<PR-1268-snapshot>` — BUILD SUCCESS.
- [x] Same against `legend-engine-pure-platform-java` and every sibling under `legend-engine-pure-platform-modular-generation/` — all BUILD SUCCESS.
- [ ] CI \"Build (Master + Docker Snapshot)\" against legend-pure PR #1268.