### PR TITLE
optional query param to exclude dq platform fields + sybase lpad

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
@@ -260,7 +260,7 @@ public class DataQualityExecute
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
     //@Prometheus(name = "data profile")
-    public Response profile(@Context HttpServletRequest request, DataQualityProfileInput dataQualityProfilingInput, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat") SerializationFormat format, @ApiParam(hidden = true) @Pac4JProfileManager() ProfileManager<CommonProfile> pm)
+    public Response profile(@Context HttpServletRequest request, DataQualityProfileInput dataQualityProfilingInput, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat") SerializationFormat format, @DefaultValue("true") @QueryParam("excludePlatformColumns") boolean excludePlatformColumns, @ApiParam(hidden = true) @Pac4JProfileManager() ProfileManager<CommonProfile> pm)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         Identity identity = Identity.makeIdentity(profiles);
@@ -268,7 +268,7 @@ public class DataQualityExecute
         try (Scope ignored = GlobalTracer.get().buildSpan("DataQuality - profiling: planGeneration").startActive(true))
         {
             PureModel pureModel = this.modelManager.loadModel(dataQualityProfilingInput.model, dataQualityProfilingInput.clientVersion, identity, null);
-            Result result = getDataProfile(request, pureModel, dataQualityProfilingInput, start, identity);
+            Result result = getDataProfile(request, pureModel, dataQualityProfilingInput, start, identity, excludePlatformColumns);
             return wrapInResponse(identity, format, start, result);
         }
         catch (Exception ex)
@@ -278,11 +278,11 @@ public class DataQualityExecute
         }
     }
 
-    private Result getDataProfile(HttpServletRequest request, PureModel pureModel, DataQualityProfileInput dataQualityProfilingInput, long start, Identity identity)
+    private Result getDataProfile(HttpServletRequest request, PureModel pureModel, DataQualityProfileInput dataQualityProfilingInput, long start, Identity identity, boolean excludePlatformColumns)
     {
         LOGGER.info(new LogInfo(identity.getName(), DataQualityLoggingEventType.DATAQUALITY_PROFILE_START).toString());
         // 2. call DQ PURE func to generate lambda
-        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction dqLambdaFunction =  DataQualityProfilingLambdaGenerator.generateLambda(pureModel, dataQualityProfilingInput.packagePath);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction dqLambdaFunction =  DataQualityProfilingLambdaGenerator.generateLambda(pureModel, dataQualityProfilingInput.packagePath, excludePlatformColumns);
         // 3. Generate Plan from the lambda generated in the previous step
         SingleExecutionPlan singleExecutionPlan = PlanGenerator.generateExecutionPlan(dqLambdaFunction, null, null, null, pureModel, dataQualityProfilingInput.clientVersion, PlanPlatform.JAVA, null, this.extensions.apply(pureModel), this.transformers);
         // 4. Execute plan
@@ -296,7 +296,7 @@ public class DataQualityExecute
     @Path("ruleSuggestions")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Produces(MediaType.APPLICATION_JSON)
-    public List<RelationValidation> ruleSuggestions(@Context HttpServletRequest request, DataQualityProfileInput dataQualityProfilingInput, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat") SerializationFormat format, @ApiParam(hidden = true) @Pac4JProfileManager() ProfileManager<CommonProfile> pm)
+    public List<RelationValidation> ruleSuggestions(@Context HttpServletRequest request, DataQualityProfileInput dataQualityProfilingInput, @DefaultValue(SerializationFormat.defaultFormatString) @QueryParam("serializationFormat") SerializationFormat format, @DefaultValue("true") @QueryParam("excludePlatformColumns") boolean excludePlatformColumns, @ApiParam(hidden = true) @Pac4JProfileManager() ProfileManager<CommonProfile> pm)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         Identity identity = Identity.makeIdentity(profiles);
@@ -306,7 +306,7 @@ public class DataQualityExecute
         PureModel pureModel = this.modelManager.loadModel(dataQualityProfilingInput.model, dataQualityProfilingInput.clientVersion, identity, null);
         Root_meta_external_dataquality_DataQualityRelationValidation validation = DataQualityProfilingLambdaGenerator.getDataQualityRelationValidation(pureModel, dataQualityProfilingInput.packagePath);
 
-        Result result = getDataProfile(request, pureModel, dataQualityProfilingInput, start, identity);
+        Result result = getDataProfile(request, pureModel, dataQualityProfilingInput, start, identity, excludePlatformColumns);
 
         RealizedRelationalResult realized = (RealizedRelationalResult) result.realizeInMemory();
 
@@ -637,6 +637,7 @@ public class DataQualityExecute
             DataQualitySampleValuesInput input,
             @DefaultValue(SerializationFormat.defaultFormatString)
             @QueryParam("serializationFormat") SerializationFormat format,
+            @DefaultValue("true") @QueryParam("excludePlatformColumns") boolean excludePlatformColumns,
             @ApiParam(hidden = true) @Pac4JProfileManager() ProfileManager<CommonProfile> pm,
             @Context UriInfo uriInfo)
     {
@@ -647,7 +648,7 @@ public class DataQualityExecute
         try (Scope ignored = GlobalTracer.get().buildSpan("DataQuality - sampleValues: execute").startActive(true))
         {
             PureModel pureModel = modelManager.loadModel(input.model, input.clientVersion, identity, null);
-            SingleExecutionPlan plan = generateSampleValuesPlan(pureModel, input);
+            SingleExecutionPlan plan = generateSampleValuesPlan(pureModel, input, excludePlatformColumns);
             Map<String, Object> params = buildParamMap(input.lambdaParameterValues);
             Response response = executePlan(request, identity, format, start, plan, params);
             if (response.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL))
@@ -664,7 +665,7 @@ public class DataQualityExecute
         }
     }
 
-    private SingleExecutionPlan generateSampleValuesPlan(PureModel pureModel, DataQualitySampleValuesInput input)
+    private SingleExecutionPlan generateSampleValuesPlan(PureModel pureModel, DataQualitySampleValuesInput input, boolean excludePlatformColumns)
     {
         if (input.query == null && input.functionPath == null)
         {
@@ -678,8 +679,8 @@ public class DataQualityExecute
         }
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> lambda =
                 input.query != null
-                        ? DataQualitySampleValuesLambdaGenerator.generateLambda(pureModel, input.query, input.maxNumberOfSampleValues)
-                        : DataQualitySampleValuesLambdaGenerator.generateLambda(pureModel, input.functionPath, input.maxNumberOfSampleValues);
+                        ? DataQualitySampleValuesLambdaGenerator.generateLambda(pureModel, input.query, input.maxNumberOfSampleValues, excludePlatformColumns)
+                        : DataQualitySampleValuesLambdaGenerator.generateLambda(pureModel, input.functionPath, input.maxNumberOfSampleValues, excludePlatformColumns);
         return PlanGenerator.generateExecutionPlan(
                 lambda, null, null, null, pureModel,
                 input.clientVersion, PlanPlatform.JAVA, null,

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityProfilingLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityProfilingLambdaGenerator.java
@@ -24,10 +24,10 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElem
 public class DataQualityProfilingLambdaGenerator
 {
 
-    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, String qualifiedPath)
+    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, String qualifiedPath, boolean excludePlatformColumns)
     {
         Root_meta_external_dataquality_DataQualityRelationValidation validation = getDataQualityRelationValidation(pureModel, qualifiedPath);
-        return generateDataProfileLambda(pureModel, validation);
+        return generateDataProfileLambda(pureModel, validation, excludePlatformColumns);
     }
 
     public static Root_meta_external_dataquality_DataQualityRelationValidation getDataQualityRelationValidation(PureModel pureModel, String qualifiedPath)
@@ -40,8 +40,8 @@ public class DataQualityProfilingLambdaGenerator
         throw new EngineException("The element at path '" + qualifiedPath + "' is not a DataQualityRelationValidation!", ExceptionCategory.USER_EXECUTION_ERROR);
     }
 
-    private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateDataProfileLambda(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationValidation packageableElement)
+    private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateDataProfileLambda(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationValidation packageableElement, boolean excludePlatformColumns)
     {
-        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataprofile.Root_meta_external_dataquality_dataprofile_getProfilingLambda_DataQualityRelationValidation_1__Boolean_1__LambdaFunction_1_(packageableElement, true,  pureModel.getExecutionSupport());
+        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataprofile.Root_meta_external_dataquality_dataprofile_getProfilingLambda_DataQualityRelationValidation_1__Boolean_1__Boolean_1__LambdaFunction_1_(packageableElement, true, excludePlatformColumns, pureModel.getExecutionSupport());
     }
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualitySampleValuesLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualitySampleValuesLambdaGenerator.java
@@ -31,10 +31,11 @@ public class DataQualitySampleValuesLambdaGenerator
     public static LambdaFunction<?> generateLambda(
             PureModel pureModel,
             org.finos.legend.engine.protocol.pure.m3.function.LambdaFunction query,
-            Integer maxNumberOfSampleValues)
+            Integer maxNumberOfSampleValues,
+            boolean excludePlatformColumns)
     {
         LambdaFunction<?> pureLambda = HelperValueSpecificationBuilder.buildLambda(query, pureModel.getContext());
-        return invokePure(pureModel, pureLambda, maxNumberOfSampleValues);
+        return invokePure(pureModel, pureLambda, maxNumberOfSampleValues, excludePlatformColumns);
     }
 
     /**
@@ -47,7 +48,8 @@ public class DataQualitySampleValuesLambdaGenerator
     public static LambdaFunction<?> generateLambda(
             PureModel pureModel,
             String functionPath,
-            Integer maxNumberOfSampleValues)
+            Integer maxNumberOfSampleValues,
+            boolean excludePlatformColumns)
     {
         PackageableElement element = pureModel.getPackageableElement(functionPath);
         if (!(element instanceof ConcreteFunctionDefinition))
@@ -63,24 +65,25 @@ public class DataQualitySampleValuesLambdaGenerator
         LambdaFunction<?> pureLambda = core_dataquality_generation_samplevalues
                 .Root_meta_external_dataquality_samplevalues_wrapFunctionDefinitionAsLambda_FunctionDefinition_1__LambdaFunction_1_(funcDef, pureModel.getExecutionSupport());
 
-        return invokePure(pureModel, pureLambda, maxNumberOfSampleValues);
+        return invokePure(pureModel, pureLambda, maxNumberOfSampleValues, excludePlatformColumns);
     }
 
     private static LambdaFunction<?> invokePure(
             PureModel pureModel,
             LambdaFunction<?> pureLambda,
-            Integer maxNumberOfSampleValues)
+            Integer maxNumberOfSampleValues,
+            boolean excludePlatformColumns)
     {
         if (maxNumberOfSampleValues != null)
         {
             return core_dataquality_generation_samplevalues
-                            .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Integer_1__Boolean_1__LambdaFunction_1_(
-                                    pureLambda, (long) maxNumberOfSampleValues, true, pureModel.getExecutionSupport());
+                            .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Integer_1__Boolean_1__Boolean_1__LambdaFunction_1_(
+                                    pureLambda, (long) maxNumberOfSampleValues, true, excludePlatformColumns, pureModel.getExecutionSupport());
         }
 
         // maxNumberOfSampleValues omitted — sensible default from within the PURE layer applies
         return core_dataquality_generation_samplevalues
-                        .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Boolean_1__LambdaFunction_1_(
-                                pureLambda, true, pureModel.getExecutionSupport());
+                        .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Boolean_1__Boolean_1__LambdaFunction_1_(
+                                pureLambda, true, excludePlatformColumns, pureModel.getExecutionSupport());
     }
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataprofile_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataprofile_test.pure
@@ -98,7 +98,7 @@ function meta::external::dataquality::tests::doTest(dq:String[1], expected:Funct
 {
   let dataqualityRelationValidation = $dq->loadDataQualityRelationValidation();
 
-  let actual = $dataqualityRelationValidation->getProfilingLambda($wrapWithFrom);
+  let actual = $dataqualityRelationValidation->getProfilingLambda($wrapWithFrom, true);
 
   let expectedPrevaled = if ($wrapWithFrom, | $expected->preval([]), | $expected);
   let actualPrevaled = if ($wrapWithFrom, | $actual->preval([]), | $actual);

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/samplevalues_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/samplevalues_test.pure
@@ -226,7 +226,7 @@ function <<test.Test>> meta::external::dataquality::tests::testSampleValuesDefau
   };
 
   // Use the 5-arg overload with no mapping/runtime to verify default limit of 20
-  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], 20, false);
+  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], 20, false, true);
 
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), false);
 }
@@ -349,6 +349,6 @@ function <<test.Test>> meta::external::dataquality::tests::testSampleValuesColum
 // ─── Test helper ──
 function meta::external::dataquality::tests::doSampleValuesTest(query: FunctionDefinition<Any>[1], expected: FunctionDefinition<Any>[1], maxNumberOfSampleValues: Integer[1]):Boolean[1]
 {
-  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], $maxNumberOfSampleValues, false);
+  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], $maxNumberOfSampleValues, false, true);
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), false);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataprofile.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataprofile.pure
@@ -23,7 +23,7 @@ import meta::external::dataquality::*;
 import meta::external::dataquality::dataprofile::*;
 import meta::pure::metamodel::relation::*;
 
-function meta::external::dataquality::dataprofile::getProfilingLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], wrapWithFrom:Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::dataprofile::getProfilingLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
 {
   assert($dqRelationValidation.query->isEndingWithFromFunction(), 'Query must end with a from in order to execute');
   let lambda = $dqRelationValidation.query->popTerminalFunctionExpression();
@@ -35,17 +35,17 @@ function meta::external::dataquality::dataprofile::getProfilingLambda(dqRelation
   assert($runtime->isEmpty() || $runtime->size() == 1, | 'multiple runtimes not supported');
   assert($mapping->isEmpty() || $mapping->size() == 1, | 'multiple mappings not supported');
 
-  getProfilingLambda($lambda, $mapping->first(), $runtime->first(), $wrapWithFrom);
+  getProfilingLambda($lambda, $mapping->first(), $runtime->first(), $wrapWithFrom, $excludePlatformCols);
 }
 
-function meta::external::dataquality::dataprofile::getProfilingLambda(l:LambdaFunction<Any>[1], mapping:Mapping[0..1], runtime:Any[0..1], wrapWithFrom:Boolean[1]):LambdaFunction<Any>[1]
+function meta::external::dataquality::dataprofile::getProfilingLambda(l:LambdaFunction<Any>[1], mapping:Mapping[0..1], runtime:Any[0..1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1]):LambdaFunction<Any>[1]
 {
   assert($l->functionReturnType().rawType->toOne()->subTypeOf(meta::pure::metamodel::relation::Relation), 'only relation functions supported');
 
   let relationType = $l.expressionSequence->evaluateAndDeactivate()->last().genericType.typeArguments.rawType->cast(@meta::pure::metamodel::relation::RelationType<Any>);
 
   let cte = var('cte', PureOne, $l->genericType());
-  let colsToExclude = getExcludedColumns();
+  let colsToExclude = getPlatformColumnsToExclude($excludePlatformCols);
 
   let queries = $relationType.columns->filter(c | !$colsToExclude->contains($c.name->toOne()))
     ->map(c |
@@ -194,7 +194,10 @@ function meta::external::dataquality::dataprofile::name(col:ProfileColumn[1]):St
   $col->value4Tag('doc', meta::pure::profiles::doc).value->toOne();
 }
 
-function meta::external::dataquality::dataprofile::getExcludedColumns(): String[*]
+function meta::external::dataquality::dataprofile::getPlatformColumnsToExclude(excludePlatformCols: Boolean[1]): String[*]
 {
-  getDQExtensions().excludedColumns->distinct();
+  if ($excludePlatformCols,
+    | getDQExtensions().platformColumns->distinct(),
+    | []
+  );
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality_extension.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality_extension.pure
@@ -16,7 +16,7 @@ import meta::external::dataquality::*;
 
 Class meta::external::dataquality::DQExtension
 {
-   excludedColumns:String[*];
+   platformColumns:String[*];
 }
 
 Profile meta::external::dataquality::dq

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataqualitysqlextension.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataqualitysqlextension.pure
@@ -42,7 +42,7 @@ function <<sql.Extension>> meta::external::dataquality::dataProfileCoreExtension
             v:ValueSpecification[1] | fail('invalid parameter to data_profile'); {|1};
           ]);
 
-          let profilingLambda = iv(getProfilingLambda($relationLambda, [], [], false));
+          let profilingLambda = iv(getProfilingLambda($relationLambda, [], [], false, true));
 
           sfe(eval_Function_1__V_m_, $profilingLambda);
           }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/samplevalues.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/samplevalues.pure
@@ -28,12 +28,12 @@ function meta::external::dataquality::samplevalues::wrapFunctionDefinitionAsLamb
   lambda($f->functionType(), $f.expressionSequence);
 }
 
-function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], wrapWithFrom: Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], wrapWithFrom: Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
 {
-  getSampleValuesLambda($lambda, 20, $wrapWithFrom);
+  getSampleValuesLambda($lambda, 20, $wrapWithFrom, $excludePlatformCols);
 }
 
-function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], maxNumberOfSampleValues: Integer[1], wrapWithFrom:Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], maxNumberOfSampleValues: Integer[1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
 {
   assert($lambda->functionReturnType().rawType->toOne()->subTypeOf(meta::pure::metamodel::relation::Relation), 'only relation functions supported');
   assert($lambda->isEndingWithFromFunction(), 'Query must end with a from in order to execute');
@@ -46,15 +46,15 @@ function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda
   assert($runtime->isEmpty() || $runtime->size() == 1, | 'multiple runtimes not supported');
   assert($mapping->isEmpty() || $mapping->size() == 1, | 'multiple mappings not supported');
 
-  getSampleValuesLambda($poppedLambda, $mapping->first(), $runtime->first(), $maxNumberOfSampleValues, $wrapWithFrom);
+  getSampleValuesLambda($poppedLambda, $mapping->first(), $runtime->first(), $maxNumberOfSampleValues, $wrapWithFrom, $excludePlatformCols);
 }
 
-function meta::external::dataquality::samplevalues::getSampleValuesLambda(l: LambdaFunction<Any>[1], mapping: Mapping[0..1], runtime: Any[0..1], maxNumberOfSampleValues: Integer[1], wrapWithFrom: Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::samplevalues::getSampleValuesLambda(l: LambdaFunction<Any>[1], mapping: Mapping[0..1], runtime: Any[0..1], maxNumberOfSampleValues: Integer[1], wrapWithFrom: Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
 {
   let relationType = $l.expressionSequence->evaluateAndDeactivate()->last().genericType.typeArguments.rawType->cast(@meta::pure::metamodel::relation::RelationType<Any>);
 
   let cte = var('cte', PureOne, $l->genericType());
-  let colsToExclude = meta::external::dataquality::dataprofile::getExcludedColumns();
+  let colsToExclude = meta::external::dataquality::dataprofile::getPlatformColumnsToExclude($excludePlatformCols);
 
   let queries = $relationType.columns->filter(c | !$colsToExclude->contains($c.name->toOne()))
     ->map(c |

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybase/legend-engine-xt-relationalStore-sybase-pure/src/main/resources/core_relational_sybase/relational/sqlQueryToString/sybaseASEExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybase/legend-engine-xt-relationalStore-sybase-pure/src/main/resources/core_relational_sybase/relational/sqlQueryToString/sybaseASEExtension.pure
@@ -50,6 +50,18 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::sybas
     dynaFnToSql('dateDiff',               $allStates,            ^ToSql(format='datediff(%s,%s,%s)', transform={p:String[*]|[$p->at(2)->replace('\'', '')->processDateDiffDurationUnitForSybase(),$p->at(0),$p->at(1)]})),
     dynaFnToSql('datePart',               $allStates,            ^ToSql(format='cast(%s as date)')),
     dynaFnToSql('isAlphaNumeric',         $allStates,            ^ToSql(format=likePatternWithoutEscape('%%%s%%'), transform={p:String[1]|$p->transformAlphaNumericParamsDefault()})),
+    dynaFnToSql('lpad',                   $allStates,            ^ToSql(format='case when char_length(%s) >= %s then substring(%s, 1, %s) else substring(replicate(%s, %s) + %s, char_length(replicate(%s, %s) + %s) - %s + 1, %s) end',
+                                                                        transform={p:String[2..*] |
+                                                                           let s = $p->at(0);
+                                                                           let n = $p->at(1);
+                                                                           let pad = if($p->size() == 2, | '\' \'', | $p->at(2));
+                                                                           [$s, $n, $s, $n, $pad, $n, $s, $pad, $n, $s, $n, $n];
+                                                                        })),
+    dynaFnToSql('rpad',                   $allStates,            ^ToSql(format='substring(%s + replicate(%s, %s), 1, %s)',
+                                                                        transform={p:String[2..*] |
+                                                                           let pad = if($p->size() == 2, | '\' \'', | $p->at(2));
+                                                                           [$p->at(0), $pad, $p->at(1), $p->at(1)];
+                                                                        })),
     dynaFnToSql('trim',                   $allStates,            ^ToSql(format='rtrim(ltrim(%s))'))
   ]->concatenate(getDynaFunctionToSqlCommonToBothSybases());
 }
@@ -126,7 +138,6 @@ function meta::relational::functions::sqlQueryToString::sybaseASE::getDynaFuncti
     dynaFnToSql('least',                  $allStates,            ^ToSql(format='%s', transform={p:String[*] | convertGreatestLeastToCaseStatement('<=', $p)})),
     dynaFnToSql('length',                 $allStates,            ^ToSql(format='char_length(%s)')),
     dynaFnToSql('log',                    $allStates,            ^ToSql(format='log(%s)')),
-    dynaFnToSql('lpad',                   $allStates,            ^ToSql(format='lpad(%s)', transform={p:String[2..*] | $p->concatenate(if ($p->size() == 2, | '\' \'', | []))->joinStrings(', ')})),
     dynaFnToSql('matches',                $allStates,            ^ToSql(format=regexpPattern('%s'), transform={p:String[2]|$p->transformRegexpParams()})),
     dynaFnToSql('md5',                    $allStates,            ^ToSql(format='hash(%s, \'MD5\')')),
     dynaFnToSql('minute',                 $allStates,            ^ToSql(format='datepart(MI, %s)')),
@@ -147,7 +158,6 @@ function meta::relational::functions::sqlQueryToString::sybaseASE::getDynaFuncti
     dynaFnToSql('rem',                    $allStates,            ^ToSql(format='%s %% %s')),
     dynaFnToSql('repeatString',           $allStates,            ^ToSql(format='replicate(%s, %s)')),
     dynaFnToSql('round',                  $allStates,            ^ToSql(format='round(%s, %s)', transform=transformRound_String_MANY__String_MANY_)),
-    dynaFnToSql('rpad',                   $allStates,            ^ToSql(format='rpad(%s)', transform={p:String[2..*] | $p->concatenate(if ($p->size() == 2, | '\' \'', | []))->joinStrings(', ')})),
     dynaFnToSql('second',                 $allStates,            ^ToSql(format='datepart(SS, %s)')),
     dynaFnToSql('sha1',                   $allStates,            ^ToSql(format='hash(%s, \'SHA1\')')),
     dynaFnToSql('sha256',                 $allStates,            ^ToSql(format='hash(%s, \'SHA256\')')),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/sqlQueryToString/sybaseIQExtension.pure
@@ -69,6 +69,18 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::sybas
     dynaFnToSql('datePart',               $allStates,            ^ToSql(format='date(%s)')),
     dynaFnToSql('endsWith',               $allStates,            ^ToSql(format=likePattern('%%%s'), transform={p:String[2]|$p->transformLikeParamsForSybaseIQ()})),
     dynaFnToSql('isAlphaNumeric',         $allStates,            ^ToSql(format=likePatternWithoutEscape('%%%s%%'), transform={p:String[1]|$p->transformAlphaNumericParamsForSybaseIQ()})),
+    dynaFnToSql('lpad',                   $allStates,            ^ToSql(format='case when char_length(%s) >= %s then substring(%s, 1, %s) else substring(repeat(%s, %s) + %s, char_length(repeat(%s, %s) + %s) - %s + 1, %s) end',
+                                                                        transform={p:String[2..*] |
+                                                                           let s = $p->at(0);
+                                                                           let n = $p->at(1);
+                                                                           let pad = if($p->size() == 2, | '\' \'', | $p->at(2));
+                                                                           [$s, $n, $s, $n, $pad, $n, $s, $pad, $n, $s, $n, $n];
+                                                                        })),
+    dynaFnToSql('rpad',                   $allStates,            ^ToSql(format='substring(%s + repeat(%s, %s), 1, %s)',
+                                                                        transform={p:String[2..*] |
+                                                                           let pad = if($p->size() == 2, | '\' \'', | $p->at(2));
+                                                                           [$p->at(0), $pad, $p->at(1), $p->at(1)];
+                                                                        })),
     dynaFnToSql('startsWith',             $allStates,            ^ToSql(format=likePattern('%s%%'), transform={p:String[2]|$p->transformLikeParamsForSybaseIQ()}))
   ]->concatenate(getDynaFunctionToSqlCommonToBothSybases());
 }


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

- optional query parameters to exclude dq platform fields defaulted to true
- change implementation of lpad and road in Sybase to ensure these functions work when doing cross store join:
    - a plain single store query against Sybase with lpad works (no temp table streaming, default fetch behaviour, IQ materialises the projection server side)
    - the same lpad inside a cross store join fails because the engine forces setfetchsize(100) and streams row by row to build the CSV and IQs cursor engine doesn't implement lpad in the driver being used 
