### PR TITLE
Skip platform_store_relational/tests/* in Test_Pure_Relational

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/test/java/org/finos/legend/pure/code/core/relational/Test_Pure_Relational.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/test/java/org/finos/legend/pure/code/core/relational/Test_Pure_Relational.java
@@ -16,6 +16,8 @@ package org.finos.legend.pure.code.core.relational;
 
 import junit.framework.TestSuite;
 import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
 import org.finos.legend.pure.m3.execution.test.TestCollection;
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
@@ -28,7 +30,7 @@ public class Test_Pure_Relational
         executionSupport.getConsole().disable();
         TestSuite suite = new TestSuite();
         //NOTE- we are not collecting parameterized test collection in meta::relational here
-        suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::relational", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
+        suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::relational", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport()) && !isPlatformStoreRelationalDbTest(ci)), executionSupport));
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::alloy::objectReference", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::alloy::service::execution", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::pure::lineage", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
@@ -42,5 +44,20 @@ public class Test_Pure_Relational
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::protocols::pure", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
 
         return suite;
+    }
+
+    // Pure-native tests under platform_store_relational/tests/ call executeInDb and need
+    // H2/DuckDB JDBC drivers at runtime. legend-pure's own runner has those drivers;
+    // engine test runners that collect under meta::relational do not. The tests are
+    // exercised by legend-pure-side TestPureDBFunction instead.
+    private static boolean isPlatformStoreRelationalDbTest(CoreInstance ci)
+    {
+        SourceInformation sourceInformation = ci.getSourceInformation();
+        if (sourceInformation == null)
+        {
+            return false;
+        }
+        String sourceId = sourceInformation.getSourceId();
+        return sourceId != null && sourceId.startsWith("/platform_store_relational/tests/");
     }
 }


### PR DESCRIPTION
## Summary

When the engine is built against legend-pure PR finos/legend-pure#1268, the
Pure-native tests added under `platform_store_relational/tests/*` get
collected by `Test_Pure_Relational` (which collects `meta::relational`
recursively) and error with `No suitable driver found for jdbc:duckdb:…` /
`cannot identify H2 driver major version` because this engine module
doesn't carry JDBC drivers on its test classpath.

Failing CI: https://github.com/finos/legend-engine/actions/runs/26120096650
(Test Module - relationalStore, 7 errors in Test_Pure_Relational).

Fix: extend the existing `satisfiesConditions` predicate on the
`collectTests(\"meta::relational\", …)` call to also exclude nodes whose
`SourceInformation.getSourceId()` starts with
`/platform_store_relational/tests/`. Pattern matches the existing
`TestCollection.buildPCTTestCollection` source-ID filter at
`legend-pure-m3-core .../TestCollection.java`.

The new tests stay exercised by legend-pure's own
`TestPureDBFunction` runner (ships H2 + duckdb_jdbc).

The parallel \"AfterPackage fan-out\" failures across many engine modules
(`Test_Pure_Relational_ConnectionEquality` ×N, `Test_Relational_UsingPureClientTestSuite`,
etc.) are addressed by a sub-package move in PR #1268 itself, not by
this engine change.

## Test plan

- [x] Legend-pure-side `TestPureDBFunction` surefire run: 8 new tests
      PASS, 2 `loadValues` `<<test.ToFix>>` correctly skipped.
- [ ] Engine CI run against legend-pure PR #1268 with this change:
      `Test_Pure_Relational` should report 0 errors related to
      `testCreateTempTable*` / `testExecuteInDb*` / `afterLoad_*`.