### PR TITLE
Skip platform_store_relational/tests/* in Test_Pure_Relational

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/test/java/org/finos/legend/pure/code/core/relational/Test_Pure_Relational.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/test/java/org/finos/legend/pure/code/core/relational/Test_Pure_Relational.java
@@ -16,6 +16,8 @@ package org.finos.legend.pure.code.core.relational;
 
 import junit.framework.TestSuite;
 import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
 import org.finos.legend.pure.m3.execution.test.TestCollection;
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
@@ -28,7 +30,7 @@ public class Test_Pure_Relational
         executionSupport.getConsole().disable();
         TestSuite suite = new TestSuite();
         //NOTE- we are not collecting parameterized test collection in meta::relational here
-        suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::relational", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
+        suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::relational", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport()) && !isPlatformStoreRelationalDbTest(ci)), executionSupport));
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::alloy::objectReference", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::alloy::service::execution", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::pure::lineage", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
@@ -42,5 +44,20 @@ public class Test_Pure_Relational
         suite.addTest(PureTestBuilderCompiled.buildSuite(TestCollection.collectTests("meta::protocols::pure", executionSupport.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())), executionSupport));
 
         return suite;
+    }
+
+    // Pure-native tests under platform_store_relational/tests/ call executeInDb and need
+    // H2/DuckDB JDBC drivers at runtime. legend-pure's own runner has those drivers;
+    // engine test runners that collect under meta::relational do not. The tests are
+    // exercised by legend-pure-side TestPureDBFunction instead.
+    private static boolean isPlatformStoreRelationalDbTest(CoreInstance ci)
+    {
+        SourceInformation sourceInformation = ci.getSourceInformation();
+        if (sourceInformation == null)
+        {
+            return false;
+        }
+        String sourceId = sourceInformation.getSourceId();
+        return sourceId != null && sourceId.startsWith("/platform_store_relational/tests/");
     }
 }


### PR DESCRIPTION
The Pure-native tests under platform_store_relational/tests/ (added by legend-pure PR finos/legend-pure#1268) call executeInDb and need H2/DuckDB JDBC drivers at runtime. They're declared in package meta::relational::tests, so Test_Pure_Relational's recursive collection from meta::relational picks them up. This engine module doesn't ship those JDBC drivers (it's not a DB-execution test harness), so the tests error with "No suitable driver" on every collection.

Filter them out via getSourceInformation().getSourceId().startsWith( "/platform_store_relational/tests/") in the predicate, matching the existing pattern in TestCollection.buildPCTTestCollection. The tests remain exercised by legend-pure's own TestPureDBFunction runner, which ships H2 + duckdb_jdbc.

The companion legend-pure PR 1268 also moves the AfterPackage hooks (afterLoad_duckdb/afterLoad_h2) into meta::relational::tests::loadValues, which addresses the parallel fan-out failures in
Test_Pure_Relational_ConnectionEquality and
Test_Relational_UsingPureClientTestSuite — those don't need an engine-side change because they only inherit the AfterPackage hooks through ancestor walking.

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
