### PR TITLE
Improvements to EMIT JUnit integration

### DIFF
--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITModelDiscovery.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITModelDiscovery.java
@@ -14,9 +14,6 @@
 
 package org.finos.legend.engine.test.emit.junit;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
@@ -24,7 +21,9 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -34,32 +33,59 @@ final class EMITModelDiscovery
     {
     }
 
-    static MutableList<Path> findEmitYamls(String classpathRoot)
+    static Path findEmitYaml(String classpathRoot, String name)
     {
-        if (classpathRoot == null || classpathRoot.isEmpty())
+        String normalizedRoot = normalizeRoot(classpathRoot);
+        ClassLoader classLoader = getClassLoader();
+        URL url = classLoader.getResource(normalizedRoot + "/" + name + ".emit.yaml");
+        if (url == null)
         {
-            throw new IllegalArgumentException("classpathRoot must be non-empty");
-        }
-        String normalised = classpathRoot.endsWith("/") ? classpathRoot.substring(0, classpathRoot.length() - 1) : classpathRoot;
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        if (classLoader == null)
-        {
-            classLoader = EMITModelDiscovery.class.getClassLoader();
+            return null;
         }
         try
         {
-            MutableList<Path> result = Lists.mutable.empty();
-            Enumeration<URL> urls = classLoader.getResources(normalised);
+            return Paths.get(url.toURI());
+        }
+        catch (URISyntaxException e)
+        {
+            throw new IllegalStateException("Invalid classpath URL: " + url, e);
+        }
+    }
+
+    static List<Path> findEmitYamls(String classpathRoot)
+    {
+        String normalizedRoot = normalizeRoot(classpathRoot);
+        ClassLoader classLoader = getClassLoader();
+        try
+        {
+            List<Path> result = new ArrayList<>();
+            Enumeration<URL> urls = classLoader.getResources(normalizedRoot);
             while (urls.hasMoreElements())
             {
                 walkRoot(urls.nextElement(), result::add);
             }
-            return result.sortThis();
+            result.sort(null);
+            return result;
         }
         catch (IOException e)
         {
             throw new UncheckedIOException("Failed to enumerate classpath resources under '" + classpathRoot + "'", e);
         }
+    }
+
+    private static String normalizeRoot(String classpathRoot)
+    {
+        if (classpathRoot == null || classpathRoot.isEmpty())
+        {
+            throw new IllegalArgumentException("classpathRoot must be non-empty");
+        }
+        return classpathRoot.endsWith("/") ? classpathRoot.substring(0, classpathRoot.length() - 1) : classpathRoot;
+    }
+
+    private static ClassLoader getClassLoader()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return (classLoader == null) ? EMITModelDiscovery.class.getClassLoader() : classLoader;
     }
 
     private static void walkRoot(URL url, Consumer<? super Path> consumer)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
@@ -14,10 +14,9 @@
 
 package org.finos.legend.engine.test.emit.junit;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
 import org.finos.legend.engine.test.emit.EMITModel;
 import org.finos.legend.engine.test.emit.EMITModelLoader;
 import org.finos.legend.engine.test.emit.EMITSourceSet;
@@ -25,12 +24,19 @@ import org.finos.legend.engine.test.emit.EMITTasks;
 import org.finos.legend.engine.test.emit.EMITTasks.ParseResult;
 import org.finos.legend.engine.test.emit.EMITTasks.TestCandidate;
 import org.finos.legend.engine.test.emit.error.EMITAssertionError;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.function.Executable;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * JUnit 5 integration for EMIT. Discovers {@code *.emit.yaml} files on the
@@ -55,9 +61,9 @@ import java.util.stream.Stream;
  * public class MyModuleEMITTestSuite
  * {
  *     @TestFactory
- *     Stream<DynamicTest> emit()
+ *     Stream<DynamicContainer> emit()
  *     {
- *         return EMITTestSuiteBuilder.taskStream("emit-models/");
+ *         return EMITTestSuiteBuilder.testContainers("emit-models/");
  *     }
  * }
  * }</pre>
@@ -69,32 +75,231 @@ public final class EMITTestSuiteBuilder
     }
 
     /**
-     * Discovers EMIT models under the given classpath root and returns a stream
-     * of dynamic tests covering every granular operation across every model.
+     * Discovers EMIT models under the given classpath root and returns a stream of dynamic tests covering every
+     * granular operation across every model. This is equivalent to calling {@link #testContainers} and flattening down
+     * to stream of tests (thus eliminating the containers).
      *
      * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
      *                      files will be located, e.g. {@code "emit-models/"}
+     * @return stream of DynamicTest
      */
+    public static Stream<DynamicTest> tests(String classpathRoot)
+    {
+        return testContainers(classpathRoot, true).flatMap(EMITTestSuiteBuilder::toTests);
+    }
+
+    /**
+     * Discovers the single named EMIT model under the given classpath root and returns a stream of dynamic tests
+     * covering its every granular operation. This is equivalent to {@link #testContainer(String, String)} flattened
+     * down to a stream of tests (thus eliminating the containers).
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param name          the location of the model's {@code *.emit.yaml}, relative to {@code classpathRoot} and
+     *                      without the {@code .emit.yaml} suffix, e.g. {@code "basic/class-simple"}
+     * @return stream of DynamicTest for the named model
+     * @throws IllegalArgumentException if no model with the given name is found under the root
+     */
+    public static Stream<DynamicTest> tests(String classpathRoot, String name)
+    {
+        return toTests(testContainer(classpathRoot, name, true, true));
+    }
+
+    /**
+     * Discovers the named EMIT models under the given classpath root and returns a stream of dynamic tests covering
+     * every granular operation across each named model, in the order the names are given.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param names         the locations of the models' {@code *.emit.yaml} files, each relative to
+     *                      {@code classpathRoot} and without the {@code .emit.yaml} suffix
+     * @return stream of DynamicTest across the named models
+     * @throws IllegalArgumentException if any named model is not found under the root
+     */
+    public static Stream<DynamicTest> tests(String classpathRoot, String... names)
+    {
+        return tests(classpathRoot, Arrays.stream(names));
+    }
+
+    /**
+     * Discovers the named EMIT models under the given classpath root and returns a stream of dynamic tests covering
+     * every granular operation across each named model, in iteration order.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param names         the locations of the models' {@code *.emit.yaml} files, each relative to
+     *                      {@code classpathRoot} and without the {@code .emit.yaml} suffix
+     * @return stream of DynamicTest across the named models
+     * @throws IllegalArgumentException if any named model is not found under the root
+     */
+    public static Stream<DynamicTest> tests(String classpathRoot, Iterable<? extends String> names)
+    {
+        return tests(classpathRoot, (names instanceof Collection) ? ((Collection<? extends String>) names).stream() : StreamSupport.stream(names.spliterator(), false));
+    }
+
+    /**
+     * Discovers the named EMIT models under the given classpath root and returns a stream of dynamic tests covering
+     * every granular operation across each named model, in stream order.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param names         the locations of the models' {@code *.emit.yaml} files, each relative to
+     *                      {@code classpathRoot} and without the {@code .emit.yaml} suffix
+     * @return stream of DynamicTest across the named models
+     * @throws IllegalArgumentException if any named model is not found under the root (thrown when the returned stream is consumed)
+     */
+    public static Stream<DynamicTest> tests(String classpathRoot, Stream<? extends String> names)
+    {
+        return testContainers(classpathRoot, names, true).flatMap(EMITTestSuiteBuilder::toTests);
+    }
+
+    /**
+     * Discovers EMIT models under the given classpath root and returns a stream of dynamic tests covering every
+     * granular operation across every model. The tests are grouped by model, then by phase.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @return stream of DynamicContainer
+     */
+    public static Stream<DynamicContainer> testContainers(String classpathRoot)
+    {
+        return testContainers(classpathRoot, false);
+    }
+
+    /**
+     * Discovers the single named EMIT model under the given classpath root and returns its {@link DynamicContainer},
+     * with the granular tasks grouped by model, then by phase.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param name          the location of the model's {@code *.emit.yaml}, relative to {@code classpathRoot} and
+     *                      without the {@code .emit.yaml} suffix, e.g. {@code "basic/class-simple"}
+     * @return the model's DynamicContainer, or {@code null} if no model with the given name is found under the root
+     */
+    public static DynamicContainer testContainer(String classpathRoot, String name)
+    {
+        return testContainer(classpathRoot, name, false, false);
+    }
+
+    /**
+     * Discovers the named EMIT models under the given classpath root and returns a stream of their
+     * {@link DynamicContainer}s (tasks grouped by model, then by phase), in the order the names are given.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param names         the locations of the models' {@code *.emit.yaml} files, each relative to
+     *                      {@code classpathRoot} and without the {@code .emit.yaml} suffix
+     * @return stream of DynamicContainer for the named models
+     * @throws IllegalArgumentException if any named model is not found under the root
+     */
+    public static Stream<DynamicContainer> testContainers(String classpathRoot, String... names)
+    {
+        return testContainers(classpathRoot, Arrays.stream(names));
+    }
+
+    /**
+     * Discovers the named EMIT models under the given classpath root and returns a stream of their
+     * {@link DynamicContainer}s (tasks grouped by model, then by phase), in iteration order.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param names         the locations of the models' {@code *.emit.yaml} files, each relative to
+     *                      {@code classpathRoot} and without the {@code .emit.yaml} suffix
+     * @return stream of DynamicContainer for the named models
+     * @throws IllegalArgumentException if any named model is not found under the root
+     */
+    public static Stream<DynamicContainer> testContainers(String classpathRoot, Iterable<? extends String> names)
+    {
+        return testContainers(classpathRoot, (names instanceof Collection) ? ((Collection<? extends String>) names).stream() : StreamSupport.stream(names.spliterator(), false));
+    }
+
+    /**
+     * Discovers the named EMIT models under the given classpath root and returns a stream of their
+     * {@link DynamicContainer}s (tasks grouped by model, then by phase), in stream order.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @param names         the locations of the models' {@code *.emit.yaml} files, each relative to
+     *                      {@code classpathRoot} and without the {@code .emit.yaml} suffix
+     * @return stream of DynamicContainer for the named models
+     * @throws IllegalArgumentException if any named model is not found under the root (thrown when the returned stream is consumed)
+     */
+    public static Stream<DynamicContainer> testContainers(String classpathRoot, Stream<? extends String> names)
+    {
+        return testContainers(classpathRoot, names, false);
+    }
+
+    /**
+     * Deprecated: use {@link #tests(String)} instead, or {@link #testContainers(String)} for better reporting structure.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @return list of DynamicTests
+     */
+    @Deprecated
     public static Stream<DynamicTest> taskStream(String classpathRoot)
     {
-        MutableList<Path> yamls = EMITModelDiscovery.findEmitYamls(classpathRoot);
-        EMITModelLoader loader = new EMITModelLoader();
-        return yamls.stream().flatMap(yaml -> tasksFor(yaml, loader).stream());
+        return tests(classpathRoot);
     }
 
+    /**
+     * Deprecated: use {@link #tests(String)} instead, or {@link #testContainers(String)} for better reporting structure.
+     *
+     * @param classpathRoot a directory on the classpath under which {@code *.emit.yaml}
+     *                      files will be located, e.g. {@code "emit-models/"}
+     * @return list of DynamicTests
+     */
+    @Deprecated
     public static List<DynamicTest> taskList(String classpathRoot)
     {
-        MutableList<Path> yamls = EMITModelDiscovery.findEmitYamls(classpathRoot);
-        EMITModelLoader loader = new EMITModelLoader();
-        return yamls.flatCollect(yaml -> tasksFor(yaml, loader));
+        return taskStream(classpathRoot).collect(Collectors.toList());
     }
 
-    private static List<DynamicTest> tasksFor(Path yaml, EMITModelLoader loader)
+    private static Stream<DynamicContainer> testContainers(String classpathRoot, boolean verboseNames)
+    {
+        List<Path> yamls = EMITModelDiscovery.findEmitYamls(classpathRoot);
+        EMITModelLoader loader = new EMITModelLoader();
+        return yamls.stream().map(yaml -> containerFor(yaml, loader, verboseNames));
+    }
+
+    private static Stream<DynamicContainer> testContainers(String classpathRoot, Stream<? extends String> names, boolean verboseNames)
+    {
+        EMITModelLoader loader = new EMITModelLoader();
+        return names.map(name -> testContainer(classpathRoot, name, loader, verboseNames, true));
+    }
+
+    private static DynamicContainer testContainer(String classpathRoot, String name, boolean verboseNames, boolean errorIfNotFound)
+    {
+        return testContainer(classpathRoot, name, new EMITModelLoader(), verboseNames, errorIfNotFound);
+    }
+
+    private static DynamicContainer testContainer(String classpathRoot, String name, EMITModelLoader loader, boolean verboseNames, boolean errorIfNotFound)
+    {
+        Path yaml = EMITModelDiscovery.findEmitYaml(classpathRoot, name);
+        if (yaml != null)
+        {
+            return containerFor(yaml, loader, verboseNames);
+        }
+        if (errorIfNotFound)
+        {
+            throw new IllegalArgumentException("Failed to find EMIT model '" + name + "' under classpath root '" + classpathRoot + "'");
+        }
+        return null;
+    }
+
+    private static Stream<DynamicTest> toTests(DynamicNode node)
+    {
+        return (node instanceof DynamicContainer) ? toTests((DynamicContainer) node) : Stream.of((DynamicTest) node);
+    }
+
+    private static Stream<DynamicTest> toTests(DynamicContainer container)
+    {
+        return container.getChildren().flatMap(EMITTestSuiteBuilder::toTests);
+    }
+
+    private static DynamicContainer containerFor(Path yaml, EMITModelLoader loader, boolean verboseNames)
     {
         String fallbackLabel = stripExtension(yaml.getFileName().toString());
-
-        MutableList<DynamicTest> tasks = Lists.mutable.empty();
-
         EMITSourceSet sourceSet;
         try
         {
@@ -102,87 +307,114 @@ public final class EMITTestSuiteBuilder
         }
         catch (Exception e)
         {
-            return tasks.with(failingTask(fallbackLabel, "Initialization", e));
+            return DynamicContainer.dynamicContainer(fallbackLabel, Stream.of(failingTask(e, verboseNames, fallbackLabel, "Load Model Descriptor")));
         }
         String label = (sourceSet.getDescriptor() != null && sourceSet.getDescriptor().getName() != null) ? sourceSet.getDescriptor().getName() : fallbackLabel;
-        tasks.add(passingTask(label, "Initialization"));
+
+        Stream.Builder<DynamicNode> builder = Stream.builder();
+        builder.add(passingTask(verboseNames, label, "Load Model Descriptor"));
+
+        EMITModel model = initializationTasks(verboseNames, label, sourceSet, builder);
+        if (model != null)
+        {
+            fileArtifactGenTasks(verboseNames, label, model, builder);
+            testTasks(verboseNames, label, model, builder);
+            servicePlanTasks(verboseNames, label, model, builder);
+        }
+        return DynamicContainer.dynamicContainer(label, builder.build());
+    }
+
+    private static EMITModel initializationTasks(boolean verboseNames, String label, EMITSourceSet sourceSet, Consumer<? super DynamicContainer> containerConsumer)
+    {
+        String containerName = "Initialization";
+        Stream.Builder<DynamicNode> builder = Stream.builder();
 
         ParseResult parseResult;
         try
         {
             parseResult = EMITTasks.parse(sourceSet);
-            tasks.add(passingTask(label, "Parsing"));
+            builder.add(passingTask(verboseNames, label, containerName, "Parsing"));
         }
         catch (EMITAssertionError | Exception e)
         {
-            return tasks.with(failingTask(label, "Parsing", e));
+            builder.add(failingTask(e, verboseNames, label, containerName, "Parsing"));
+            containerConsumer.accept(DynamicContainer.dynamicContainer(containerName, builder.build()));
+            return null;
         }
 
         PureModel pureModel;
         try
         {
             pureModel = EMITTasks.compile(parseResult.getPmcd());
-            tasks.add(passingTask(label, "Compilation"));
+            builder.add(passingTask(verboseNames, label, containerName, "Compilation"));
         }
         catch (EMITAssertionError | Exception e)
         {
-            return tasks.with(failingTask(label, "Compilation", e));
+            builder.add(failingTask(e, verboseNames, label, containerName, "Compilation"));
+            containerConsumer.accept(DynamicContainer.dynamicContainer(containerName, builder.build()));
+            return null;
         }
 
-        EMITModel coreModel = new EMITModel(sourceSet, parseResult.getPmcd(), pureModel, parseResult.getPrimarySourceIds());
+        EMITModel model = new EMITModel(sourceSet, parseResult.getPmcd(), pureModel, parseResult.getPrimarySourceIds());
         EMITTasks.ModelGenResult modelGenResult;
         try
         {
-            modelGenResult = EMITTasks.runModelGeneration(coreModel);
-            tasks.add(passingTask(label, "Model Generation"));
+            modelGenResult = EMITTasks.runModelGeneration(model);
+            builder.add(passingTask(verboseNames, label, containerName, "Model Generation"));
         }
         catch (EMITAssertionError | Exception e)
         {
             modelGenResult = null;
-            tasks.add(failingTask(label, "Model Generation", e));
+            builder.add(failingTask(e, verboseNames, label, containerName, "Model Generation"));
         }
-        EMITModel model = ((modelGenResult == null) || (modelGenResult.getNewModel() == null)) ? coreModel : modelGenResult.getNewModel();
+        containerConsumer.accept(DynamicContainer.dynamicContainer(containerName, builder.build()));
+        return ((modelGenResult == null) || (modelGenResult.getNewModel() == null)) ? model : modelGenResult.getNewModel();
+    }
 
-        ListIterate.collect(EMITTasks.findFileGenerationSpecs(model), spec ->
+    private static void fileArtifactGenTasks(boolean verboseNames, String label, EMITModel model, Consumer<? super DynamicContainer> containerConsumer)
+    {
+        List<FileGenerationSpecification> fileGenSpecs = EMITTasks.findFileGenerationSpecs(model);
+        List<EMITTasks.ArtifactCandidate> artifactCandidates = EMITTasks.findArtifactGenerationCandidates(model);
+        if (!(fileGenSpecs.isEmpty() && artifactCandidates.isEmpty()))
         {
-            String name = "File Generation: " + spec.getPath();
-            return test(label, name, () -> EMITTasks.runFileGeneration(spec, model.getPureModel()));
-        }, tasks);
+            Stream<DynamicNode> fileGenStream = fileGenSpecs.isEmpty() ? null : fileGenSpecs.stream().map(spec -> test(() -> EMITTasks.runFileGeneration(spec, model.getPureModel()), verboseNames, label, "File Generation", spec.getPath()));
+            Stream<DynamicNode> artGenStream = artifactCandidates.isEmpty() ? null : artifactCandidates.stream().map(candidate -> test(() -> EMITTasks.runArtifactGeneration(candidate.extension, candidate.pureElement, model.getPmcd(), model.getPureModel()), verboseNames, label, "Artifact Generation", candidate.elementPath + " (" + candidate.extension.getKey() + ")"));
+            containerConsumer.accept(DynamicContainer.dynamicContainer("File/Artifact Generation", (fileGenStream == null) ? artGenStream : ((artGenStream == null) ? fileGenStream : Stream.concat(fileGenStream, artGenStream))));
+        }
+    }
 
-        ListIterate.collect(EMITTasks.findArtifactGenerationCandidates(model), candidate ->
+    private static void testTasks(boolean verboseNames, String label, EMITModel model, Consumer<? super DynamicContainer> containerConsumer)
+    {
+        List<TestCandidate> testCandidates = EMITTasks.findTestCandidates(model);
+        List<EMITTasks.LegacyMappingTestCandidate> legacyMappingTestCandidates = EMITTasks.findLegacyMappingTestCandidates(model);
+        List<EMITTasks.LegacyServiceTestCandidate> legacyServiceTestCandidates = EMITTasks.findLegacyServiceTestCandidates(model);
+        if (!(testCandidates.isEmpty() && legacyMappingTestCandidates.isEmpty() && legacyServiceTestCandidates.isEmpty()))
         {
-            String name = "Artifact Generation: " + candidate.elementPath + " (" + candidate.extension.getKey() + ")";
-            return test(label, name, () -> EMITTasks.runArtifactGeneration(candidate.extension, candidate.pureElement, model.getPmcd(), model.getPureModel()));
-        }, tasks);
+            String containerName = "Test";
+            Stream<DynamicNode> testableStream = testCandidates.isEmpty() ? null : testCandidates.stream().map(candidate ->
+                    test(() -> assertTestPassed(model, candidate), verboseNames, label, containerName, candidate.testablePath + ((candidate.suiteId == null) ? "" : (" / " + candidate.suiteId)) + " / " + candidate.atomicTestId));
+            Stream<DynamicNode> legacyMappingTestStream = legacyMappingTestCandidates.isEmpty() ? null : legacyMappingTestCandidates.stream().map(candidate ->
+                    test(() -> EMITTasks.assertLegacyMappingTestPassed(EMITTasks.runLegacyMappingTest(candidate.mappingPath, candidate.test, model.getPureModel())), verboseNames, label, containerName, "Legacy Mapping Test", candidate.mappingPath + " / " + candidate.test.name));
+            Stream<DynamicNode> legacyServiceTestSteam = legacyServiceTestCandidates.isEmpty() ? null : legacyServiceTestCandidates.stream().map(candidate ->
+                    test(() -> EMITTasks.assertLegacyServiceTestPassed(EMITTasks.runLegacyServiceTest(candidate.service, model.getPmcd(), model.getPureModel())), verboseNames, label, containerName, "Legacy Service Test", candidate.servicePath));
+            Stream<DynamicNode> legacyTestStream = (legacyMappingTestStream == null)
+                                                   ? legacyServiceTestSteam
+                                                   : ((legacyServiceTestSteam == null) ? legacyMappingTestStream : Stream.concat(legacyMappingTestStream, legacyServiceTestSteam));
+            Stream<DynamicNode> testStream = (testableStream == null)
+                                             ? legacyTestStream
+                                             : (legacyTestStream == null) ? testableStream : Stream.concat(testableStream, legacyTestStream);
+            containerConsumer.accept(DynamicContainer.dynamicContainer(containerName, testStream));
+        }
+    }
 
-        ListIterate.collect(EMITTasks.findTestCandidates(model), candidate ->
+    private static void servicePlanTasks(boolean verboseNames, String label, EMITModel model, Consumer<? super DynamicContainer> containerConsumer)
+    {
+        List<Service> services = EMITTasks.findServices(model);
+        if (!services.isEmpty())
         {
-            String suitePart = (candidate.suiteId == null) ? "" : (" / " + candidate.suiteId);
-            String name = "Test: " + candidate.testablePath + suitePart + " / " + candidate.atomicTestId;
-            return test(label, name, () -> assertTestPassed(model, candidate));
-        }, tasks);
-
-        ListIterate.collect(EMITTasks.findServices(model), service ->
-        {
-            String name = "Plan: " + service.getPath();
-            return test(label, name, () -> EMITTasks.runPlan(service, model.getPureModel()));
-        }, tasks);
-
-        ListIterate.collect(EMITTasks.findLegacyMappingTestCandidates(model), candidate ->
-        {
-            String name = "Legacy Mapping Test: " + candidate.mappingPath + " / " + candidate.test.name;
-            return test(label, name, () -> EMITTasks.assertLegacyMappingTestPassed(
-                    EMITTasks.runLegacyMappingTest(candidate.mappingPath, candidate.test, model.getPureModel())));
-        }, tasks);
-
-        ListIterate.collect(EMITTasks.findLegacyServiceTestCandidates(model), candidate ->
-        {
-            String name = "Legacy Service Test: " + candidate.servicePath;
-            return test(label, name, () -> EMITTasks.assertLegacyServiceTestPassed(
-                    EMITTasks.runLegacyServiceTest(candidate.service, model.getPmcd(), model.getPureModel())));
-        }, tasks);
-
-        return tasks;
+            containerConsumer.accept(DynamicContainer.dynamicContainer("Service Plan Generation", services.stream()
+                    .map(service -> test(() -> EMITTasks.runPlan(service, model.getPureModel()), verboseNames, label, "Plan", service.getPath()))));
+        }
     }
 
     private static void assertTestPassed(EMITModel model, TestCandidate candidate)
@@ -190,30 +422,60 @@ public final class EMITTestSuiteBuilder
         EMITTasks.assertTestPassed(EMITTasks.runTest(candidate.testablePath, candidate.suiteId, candidate.atomicTestId, model.getPmcd(), model.getPureModel()));
     }
 
-    private static DynamicTest test(String label, String taskName, Executable executable)
+    private static DynamicTest test(Executable executable, boolean verboseName, String name, String... moreNames)
     {
-        return DynamicTest.dynamicTest(format(label, taskName), executable);
+        return DynamicTest.dynamicTest(format(verboseName, name, moreNames), executable);
     }
 
-    private static DynamicTest passingTask(String label, String taskName)
+    private static DynamicTest passingTask(boolean verboseName, String name, String... moreNames)
     {
-        return DynamicTest.dynamicTest(format(label, taskName), () ->
+        return DynamicTest.dynamicTest(format(verboseName, name, moreNames), () ->
         {
             // do nothing for pass
         });
     }
 
-    private static DynamicTest failingTask(String label, String taskName, Throwable failure)
+    private static DynamicTest failingTask(Throwable failure, boolean verboseName, String name, String... moreNames)
     {
-        return DynamicTest.dynamicTest(format(label, taskName), () ->
+        return DynamicTest.dynamicTest(format(verboseName, name, moreNames), () ->
         {
             throw failure;
         });
     }
 
-    private static String format(String label, String taskName)
+    private static String format(boolean verbose, String name, String... moreNames)
     {
-        return "[" + label + "] " + taskName;
+        int lastNameIndex = (moreNames == null) ? -1 : moreNames.length - 1;
+        if (lastNameIndex == -1)
+        {
+            return name;
+        }
+        String lastName = moreNames[lastNameIndex];
+        if (!verbose)
+        {
+            return lastName;
+        }
+        switch (lastNameIndex)
+        {
+            case 0:
+            {
+                return "[" + name + "] " + lastName;
+            }
+            case 1:
+            {
+                return "[" + name + "] " + moreNames[0] + ": " + lastName;
+            }
+            default:
+            {
+                StringBuilder sb = new StringBuilder().append("[").append(name).append("] ");
+                for (int i = 0; i < lastNameIndex; i++)
+                {
+                    sb.append(moreNames[i]).append(" / ");
+                }
+                sb.setLength(sb.length() - 3);
+                return sb.append(": ").append(lastName).toString();
+            }
+        }
     }
 
     private static String stripExtension(String fileName)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
@@ -21,173 +21,204 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.engine.test.emit.error.EMITAssertionError;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class TestEMITTestSuiteBuilder
 {
     @Test
-    void buildTasksDiscoversAllYamlsUnderRoot()
+    void discoversOneContainerPerModel()
     {
-        List<DynamicTest> tasks = EMITTestSuiteBuilder.taskList("emit-models/");
+        MutableList<String> modelNames = Lists.mutable.fromStream(EMITTestSuiteBuilder.testContainers("emit-models/").map(DynamicNode::getDisplayName)).sortThis();
 
-        // An Initialization task is added for every discovered yaml regardless of whether
-        // its downstream phases succeed, so it is the most accurate per-model marker.
-        int initTasks = ListIterate.count(tasks, t -> t.getDisplayName().endsWith("] Initialization"));
-        Assertions.assertEquals(5, initTasks,
-                () -> "Expected one Initialization task per discovered model (artifact-generation, class-simple, file-generation, m2m-passing, model-generation); got names:\n" + names(tasks));
+        // Every discovered yaml becomes exactly one top-level container, named after the model.
+        Assertions.assertEquals(
+                Lists.fixedSize.with("artifact-generation", "class-simple", "file-generation", "m2m-passing", "model-generation"),
+                modelNames,
+                () -> "Expected one container per discovered model (artifact-generation, class-simple, file-generation, m2m-passing, model-generation); got: " + modelNames);
     }
 
     @Test
-    void classSimpleYieldsOnlyAnInitTask() throws Throwable
+    void testContainerGroupsByPhase() throws Throwable
     {
-        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "class-simple");
+        // m2m-passing has both an Initialization phase and a Test phase, so it exercises grouping well.
+        // A model is named by the location of its yaml relative to the root, without the .emit.yaml suffix.
+        DynamicContainer container = EMITTestSuiteBuilder.testContainer("emit-models/", "basic/m2m-passing");
+        Assertions.assertNotNull(container, "expected to find the m2m-passing model");
+        Assertions.assertEquals("m2m-passing", container.getDisplayName(), "container should be named after the model descriptor");
 
-        // class-simple has no Testable elements and no Services; the only mandatory
-        // task is Initialization. Artifact generators registered on the classpath
-        // could in principle yield additional Artifact Generation tasks for the
-        // demo::Person class — assert the init task exists, and assert the
-        // ones that do exist all execute successfully.
-        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Initialization".equals(t.getDisplayName())),
-                () -> "Missing Initialization task; got:\n" + names(tasks));
-        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Parsing".equals(t.getDisplayName())),
-                () -> "Missing Parsing task; got:\n" + names(tasks));
-        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Compilation".equals(t.getDisplayName())),
-                () -> "Missing Compilation task; got:\n" + names(tasks));
-        Assertions.assertTrue(tasks.anySatisfy(t -> "[class-simple] Model Generation".equals(t.getDisplayName())),
-                () -> "Missing Model Generation task; got:\n" + names(tasks));
-        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Test:")),
-                () -> "class-simple should not produce any Test tasks; got:\n" + names(tasks));
-        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Plan:")),
-                () -> "class-simple should not produce any Plan tasks; got:\n" + names(tasks));
-        for (DynamicTest task : tasks)
-        {
-            task.getExecutable().execute();
-        }
+        MutableList<DynamicNode> children = childrenOf(container);
+        MutableList<String> childNames = children.collect(DynamicNode::getDisplayName);
+        Assertions.assertEquals(
+                Lists.mutable.with("Load Model Descriptor", "Initialization", "Test"),
+                childNames,
+                () -> "Expected the model container to group into 'Load Model Descriptor', 'Initialization' and 'Test'; got: " + childNames);
+
+        // The Initialization phase nests the parse/compile/model-generation tasks.
+        DynamicContainer initialization = (DynamicContainer) children.detect(n -> (n instanceof DynamicContainer) && "Initialization".equals(n.getDisplayName()));
+        MutableList<DynamicNode> initChildren = childrenOf(initialization);
+        Assertions.assertEquals(
+                Lists.mutable.with("Parsing", "Compilation", "Model Generation"),
+                initChildren.collect(DynamicNode::getDisplayName),
+                "Initialization container should hold Parsing, Compilation and Model Generation, in order");
+
+        // The Test phase nests one task per atomic test; running them exercises the model end-to-end.
+        DynamicContainer testPhase = (DynamicContainer) children.detect(n -> (n instanceof DynamicContainer) && "Test".equals(n.getDisplayName()));
+        MutableList<DynamicNode> testChildren = childrenOf(testPhase);
+        Assertions.assertEquals(
+                Lists.mutable.with("demo::PersonM2MMapping / fullNameSuite / johnSmith", "demo::PersonM2MMapping / fullNameSuite / janeDoe"),
+                testChildren.collect(DynamicNode::getDisplayName),
+                "Test container should hold one task per atomic test");
+        executeAll(initChildren);
+        executeAll(testChildren);
     }
 
     @Test
-    void m2mPassingYieldsInitPlusOneTaskPerAtomicTest() throws Throwable
+    void testContainerReturnsNullForUnknownModel()
     {
-        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "m2m-passing");
-
-        MutableList<String> names = tasks.collect(DynamicTest::getDisplayName);
-        Assertions.assertTrue(names.contains("[m2m-passing] Initialization"),
-                () -> "Missing Initialization task; got: " + names);
-        Assertions.assertTrue(names.contains("[m2m-passing] Parsing"),
-                () -> "Missing Parsing task; got: " + names);
-        Assertions.assertTrue(names.contains("[m2m-passing] Compilation"),
-                () -> "Missing Compilation task; got: " + names);
-        Assertions.assertTrue(names.contains("[m2m-passing] Model Generation"),
-                () -> "Missing Model Generation task; got: " + names);
-        Assertions.assertTrue(names.contains("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / johnSmith"),
-                () -> "Missing johnSmith test task; got: " + names);
-        Assertions.assertTrue(names.contains("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / janeDoe"),
-                () -> "Missing janeDoe test task; got: " + names);
-
-        int testTasks = tasks.count(t -> t.getDisplayName().contains("] Test:"));
-        Assertions.assertEquals(2, testTasks,
-                () -> "Expected exactly 2 Test tasks for m2m-passing; got:\n" + names);
-
-        for (DynamicTest task : tasks)
-        {
-            task.getExecutable().execute();
-        }
+        Assertions.assertNull(EMITTestSuiteBuilder.testContainer("emit-models/", "basic/does-not-exist"),
+                "testContainer should return null when the named model is absent");
     }
 
     @Test
-    void modelGenerationYieldsInitPlusModelGenTask() throws Throwable
+    void testsForNamedModelMatchesFilteredDiscovery()
     {
-        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "model-generation");
+        // Looking a model up by name should yield exactly the same flattened tasks (and order) as
+        // discovering every model and filtering down to that one. This is the equivalence that lets
+        // the rest of these tests address a single model by name rather than filtering discovery.
+        MutableList<DynamicTest> named = tasksFor("emit-models/", "basic/m2m-passing");
+        MutableList<DynamicTest> filtered = Lists.mutable.fromStream(
+                EMITTestSuiteBuilder.tests("emit-models/").filter(t -> t.getDisplayName().startsWith("[m2m-passing] ")));
 
-        Assertions.assertEquals(4, tasks.size(),
-                () -> "model-generation should yield exactly four tasks (Initialization, Parsing, Compilation, and Model Generation); got:\n" + names(tasks));
-        Assertions.assertEquals("[model-generation] Initialization", tasks.get(0).getDisplayName());
-        Assertions.assertEquals("[model-generation] Parsing", tasks.get(1).getDisplayName());
-        Assertions.assertEquals("[model-generation] Compilation", tasks.get(2).getDisplayName());
-        Assertions.assertEquals("[model-generation] Model Generation", tasks.get(3).getDisplayName());
-
-        for (DynamicTest task : tasks)
-        {
-            task.getExecutable().execute();
-        }
+        Assertions.assertFalse(named.isEmpty(), "expected the named lookup to find m2m-passing");
+        Assertions.assertEquals(
+                filtered.collect(DynamicTest::getDisplayName),
+                named.collect(DynamicTest::getDisplayName),
+                "tests(root, name) should match the m2m-passing slice of full discovery");
     }
 
     @Test
-    void fileGenerationYieldsInitPlusOneFileGenTask() throws Throwable
+    void classSimpleYieldsOnlyTheInitializationPhase() throws Throwable
     {
-        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "file-generation");
+        MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/class-simple");
 
-        MutableList<String> taskNames = tasks.collect(DynamicTest::getDisplayName);
-        Assertions.assertTrue(taskNames.contains("[file-generation] Initialization"),
-                () -> "Missing Initialization task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[file-generation] Parsing"),
-                () -> "Missing Parsing task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[file-generation] Compilation"),
-                () -> "Missing Compilation task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[file-generation] Model Generation"),
-                () -> "Missing Model Generation task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[file-generation] File Generation: demo::filegen::PersonFileGen"),
-                () -> "Missing File Generation task; got: " + taskNames);
-
-        int fileGenTasks = tasks.count(t -> t.getDisplayName().contains("] File Generation:"));
-        Assertions.assertEquals(1, fileGenTasks,
-                () -> "Expected exactly 1 File Generation task; got:\n" + taskNames);
-        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] Artifact Generation:")),
-                () -> "file-generation should not produce any Artifact Generation tasks; got:\n" + taskNames);
-
-        for (DynamicTest task : tasks)
-        {
-            task.getExecutable().execute();
-        }
+        // class-simple has no Testable elements, no Services, and its demo::Person class is outside the
+        // demo::artifactgen:: package the test artifact generator fires on, so it yields exactly the
+        // descriptor load and the initialization phase — no Test, Plan, file- or artifact-generation tasks.
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[class-simple] Load Model Descriptor",
+                        "[class-simple] Initialization: Parsing",
+                        "[class-simple] Initialization: Compilation",
+                        "[class-simple] Initialization: Model Generation"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "class-simple should yield only the load + initialization-phase tasks; got:\n" + names(tasks));
+        executeAll(tasks);
     }
 
     @Test
-    void artifactGenerationYieldsInitPlusOneArtifactTaskPerClass() throws Throwable
+    void m2mPassingYieldsOneTaskPerAtomicTest() throws Throwable
     {
-        MutableList<DynamicTest> tasks = tasksForLabel("emit-models/", "artifact-generation");
+        MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/m2m-passing");
 
-        MutableList<String> taskNames = tasks.collect(DynamicTest::getDisplayName);
-        Assertions.assertTrue(taskNames.contains("[artifact-generation] Initialization"),
-                () -> "Missing Initialization task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[artifact-generation] Parsing"),
-                () -> "Missing Parsing task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[artifact-generation] Compilation"),
-                () -> "Missing Compilation task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[artifact-generation] Model Generation"),
-                () -> "Missing Model Generation task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[artifact-generation] Artifact Generation: demo::artifactgen::Person (emit-demo-artifact)"),
-                () -> "Missing Person Artifact Generation task; got: " + taskNames);
-        Assertions.assertTrue(taskNames.contains("[artifact-generation] Artifact Generation: demo::artifactgen::Firm (emit-demo-artifact)"),
-                () -> "Missing Firm Artifact Generation task; got: " + taskNames);
+        // The load + initialization phase, followed by one Test task per atomic test in the suite.
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[m2m-passing] Load Model Descriptor",
+                        "[m2m-passing] Initialization: Parsing",
+                        "[m2m-passing] Initialization: Compilation",
+                        "[m2m-passing] Initialization: Model Generation",
+                        "[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / johnSmith",
+                        "[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / janeDoe"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "m2m-passing should yield the load + init phase plus one task per atomic test; got:\n" + names(tasks));
 
-        int artifactTasks = tasks.count(t -> t.getDisplayName().contains("] Artifact Generation:"));
-        Assertions.assertEquals(2, artifactTasks,
-                () -> "Expected exactly 2 Artifact Generation tasks; got:\n" + taskNames);
-        Assertions.assertTrue(tasks.noneSatisfy(t -> t.getDisplayName().contains("] File Generation:")),
-                () -> "artifact-generation should not produce any File Generation tasks; got:\n" + taskNames);
+        executeAll(tasks);
+    }
 
-        for (DynamicTest task : tasks)
-        {
-            task.getExecutable().execute();
-        }
+    @Test
+    void modelGenerationYieldsOnlyTheInitializationPhase() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/model-generation");
+
+        // The JUnit integration does not itself run model generation, so a model that only declares
+        // a GenerationSpecification yields exactly the descriptor load plus the initialization phase.
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[model-generation] Load Model Descriptor",
+                        "[model-generation] Initialization: Parsing",
+                        "[model-generation] Initialization: Compilation",
+                        "[model-generation] Initialization: Model Generation"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "model-generation should yield only the load + initialization-phase tasks; got:\n" + names(tasks));
+
+        executeAll(tasks);
+    }
+
+    @Test
+    void fileGenerationYieldsOneFileGenTask() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/file-generation");
+
+        // The load + initialization phase, followed by exactly one file-generation task (and no
+        // artifact-generation task, since the model is outside the demo::artifactgen:: package).
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[file-generation] Load Model Descriptor",
+                        "[file-generation] Initialization: Parsing",
+                        "[file-generation] Initialization: Compilation",
+                        "[file-generation] Initialization: Model Generation",
+                        "[file-generation] File Generation: demo::filegen::PersonFileGen"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "file-generation should yield the load + init phase plus one file-generation task; got:\n" + names(tasks));
+
+        executeAll(tasks);
+    }
+
+    @Test
+    void artifactGenerationYieldsOneArtifactTaskPerClass() throws Throwable
+    {
+        MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/artifact-generation");
+
+        // The load + initialization phase, followed by one artifact-generation task per class (in
+        // model-definition order: Person then Firm), and no file-generation task.
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[artifact-generation] Load Model Descriptor",
+                        "[artifact-generation] Initialization: Parsing",
+                        "[artifact-generation] Initialization: Compilation",
+                        "[artifact-generation] Initialization: Model Generation",
+                        "[artifact-generation] Artifact Generation: demo::artifactgen::Person (emit-demo-artifact)",
+                        "[artifact-generation] Artifact Generation: demo::artifactgen::Firm (emit-demo-artifact)"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "artifact-generation should yield the load + init phase plus one artifact task per class; got:\n" + names(tasks));
+
+        executeAll(tasks);
     }
 
     @Test
     void compileFailureYieldsFailingCompilationTask() throws Throwable
     {
-        List<DynamicTest> tasks = EMITTestSuiteBuilder.taskList("emit-models-failure/");
+        MutableList<DynamicTest> tasks = tasksFor("emit-models-failure/", "compile-failure");
 
-        Assertions.assertEquals(3, tasks.size(),
-                () -> "compile-failure should yield exactly three tasks (Initialization, Parsing, failing Compilation); got:\n" + names(tasks));
-        Assertions.assertEquals("[compile-failure] Initialization", tasks.get(0).getDisplayName());
-        Assertions.assertEquals("[compile-failure] Parsing", tasks.get(1).getDisplayName());
-        Assertions.assertEquals("[compile-failure] Compilation", tasks.get(2).getDisplayName());
+        // PARSE succeeds but COMPILE fails, so initialization stops at Compilation and no later
+        // phases are emitted. The descriptor load and parse pass; compilation surfaces the failure.
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[compile-failure] Load Model Descriptor",
+                        "[compile-failure] Initialization: Parsing",
+                        "[compile-failure] Initialization: Compilation"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "compile-failure should yield exactly the load, parse and failing-compile tasks; got:\n" + names(tasks));
 
-        // Initialization and Parsing must pass; Compilation is where the failure surfaces.
+        // Load Model Descriptor and Parsing must pass; Compilation is where the failure surfaces.
         tasks.get(0).getExecutable().execute();
         tasks.get(1).getExecutable().execute();
 
@@ -200,17 +231,120 @@ public class TestEMITTestSuiteBuilder
     }
 
     @Test
-    void taskStreamEqualsTaskList()
+    void testsForNamedModelsPreservesGivenOrder() throws Throwable
     {
-        List<DynamicTest> listTasks = EMITTestSuiteBuilder.taskList("emit-models-failure/");
-        List<DynamicTest> streamTasks = EMITTestSuiteBuilder.taskStream("emit-models-failure/").collect(Collectors.toList());
-        Assertions.assertEquals(ListIterate.collect(listTasks, DynamicTest::getDisplayName), ListIterate.collect(streamTasks, DynamicTest::getDisplayName));
+        // The varargs overload concatenates the named models' tasks in the order requested.
+        MutableList<DynamicTest> tasks = Lists.mutable.fromStream(EMITTestSuiteBuilder.tests("emit-models/", "basic/model-generation", "basic/class-simple"));
+
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[model-generation] Load Model Descriptor",
+                        "[model-generation] Initialization: Parsing",
+                        "[model-generation] Initialization: Compilation",
+                        "[model-generation] Initialization: Model Generation",
+                        "[class-simple] Load Model Descriptor",
+                        "[class-simple] Initialization: Parsing",
+                        "[class-simple] Initialization: Compilation",
+                        "[class-simple] Initialization: Model Generation"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "tests(root, names...) should concatenate the named models' tasks in the order requested; got:\n" + names(tasks));
+        executeAll(tasks);
     }
 
-    private static MutableList<DynamicTest> tasksForLabel(String classpathRoot, String label)
+    @Test
+    void testContainersForNamedModelsPreservesGivenOrder()
     {
-        String prefix = "[" + label + "] ";
-        return Lists.mutable.fromStream(EMITTestSuiteBuilder.taskStream(classpathRoot).filter(t -> t.getDisplayName().startsWith(prefix)));
+        MutableList<String> names = Lists.mutable.fromStream(
+                EMITTestSuiteBuilder.testContainers("emit-models/", "basic/class-simple", "basic/model-generation").map(DynamicNode::getDisplayName));
+        Assertions.assertEquals(
+                Lists.mutable.with("class-simple", "model-generation"),
+                names,
+                "testContainers(root, names...) should return one container per name, in order");
+    }
+
+    @Test
+    void namedOverloadsAcceptIterables() throws Throwable
+    {
+        List<String> requested = Lists.mutable.with("basic/class-simple", "basic/model-generation");
+
+        MutableList<String> containerNames = Lists.mutable.fromStream(
+                EMITTestSuiteBuilder.testContainers("emit-models/", requested).map(DynamicNode::getDisplayName));
+        Assertions.assertEquals(Lists.mutable.with("class-simple", "model-generation"), containerNames,
+                "testContainers(root, Iterable) should return one container per name, in iteration order");
+
+        MutableList<DynamicTest> tasks = Lists.mutable.fromStream(EMITTestSuiteBuilder.tests("emit-models/", requested));
+        Assertions.assertEquals(
+                Lists.mutable.with(
+                        "[class-simple] Load Model Descriptor",
+                        "[class-simple] Initialization: Parsing",
+                        "[class-simple] Initialization: Compilation",
+                        "[class-simple] Initialization: Model Generation",
+                        "[model-generation] Load Model Descriptor",
+                        "[model-generation] Initialization: Parsing",
+                        "[model-generation] Initialization: Compilation",
+                        "[model-generation] Initialization: Model Generation"),
+                tasks.collect(DynamicTest::getDisplayName),
+                () -> "tests(root, Iterable) should yield the named models' tasks in iteration order; got:\n" + names(tasks));
+        executeAll(tasks);
+    }
+
+    @Test
+    void namedLookupThrowsForUnknownModel()
+    {
+        // tests(root, name) resolves the model eagerly, so a missing name throws on the call itself.
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EMITTestSuiteBuilder.tests("emit-models/", "basic/does-not-exist"),
+                "tests(root, name) should throw for an unknown model");
+
+        // The stream-producing overloads resolve lazily, so the failure surfaces on consumption.
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EMITTestSuiteBuilder.testContainers("emit-models/", "basic/does-not-exist").forEach(c ->
+                {
+                    // do nothing
+                }),
+                "testContainers(root, names...) should throw for an unknown model when consumed");
+    }
+
+    @Test
+    void deprecatedMethodsDelegateToTests()
+    {
+        // taskStream/taskList are retained only as deprecated shims over tests(...); confirm they
+        // still produce the same flattened sequence so existing callers are not broken.
+        List<String> viaTests = EMITTestSuiteBuilder.tests("emit-models-failure/").map(DynamicTest::getDisplayName).collect(Collectors.toList());
+        List<String> viaTaskStream = EMITTestSuiteBuilder.taskStream("emit-models-failure/").map(DynamicTest::getDisplayName).collect(Collectors.toList());
+        List<String> viaTaskList = ListIterate.collect(EMITTestSuiteBuilder.taskList("emit-models-failure/"), DynamicTest::getDisplayName);
+
+        Assertions.assertEquals(viaTests, viaTaskStream, "taskStream should delegate to tests");
+        Assertions.assertEquals(viaTests, viaTaskList, "taskList should delegate to tests");
+    }
+
+    private static MutableList<DynamicTest> tasksFor(String classpathRoot, String name)
+    {
+        return Lists.mutable.fromStream(EMITTestSuiteBuilder.tests(classpathRoot, name));
+    }
+
+    // DynamicContainer#getChildren may only be consumed once, so materialise it eagerly.
+    private static MutableList<DynamicNode> childrenOf(DynamicContainer container)
+    {
+        return Lists.mutable.fromStream(container.getChildren());
+    }
+
+    private static void executeAll(Iterable<? extends DynamicNode> nodes) throws Throwable
+    {
+        Deque<DynamicNode> deque = new ArrayDeque<>();
+        nodes.forEach(deque::addLast);
+        while (!deque.isEmpty())
+        {
+            DynamicNode node = deque.removeFirst();
+            if (node instanceof DynamicContainer)
+            {
+                ((DynamicContainer) node).getChildren().forEach(deque::addLast);
+            }
+            else
+            {
+                ((DynamicTest) node).getExecutable().execute();
+            }
+        }
     }
 
     private static String names(List<DynamicTest> tasks)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/java/org/finos/legend/engine/test/emit/relational/RelationalEMITTestSuite.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/java/org/finos/legend/engine/test/emit/relational/RelationalEMITTestSuite.java
@@ -15,7 +15,7 @@
 package org.finos.legend.engine.test.emit.relational;
 
 import org.finos.legend.engine.test.emit.junit.EMITTestSuiteBuilder;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.TestFactory;
 
 import java.util.stream.Stream;
@@ -29,8 +29,8 @@ import java.util.stream.Stream;
 public class RelationalEMITTestSuite
 {
     @TestFactory
-    Stream<DynamicTest> emit()
+    Stream<DynamicContainer> emit()
     {
-        return EMITTestSuiteBuilder.taskStream("emit-models/");
+        return EMITTestSuiteBuilder.testContainers("emit-models/");
     }
 }


### PR DESCRIPTION
Improvements to EMIT JUnit integration. Add methods for generating test containers, rather than just a flat list/stream of tests. Also, add methods for generating tests or test containers for a specific model or list of models.