### PR TITLE
DQ validation fixes for join bugs

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
@@ -2007,3 +2007,43 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testS
    );
 }
 
+function <<PCT.test>> meta::pure::functions::relation::tests::composition::testConcatenateWithJoinOnOneSide<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+   let expr = {|
+      let source = #TDS
+                      id, firstName, firmId
+                      1, Peter, 10
+                      2, John, 10
+                      3, Alice, 20
+                      4, Bob, 20
+                      5, Eve, 30
+                   #;
+      let firms = #TDS
+                     fId, legalName
+                     10, FirmA
+                     20, FirmB
+                     30, FirmC
+                  #;
+      // Left arm: join produces Alias columns (wrapping CTE's TableAliasColumn)
+      $source->filter(x | $x.id <= 4)
+         ->join($firms, JoinKind.LEFT, {a, b | $a.firmId == $b.fId})
+         ->select(~[id, firstName])
+      ->concatenate(
+         // Right arm: simple filter+select keeps TableAliasColumn from CTE reference
+         $source->filter(x | $x.id > 4)
+            ->select(~[id, firstName])
+      );
+   };
+
+   let res = $f->eval($expr);
+
+   assertEquals( '#TDS\n'+
+                 '   id,firstName\n'+
+                 '   1,Peter\n'+
+                 '   2,John\n'+
+                 '   3,Alice\n'+
+                 '   4,Bob\n'+
+                 '   5,Eve\n'+
+                 '#', $res->sort(~id->ascending())->toString());
+}
+

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -192,11 +192,11 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
     'validFirstName',
-    {|#>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
+    {|eval(|#>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
                                                     ->filter(row2|$row2.FIRSTNAME->meta::pure::functions::collection::isNotEmpty()->meta::pure::functions::boolean::not())
                                                     ->extend(~DQ_RULE_NAME: row | 'validFirstName')
                                                     ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()) + if($row.LASTNAME->isEmpty(), | '', |$row.LASTNAME->toOne()->toString()) + if($row.fullname->isEmpty(), | '', |$row.fullname->toOne()->toString()) + if($row.DQ_RULE_NAME->isEmpty(), | '', |$row.DQ_RULE_NAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
-                                                    ->extend(~DQ_DEFECT_ID: row | generateGuid())},
+                                                    ->extend(~DQ_DEFECT_ID: row | generateGuid()))},
     'meta::external::dataquality::tests::domain::DataQualityRuntime'
     )
 }
@@ -233,7 +233,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
 
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_parameterized_relationValidation_row_level():Boolean[1]
 {
-  doRelationTest(
+  doRelationTestExpectingEvalWrapper(
     '###DataQualityValidation' +
     '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
     '      {' +
@@ -274,12 +274,12 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
     'validFirstName',
-    {|#>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
+    {|eval(|#>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
                    ->filter(row2|$row2.FIRSTNAME->meta::pure::functions::collection::isNotEmpty()->meta::pure::functions::boolean::not())
                    ->extend(~DQ_RULE_NAME: row | 'validFirstName')
                    ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()) + if($row.LASTNAME->isEmpty(), | '', |$row.LASTNAME->toOne()->toString()) + if($row.fullname->isEmpty(), | '', |$row.fullname->toOne()->toString()) + if($row.DQ_RULE_NAME->isEmpty(), | '', |$row.DQ_RULE_NAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
                    ->extend(~DQ_DEFECT_ID: row | generateGuid())                   
-                   ->take(100)},
+                   ->take(100))},
     100,
     'meta::external::dataquality::tests::domain::DataQualityRuntime'
     )
@@ -324,9 +324,9 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
     'validFirstName',
-    {|#>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
+    {|eval(|#>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->extend(~fullname:x|[$x.FIRSTNAME->meta::pure::functions::multiplicity::toOne(), $x.LASTNAME->meta::pure::functions::multiplicity::toOne()]->joinStrings())
                                                     ->filter(row2|$row2.FIRSTNAME->meta::pure::functions::collection::isNotEmpty()->meta::pure::functions::boolean::not())
-                                                    },
+                                                    )},
     'meta::external::dataquality::tests::domain::DataQualityRuntime'
     )
 }
@@ -494,20 +494,20 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
           'nonEmptyDataset',
-          {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+          {|eval(|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
                     $rel->aggregate(~COUNT : x | 1 : y | $y->count())->filter(row|$row.COUNT == 0)
                         ->extend(~DQ_RULE_NAME: row | 'nonEmptyDataset')
                         ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.COUNT->isEmpty(), | '', |$row.COUNT->toOne()->toString()) + if($row.DQ_RULE_NAME->isEmpty(), | '', |$row.DQ_RULE_NAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
                         ->extend(~DQ_DEFECT_ID: row | generateGuid())
             }
-            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));},
+            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME])))},
             'meta::external::dataquality::tests::domain::DataQualityRuntime'        
     );
 }
 
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_relationValidation_withParametersInAssertion():Boolean[1]
 {
-  doRelationTest(
+  doRelationTestExpectingEvalWrapper(
     '###DataQualityValidation' +
     '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
     '      {' +
@@ -527,7 +527,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
                         ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()) + if($row.LASTNAME->isEmpty(), | '', |$row.LASTNAME->toOne()->toString()) + if($row.DQ_RULE_NAME->isEmpty(), | '', |$row.DQ_RULE_NAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
                         ->extend(~DQ_DEFECT_ID: row | generateGuid())
             }
-            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->filter(row|$row.AGE >= $age)->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));},
+            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->filter(row|$row.AGE >= $age)->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]))},
           'meta::external::dataquality::tests::domain::DataQualityRuntime'        
     );
 }
@@ -548,14 +548,14 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
           'firstNameMissing',
-          {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200), AGE:meta::pure::precisePrimitives::Int)>[1] |
+          {|eval(|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200), AGE:meta::pure::precisePrimitives::Int)>[1] |
                   $rel->filter(row|$row.FIRSTNAME->isEmpty())
                     ->select(~[FIRSTNAME,LASTNAME,AGE])
                     ->extend(~DQ_RULE_NAME: row | 'firstNameMissing')
                     ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()) + if($row.LASTNAME->isEmpty(), | '', |$row.LASTNAME->toOne()->toString()) + if($row.AGE->isEmpty(), | '', |$row.AGE->toOne()->toString()) + if($row.DQ_RULE_NAME->isEmpty(), | '', |$row.DQ_RULE_NAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
                     ->extend(~DQ_DEFECT_ID: row | generateGuid())}
                   ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME,AGE]))
-                  ->meta::pure::functions::relation::limit(100);},
+                  ->meta::pure::functions::relation::limit(100))},
           100,
           'meta::external::dataquality::tests::domain::DataQualityRuntime'
     );
@@ -564,7 +564,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
 
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_relationValidation_withLimit_and_parametersInAssertion():Boolean[1]
 {
-    doRelationTestWithLimit(
+    doRelationTestExpectingEvalWrapper(
       '###DataQualityValidation' +
     '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
     '      {' +
@@ -585,9 +585,11 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
                     ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()) + if($row.AGE->isEmpty(), | '', |$row.AGE->toOne()->toString()) + if($row.DQ_RULE_NAME->isEmpty(), | '', |$row.DQ_RULE_NAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
                     ->extend(~DQ_DEFECT_ID: row | generateGuid())}
                   ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME,AGE]))
-                  ->meta::pure::functions::relation::limit(100);},
+                  ->meta::pure::functions::relation::limit(100)},
           100,
-          'meta::external::dataquality::tests::domain::DataQualityRuntime'
+          'meta::external::dataquality::tests::domain::DataQualityRuntime',
+          true,
+          false
     );
 
 }
@@ -609,13 +611,13 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
           'invalidFirstName',
-          {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200),LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+          {|eval(|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200),LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
                 $rel->filter(row|$row.FIRSTNAME == 'invalid')
                     ->select(~[FIRSTNAME])
                     ->extend(~DQ_RULE_NAME: row | 'invalidFirstName')
                     ->extend(~DQ_LOGICAL_DEFECT_ID: row | meta::pure::functions::hash::hash(if($row.FIRSTNAME->isEmpty(), | '', |$row.FIRSTNAME->toOne()->toString()) + if($row.DQ_RULE_NAME->isEmpty(), | '', |$row.DQ_RULE_NAME->toOne()->toString()), meta::pure::functions::hash::HashType.MD5))
                     ->extend(~DQ_DEFECT_ID: row | generateGuid())}
-                ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));},
+                ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME])))},
           'meta::external::dataquality::tests::domain::DataQualityRuntime'        
     )
 }
@@ -642,17 +644,17 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
           'nonEmptyDataset',
-          {|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
+          {|eval(|{rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
                     $rel->aggregate(~COUNT : x | 1 : y | $y->count())->filter(row|$row.COUNT == 0)
             }
-            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));},
+            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME])))},
             'meta::external::dataquality::tests::domain::DataQualityRuntime'        
     );
 }
 
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_relationValidation_withParametersInAssertion_withoutDQColumns():Boolean[1]
 {
-  doRelationTestWithoutDQColumns(
+  doRelationTestExpectingEvalWrapper(
     '###DataQualityValidation' +
     '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
     '      {' +
@@ -670,8 +672,11 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
                 {rel: meta::pure::metamodel::relation::Relation<(FIRSTNAME:meta::pure::precisePrimitives::Varchar(200), LASTNAME:meta::pure::precisePrimitives::Varchar(200))>[1] |
                     $rel->filter(row|$row.FIRSTNAME==$firstName)->select(~[FIRSTNAME,LASTNAME])
             }
-            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->filter(row|$row.AGE >= $age)->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]));},
-          'meta::external::dataquality::tests::domain::DataQualityRuntime'        
+            ->meta::pure::functions::lang::eval(#>{meta::external::dataquality::tests::domain::db.personTable}#->filter(row|$row.AGE >= $age)->meta::pure::functions::relation::select(~[FIRSTNAME,LASTNAME]))},
+          [],
+          'meta::external::dataquality::tests::domain::DataQualityRuntime',
+          false,
+          false
     );
 }
 
@@ -927,10 +932,10 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
     '         ];' +
     '      }',
           'mustBeOfLegalAge',
-          {|meta::pure::functions::lang::eval(rel: meta::pure::metamodel::relation::Relation<(name:String[1], mustBeOfLegalAge:String)>[1]|
+          {|eval(|meta::pure::functions::lang::eval(rel: meta::pure::metamodel::relation::Relation<(name:String[1], mustBeOfLegalAge:String)>[1]|
             $rel->filter(row: (name:String[1], mustBeOfLegalAge:String[0..1])[1]|$row.mustBeOfLegalAge->isNotEmpty())
               ->select(~[name,mustBeOfLegalAge]), 
-              Person.all()->project(~[name: {x | $x.name},mustBeOfLegalAge: {x| $x->meta::pure::constraints::functions::createConstraintFailureMessage('mustBeOfLegalAge')}]))},
+              Person.all()->project(~[name: {x | $x.name},mustBeOfLegalAge: {x| $x->meta::pure::constraints::functions::createConstraintFailureMessage('mustBeOfLegalAge')}])))},
           'meta::external::dataquality::tests::domain::DataQualityRuntime'        
     );
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_utils.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test_utils.pure
@@ -107,7 +107,26 @@ function meta::external::dataquality::tests::doRelationTestWithoutDQColumns(dq:S
   let actual = $dataqualityRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationName, [], false);
 
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), $packageableRuntimeAsString);
-}                             
+}
+
+function meta::external::dataquality::tests::doRelationTestExpectingEvalWrapper(dq:String[1], validationNames:String[*], innerExpected:FunctionDefinition<Any>[1], packageableRuntimeAsString: String[1]):Boolean[1]
+{
+  doRelationTestExpectingEvalWrapper($dq, $validationNames, $innerExpected, [], $packageableRuntimeAsString, true, false);
+}
+
+function meta::external::dataquality::tests::doRelationTestExpectingEvalWrapper(dq:String[1], validationNames:String[*], innerExpected:FunctionDefinition<Any>[1], defectsLimit:Integer[0..1], packageableRuntimeAsString: String[1], enrichDQColumns:Boolean[1], castDQColumnsToPrimitive:Boolean[1]):Boolean[1]
+{
+  let dataqualityRelationValidation = $dq->loadDataQualityRelationValidation();
+  let actual = $dataqualityRelationValidation->meta::external::dataquality::generateDataqualityRelationValidationLambda($validationNames, $defectsLimit, $enrichDQColumns, $castDQColumnsToPrimitive, false);
+  let config = grammarConfig();
+  let ctx = ^meta::pure::metamodel::serialization::grammar::GContext(space='');
+  let innerStr = $innerExpected->printFunctionDefinition($config, $ctx);
+  let paramEndIdx = $innerStr->indexOf('|');
+  let paramSection = $innerStr->substring(0, $paramEndIdx + 1);
+  let needsClosingBrace = $innerStr->startsWith('{');
+  let expectedStr = $paramSection + 'meta::pure::functions::lang::eval(' + $innerStr + ')' + if($needsClosingBrace, |'}', |'');
+  assertLambdaEquals($expectedStr, $actual->cast(@LambdaFunction<Any>), $packageableRuntimeAsString, true);
+}
 
 function meta::external::dataquality::tests::doRelationTestWithTotalDefectCountAndLimit(dq:String[1], validationNames:String[*], expected:FunctionDefinition<Any>[1], resultLimit: Integer[1], packageableRuntimeAsString: String[1]):Boolean[1]
 {

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -506,7 +506,7 @@ function meta::external::dataquality::generateDataqualityRelationValidationLambd
   );
   let containsFrom = $dqRelationValidation.query->isEndingWithFromFunction();
   let multipleValidations = $selectedValidations->size() > 1;
-  let lambda = if (($removeFrom || $multipleValidations) && $containsFrom, //if we are running multiple validations we will wrap the expression in an eval on the from function at the end to ensure correct sql generated
+  let lambda = if (($removeFrom || $containsFrom),
     | $dqRelationValidation.query->popTerminalFunctionExpression(), 
     | $dqRelationValidation.query
   );
@@ -526,7 +526,7 @@ function meta::external::dataquality::generateDataqualityRelationValidationLambd
         | [buildLetExpression('sourceQuery', $query), $validationsUnion],
         | $validationsUnion
       );
-      if (!$removeFrom && $multipleValidations && $containsFrom, 
+      if (!$removeFrom && $containsFrom, 
         | let from = $dqRelationValidation.query.expressionSequence->evaluateAndDeactivate()->last()->cast(@SimpleFunctionExpression)->toOne();
           ^$lambda(expressionSequence = $expressionSequence)->wrapWithEvalOnFrom($from);, //need to wrap in eval on from so that let expression works correctly (correct sql can be generated)
         | ^$lambda(expressionSequence = $expressionSequence)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -2415,7 +2415,7 @@ function meta::relational::functions::pureToSqlQuery::processConcatenate(f:Funct
 
    // Fix columns ----------------
    let columns = $processed.element->cast(@SelectWithCursor).select.columns;
-   let transformed = if (!$columns->isEmpty() && $columns->at(0)->instanceOf(Alias),
+   let transformed = if (!$columns->isEmpty() && ($columns->at(0)->instanceOf(Alias) || $columns->at(0)->instanceOf(TableAliasColumn)),
                            | $processed->map(p|let selectWithCursor = $p.element->cast(@SelectWithCursor);
                                                let select = $selectWithCursor.select->alignJoinAndPkColumnsForUnion($columns);
                                                let element = $elements->at($processed->indexOf($p));
@@ -2594,10 +2594,10 @@ function meta::relational::functions::pureToSqlQuery::buildConcatenateSubSelect(
 
 function <<access.private>> meta::relational::functions::pureToSqlQuery::alignJoinAndPkColumnsForUnion(select: SelectSQLQuery[1], allColumns:RelationalOperationElement[*]):SelectSQLQuery[1]
 {
-   let allCols = $allColumns->map(c | $c->cast(@Alias).name)->removeDuplicates();
+   let allCols = $allColumns->map(c | $c->extractColumnName())->removeDuplicates();
 
    let sqlNull = ^Literal(value=^SQLNull());
-   let newCols = $allCols->map(a| let col = $select.columns->filter(c|$c->cast(@Alias).name == $a);
+   let newCols = $allCols->map(a| let col = $select.columns->filter(c|$c->extractColumnName() == $a);
                                   if ($col->isEmpty(),
                                       |^Alias(name=$a, relationalElement=$sqlNull),
                                       |$col->at(0)


### PR DESCRIPTION
- Small bug fix for pureToSql to handle tableAliasColumn
- move where ”from” is applied in dq validation e.g the same way we do for running multiple validations

